### PR TITLE
Refactor manager-based permissions and add integration tests

### DIFF
--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -383,11 +383,16 @@ class GraphQL:
         general_manager_class: type[GeneralManager],
         info: GraphQLResolveInfo,
     ) -> Bucket:
+        import copy
+
         """
         Wendet die vom Permission-Interface vorgegebenen Filter auf das Queryset an.
         """
         permission_filters = getReadPermissionFilter(general_manager_class, info)
-        filtered_queryset = queryset
+        if not permission_filters:
+            return queryset
+
+        filtered_queryset = queryset.none()
         for perm_filter, perm_exclude in permission_filters:
             qs_perm = queryset.exclude(**perm_exclude).filter(**perm_filter)
             filtered_queryset = filtered_queryset | qs_perm

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -384,7 +384,10 @@ class GraphQL:
         info: GraphQLResolveInfo,
     ) -> Bucket:
         """
-        Wendet die vom Permission-Interface vorgegebenen Filter auf das Queryset an.
+        Applies permission-based filters to a queryset according to the permission interface of the given manager class.
+        
+        Returns:
+            A queryset containing only the items allowed by the user's read permissions. If no permission filters are defined, returns the original queryset unchanged.
         """
         permission_filters = getReadPermissionFilter(general_manager_class, info)
         if not permission_filters:

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -383,8 +383,6 @@ class GraphQL:
         general_manager_class: type[GeneralManager],
         info: GraphQLResolveInfo,
     ) -> Bucket:
-        import copy
-
         """
         Wendet die vom Permission-Interface vorgegebenen Filter auf das Queryset an.
         """

--- a/src/general_manager/bucket/baseBucket.py
+++ b/src/general_manager/bucket/baseBucket.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from django.db.models import QuerySet
 from typing import (
     Type,
     Generator,

--- a/src/general_manager/bucket/baseBucket.py
+++ b/src/general_manager/bucket/baseBucket.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from django.db.models import QuerySet
 from typing import (
     Type,
     Generator,
@@ -62,10 +63,10 @@ class Bucket(ABC, Generic[GeneralManagerType]):
     ) -> Bucket[GeneralManagerType]:
         """
         Return a new bucket containing the union of this bucket and another bucket or manager instance.
-        
+
         Parameters:
             other: Another bucket or a single manager instance to combine with this bucket.
-        
+
         Returns:
             A new bucket containing all unique items from both sources.
         """
@@ -240,3 +241,9 @@ class Bucket(ABC, Generic[GeneralManagerType]):
         from general_manager.bucket.groupBucket import GroupBucket
 
         return GroupBucket(self._manager_class, group_by_keys, self)
+
+    def none(self) -> Bucket[GeneralManagerType]:
+        raise NotImplementedError(
+            "The 'none' method is not implemented in the base Bucket class. "
+            "Subclasses should implement this method to return an empty bucket."
+        )

--- a/src/general_manager/bucket/baseBucket.py
+++ b/src/general_manager/bucket/baseBucket.py
@@ -61,13 +61,13 @@ class Bucket(ABC, Generic[GeneralManagerType]):
         other: Bucket[GeneralManagerType] | GeneralManagerType,
     ) -> Bucket[GeneralManagerType]:
         """
-        Return a new bucket containing the union of this bucket and another bucket or manager instance.
-
+        Return a new bucket representing the union of this bucket and another bucket or a single manager instance.
+        
         Parameters:
-            other: Another bucket or a single manager instance to combine with this bucket.
-
+            other: Another bucket or a single manager instance to include in the union.
+        
         Returns:
-            A new bucket containing all unique items from both sources.
+            A new bucket containing all unique items from both this bucket and the provided argument.
         """
         raise NotImplementedError
 
@@ -229,19 +229,22 @@ class Bucket(ABC, Generic[GeneralManagerType]):
 
     def group_by(self, *group_by_keys: str) -> GroupBucket[GeneralManagerType]:
         """
-        Groups the bucket's data by one or more specified keys.
-
-        Args:
-            *group_by_keys: One or more attribute names to group the data by.
-
+        Return a GroupBucket that groups the items in this bucket by the specified attribute keys.
+        
+        Parameters:
+            *group_by_keys (str): Attribute names to group the items by.
+        
         Returns:
-            A GroupBucket instance containing the grouped data.
+            GroupBucket[GeneralManagerType]: A bucket containing items grouped by the given keys.
         """
         from general_manager.bucket.groupBucket import GroupBucket
 
         return GroupBucket(self._manager_class, group_by_keys, self)
 
     def none(self) -> Bucket[GeneralManagerType]:
+        """
+        Raise NotImplementedError to indicate that subclasses must implement a method returning an empty bucket.
+        """
         raise NotImplementedError(
             "The 'none' method is not implemented in the base Bucket class. "
             "Subclasses should implement this method to return an empty bucket."

--- a/src/general_manager/bucket/calculationBucket.py
+++ b/src/general_manager/bucket/calculationBucket.py
@@ -96,13 +96,13 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         other: Bucket[GeneralManagerType] | GeneralManagerType,
     ) -> CalculationBucket[GeneralManagerType]:
         """
-        Combine this CalculationBucket with another bucket or manager instance of the same manager class.
-
-        If combined with a manager instance, returns a bucket filtered to that manager's identification. If combined with another CalculationBucket of the same manager class, returns a new bucket containing only the filters and excludes that are present and identical in both buckets.
-
+        Combine this CalculationBucket with another bucket or a manager instance of the same manager class.
+        
+        If combined with a manager instance, returns a bucket filtered to that instance's identification. If combined with another CalculationBucket of the same manager class, returns a new bucket containing only the filters and excludes that are present and identical in both buckets.
+        
         Raises:
             ValueError: If the other object is not a CalculationBucket or manager of the same class.
-
+        
         Returns:
             CalculationBucket[GeneralManagerType]: A new CalculationBucket representing the intersection of filters and excludes, or a filtered bucket for the given manager instance.
         """
@@ -184,17 +184,18 @@ class CalculationBucket(Bucket[GeneralManagerType]):
 
     def all(self) -> CalculationBucket:
         """
-        Returns the current CalculationBucket instance.
-
-        This method allows for compatibility with interfaces expecting an `all()` method that returns the full set of items.
+        Return a deep copy of the current CalculationBucket instance.
+        
+        Use this method to obtain an independent copy of the bucket, ensuring that modifications to the returned instance do not affect the original.
         """
         return deepcopy(self)
 
     def __iter__(self) -> Generator[GeneralManagerType, None, None]:
         """
-        Yields manager instances for each valid combination of input parameters.
-
-        Iterates over all generated input combinations, instantiating the manager class with each set of parameters.
+        Iterate over all valid input combinations, yielding a manager instance for each.
+        
+        Yields:
+            Manager instances created with each valid set of input parameters.
         """
         combinations = self.generate_combinations()
         for combo in combinations:
@@ -471,14 +472,14 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         self, key: str | tuple[str], reverse: bool = False
     ) -> CalculationBucket[GeneralManagerType]:
         """
-        Returns a new CalculationBucket with updated sorting parameters.
-
-        Args:
-            key: The field name or tuple of field names to sort combinations by.
-            reverse: If True, sorts in descending order.
-
+        Return a new CalculationBucket instance with updated sorting criteria.
+        
+        Parameters:
+            key (str or tuple of str): Field name(s) to sort the combinations by.
+            reverse (bool): Whether to sort in descending order.
+        
         Returns:
-            A new CalculationBucket instance with the specified sorting applied.
+            CalculationBucket: A new bucket instance sorted according to the specified key and order.
         """
         return CalculationBucket(
             self._manager_class, self.filters, self.excludes, key, reverse
@@ -486,9 +487,9 @@ class CalculationBucket(Bucket[GeneralManagerType]):
 
     def none(self) -> CalculationBucket[GeneralManagerType]:
         """
-        Returns a new CalculationBucket with no items, maintaining the same class type.
-
-        This method is useful for creating a bucket that contains no items, while preserving the class type.
+        Return a new CalculationBucket instance of the same type containing no items.
+        
+        The returned bucket has all filters, excludes, and cached combinations cleared, representing an empty set of combinations.
         """
         own = self.all()
         own._current_combinations = None

--- a/src/general_manager/bucket/calculationBucket.py
+++ b/src/general_manager/bucket/calculationBucket.py
@@ -9,6 +9,7 @@ from typing import (
     Generator,
     List,
 )
+from copy import deepcopy
 from general_manager.interface.baseInterface import (
     generalManagerClassName,
     GeneralManagerType,
@@ -96,12 +97,12 @@ class CalculationBucket(Bucket[GeneralManagerType]):
     ) -> CalculationBucket[GeneralManagerType]:
         """
         Combine this CalculationBucket with another bucket or manager instance of the same manager class.
-        
+
         If combined with a manager instance, returns a bucket filtered to that manager's identification. If combined with another CalculationBucket of the same manager class, returns a new bucket containing only the filters and excludes that are present and identical in both buckets.
-        
+
         Raises:
             ValueError: If the other object is not a CalculationBucket or manager of the same class.
-            
+
         Returns:
             CalculationBucket[GeneralManagerType]: A new CalculationBucket representing the intersection of filters and excludes, or a filtered bucket for the given manager instance.
         """
@@ -187,7 +188,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
 
         This method allows for compatibility with interfaces expecting an `all()` method that returns the full set of items.
         """
-        return self
+        return deepcopy(self)
 
     def __iter__(self) -> Generator[GeneralManagerType, None, None]:
         """
@@ -482,3 +483,15 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         return CalculationBucket(
             self._manager_class, self.filters, self.excludes, key, reverse
         )
+
+    def none(self) -> CalculationBucket[GeneralManagerType]:
+        """
+        Returns a new CalculationBucket with no items, maintaining the same class type.
+
+        This method is useful for creating a bucket that contains no items, while preserving the class type.
+        """
+        own = self.all()
+        own._current_combinations = None
+        own.filters = {}
+        own.excludes = {}
+        return own

--- a/src/general_manager/bucket/databaseBucket.py
+++ b/src/general_manager/bucket/databaseBucket.py
@@ -227,3 +227,13 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         else:
             sorted_data = self._data.order_by(*key)
         return self.__class__(sorted_data, self._manager_class)
+
+    def none(self) -> DatabaseBucket[GeneralManagerType]:
+        """
+        Returns a new DatabaseBucket with no items, maintaining the same class type.
+
+        This method is useful for creating a bucket that contains no items, while maintaining the same class type.
+        """
+        own = self.all()
+        own._data = own._data.none()
+        return own

--- a/src/general_manager/bucket/databaseBucket.py
+++ b/src/general_manager/bucket/databaseBucket.py
@@ -211,14 +211,14 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         reverse: bool = False,
     ) -> DatabaseBucket:
         """
-        Return a new DatabaseBucket sorted by the specified field or fields.
-
+        Return a new DatabaseBucket with items sorted by the specified field or fields.
+        
         Parameters:
             key (str or tuple of str): Field name or tuple of field names to sort by.
             reverse (bool): If True, sort in descending order.
-
+        
         Returns:
-            DatabaseBucket: A new bucket instance containing the sorted queryset.
+            DatabaseBucket: A new bucket containing the sorted items.
         """
         if isinstance(key, str):
             key = (key,)
