### PR TITLE
Add interface documentation

### DIFF
--- a/docs/CalculationInterface.md
+++ b/docs/CalculationInterface.md
@@ -1,0 +1,37 @@
+# CalculationInterface
+
+`CalculationInterface` is used for managers that represent derived or calculated information. These managers do not store data in the database. Instead, they combine input values to produce results.
+
+## Basic usage
+
+Declare the required inputs with the `Input` class. Each input defines its type and optional choices or dependencies. The interface provides methods to generate combinations of inputs using a `CalculationBucket`. Calculations are exposed through methods decorated with `@graphQlProperty`.
+
+```python
+class ProjectSummary(GeneralManager):
+    project: Project
+    date: date
+
+    class Interface(CalculationInterface):
+        project = Input(Project)
+        date = Input(date)
+
+    @graphQlProperty
+    def volume(self) -> int:
+        return sum(
+            v.volume
+            for v in self.project.derivativevolume_list.filter(date=self.date)
+        )
+```
+
+`graphQlProperty` turns a method into a read-only attribute and registers it as a resolver for GraphQL queries. The calculation runs lazily when the property is accessed.
+
+To iterate over all possible combinations you can call `all()` or filter by inputs:
+
+```python
+for summary in ProjectSummary.all():
+    print(summary.project, summary.date)
+
+filtered = ProjectSummary.filter(project=my_project)
+```
+
+Because calculation managers have no persistent records, `create`, `update` and `deactivate` are not available.

--- a/docs/CalculationInterface.md
+++ b/docs/CalculationInterface.md
@@ -19,13 +19,13 @@ class ProjectSummary(GeneralManager):
     def volume(self) -> int:
         return sum(
             v.volume
-            for v in self.project.derivativevolume_list.filter(date=self.date)
+            for v in self.project.derivative_volume_list.filter(date=self.date)
         )
 ```
 
 `graphQlProperty` turns a method into a read-only attribute and registers it as a resolver for GraphQL queries. The calculation runs lazily when the property is accessed.
 
-To iterate over all possible combinations you can call `all()` or filter by inputs:
+To iterate over all possible combinations you can call `all()`, or filter by inputs:
 
 ```python
 for summary in ProjectSummary.all():

--- a/docs/DatabaseInterface.md
+++ b/docs/DatabaseInterface.md
@@ -1,0 +1,43 @@
+# DatabaseInterface
+
+`DatabaseInterface` connects a manager with a Django model and provides create, update and deactivate operations. It is the most common interface for working with persistent data.
+
+## Basic usage
+
+Define the model fields inside the interface class. Managers inherit automatic CRUD methods from `GeneralManager` that delegate to the interface.
+
+```python
+class Book(GeneralManager):
+    title: str
+    author: User
+
+    class Interface(DatabaseInterface):
+        title = CharField(max_length=50)
+        author = ForeignKey(User, on_delete=models.CASCADE)
+        readers = ManyToManyField(User, blank=True)
+```
+
+Creating a new instance automatically validates the model and records the user who made the change:
+
+```python
+book = Book.create(
+    creator_id=request.user.id,
+    history_comment="initial import",
+    title="My Book",
+    author=request.user,
+)
+```
+
+Updating or deactivating an existing manager works the same way:
+
+```python
+manager = Book(book_id)
+manager.update(creator_id=user.id, title="Updated")
+manager.deactivate(creator_id=user.id, history_comment="outdated")
+```
+
+Many-to-many fields are passed using the `<field>_id_list` convention. The interface handles sorting these values and applying them after saving the instance.
+
+## Rules and permissions
+
+`DatabaseInterface` supports rule validation and permission checks. Rules allow you to validate incoming data before it is saved. Permissions restrict which users may perform create, update or delete operations. See [Rule Validation](Rules.md) and the README section on permissions for more details.

--- a/docs/DatabaseInterface.md
+++ b/docs/DatabaseInterface.md
@@ -31,13 +31,13 @@ book = Book.create(
 Updating or deactivating an existing manager works the same way:
 
 ```python
-manager = Book(book_id)
+manager = Book(existing_book_id)
 manager.update(creator_id=user.id, title="Updated")
 manager.deactivate(creator_id=user.id, history_comment="outdated")
 ```
 
 Many-to-many fields are passed using the `<field>_id_list` convention. The interface handles sorting these values and applying them after saving the instance.
 
-## Rules and permissions
+## Rules
 
-`DatabaseInterface` supports rule validation and permission checks. Rules allow you to validate incoming data before it is saved. Permissions restrict which users may perform create, update or delete operations. See [Rule Validation](Rules.md) and the README section on permissions for more details.
+`DatabaseInterface` supports rule validation. Rules allow you to validate incoming data before it is saved. See [Rule Validation](Rules.md) for more details.

--- a/docs/ReadOnlyInterface.md
+++ b/docs/ReadOnlyInterface.md
@@ -1,0 +1,33 @@
+# ReadOnlyInterface
+
+`ReadOnlyInterface` is intended for static data that should be stored in the database but never modified through the framework. Instances of a manager using this interface read their information from JSON provided on the manager class and the interface keeps the corresponding table in sync.
+
+## Basic usage
+
+A manager class must define the data as a list or JSON string on the `_data` attribute. The interface describes the Django model fields just like `DatabaseInterface`.
+
+```python
+class Country(GeneralManager):
+    _data = [
+        {"code": "US", "name": "United States"},
+        {"code": "DE", "name": "Germany"},
+    ]
+
+    class Interface(ReadOnlyInterface):
+        code = CharField(max_length=2, unique=True)
+        name = CharField(max_length=50)
+```
+
+During start-up the framework checks that the database schema matches the interface. When the application runs the data is automatically synchronised with the table. New entries are created, changed rows are updated and obsolete ones are deactivated.
+
+```python
+# trigger synchronisation manually if needed
+Country.Interface.syncData()
+```
+
+The interface exposes only read methods. Objects cannot be created or updated through the manager. Filtering works as with `DatabaseInterface`:
+
+```python
+all_countries = Country.all()
+english_speaking = Country.filter(code__in=["US", "GB"])
+```

--- a/docs/ReadOnlyInterface.md
+++ b/docs/ReadOnlyInterface.md
@@ -18,10 +18,10 @@ class Country(GeneralManager):
         name = CharField(max_length=50)
 ```
 
-During start-up the framework checks that the database schema matches the interface. When the application runs the data is automatically synchronised with the table. New entries are created, changed rows are updated and obsolete ones are deactivated.
+During start-up the framework checks that the database schema matches the interface. When the application runs the data is automatically synchronized with the table. New entries are created, changed rows are updated and obsolete ones are deactivated.
 
 ```python
-# trigger synchronisation manually if needed
+# trigger synchroniation manually if needed
 Country.Interface.syncData()
 ```
 


### PR DESCRIPTION
## Summary
- document `ReadOnlyInterface` for synchronizing static JSON data
- document `DatabaseInterface` CRUD operations
- document `CalculationInterface` for non-persistent calculations
- reference rules and permissions in DatabaseInterface guide
- update calculation interface example to use `@graphQlProperty`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859a927f57c83249621b16c66434296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added new documentation files explaining the CalculationInterface, DatabaseInterface, and ReadOnlyInterface concepts, including usage examples, available operations, and integration details for managing and accessing data within the framework. These guides clarify how to work with calculated, database-backed, and static read-only data managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->