### PR TITLE
ci: add SSH key for repository checkout in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -58,6 +58,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.13'
+          
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
 
       # 1) Semantic Release nur zum Bump & Taggen
       - id: semantic_release

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ssh-key: ${{ secrets.SSH_DEPLOY_KEY }}
           fetch-depth: 0
           ref: main
 

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     name: 🧪 Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.13'
-          
+
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.5.4
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow to use an SSH key for repository authentication during the release process. No changes to application features or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->