@@ -230,9 +230,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
 
     def none(self) -> DatabaseBucket[GeneralManagerType]:
         """
-        Returns a new DatabaseBucket with no items, maintaining the same class type.
-
-        This method is useful for creating a bucket that contains no items, while maintaining the same class type.
+        Return a new DatabaseBucket instance of the same type containing no items.
+        
+        This method creates an empty bucket while preserving the current manager class and bucket type.
         """
         own = self.all()
         own._data = own._data.none()

--- a/src/general_manager/bucket/groupBucket.py
+++ b/src/general_manager/bucket/groupBucket.py
@@ -285,8 +285,8 @@ class GroupBucket(Bucket[GeneralManagerType]):
 
     def group_by(self, *group_by_keys: str) -> GroupBucket[GeneralManagerType]:
         """
-        Returns a new GroupBucket grouped by the current and additional specified attribute keys.
-
+        Return a new GroupBucket grouped by the current and additional attribute keys.
+        
         Additional group-by keys are appended to the existing grouping, and the new GroupBucket is constructed from the same underlying data.
         """
         return GroupBucket(
@@ -297,9 +297,9 @@ class GroupBucket(Bucket[GeneralManagerType]):
 
     def none(self) -> GroupBucket[GeneralManagerType]:
         """
-        Returns a new GroupBucket with no items, maintaining the same class type and group-by keys.
-
-        This method is useful for creating a bucket that contains no items, while maintaining the same class type.
+        Return a new empty GroupBucket with the same manager class and group-by keys as the current instance.
+        
+        This method creates a GroupBucket containing no items, preserving the grouping configuration of the original.
         """
         return GroupBucket(
             self._manager_class, self._group_by_keys, self._basis_data.none()

--- a/src/general_manager/bucket/groupBucket.py
+++ b/src/general_manager/bucket/groupBucket.py
@@ -294,3 +294,13 @@ class GroupBucket(Bucket[GeneralManagerType]):
             tuple([*self._group_by_keys, *group_by_keys]),
             self._basis_data,
         )
+
+    def none(self) -> GroupBucket[GeneralManagerType]:
+        """
+        Returns a new GroupBucket with no items, maintaining the same class type and group-by keys.
+
+        This method is useful for creating a bucket that contains no items, while maintaining the same class type.
+        """
+        return GroupBucket(
+            self._manager_class, self._group_by_keys, self._basis_data.none()
+        )

--- a/src/general_manager/interface/databaseInterface.py
+++ b/src/general_manager/interface/databaseInterface.py
@@ -91,7 +91,7 @@ class DatabaseInterface(DBBasedInterface[GeneralManagerModel]):
         from general_manager.manager.generalManager import GeneralManager
 
         for key, value in many_to_many_kwargs.items():
-            if not value:
+            if value is None or value is NOT_PROVIDED:
                 continue
             field_name = key.removesuffix("_id_list")
             if isinstance(value, list) and all(

--- a/src/general_manager/interface/databaseInterface.py
+++ b/src/general_manager/interface/databaseInterface.py
@@ -84,9 +84,12 @@ class DatabaseInterface(DBBasedInterface[GeneralManagerModel]):
         instance: GeneralManagerModel, many_to_many_kwargs: dict[str, list[Any]]
     ) -> GeneralManagerModel:
         """
-        Set many-to-many relationship fields on a model instance using provided values.
-
-        Converts lists of `GeneralManager` instances to their corresponding IDs before updating the relationships. Returns the updated instance.
+        Set many-to-many relationship fields on a model instance using the provided values.
+        
+        For each field, converts lists of `GeneralManager` instances to their IDs if necessary, and updates the corresponding many-to-many relationship on the instance. Fields with values of `None` or `NOT_PROVIDED` are ignored.
+        
+        Returns:
+            GeneralManagerModel: The updated model instance with many-to-many relationships set.
         """
         from general_manager.manager.generalManager import GeneralManager
 

--- a/src/general_manager/permission/managerBasedPermission.py
+++ b/src/general_manager/permission/managerBasedPermission.py
@@ -65,8 +65,8 @@ class ManagerBasedPermission(BasePermission):
             raise ValueError(
                 f"Based on object {__based_on__} not found in instance {self.instance}"
             )
-        if not isinstance(basis_object, GeneralManager) and not issubclass(
-            basis_object, GeneralManager
+        if not isinstance(basis_object, GeneralManager) and not (
+            isinstance(basis_object, type) and issubclass(basis_object, GeneralManager)
         ):
             raise TypeError(f"Based on object {__based_on__} is not a GeneralManager")
 

--- a/src/general_manager/permission/managerBasedPermission.py
+++ b/src/general_manager/permission/managerBasedPermission.py
@@ -30,6 +30,11 @@ class ManagerBasedPermission(BasePermission):
         request_user: AbstractUser,
     ) -> None:
 
+        """
+        Initialize the ManagerBasedPermission with a manager instance and a requesting user.
+        
+        Sets up default CRUD permission lists based on whether a related "based on" permission is specified, populates attribute-specific permissions, and prepares internal state for permission checks.
+        """
         super().__init__(instance, request_user)
 
         default_read = ["public"]
@@ -54,6 +59,16 @@ class ManagerBasedPermission(BasePermission):
         }
 
     def __getBasedOnPermission(self) -> Optional[BasePermission]:
+        """
+        Retrieve and instantiate the permission object associated with the `__based_on__` attribute.
+        
+        Returns:
+            An instance of the related `BasePermission` subclass if the `__based_on__` attribute exists on the instance and its `Permission` class is valid; otherwise, returns `None`.
+        
+        Raises:
+            ValueError: If the `__based_on__` attribute is missing from the instance.
+            TypeError: If the `__based_on__` attribute is not a `GeneralManager` or its subclass.
+        """
         from general_manager.manager.generalManager import GeneralManager
 
         __based_on__ = getattr(self, "__based_on__")
@@ -137,6 +152,15 @@ class ManagerBasedPermission(BasePermission):
         self,
         permissions: list[str],
     ) -> bool:
+        """
+        Return True if the provided permissions list is empty or if any permission string is valid for the user.
+        
+        Parameters:
+            permissions (list[str]): List of permission strings to validate.
+        
+        Returns:
+            bool: True if no permissions are required or at least one permission string is valid; otherwise, False.
+        """
         if not permissions:
             return True
         for permission in permissions:

--- a/src/general_manager/permission/managerBasedPermission.py
+++ b/src/general_manager/permission/managerBasedPermission.py
@@ -19,10 +19,10 @@ type permission_type = Literal[
 
 class ManagerBasedPermission(BasePermission):
     __based_on__: Optional[str] = None
-    __read__: list[str] = ["public"]
-    __create__: list[str] = ["isAuthenticated"]
-    __update__: list[str] = ["isAuthenticated"]
-    __delete__: list[str] = ["isAuthenticated"]
+    __read__: list[str]
+    __create__: list[str]
+    __update__: list[str]
+    __delete__: list[str]
 
     def __init__(
         self,
@@ -31,6 +31,19 @@ class ManagerBasedPermission(BasePermission):
     ) -> None:
 
         super().__init__(instance, request_user)
+
+        default_read = ["public"]
+        default_write = ["isAuthenticated"]
+
+        if self.__based_on__ is not None:
+            default_read = []
+            default_write = []
+
+        self.__read__ = getattr(self, "__read__", default_read)
+        self.__create__ = getattr(self, "__create__", default_write)
+        self.__update__ = getattr(self, "__update__", default_write)
+        self.__delete__ = getattr(self, "__delete__", default_write)
+
         self.__attribute_permissions = self.__getAttributePermissions()
         self.__based_on_permission = self.__getBasedOnPermission()
         self.__overall_results: Dict[permission_type, Optional[bool]] = {
@@ -124,6 +137,8 @@ class ManagerBasedPermission(BasePermission):
         self,
         permissions: list[str],
     ) -> bool:
+        if not permissions:
+            return True
         for permission in permissions:
             if self.validatePermissionString(permission):
                 return True

--- a/src/general_manager/permission/managerBasedPermission.py
+++ b/src/general_manager/permission/managerBasedPermission.py
@@ -34,9 +34,9 @@ class ManagerBasedPermission(BasePermission):
         request_user: AbstractUser,
     ) -> None:
         """
-        Initialize the ManagerBasedPermission with a manager instance and a requesting user.
-
-        Sets up default CRUD permission lists based on whether a related "based on" permission is specified, populates attribute-specific permissions, and prepares internal state for permission checks.
+        Initializes the ManagerBasedPermission with a manager instance and the requesting user.
+        
+        Configures default CRUD permissions, collects attribute-specific permissions, and sets up any related "based on" permission for cascading checks.
         """
         super().__init__(instance, request_user)
         self.__setPermissions()
@@ -52,6 +52,11 @@ class ManagerBasedPermission(BasePermission):
 
     def __setPermissions(self, skip_based_on: bool = False) -> None:
 
+        """
+        Assigns default permission lists for CRUD actions based on the presence of a related permission attribute.
+        
+        If the permission is based on another attribute and `skip_based_on` is False, all default permissions are set to empty lists. Otherwise, read permissions default to `["public"]` and write permissions to `["isAuthenticated"]`. Class-level overrides are respected if present.
+        """
         default_read = ["public"]
         default_write = ["isAuthenticated"]
 
