### PR TITLE
Add GitHub Actions workflows for testing and publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,43 +1,13 @@
-name: Test and Publish
+name: Publish and Release
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
-  test:
-    name: 🧪 Run Tests
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.13'
-
-      - name: Install package in editable mode + test deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest pytest-django
-
-      - name: Run pytest
-        run: python3 -m pytest --maxfail=1 --disable-warnings -q
-
   release:
-    name: 🚀 Release
-    if: github.event_name == 'push'
-    needs: test
+    name: 🚀 Release & Publish
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         run: python3 -m pytest --cov=general_manager --cov-report=xml:coverage.xml
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@5a10915 #V5.5.1
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: coverage.xml
           flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         run: python3 -m pytest --cov=general_manager --cov-report=xml:coverage.xml
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@5a10915 #V5.5.1
         with:
           files: coverage.xml
           flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: 🧪 Run Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package in editable mode + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-django pytest-cov
+
+      - name: Run pytest with coverage
+        run: python3 -m pytest --cov=general_manager --cov-report=xml:coverage.xml
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          flags: unittests
+          fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Django",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
@@ -48,7 +50,7 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["src", "general_manager"]
+where = ["src"]
 
 [tool.semantic_release]
 allow_zero_version = true


### PR DESCRIPTION
Introduce a new testing workflow that runs tests across multiple Python versions and integrates coverage reporting. Update the publishing workflow to streamline the release process and adjust Python classifiers in the package configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for Python 3.13.

* Tests
  * Introduced a dedicated “Test” workflow running on push to main and pull requests with Python 3.12 and 3.13.
  * Generates coverage reports and uploads to Codecov.

* Chores
  * Simplified and renamed the publish workflow to “Publish and Release,” focusing solely on release and publish steps.
  * Separated testing from publishing; removed tests from the publish pipeline.
  * Adjusted packaging configuration to discover packages only under src for cleaner builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->