### PR TITLE
Fix manager cleanup in test utilities

### DIFF
--- a/src/general_manager/bucket/baseBucket.py
+++ b/src/general_manager/bucket/baseBucket.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from general_manager.manager.generalManager import GeneralManager
     from general_manager.manager.groupManager import GroupManager
     from general_manager.bucket.groupBucket import GroupBucket
+    from general_manager.interface.baseInterface import InterfaceBase
 
 
 class Bucket(ABC, Generic[GeneralManagerType]):
@@ -56,7 +57,11 @@ class Bucket(ABC, Generic[GeneralManagerType]):
 
     @abstractmethod
     def __or__(
-        self, other: Bucket[GeneralManagerType] | GeneralManager[GeneralManagerType]
+        self,
+        other: (
+            Bucket[GeneralManagerType]
+            | GeneralManager[GeneralManagerType, InterfaceBase]
+        ),
     ) -> Bucket[GeneralManagerType]:
         """
         Returns a new bucket representing the union of this bucket and another bucket or manager instance.

--- a/src/general_manager/bucket/baseBucket.py
+++ b/src/general_manager/bucket/baseBucket.py
@@ -22,7 +22,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def __init__(self, manager_class: Type[GeneralManagerType]):
         """
         Initializes the Bucket with a specified manager class.
-        
+
         Args:
             manager_class: The class of manager objects this bucket will manage.
         """
@@ -34,7 +34,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def __eq__(self, other: object) -> bool:
         """
         Checks if this Bucket is equal to another by comparing class, data, and manager class.
-        
+
         Returns:
             True if both objects are of the same class and have equal internal data and manager class; otherwise, False.
         """
@@ -45,7 +45,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def __reduce__(self) -> str | tuple[Any, ...]:
         """
         Prepares the object for pickling by returning the class and initialization arguments.
-        
+
         Returns:
             A tuple containing the class and a tuple of arguments needed to reconstruct the object during unpickling.
         """
@@ -60,10 +60,10 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     ) -> Bucket[GeneralManagerType]:
         """
         Returns a new bucket representing the union of this bucket and another bucket or manager instance.
-        
+
         Args:
             other: Another bucket or a single manager instance to combine with this bucket.
-        
+
         Returns:
             A new bucket containing all unique items from both sources.
         """
@@ -72,10 +72,10 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     @abstractmethod
     def __iter__(
         self,
-    ) -> Generator[GeneralManagerType | GroupManager[GeneralManagerType]]:
+    ) -> Generator[GeneralManagerType | GroupManager[GeneralManagerType], None, None]:
         """
         Returns an iterator over the items in the bucket.
-        
+
         Yields:
             Instances of the managed type or group manager contained in the bucket.
         """
@@ -85,10 +85,10 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def filter(self, **kwargs: Any) -> Bucket[GeneralManagerType]:
         """
         Returns a new bucket containing only items that match the specified filter criteria.
-        
+
         Args:
             **kwargs: Field-value pairs used to filter items in the bucket.
-        
+
         Returns:
             A new Bucket instance with items matching the given criteria.
         """
@@ -98,10 +98,10 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def exclude(self, **kwargs: Any) -> Bucket[GeneralManagerType]:
         """
         Returns a new Bucket excluding items that match the specified criteria.
-        
+
         Args:
             **kwargs: Field-value pairs specifying the exclusion criteria.
-        
+
         Returns:
             A new Bucket instance with items matching the criteria excluded.
         """
@@ -111,7 +111,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def first(self) -> GeneralManagerType | GroupManager[GeneralManagerType] | None:
         """
         Returns the first item in the bucket, or None if the bucket is empty.
-        
+
         Returns:
             The first GeneralManager or GroupManager instance, or None if no items exist.
         """
@@ -121,7 +121,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def last(self) -> GeneralManagerType | GroupManager[GeneralManagerType] | None:
         """
         Returns the last item in the bucket, or None if the bucket is empty.
-        
+
         Returns:
             The last GeneralManager or GroupManager instance, or None if no items exist.
         """
@@ -131,7 +131,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def count(self) -> int:
         """
         Returns the number of items in the bucket.
-        
+
         Subclasses must implement this method to provide the count of contained elements.
         """
         raise NotImplementedError
@@ -140,7 +140,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def all(self) -> Bucket[GeneralManagerType]:
         """
         Returns a bucket containing all items managed by this instance.
-        
+
         Subclasses must implement this method to provide access to the complete collection without filters or exclusions applied.
         """
         raise NotImplementedError
@@ -151,13 +151,13 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     ) -> GeneralManagerType | GroupManager[GeneralManagerType]:
         """
         Retrieves a single item matching the specified criteria.
-        
+
         Args:
             **kwargs: Field-value pairs used to identify the item.
-        
+
         Returns:
             The matching GeneralManager or GroupManager instance.
-        
+
         Raises:
             NotImplementedError: If the method is not implemented by a subclass.
         """
@@ -173,13 +173,13 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     ):
         """
         Retrieves an item or a slice from the bucket.
-        
+
         Args:
             item: An integer index to retrieve a single element, or a slice to retrieve a subset.
-        
+
         Returns:
             A single manager instance if an integer is provided, or a new Bucket containing the sliced elements if a slice is provided.