@@ -66,11 +71,11 @@ class ManagerBasedPermission(BasePermission):
 
     def __getBasedOnPermission(self) -> Optional[BasePermission]:
         """
-        Retrieve and instantiate the permission object associated with the `__based_on__` attribute.
-
+        Retrieves the permission object associated with the `__based_on__` attribute, if present and valid.
+        
         Returns:
-            An instance of the related `BasePermission` subclass if the `__based_on__` attribute exists on the instance and its `Permission` class is valid; otherwise, returns `None`.
-
+            An instance of the related `BasePermission` subclass if the `__based_on__` attribute exists on the instance and its `Permission` class is a subclass of `BasePermission`; otherwise, returns `None`.
+        
         Raises:
             ValueError: If the `__based_on__` attribute is missing from the instance.
             TypeError: If the `__based_on__` attribute is not a `GeneralManager` or its subclass.
@@ -162,13 +167,9 @@ class ManagerBasedPermission(BasePermission):
         permissions: list[str],
     ) -> bool:
         """
-        Return True if the provided permissions list is empty or if any permission string is valid for the user.
-
-        Parameters:
-            permissions (list[str]): List of permission strings to validate.
-
-        Returns:
-            bool: True if no permissions are required or at least one permission string is valid; otherwise, False.
+        Return True if no permissions are required or if at least one permission string is valid for the user.
+        
+        If the permissions list is empty, access is granted. Otherwise, returns True if any permission string in the list is validated for the user; returns False if none are valid.
         """
         if not permissions:
             return True

--- a/src/general_manager/permission/permissionChecks.py
+++ b/src/general_manager/permission/permissionChecks.py
@@ -34,6 +34,11 @@ permission_functions: dict[str, PermissionDict] = {
         "permission_method": lambda instance, user, config: True,
         "permission_filter": lambda user, config: None,
     },
+    "matches": {
+        "permission_method": lambda instance, user, config: getattr(instance, config[0])
+        == config[1],
+        "permission_filter": lambda user, config: {"filter": {config[0]: config[1]}},
+    },
     "ends_with": {
         "permission_method": lambda instance, user, config: getattr(
             instance, config[0]

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from django.db import models
-from django.db import IntegrityError, DataError
+from django.core.exceptions import ValidationError
+from django.contrib.auth.models import User
 from general_manager.manager.generalManager import GeneralManager
 from general_manager.interface.databaseInterface import DatabaseInterface
 from general_manager.bucket.baseBucket import Bucket
@@ -14,7 +15,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def setUpClass(cls):
         """
         Defines and assigns nested GeneralManager model classes with interfaces and permissions for integration tests.
-        
+
         This method creates three model classes—TestCountry1, TestHuman1, and TestFamily1—each with Django ORM fields and manager-based permissions. The classes are assigned to class variables for use in test methods, and lists of all manager classes and read-only classes are initialized.
         """
 
@@ -72,16 +73,17 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         cls.TestHuman = TestHuman1
         cls.TestFamily = TestFamily1
         cls.general_manager_classes = [TestCountry1, TestHuman1, TestFamily1]
-        cls.read_only_classes = [TestCountry1]
 
     def setUp(self):
         """
         Populate the test database with sample countries, humans, and a family for integration testing.
-        
+
         Creates two country instances, three human instances (one linked to a country), and a family instance associating two humans. All objects are created with permissions bypassed for test setup.
         """
         super().setUp()
-
+        self.user: User = User.objects.create_user(
+            username="testuser", password="testpassword", email="testuser@example.com"
+        )
         self.us = self.TestCountry.create(
             creator_id=None,
             code="US",
@@ -124,7 +126,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_update_family(self):
         """
         Verify that updating a family instance correctly changes its name and updates its associated humans.
-        
+
         Asserts that the family initially contains the expected humans, then updates the family's name and membership, and verifies the changes are reflected in the relationships.
         """
         self.assertEqual(self.test_family.name, "Smith Family")
@@ -143,7 +145,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_based_on_permissions_public(self):
         """
         Test that manager-based permissions allow updating and creating human instances.
-        
+
         Verifies that a human's name can be updated and a new human can be created with a country association, ensuring permission logic is correctly enforced.
         """
 
@@ -163,41 +165,42 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_permission_based_on_field_inheritance(self):
         """
         Test that permissions are correctly inherited based on the __based_on__ field.
-        
+
         Verifies that humans inherit permissions from their associated country.
         """
         # Test that human with US country inherits US permissions
-        self.assertEqual(self.test_human1.country.code, "US")
-        
+        self.assertEqual(self.test_human1.country.code, "US")  # type: ignore
+
         # Test that human without country has no country-based permissions
         self.assertIsNone(self.test_human2.country)
-        
+
         # Update human2 to have a country and verify permission inheritance
         self.test_human2 = self.test_human2.update(
-            country=self.de,
-            ignore_permission=True
+            country=self.de, ignore_permission=True
         )
-        self.assertEqual(self.test_human2.country.code, "DE")
+        self.assertEqual(self.test_human2.country.code, "DE")  # type: ignore
 
     def test_create_with_permission_validation(self):
         """
         Test creating instances with different permission scenarios.
-        
+
         Validates that permission checking works correctly during creation.
         """
-        # Test creating human with valid country reference
+        # Test creating human with valid country reference -> should use country-based permissions
         human_with_country = self.TestHuman.create(
-            creator_id=None,
-            name="David",
-            country=self.us
+            creator_id=None, name="David", country=self.us
         )
         self.assertEqual(human_with_country.name, "David")
-        self.assertEqual(human_with_country.country.code, "US")
-        
-        # Test creating human without country
+        self.assertEqual(human_with_country.country.code, "US")  # type: ignore
+
+        # Test creating human without country -> should fall back to default permissions
+        with self.assertRaises(PermissionError):
+            self.TestHuman.create(
+                creator_id=None,
+                name="Eve",
+            )
         human_without_country = self.TestHuman.create(
-            creator_id=None,
-            name="Eva"
+            creator_id=self.user.id, name="Eva"  # type: ignore
         )
         self.assertEqual(human_without_country.name, "Eva")
         self.assertIsNone(human_without_country.country)
@@ -205,195 +208,124 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_update_with_permission_validation(self):
         """
         Test updating instances with different permission scenarios.
-        
+
         Validates that permission checking works correctly during updates.
         """
         # Test updating human's country association
         original_country = self.test_human1.country
-        self.assertEqual(original_country.code, "US")
-        
+        self.assertEqual(original_country.code, "US")  # type: ignore
+
         updated_human = self.test_human1.update(country=self.de)
-        self.assertEqual(updated_human.country.code, "DE")
-        
+        self.assertEqual(updated_human.country.code, "DE")  # type: ignore
+
         # Test updating human to remove country association
-        updated_human = updated_human.update(country=None)
+        with self.assertRaises(PermissionError):
+            updated_human = updated_human.update(country=None)
+        updated_human = updated_human.update(country=None, creator_id=self.user.id)  # type: ignore
         self.assertIsNone(updated_human.country)
 
     def test_delete_with_permissions(self):
         """
         Test deletion scenarios with permission validation.
-        
+
         Verifies that deletion works correctly with manager-based permissions.
         """
         # Create a temporary human for deletion test
         temp_human = self.TestHuman.create(
-            creator_id=None,
-            name="Temporary",
-            country=self.us,
-            ignore_permission=True
+            creator_id=None, name="Temporary", country=self.us, ignore_permission=True
         )
-        
-        human_id = temp_human.id
-        temp_human.delete()
-        
+
+        human_id = temp_human.id  # type: ignore
+        temp_human.deactivate()
+
         # Verify the human was deleted
-        deleted_human = self.TestHuman.filter(id=human_id).first()
+        deleted_human = self.TestHuman.filter(id=human_id, is_active=True).first()
         self.assertIsNone(deleted_human)
-
-    def test_bucket_relationship_operations(self):
-        """
-        Test operations on bucket relationships between models.
-        
-        Validates that many-to-many and related field operations work correctly.
-        """
-        # Test initial family-human relationships
-        self.assertEqual(len(self.test_family.humans_list), 2)
-        self.assertIn(self.test_human1, self.test_family.humans_list)
-        self.assertIn(self.test_human2, self.test_family.humans_list)
-        
-        # Test adding human to family
-        self.test_family = self.test_family.update(
-            humans=[self.test_human1, self.test_human2, self.test_human3]
-        )
-        self.assertEqual(len(self.test_family.humans_list), 3)
-        self.assertIn(self.test_human3, self.test_family.humans_list)
-        
-        # Test removing human from family
-        self.test_family = self.test_family.update(
-            humans=[self.test_human1, self.test_human3]
-        )
-        self.assertEqual(len(self.test_family.humans_list), 2)
-        self.assertNotIn(self.test_human2, self.test_family.humans_list)
-
-    def test_country_human_cascade_relationship(self):
-        """
-        Test cascade behavior when country is deleted.
-        
-        Verifies that deleting a country properly handles related humans.
-        """
-        # Create a test country and human for cascade testing
-        test_country = self.TestCountry.create(
-            creator_id=None,
-            code="FR",
-            name="France",
-            ignore_permission=True
-        )
-        
-        test_human = self.TestHuman.create(
-            creator_id=None,
-            name="Pierre",
-            country=test_country,
-            ignore_permission=True
-        )
-        
-        country_id = test_country.id
-        human_id = test_human.id
-        
-        # Delete the country
-        test_country.delete()
-        
-        # Verify cascade deletion
-        deleted_country = self.TestCountry.filter(id=country_id).first()
-        deleted_human = self.TestHuman.filter(id=human_id).first()
-        
-        self.assertIsNone(deleted_country)
-        self.assertIsNone(deleted_human)  # Should be deleted due to CASCADE
 
     def test_filter_operations_with_permissions(self):
         """
         Test filtering operations work correctly with permission system.
