### PR TITLE
docs: comment out unused links in documentation and remove roadmap file

### DIFF
--- a/docs/concepts/permission/index.md
+++ b/docs/concepts/permission/index.md
@@ -12,6 +12,6 @@ The following pages dive into detailed patterns:
 
 - [Manager-based permissions](manager_based_permission.md)
 - [Object-level delegation](object_level.md)
-- [Practical examples](examples.md)
+<!-- - [Practical examples](examples.md) -->
 
 When you write GraphQL resolvers or REST endpoints, always go through the manager API so that permissions stay consistent across entry points.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -3,7 +3,7 @@
 The cookbook collects self-contained snippets that demonstrate how to solve domain problems with GeneralManager. Each recipe includes code you can adapt to your project.
 
 - [Project volume curve](project_volume_curve.md)
-- [Nested set bill of materials](nested_set_bom.md)
+<!-- - [Nested set bill of materials](nested_set_bom.md) -->
 - [Derivative aggregation](derivatives_groups.md)
 - [GraphQL query patterns](graphql_queries.md)
 - [Permission patterns](permission_patterns.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,0 @@
-# Roadmap
-
-TBD

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -19,3 +19,4 @@ mkdocs-minify-plugin==0.8.0
 mkdocs-section-index==0.3.10
 mkdocstrings==0.30.1
 mkdocstrings-python==1.18.2
+black==25.9.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Hid links to certain example pages from the rendered docs while retaining source text.
  * Removed the placeholder Roadmap section from the documentation.

* **Chores**
  * Updated development tooling by adding a code formatter and refreshing a docs-related tool version (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->