-        
+
         Raises:
             NotImplementedError: This method must be implemented by subclasses.
         """
@@ -189,7 +189,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def __len__(self) -> int:
         """
         Returns the number of items in the bucket.
-        
+
         Subclasses must implement this method to provide the count of contained elements.
         """
         raise NotImplementedError
@@ -198,12 +198,12 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def __contains__(self, item: GeneralManagerType) -> bool:
         """
         Checks whether the specified item is present in the bucket.
-        
+
         Args:
-        	item: The manager instance to check for membership.
-        
+                item: The manager instance to check for membership.
+
         Returns:
-        	True if the item is contained in the bucket, otherwise False.
+                True if the item is contained in the bucket, otherwise False.
         """
         raise NotImplementedError
 
@@ -215,11 +215,11 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     ) -> Bucket[GeneralManagerType]:
         """
         Returns a new Bucket with items sorted by the specified key or keys.
-        
+
         Args:
             key: A string or tuple of strings specifying the attribute(s) to sort by.
             reverse: If True, sorts in descending order. Defaults to False.
-        
+
         Returns:
             A new Bucket instance with items sorted according to the given key(s).
         """
@@ -228,10 +228,10 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     def group_by(self, *group_by_keys: str) -> GroupBucket[GeneralManagerType]:
         """
         Groups the bucket's data by one or more specified keys.
-        
+
         Args:
             *group_by_keys: One or more attribute names to group the data by.
-        
+
         Returns:
             A GroupBucket instance containing the grouped data.
         """

--- a/src/general_manager/bucket/calculationBucket.py
+++ b/src/general_manager/bucket/calculationBucket.py
@@ -190,7 +190,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         """
         return self
 
-    def __iter__(self) -> Generator[GeneralManagerType]:
+    def __iter__(self) -> Generator[GeneralManagerType, None, None]:
         """
         Yields manager instances for each valid combination of input parameters.
 

--- a/src/general_manager/bucket/databaseBucket.py
+++ b/src/general_manager/bucket/databaseBucket.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     Generator,
     TypeVar,
+    TYPE_CHECKING,
 )
 from django.db import models
 from general_manager.interface.baseInterface import (
@@ -14,6 +15,9 @@ from general_manager.bucket.baseBucket import Bucket
 from general_manager.manager.generalManager import GeneralManager
 
 modelsModel = TypeVar("modelsModel", bound=models.Model)
+
+if TYPE_CHECKING:
+    from general_manager.interface.databaseInterface import DatabaseInterface
 
 
 class DatabaseBucket(Bucket[GeneralManagerType]):
@@ -40,7 +44,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         self.filters = {**(filter_definitions or {})}
         self.excludes = {**(exclude_definitions or {})}
 
-    def __iter__(self) -> Generator[GeneralManagerType]:
+    def __iter__(self) -> Generator[GeneralManagerType, None, None]:
         """
         Yields manager instances for each item in the underlying queryset.
 
@@ -51,7 +55,10 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
 
     def __or__(
         self,
-        other: Bucket[GeneralManagerType] | GeneralManager[GeneralManagerType],
+        other: (
+            Bucket[GeneralManagerType]
+            | GeneralManager[GeneralManagerType, DatabaseInterface]
+        ),
     ) -> DatabaseBucket[GeneralManagerType]:
         """
         Combines this bucket with another bucket or manager instance using the union operator.

--- a/src/general_manager/bucket/groupBucket.py
+++ b/src/general_manager/bucket/groupBucket.py
@@ -117,7 +117,7 @@ class GroupBucket(Bucket[GeneralManagerType]):
             self._basis_data | other._basis_data,
         )
 
-    def __iter__(self) -> Generator[GroupManager[GeneralManagerType]]:
+    def __iter__(self) -> Generator[GroupManager[GeneralManagerType], None, None]:
         """
         Yields each grouped manager in the current GroupBucket.
 

--- a/src/general_manager/cache/modelDependencyCollector.py
+++ b/src/general_manager/cache/modelDependencyCollector.py
@@ -11,15 +11,17 @@ from general_manager.cache.dependencyIndex import (
 class ModelDependencyCollector:
 
     @staticmethod
-    def collect(obj) -> Generator[tuple[general_manager_name, filter_type, str]]:
+    def collect(
+        obj,
+    ) -> Generator[tuple[general_manager_name, filter_type, str], None, None]:
         """
         Recursively extracts dependency information from Django model-related objects.
-        
+
         Inspects the input object and its nested structures to identify instances of GeneralManager and Bucket, yielding a tuple for each dependency found. Each tuple contains the manager class name, the dependency type ("identification", "filter", or "exclude"), and the string representation of the dependency value.
-        
+
         Args:
             obj: The object or collection to inspect for model dependencies.
-        
+
         Yields:
             Tuples of (manager class name, dependency type, dependency value) for each dependency discovered.
         """


### PR DESCRIPTION
## Summary
- properly clean up dynamically created GeneralManager models in tests
- add regression test with duplicate `TestProject` manager name

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686c33220f688324821c5ed0541aa801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new tests for creating projects via custom GraphQL mutations, including setup and verification of project creation.
  * Enhanced test cleanup to ensure complete removal of test data and configurations after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->