-        
+
         Validates that filtering respects permission boundaries.
         """
         # Test filtering countries
-        us_countries = self.TestCountry.filter(code="US")
-        self.assertEqual(len(us_countries), 1)
-        self.assertEqual(us_countries[0].name, "United States")
-        
-        # Test filtering humans by country
-        us_humans = self.TestHuman.filter(country__code="US")
-        self.assertEqual(len(us_humans), 1)
-        self.assertEqual(us_humans[0].name, "Alice Updated")
-        
-        # Test filtering humans without country
-        humans_without_country = self.TestHuman.filter(country__isnull=True)
-        self.assertGreaterEqual(len(humans_without_country), 2)
 
-    def test_permission_class_inheritance(self):
+        self.TestCountry.Permission.__read__ = ["matches:code:DE"]
+        gql_query = """
+        query {
+            testcountry1List(filter: {code: "DE"}) {
+                items {
+                    code
+                    name
+                }
+            }
+        }
         """
-        Test that permission classes are properly configured and inherited.
-        
-        Validates the permission class hierarchy and configuration.
+        response = self.query(gql_query)
+        self.assertResponseNoErrors(response)
+        response = response.json()
+        data = response.get("data", {})
+        self.assertEqual(len(data["testcountry1List"]["items"]), 1)
+
+        gql_query_2 = """
+        query {
+            testcountry1List(filter: {code: "US"}) {
+                items {
+                    code
+                    name
+                }
+            }
+        }
         """
-        # Test that TestCountry has public permissions
-        country_permissions = self.TestCountry.Permission
-        self.assertTrue(hasattr(country_permissions, '__read__'))
-        self.assertTrue(hasattr(country_permissions, '__create__'))
-        self.assertTrue(hasattr(country_permissions, '__update__'))
-        self.assertTrue(hasattr(country_permissions, '__delete__'))
-        
-        # Test that TestHuman has based_on permission
-        human_permissions = self.TestHuman.Permission
-        self.assertTrue(hasattr(human_permissions, '__based_on__'))
-        self.assertEqual(human_permissions.__based_on__, "country")
-        
-        # Test that TestFamily has public permissions
-        family_permissions = self.TestFamily.Permission
-        self.assertTrue(hasattr(family_permissions, '__read__'))
-        self.assertTrue(hasattr(family_permissions, '__create__'))
-        self.assertTrue(hasattr(family_permissions, '__update__'))
-        self.assertTrue(hasattr(family_permissions, '__delete__'))
+        response_2 = self.query(gql_query_2)
+        self.assertResponseNoErrors(response_2)
+        response_2 = response_2.json()
+        data_2 = response_2.get("data", {})
+        print(data_2["testcountry1List"]["items"])
+        self.assertEqual(len(data_2["testcountry1List"]["items"]), 0)
 
     def test_edge_case_empty_relationships(self):
         """
         Test edge cases with empty relationships and null values.
-        
+
         Validates behavior when dealing with empty or null relationship data.
         """
         # Test creating family with empty humans list
         empty_family = self.TestFamily.create(
-            creator_id=None,
-            name="Empty Family",
-            humans=[],
-            ignore_permission=True
+            creator_id=None, name="Empty Family", humans=[], ignore_permission=True
         )
         self.assertEqual(len(empty_family.humans_list), 0)
-        
+
         # Test updating family to remove all humans
         self.test_family = self.test_family.update(humans=[])
         self.assertEqual(len(self.test_family.humans_list), 0)
-        
+
         # Test human with null country operations
         null_country_human = self.TestHuman.create(
-            creator_id=None,
-            name="Stateless",
-            country=None,
-            ignore_permission=True
+            creator_id=None, name="Stateless", country=None, ignore_permission=True
         )
         self.assertIsNone(null_country_human.country)
 
     def test_bulk_operations_with_permissions(self):
         """
         Test bulk create and update operations with permission validation.
-        
+
         Validates that bulk operations respect permission boundaries.
         """
         # Test bulk creation of humans
         humans_data = [
             {"name": "Bulk1", "country": self.us},
             {"name": "Bulk2", "country": self.de},
-            {"name": "Bulk3", "country": None}
+            {"name": "Bulk3", "country": None},
         ]
-        
+
         created_humans = []
         for data in humans_data:
             human = self.TestHuman.create(
-                creator_id=None,
-                ignore_permission=True,
-                **data
+                creator_id=None, ignore_permission=True, **data
             )
             created_humans.append(human)
-        
+
         self.assertEqual(len(created_humans), 3)
         self.assertEqual(created_humans[0].country.code, "US")
         self.assertEqual(created_humans[1].country.code, "DE")
@@ -402,73 +334,53 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_field_validation_and_constraints(self):
         """
         Test field validation and database constraints work correctly.
-        
+
         Validates that model field constraints are properly enforced.
         """
         # Test unique constraint on country code
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValidationError):
             self.TestCountry.create(
                 creator_id=None,
                 code="US",  # Duplicate code
                 name="Another US",
-                ignore_permission=True
+                ignore_permission=True,
             )
-        
+
         # Test max_length constraint on country code
-        with self.assertRaises(DataError):
+        with self.assertRaises(ValidationError):
             self.TestCountry.create(
                 creator_id=None,
                 code="TOOLONG",  # Exceeds max_length=2
                 name="Invalid Country",
-                ignore_permission=True
+                ignore_permission=True,
             )
 
     def test_complex_permission_scenarios(self):
         """
         Test complex permission scenarios with nested relationships.
-        
+
         Validates permission logic in complex relationship hierarchies.
         """
         # Create a human in Germany
         german_human = self.TestHuman.create(
-            creator_id=None,
-            name="Hans",
-            country=self.de,
-            ignore_permission=True
+            creator_id=None, name="Hans", country=self.de, ignore_permission=True
         )
-        
+
         # Create a family with humans from different countries
         international_family = self.TestFamily.create(
             creator_id=None,
             name="International Family",
             humans=[self.test_human1, german_human],  # US and DE humans
-            ignore_permission=True
+            ignore_permission=True,
         )
-        
+
         self.assertEqual(len(international_family.humans_list), 2)
-        
+
         # Verify humans in family have different countries
-        countries = [human.country.code for human in international_family.humans_list if human.country]
+        countries = [
+            human.country.code
+            for human in international_family.humans_list
+            if human.country
+        ]
         self.assertIn("US", countries)
         self.assertIn("DE", countries)
-
-    def test_manager_class_metadata(self):
-        """
-        Test that manager classes are properly configured and accessible.
-        
-        Validates the class-level configuration and metadata.
-        """
-        # Test that all manager classes are properly initialized
-        self.assertEqual(len(self.general_manager_classes), 3)
-        self.assertIn(self.TestCountry, self.general_manager_classes)
-        self.assertIn(self.TestHuman, self.general_manager_classes)
-        self.assertIn(self.TestFamily, self.general_manager_classes)
-        
-        # Test read-only classes configuration
-        self.assertEqual(len(self.read_only_classes), 1)
-        self.assertIn(self.TestCountry, self.read_only_classes)
-        
-        # Test that classes have proper inheritance
-        self.assertTrue(issubclass(self.TestCountry, GeneralManager))
-        self.assertTrue(issubclass(self.TestHuman, GeneralManager))
-        self.assertTrue(issubclass(self.TestFamily, GeneralManager))

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 from django.db import models
-from django.contrib.auth.models import User
 from general_manager.manager.generalManager import GeneralManager
 from general_manager.interface.databaseInterface import DatabaseInterface
-from general_manager.interface.readOnlyInterface import ReadOnlyInterface
 from general_manager.bucket.baseBucket import Bucket
 from general_manager.permission.managerBasedPermission import ManagerBasedPermission
 

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -281,7 +281,6 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertResponseNoErrors(response_2)
         response_2 = response_2.json()
         data_2 = response_2.get("data", {})
-        print(data_2["testcountry1List"]["items"])
         self.assertEqual(len(data_2["testcountry1List"]["items"]), 0)
 
     def test_edge_case_empty_relationships(self):

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -12,9 +12,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Define and assign GeneralManager model classes for use in integration tests.
-
-        This method creates three nested model classes—TestCountry, TestHuman, and TestFamily—each with associated Django model interfaces and relationships. The classes are assigned to class variables for use in test methods, and lists of all manager classes and read-only classes are maintained.
+        Defines and assigns nested GeneralManager model classes with interfaces and permissions for integration tests.
+        
+        This method creates three model classes—TestCountry1, TestHuman1, and TestFamily1—each with Django ORM fields and manager-based permissions. The classes are assigned to class variables for use in test methods, and lists of all manager classes and read-only classes are initialized.
         """
 
         class TestCountry1(GeneralManager):
@@ -75,9 +75,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def setUp(self):
         """
-        Prepares the test database with sample country, human, and family data for integration tests.
-
-        Synchronizes country data, creates two human instances (one linked to a country), and a family instance associating both humans.
+        Populate the test database with sample countries, humans, and a family for integration testing.
+        
+        Creates two country instances, three human instances (one linked to a country), and a family instance associating two humans. All objects are created with permissions bypassed for test setup.
         """
         super().setUp()
 
@@ -122,9 +122,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_update_family(self):
         """
-        Tests the update of a family with three humans and verifies the family and human relationships.
-
-        This test checks that the family is updated successfully, that it contains the correct humans, and that the humans are linked to the family.
+        Verify that updating a family instance correctly changes its name and updates its associated humans.
+        
+        Asserts that the family initially contains the expected humans, then updates the family's name and membership, and verifies the changes are reflected in the relationships.
         """
         self.assertEqual(self.test_family.name, "Smith Family")
         self.assertIn(self.test_human1, self.test_family.humans_list)
@@ -141,7 +141,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_based_on_permissions_public(self):
         """
-        Tests the manager-based permissions for the family model.
+        Test that manager-based permissions allow updating and creating human instances.
+        
+        Verifies that a human's name can be updated and a new human can be created with a country association, ensuring permission logic is correctly enforced.
         """
 
         self.test_human1 = self.test_human1.update(

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+from django.db import models
+from django.contrib.auth.models import User
+from general_manager.manager.generalManager import GeneralManager
+from general_manager.interface.databaseInterface import DatabaseInterface
+from general_manager.interface.readOnlyInterface import ReadOnlyInterface
+from general_manager.bucket.baseBucket import Bucket
+from general_manager.permission.managerBasedPermission import ManagerBasedPermission
+
+from general_manager.utils.testing import GeneralManagerTransactionTestCase
+
+
+class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Define and assign GeneralManager model classes for use in integration tests.
+
+        This method creates three nested model classes—TestCountry, TestHuman, and TestFamily—each with associated Django model interfaces and relationships. The classes are assigned to class variables for use in test methods, and lists of all manager classes and read-only classes are maintained.
+        """
+
+        class TestCountry1(GeneralManager):
+            code: str
+            name: str
+            humans_list: Bucket[TestHuman1]
+
+            class Interface(DatabaseInterface):
+                code = models.CharField(max_length=2, unique=True)
+                name = models.CharField(max_length=50)
+
+            class Permission(ManagerBasedPermission):
+                __read__ = ["public"]
+                __create__ = ["public"]
+                __update__ = ["public"]
+                __delete__ = ["public"]
+
+        class TestHuman1(GeneralManager):
+            name: str
+            country: TestCountry1 | None
+            families_list: Bucket[TestFamily1]
+
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=50)
+                country = models.ForeignKey(
+                    "general_manager.TestCountry1",
+                    on_delete=models.CASCADE,
+                    related_name="humans",
+                    null=True,
+                    blank=True,
+                )
+
+            class Permission(ManagerBasedPermission):
+                __based_on__ = "country"
+
+        class TestFamily1(GeneralManager):
+            name: str
+            humans_list: Bucket[TestHuman1]
+
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=50)
+                humans = models.ManyToManyField(
+                    "general_manager.TestHuman1",
+                    related_name="families",
+                )
+
+            class Permission(ManagerBasedPermission):
+                __read__ = ["public"]
+                __create__ = ["public"]
+                __update__ = ["public"]
+                __delete__ = ["public"]
+
+        cls.TestCountry = TestCountry1
+        cls.TestHuman = TestHuman1
+        cls.TestFamily = TestFamily1
+        cls.general_manager_classes = [TestCountry1, TestHuman1, TestFamily1]
+        cls.read_only_classes = [TestCountry1]
+
+    def setUp(self):
+        """
+        Prepares the test database with sample country, human, and family data for integration tests.
+
+        Synchronizes country data, creates two human instances (one linked to a country), and a family instance associating both humans.
+        """
+        super().setUp()
+
+        self.us = self.TestCountry.create(
+            creator_id=None,
+            code="US",
+            name="United States",
+            ignore_permission=True,
+        )
+        self.de = self.TestCountry.create(
+            creator_id=None,
+            code="DE",
+            name="Germany",
+            ignore_permission=True,
+        )
+
+        self.test_human1 = self.TestHuman.create(
+            creator_id=None,
+            name="Alice",
+            country=self.TestCountry.filter(code="US").first(),
+            ignore_permission=True,
+        )
+
+        self.test_human2 = self.TestHuman.create(
+            creator_id=None,
+            name="Bob",
+            ignore_permission=True,
+        )
+
+        self.test_human3 = self.TestHuman.create(
+            creator_id=None,
+            name="Tim",
+            ignore_permission=True,
+        )
+
+        self.test_family = self.TestFamily.create(
+            creator_id=None,
+            name="Smith Family",
+            humans=[self.test_human1, self.test_human2],
+            ignore_permission=True,
+        )
+
+    def test_update_family(self):
+        """
+        Tests the update of a family with three humans and verifies the family and human relationships.
+
+        This test checks that the family is updated successfully, that it contains the correct humans, and that the humans are linked to the family.
+        """
+        self.assertEqual(self.test_family.name, "Smith Family")
+        self.assertIn(self.test_human1, self.test_family.humans_list)
+        self.assertIn(self.test_human2, self.test_family.humans_list)
+
+        self.test_family = self.test_family.update(
+            name="Johnson Family",
+            humans=[self.test_human1, self.test_human2, self.test_human3],
+        )
+        self.assertEqual(self.test_family.name, "Johnson Family")
+        self.assertIn(self.test_human1, self.test_family.humans_list)
+        self.assertIn(self.test_human2, self.test_family.humans_list)
+        self.assertIn(self.test_human3, self.test_family.humans_list)
+
+    def test_based_on_permissions_public(self):
+        """
+        Tests the manager-based permissions for the family model.
+        """
+
+        self.test_human1 = self.test_human1.update(
+            name="Alice Updated",
+        )
+
+        self.assertEqual(self.test_human1.name, "Alice Updated")
+
+        new_human = self.TestHuman.create(
+            creator_id=None,
+            name="Charlie",
+            country=self.TestCountry.filter(code="DE").first(),
+        )
+        self.assertEqual(new_human.name, "Charlie")

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -15,7 +15,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def setUpClass(cls):
         """
         Defines and assigns test model classes with interfaces and permissions for integration tests.
-        
+
         This class method creates three nested GeneralManager-based models—TestCountry1, TestHuman1, and TestFamily1—each with Django ORM fields and manager-based permissions. The models are assigned to class variables for use in test cases, and a list of all manager classes is initialized.
         """
 
@@ -77,7 +77,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def setUp(self):
         """
         Sets up initial test data including users, countries, humans, and a family for integration tests.
-        
+
         Creates a test user, two country instances, three human instances (one linked to a country), and a family associating two humans. All objects are created with permissions bypassed to ensure consistent test setup.
         """
         super().setUp()
@@ -126,7 +126,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_update_family(self):
         """
         Test that updating a family instance changes its name and updates its associated humans.
-        
+
         Verifies the initial family name and membership, performs an update to change the name and add a human, and asserts that the changes are correctly reflected.
         """
         self.assertEqual(self.test_family.name, "Smith Family")
@@ -145,7 +145,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_based_on_permissions_public(self):
         """
         Verify that manager-based permissions allow updating an existing human and creating a new human with a country association.
-        
+
         Ensures that permission logic permits modifying a human's name and adding a new human linked to a specific country.
         """
 
@@ -162,28 +162,10 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         )
         self.assertEqual(new_human.name, "Charlie")
 
-    def test_permission_based_on_field_inheritance(self):
-        """
-        Test that permission inheritance is correctly applied based on the `__based_on__` field.
-        
-        Verifies that a human instance inherits permissions from its associated country, and that updating the country field updates the inherited permissions accordingly.
-        """
-        # Test that human with US country inherits US permissions
-        self.assertEqual(self.test_human1.country.code, "US")  # type: ignore
-
-        # Test that human without country has no country-based permissions
-        self.assertIsNone(self.test_human2.country)
-
-        # Update human2 to have a country and verify permission inheritance
-        self.test_human2 = self.test_human2.update(
-            country=self.de, ignore_permission=True
-        )
-        self.assertEqual(self.test_human2.country.code, "DE")  # type: ignore
-
     def test_create_with_permission_validation(self):
         """
         Test creation of human instances under various permission scenarios.
-        
+
         Verifies that creating a human with a valid country reference succeeds, while attempting to create a human without a country and without a creator ID raises a PermissionError. Also confirms that providing a creator ID allows creation without a country.
         """
         # Test creating human with valid country reference -> should use country-based permissions
@@ -208,7 +190,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_update_with_permission_validation(self):
         """
         Test updating a human's country association with permission enforcement.
-        
+
         Validates that updating a human's country field requires appropriate permissions, raising a PermissionError when permissions are insufficient, and allowing the update when a valid creator ID is provided.
         """
         # Test updating human's country association
@@ -243,7 +225,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_filter_operations_with_permissions(self):
         """
         Verify that filtering queries return only permitted results according to the permission system.
-        
+
         Ensures that when read permissions are restricted (e.g., to a specific country code), filtered queries via GraphQL only return items the user is allowed to access, and items outside the permission scope are excluded.
         """
         # Test filtering countries
@@ -284,7 +266,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_edge_case_empty_relationships(self):
         """
         Test handling of empty many-to-many and null foreign key relationships.
-        
+
         Verifies that creating or updating a family with an empty humans list results in no associated humans, and that creating a human with a null country is handled correctly.
         """
         # Test creating family with empty humans list
@@ -306,7 +288,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_bulk_operations_with_permissions(self):
         """
         Tests bulk creation of human instances with various country associations, ensuring permission rules are respected.
-        
+
         Creates multiple humans in a single operation, assigning different country relationships, and verifies correct assignment and creation.
         """
         # Test bulk creation of humans
@@ -331,7 +313,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_field_validation_and_constraints(self):
         """
         Test that model field validation and database constraints are enforced.
-        
+
         Verifies that creating a country with a duplicate code raises a ValidationError due to the unique constraint, and that exceeding the maximum length for the code field also raises a ValidationError.
         """
         # Test unique constraint on country code
@@ -355,7 +337,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     def test_complex_permission_scenarios(self):
         """
         Test permission logic in scenarios involving nested relationships across models.
-        
+
         Creates humans from different countries and a family containing them, then verifies that the family includes members with distinct country associations.
         """
         # Create a human in Germany

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from django.db import models
+from django.db import IntegrityError, DataError
 from general_manager.manager.generalManager import GeneralManager
 from general_manager.interface.databaseInterface import DatabaseInterface
 from general_manager.bucket.baseBucket import Bucket
@@ -158,3 +159,316 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             country=self.TestCountry.filter(code="DE").first(),
         )
         self.assertEqual(new_human.name, "Charlie")
+
+    def test_permission_based_on_field_inheritance(self):
+        """
+        Test that permissions are correctly inherited based on the __based_on__ field.
+        
+        Verifies that humans inherit permissions from their associated country.
+        """
+        # Test that human with US country inherits US permissions
+        self.assertEqual(self.test_human1.country.code, "US")
+        
+        # Test that human without country has no country-based permissions
+        self.assertIsNone(self.test_human2.country)
+        
+        # Update human2 to have a country and verify permission inheritance
+        self.test_human2 = self.test_human2.update(
+            country=self.de,
+            ignore_permission=True
+        )
+        self.assertEqual(self.test_human2.country.code, "DE")
+
+    def test_create_with_permission_validation(self):
+        """
+        Test creating instances with different permission scenarios.
+        
+        Validates that permission checking works correctly during creation.
+        """
+        # Test creating human with valid country reference
+        human_with_country = self.TestHuman.create(
+            creator_id=None,
+            name="David",
+            country=self.us
+        )
+        self.assertEqual(human_with_country.name, "David")
+        self.assertEqual(human_with_country.country.code, "US")
+        
+        # Test creating human without country
+        human_without_country = self.TestHuman.create(
+            creator_id=None,
+            name="Eva"
+        )
+        self.assertEqual(human_without_country.name, "Eva")
+        self.assertIsNone(human_without_country.country)
+
+    def test_update_with_permission_validation(self):
+        """
+        Test updating instances with different permission scenarios.
+        
+        Validates that permission checking works correctly during updates.
+        """
+        # Test updating human's country association
+        original_country = self.test_human1.country
+        self.assertEqual(original_country.code, "US")
+        
+        updated_human = self.test_human1.update(country=self.de)
+        self.assertEqual(updated_human.country.code, "DE")
+        
+        # Test updating human to remove country association
+        updated_human = updated_human.update(country=None)
+        self.assertIsNone(updated_human.country)
+
+    def test_delete_with_permissions(self):
+        """
+        Test deletion scenarios with permission validation.
+        
+        Verifies that deletion works correctly with manager-based permissions.
+        """
+        # Create a temporary human for deletion test
+        temp_human = self.TestHuman.create(
+            creator_id=None,
+            name="Temporary",
+            country=self.us,
+            ignore_permission=True
+        )
+        
+        human_id = temp_human.id
+        temp_human.delete()
+        
+        # Verify the human was deleted
+        deleted_human = self.TestHuman.filter(id=human_id).first()
+        self.assertIsNone(deleted_human)
+
+    def test_bucket_relationship_operations(self):
+        """
+        Test operations on bucket relationships between models.
+        
+        Validates that many-to-many and related field operations work correctly.
+        """
+        # Test initial family-human relationships
+        self.assertEqual(len(self.test_family.humans_list), 2)
+        self.assertIn(self.test_human1, self.test_family.humans_list)
+        self.assertIn(self.test_human2, self.test_family.humans_list)
+        
+        # Test adding human to family
+        self.test_family = self.test_family.update(
+            humans=[self.test_human1, self.test_human2, self.test_human3]
+        )
+        self.assertEqual(len(self.test_family.humans_list), 3)
+        self.assertIn(self.test_human3, self.test_family.humans_list)
+        
+        # Test removing human from family
+        self.test_family = self.test_family.update(
+            humans=[self.test_human1, self.test_human3]
+        )
+        self.assertEqual(len(self.test_family.humans_list), 2)
+        self.assertNotIn(self.test_human2, self.test_family.humans_list)
+
+    def test_country_human_cascade_relationship(self):
+        """
+        Test cascade behavior when country is deleted.
+        
+        Verifies that deleting a country properly handles related humans.
+        """
+        # Create a test country and human for cascade testing
+        test_country = self.TestCountry.create(
+            creator_id=None,
+            code="FR",
+            name="France",
+            ignore_permission=True
+        )
+        
+        test_human = self.TestHuman.create(
+            creator_id=None,
+            name="Pierre",
+            country=test_country,
+            ignore_permission=True
+        )
+        
+        country_id = test_country.id
+        human_id = test_human.id
+        
+        # Delete the country
+        test_country.delete()
+        
+        # Verify cascade deletion
+        deleted_country = self.TestCountry.filter(id=country_id).first()
+        deleted_human = self.TestHuman.filter(id=human_id).first()
+        
+        self.assertIsNone(deleted_country)
+        self.assertIsNone(deleted_human)  # Should be deleted due to CASCADE
+
+    def test_filter_operations_with_permissions(self):
+        """
+        Test filtering operations work correctly with permission system.
+        
+        Validates that filtering respects permission boundaries.
+        """
+        # Test filtering countries
+        us_countries = self.TestCountry.filter(code="US")
+        self.assertEqual(len(us_countries), 1)
+        self.assertEqual(us_countries[0].name, "United States")
+        
+        # Test filtering humans by country
+        us_humans = self.TestHuman.filter(country__code="US")
+        self.assertEqual(len(us_humans), 1)
+        self.assertEqual(us_humans[0].name, "Alice Updated")
+        
+        # Test filtering humans without country
+        humans_without_country = self.TestHuman.filter(country__isnull=True)
+        self.assertGreaterEqual(len(humans_without_country), 2)
+
+    def test_permission_class_inheritance(self):
+        """
+        Test that permission classes are properly configured and inherited.
+        
+        Validates the permission class hierarchy and configuration.
+        """
+        # Test that TestCountry has public permissions
+        country_permissions = self.TestCountry.Permission
+        self.assertTrue(hasattr(country_permissions, '__read__'))
+        self.assertTrue(hasattr(country_permissions, '__create__'))
+        self.assertTrue(hasattr(country_permissions, '__update__'))
+        self.assertTrue(hasattr(country_permissions, '__delete__'))
+        
+        # Test that TestHuman has based_on permission
+        human_permissions = self.TestHuman.Permission
+        self.assertTrue(hasattr(human_permissions, '__based_on__'))
+        self.assertEqual(human_permissions.__based_on__, "country")
+        
+        # Test that TestFamily has public permissions
+        family_permissions = self.TestFamily.Permission
+        self.assertTrue(hasattr(family_permissions, '__read__'))
+        self.assertTrue(hasattr(family_permissions, '__create__'))
+        self.assertTrue(hasattr(family_permissions, '__update__'))
+        self.assertTrue(hasattr(family_permissions, '__delete__'))
+
+    def test_edge_case_empty_relationships(self):
+        """
+        Test edge cases with empty relationships and null values.
+        
+        Validates behavior when dealing with empty or null relationship data.
+        """
+        # Test creating family with empty humans list
+        empty_family = self.TestFamily.create(
+            creator_id=None,
+            name="Empty Family",
+            humans=[],
+            ignore_permission=True
+        )
+        self.assertEqual(len(empty_family.humans_list), 0)
+        
+        # Test updating family to remove all humans
+        self.test_family = self.test_family.update(humans=[])
+        self.assertEqual(len(self.test_family.humans_list), 0)
+        
+        # Test human with null country operations
+        null_country_human = self.TestHuman.create(
+            creator_id=None,
+            name="Stateless",
+            country=None,
+            ignore_permission=True
+        )
+        self.assertIsNone(null_country_human.country)
+
+    def test_bulk_operations_with_permissions(self):
+        """
+        Test bulk create and update operations with permission validation.
+        
+        Validates that bulk operations respect permission boundaries.
+        """
+        # Test bulk creation of humans
+        humans_data = [
+            {"name": "Bulk1", "country": self.us},
+            {"name": "Bulk2", "country": self.de},
+            {"name": "Bulk3", "country": None}
+        ]
+        
+        created_humans = []
+        for data in humans_data:
+            human = self.TestHuman.create(
+                creator_id=None,
+                ignore_permission=True,
+                **data
+            )
+            created_humans.append(human)
+        
+        self.assertEqual(len(created_humans), 3)
+        self.assertEqual(created_humans[0].country.code, "US")
+        self.assertEqual(created_humans[1].country.code, "DE")
+        self.assertIsNone(created_humans[2].country)
+
+    def test_field_validation_and_constraints(self):
+        """
+        Test field validation and database constraints work correctly.
+        
+        Validates that model field constraints are properly enforced.
+        """
+        # Test unique constraint on country code
+        with self.assertRaises(IntegrityError):
+            self.TestCountry.create(
+                creator_id=None,
+                code="US",  # Duplicate code
+                name="Another US",
+                ignore_permission=True
+            )
+        
+        # Test max_length constraint on country code
+        with self.assertRaises(DataError):
+            self.TestCountry.create(
+                creator_id=None,
+                code="TOOLONG",  # Exceeds max_length=2
+                name="Invalid Country",
+                ignore_permission=True
+            )
+
+    def test_complex_permission_scenarios(self):
+        """
+        Test complex permission scenarios with nested relationships.
+        
+        Validates permission logic in complex relationship hierarchies.
+        """
+        # Create a human in Germany
+        german_human = self.TestHuman.create(
+            creator_id=None,
+            name="Hans",
+            country=self.de,
+            ignore_permission=True
+        )
+        
+        # Create a family with humans from different countries
+        international_family = self.TestFamily.create(
+            creator_id=None,
+            name="International Family",
+            humans=[self.test_human1, german_human],  # US and DE humans
+            ignore_permission=True
+        )
+        
+        self.assertEqual(len(international_family.humans_list), 2)
+        
+        # Verify humans in family have different countries
+        countries = [human.country.code for human in international_family.humans_list if human.country]
+        self.assertIn("US", countries)
+        self.assertIn("DE", countries)
+
+    def test_manager_class_metadata(self):
+        """
+        Test that manager classes are properly configured and accessible.
+        
+        Validates the class-level configuration and metadata.
+        """
+        # Test that all manager classes are properly initialized
+        self.assertEqual(len(self.general_manager_classes), 3)
+        self.assertIn(self.TestCountry, self.general_manager_classes)
+        self.assertIn(self.TestHuman, self.general_manager_classes)
+        self.assertIn(self.TestFamily, self.general_manager_classes)
+        
+        # Test read-only classes configuration
+        self.assertEqual(len(self.read_only_classes), 1)
+        self.assertIn(self.TestCountry, self.read_only_classes)
+        
+        # Test that classes have proper inheritance
+        self.assertTrue(issubclass(self.TestCountry, GeneralManager))
+        self.assertTrue(issubclass(self.TestHuman, GeneralManager))
+        self.assertTrue(issubclass(self.TestFamily, GeneralManager))

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -14,9 +14,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Defines and assigns nested GeneralManager model classes with interfaces and permissions for integration tests.
-
-        This method creates three model classes—TestCountry1, TestHuman1, and TestFamily1—each with Django ORM fields and manager-based permissions. The classes are assigned to class variables for use in test methods, and lists of all manager classes and read-only classes are initialized.
+        Defines and assigns test model classes with interfaces and permissions for integration tests.
+        
+        This class method creates three nested GeneralManager-based models—TestCountry1, TestHuman1, and TestFamily1—each with Django ORM fields and manager-based permissions. The models are assigned to class variables for use in test cases, and a list of all manager classes is initialized.
         """
 
         class TestCountry1(GeneralManager):
@@ -76,9 +76,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def setUp(self):
         """
-        Populate the test database with sample countries, humans, and a family for integration testing.
-
-        Creates two country instances, three human instances (one linked to a country), and a family instance associating two humans. All objects are created with permissions bypassed for test setup.
+        Sets up initial test data including users, countries, humans, and a family for integration tests.
+        
+        Creates a test user, two country instances, three human instances (one linked to a country), and a family associating two humans. All objects are created with permissions bypassed to ensure consistent test setup.
         """
         super().setUp()
         self.user: User = User.objects.create_user(
@@ -125,9 +125,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_update_family(self):
         """
-        Verify that updating a family instance correctly changes its name and updates its associated humans.
-
-        Asserts that the family initially contains the expected humans, then updates the family's name and membership, and verifies the changes are reflected in the relationships.
+        Test that updating a family instance changes its name and updates its associated humans.
+        
+        Verifies the initial family name and membership, performs an update to change the name and add a human, and asserts that the changes are correctly reflected.
         """
         self.assertEqual(self.test_family.name, "Smith Family")
         self.assertIn(self.test_human1, self.test_family.humans_list)
@@ -144,9 +144,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_based_on_permissions_public(self):
         """
-        Test that manager-based permissions allow updating and creating human instances.
-
-        Verifies that a human's name can be updated and a new human can be created with a country association, ensuring permission logic is correctly enforced.
+        Verify that manager-based permissions allow updating an existing human and creating a new human with a country association.
+        
+        Ensures that permission logic permits modifying a human's name and adding a new human linked to a specific country.
         """
 
         self.test_human1 = self.test_human1.update(
@@ -164,9 +164,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_permission_based_on_field_inheritance(self):
         """
-        Test that permissions are correctly inherited based on the __based_on__ field.
-
-        Verifies that humans inherit permissions from their associated country.
+        Test that permission inheritance is correctly applied based on the `__based_on__` field.
+        
+        Verifies that a human instance inherits permissions from its associated country, and that updating the country field updates the inherited permissions accordingly.
         """
         # Test that human with US country inherits US permissions
         self.assertEqual(self.test_human1.country.code, "US")  # type: ignore
@@ -182,9 +182,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_create_with_permission_validation(self):
         """
-        Test creating instances with different permission scenarios.
-
-        Validates that permission checking works correctly during creation.
+        Test creation of human instances under various permission scenarios.
+        
+        Verifies that creating a human with a valid country reference succeeds, while attempting to create a human without a country and without a creator ID raises a PermissionError. Also confirms that providing a creator ID allows creation without a country.
         """
         # Test creating human with valid country reference -> should use country-based permissions
         human_with_country = self.TestHuman.create(
@@ -207,9 +207,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_update_with_permission_validation(self):
         """
-        Test updating instances with different permission scenarios.
-
-        Validates that permission checking works correctly during updates.
+        Test updating a human's country association with permission enforcement.
+        
+        Validates that updating a human's country field requires appropriate permissions, raising a PermissionError when permissions are insufficient, and allowing the update when a valid creator ID is provided.
         """
         # Test updating human's country association
         original_country = self.test_human1.country
@@ -226,9 +226,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_delete_with_permissions(self):
         """
-        Test deletion scenarios with permission validation.
-
-        Verifies that deletion works correctly with manager-based permissions.
+        Tests that a human instance can be deleted (deactivated) when permissions allow, and verifies the instance is no longer active in the database.
         """
         # Create a temporary human for deletion test
         temp_human = self.TestHuman.create(
@@ -244,9 +242,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_filter_operations_with_permissions(self):
         """
-        Test filtering operations work correctly with permission system.
-
-        Validates that filtering respects permission boundaries.
+        Verify that filtering queries return only permitted results according to the permission system.
+        
+        Ensures that when read permissions are restricted (e.g., to a specific country code), filtered queries via GraphQL only return items the user is allowed to access, and items outside the permission scope are excluded.
         """
         # Test filtering countries
 
@@ -285,9 +283,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_edge_case_empty_relationships(self):
         """
-        Test edge cases with empty relationships and null values.
-
-        Validates behavior when dealing with empty or null relationship data.
+        Test handling of empty many-to-many and null foreign key relationships.
+        
+        Verifies that creating or updating a family with an empty humans list results in no associated humans, and that creating a human with a null country is handled correctly.
         """
         # Test creating family with empty humans list
         empty_family = self.TestFamily.create(
@@ -307,9 +305,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_bulk_operations_with_permissions(self):
         """
-        Test bulk create and update operations with permission validation.
-
-        Validates that bulk operations respect permission boundaries.
+        Tests bulk creation of human instances with various country associations, ensuring permission rules are respected.
+        
+        Creates multiple humans in a single operation, assigning different country relationships, and verifies correct assignment and creation.
         """
         # Test bulk creation of humans
         humans_data = [
@@ -332,9 +330,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_field_validation_and_constraints(self):
         """
-        Test field validation and database constraints work correctly.
-
-        Validates that model field constraints are properly enforced.
+        Test that model field validation and database constraints are enforced.
+        
+        Verifies that creating a country with a duplicate code raises a ValidationError due to the unique constraint, and that exceeding the maximum length for the code field also raises a ValidationError.
         """
         # Test unique constraint on country code
         with self.assertRaises(ValidationError):
@@ -356,9 +354,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
     def test_complex_permission_scenarios(self):
         """
-        Test complex permission scenarios with nested relationships.
-
-        Validates permission logic in complex relationship hierarchies.
+        Test permission logic in scenarios involving nested relationships across models.
+        
+        Creates humans from different countries and a family containing them, then verifies that the family includes members with distinct country associations.
         """
         # Create a human in Germany
         german_human = self.TestHuman.create(

--- a/tests/unit/test_calculationBucket.py
+++ b/tests/unit/test_calculationBucket.py
@@ -19,7 +19,7 @@ class DummyGeneralManager:
         # Initialize with any keyword arguments, simulating a manager
         """
         Initializes the dummy manager with provided keyword arguments.
-        
+
         Stores all keyword arguments for later comparison and representation.
         """
         self.kwargs = kwargs
@@ -27,7 +27,7 @@ class DummyGeneralManager:
     def __eq__(self, value: object) -> bool:
         """
         Checks equality with another DummyGeneralManager based on initialization arguments.
-        
+
         Returns:
             True if the other object is a DummyGeneralManager with identical kwargs; otherwise, False.
         """
@@ -55,7 +55,7 @@ class TestCalculationBucket(TestCase):
         # Test basic initialization without optional parameters
         """
         Tests that CalculationBucket initializes with default values when only the manager class is provided.
-        
+
         Verifies that filters, excludes, sort key, and reverse flag are set to their defaults, and that input fields are sourced from the associated interface.
         """
         bucket = CalculationBucket(manager_class=DummyGeneralManager)
@@ -72,7 +72,7 @@ class TestCalculationBucket(TestCase):
         # Filters and excludes passed directly to constructor
         """
         Tests that CalculationBucket initializes with provided filter and exclude definitions, sort key, and reverse flag.
-        
+
         Verifies that the constructor correctly assigns the given filters, excludes, sort key, and reverse attributes.
         """
         fdefs = {"f": {"filter_kwargs": {"f": 1}}}
@@ -93,7 +93,7 @@ class TestCalculationBucket(TestCase):
         # Test pickling support
         """
         Tests that CalculationBucket supports pickling and unpickling via __reduce__ and __setstate__.
-        
+
         Verifies that the reduced state includes current combinations and that state restoration
         correctly sets the internal combinations on a new instance.
         """
@@ -145,7 +145,7 @@ class TestCalculationBucket(TestCase):
     def test_str_and_repr_formatting(self, mock_parse):
         """
         Tests the string and repr formatting of CalculationBucket instances.
-        
+
         Verifies that the string representation displays the total count and up to five combinations, using an ellipsis if more exist, and that the repr shows the constructor parameters.
         """
         bucket = CalculationBucket(DummyGeneralManager)
@@ -170,14 +170,14 @@ class TestCalculationBucket(TestCase):
     def test_all_iter_len_count(self, mock_parse):
         """
         Tests that CalculationBucket's all(), iteration, count(), and length methods behave as expected.
-        
+
         Verifies that all() returns the bucket itself, iteration yields one manager instance per combination, and both count() and len() return the correct number of combinations.
         """
         bucket = CalculationBucket(DummyGeneralManager)
         # Set a single empty combination so manager(**{}) works
         bucket._current_combinations = [{}] * 4
         # all() returns self
-        self.assertIs(bucket.all(), bucket)
+        self.assertEqual(bucket.all(), bucket)
         # Iteration yields one manager per combo
         items = list(bucket)
         self.assertEqual(len(items), 4)
@@ -188,7 +188,7 @@ class TestCalculationBucket(TestCase):
     def test_first_last_empty_and_nonempty(self, mock_parse):
         """
         Tests the behavior of the `first()` and `last()` methods on a `CalculationBucket`.
-        
+
         Verifies that `first()` and `last()` return `None` when the bucket has no combinations, and return the same manager instance when only one combination exists.
         """
         bucket = CalculationBucket(DummyGeneralManager)
@@ -240,13 +240,14 @@ class TestGenerateCombinations(TestCase):
         # Dynamically create an interface and manager class with given input_fields
         """
         Creates a CalculationBucket with dynamically defined input fields.
-        
+
         Args:
             fields: A list of input field definitions to assign to the generated interface.
-        
+
         Returns:
             A CalculationBucket instance using a dynamically created manager and interface with the specified input fields.
         """
+
         class DynInterface(CalculationInterface):
             input_fields = fields
 
@@ -260,7 +261,7 @@ class TestGenerateCombinations(TestCase):
         # Two independent fields produce a Cartesian product
         """
         Tests that generate_combinations produces the Cartesian product of independent input fields.
-        
+
         Verifies that two fields with independent possible values yield all possible combinations.
         """
         fields = {
@@ -297,9 +298,10 @@ class TestGenerateCombinations(TestCase):
         # Field2 depends on field1 and its possible_values is a callable
         """
         Tests that a dependent input field with callable possible values generates combinations reflecting the dependency.
-        
+
         Verifies that when one field's possible values depend on another field's value, the generated combinations correctly incorporate this relationship.
         """
+
         def pv_func(a):
             return [a * 10]
 
@@ -319,7 +321,7 @@ class TestGenerateCombinations(TestCase):
         # Apply filter_funcs to include only even numbers, and exclude a specific value
         """
         Tests that filter and exclude functions are correctly applied to input values.
-        
+
         Verifies that only even numbers are included and a specific value is excluded from the generated combinations.
         """
         fields = {
@@ -337,7 +339,7 @@ class TestGenerateCombinations(TestCase):
         # Three values, sorted and reversed
         """
         Tests that sorting and reversing combinations works as expected and that results are cached.
-        
+
         Verifies that combinations are sorted in descending order by the specified key, and that repeated calls to `generate_combinations` return the cached result.
         """
         fields = {

--- a/tests/unit/test_calculationBucket.py
+++ b/tests/unit/test_calculationBucket.py
@@ -18,18 +18,18 @@ class DummyGeneralManager:
     def __init__(self, **kwargs):
         # Initialize with any keyword arguments, simulating a manager
         """
-        Initializes the dummy manager with provided keyword arguments.
-
-        Stores all keyword arguments for later comparison and representation.
+        Initialize the dummy manager with arbitrary keyword arguments.
+        
+        All provided keyword arguments are stored for later comparison and representation.
         """
         self.kwargs = kwargs
 
     def __eq__(self, value: object) -> bool:
         """
-        Checks equality with another DummyGeneralManager based on initialization arguments.
-
+        Determine if another object is a DummyGeneralManager with identical initialization arguments.
+        
         Returns:
-            True if the other object is a DummyGeneralManager with identical kwargs; otherwise, False.
+            bool: True if the other object is a DummyGeneralManager and has the same kwargs; otherwise, False.
         """
         if not isinstance(value, DummyGeneralManager):
             return False
@@ -54,9 +54,9 @@ class TestCalculationBucket(TestCase):
     def test_initialization_defaults(self, mock_parse):
         # Test basic initialization without optional parameters
         """
-        Tests that CalculationBucket initializes with default values when only the manager class is provided.
-
-        Verifies that filters, excludes, sort key, and reverse flag are set to their defaults, and that input fields are sourced from the associated interface.
+        Test that CalculationBucket initializes with default parameters when only the manager class is provided.
+        
+        Ensures filters and excludes are empty, sort key is None, reverse is False, and input fields are taken from the associated interface.
         """
         bucket = CalculationBucket(manager_class=DummyGeneralManager)
         self.assertIsInstance(bucket, CalculationBucket)
@@ -71,9 +71,9 @@ class TestCalculationBucket(TestCase):
     def test_initialization_with_filters_and_excludes(self, mock_parse):
         # Filters and excludes passed directly to constructor
         """
-        Tests that CalculationBucket initializes with provided filter and exclude definitions, sort key, and reverse flag.
-
-        Verifies that the constructor correctly assigns the given filters, excludes, sort key, and reverse attributes.
+        Test that CalculationBucket initializes with specified filters, excludes, sort key, and reverse flag.
+        
+        Verifies that the constructor assigns the provided filter and exclude definitions, sort key, and reverse attribute as expected.
         """
         fdefs = {"f": {"filter_kwargs": {"f": 1}}}
         edefs = {"e": {"filter_kwargs": {"e": 2}}}
@@ -92,10 +92,9 @@ class TestCalculationBucket(TestCase):
     def test_reduce_and_setstate(self, mock_parse):
         # Test pickling support
         """
-        Tests that CalculationBucket supports pickling and unpickling via __reduce__ and __setstate__.
-
-        Verifies that the reduced state includes current combinations and that state restoration
-        correctly sets the internal combinations on a new instance.
+        Tests that CalculationBucket instances can be pickled and unpickled using __reduce__ and __setstate__.
+        
+        Ensures that the reduced state includes the current combinations and that restoring state correctly sets the internal combinations on a new instance.
         """
         bucket = CalculationBucket(DummyGeneralManager, {"a": 1}, {"b": 2}, "k", True)
         # Prepopulate state
@@ -144,9 +143,9 @@ class TestCalculationBucket(TestCase):
 
     def test_str_and_repr_formatting(self, mock_parse):
         """
-        Tests the string and repr formatting of CalculationBucket instances.
-
-        Verifies that the string representation displays the total count and up to five combinations, using an ellipsis if more exist, and that the repr shows the constructor parameters.
+        Tests that the string and repr representations of CalculationBucket instances display the correct format.
+        
+        Verifies that the string representation shows the total number of combinations and up to five example combinations, using an ellipsis if there are more than five. Also checks that the repr output includes the constructor parameters.
         """
         bucket = CalculationBucket(DummyGeneralManager)
         # Manually set combinations for string formatting tests
@@ -169,9 +168,9 @@ class TestCalculationBucket(TestCase):
 
     def test_all_iter_len_count(self, mock_parse):
         """
-        Tests that CalculationBucket's all(), iteration, count(), and length methods behave as expected.
-
-        Verifies that all() returns the bucket itself, iteration yields one manager instance per combination, and both count() and len() return the correct number of combinations.
+        Test that CalculationBucket's all(), iteration, count(), and length methods return the expected results.
+        
+        Ensures that all() returns the bucket itself, iteration yields one manager instance per combination, and both count() and len() reflect the number of combinations.
         """
         bucket = CalculationBucket(DummyGeneralManager)
         # Set a single empty combination so manager(**{}) works
@@ -187,9 +186,7 @@ class TestCalculationBucket(TestCase):
 
     def test_first_last_empty_and_nonempty(self, mock_parse):
         """
-        Tests the behavior of the `first()` and `last()` methods on a `CalculationBucket`.
-
-        Verifies that `first()` and `last()` return `None` when the bucket has no combinations, and return the same manager instance when only one combination exists.
+        Test that `first()` and `last()` on a `CalculationBucket` return `None` when there are no combinations, and return the same manager instance when only one combination exists.
         """
         bucket = CalculationBucket(DummyGeneralManager)
         # Empty combos
@@ -239,13 +236,13 @@ class TestGenerateCombinations(TestCase):
     def _make_bucket_with_fields(self, fields):
         # Dynamically create an interface and manager class with given input_fields
         """
-        Creates a CalculationBucket with dynamically defined input fields.
-
-        Args:
-            fields: A list of input field definitions to assign to the generated interface.
-
+        Create a CalculationBucket instance using dynamically generated input fields.
+        
+        Parameters:
+        	fields (list): Input field definitions to assign to the generated interface.
+        
         Returns:
-            A CalculationBucket instance using a dynamically created manager and interface with the specified input fields.
+        	CalculationBucket: An instance configured with a manager and interface using the specified input fields.
         """
 
         class DynInterface(CalculationInterface):
@@ -260,9 +257,9 @@ class TestGenerateCombinations(TestCase):
     def test_basic_cartesian_product(self, mock_parse):
         # Two independent fields produce a Cartesian product
         """
-        Tests that generate_combinations produces the Cartesian product of independent input fields.
-
-        Verifies that two fields with independent possible values yield all possible combinations.
+        Tests that generate_combinations returns all possible combinations for independent input fields.
+        
+        Verifies that when two fields have independent possible values, the resulting combinations form the full Cartesian product.
         """
         fields = {
             "num": Input(type=int, possible_values=[1, 2]),
@@ -297,12 +294,21 @@ class TestGenerateCombinations(TestCase):
     def test_dependent_field(self, mock_parse):
         # Field2 depends on field1 and its possible_values is a callable
         """
-        Tests that a dependent input field with callable possible values generates combinations reflecting the dependency.
-
-        Verifies that when one field's possible values depend on another field's value, the generated combinations correctly incorporate this relationship.
+        Test that dependent input fields with callable possible values generate correct combinations.
+        
+        Verifies that when a field's possible values are defined as a callable depending on another field, the generated combinations reflect this dependency.
         """
 
         def pv_func(a):
+            """
+            Return a list containing the input value multiplied by 10.
+            
+            Parameters:
+            	a (int or float): The value to be multiplied.
+            
+            Returns:
+            	list: A single-element list with the result of a * 10.
+            """
             return [a * 10]
 
         fields = {
@@ -320,9 +326,9 @@ class TestGenerateCombinations(TestCase):
     def test_filters_and_excludes(self, mock_parse):
         # Apply filter_funcs to include only even numbers, and exclude a specific value
         """
-        Tests that filter and exclude functions are correctly applied to input values.
-
-        Verifies that only even numbers are included and a specific value is excluded from the generated combinations.
+        Test that filter and exclude functions are correctly applied to input values when generating combinations.
+        
+        Ensures that only even numbers are included and a specified value is excluded from the resulting combinations.
         """
         fields = {
             "n": Input(type=int, possible_values=[1, 2, 3, 4]),
@@ -338,9 +344,9 @@ class TestGenerateCombinations(TestCase):
     def test_sort_and_reverse_and_caching(self, mock_parse):
         # Three values, sorted and reversed
         """
-        Tests that sorting and reversing combinations works as expected and that results are cached.
-
-        Verifies that combinations are sorted in descending order by the specified key, and that repeated calls to `generate_combinations` return the cached result.
+        Tests that sorting and reversing combinations in a CalculationBucket works as expected and that the generated combinations are cached.
+        
+        Verifies that combinations are sorted in descending order by the specified key and that repeated calls to `generate_combinations` return the same cached result.
         """
         fields = {
             "v": Input(type=int, possible_values=[3, 1, 2]),


### PR DESCRIPTION
Refactor the initialization of permission attributes and enhance type checking for the `based_on` condition in `ManagerBasedPermission`. Add integration tests to verify the functionality of manager-based permissions and family updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission handling with dynamic default assignments, refined type checks, and clearer error messages.
  * Enhanced permission checks to immediately allow empty permission lists.
  * Narrowed criteria for many-to-many attribute updates to better handle empty values.

* **New Features**
  * Added a new permission type for exact attribute matching.
  * Introduced methods to obtain empty buckets across multiple bucket types for improved data handling.

* **Tests**
  * Added comprehensive integration tests validating permission logic, data relationships, and enforcement across nested models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->