### PR TITLE
[codex] Harden GraphQL relation mutation handling

### DIFF
--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -21,6 +21,30 @@ Create, update, and delete mutations are added automatically when the interface 
 
 Custom mutations use the `@graph_ql_mutation` decorator from `general_manager.api.mutation`. The decorator analyses the function signature to generate GraphQL input arguments and return types.
 
+### Relation input contract
+
+Automatic GraphQL mutations accept relation inputs in the GraphQL-facing forms below and normalize them to the ORM mutation contract before persistence:
+
+- Single-valued relations: `<field>` or `<field>_id`
+- Many-valued relations: `<field>_list` or `<field>_id_list`
+
+Internally, GeneralManager treats the canonical mutation payload as:
+
+- Single-valued relations: `<field>_id`
+- Many-valued relations: `<field>_id_list`
+
+This keeps GraphQL mutations compatible with Graphene field naming while preserving a predictable backend contract for ORM-backed interfaces.
+
+### Schema-generation expectations
+
+Schema generation should remain resilient when interface metadata includes edge-case field types:
+
+- Measurement fields continue to map to `MeasurementScalar` / `MeasurementType`
+- Large integer ORM fields may opt into `BigIntScalar` through `graphql_scalar="bigint"`
+- Non-relational field types that do not map cleanly to a specific GraphQL scalar fall back to string-like handling instead of aborting schema construction
+
+The intended behavior is that startup and schema registration remain reviewable and predictable even when a manager exposes less common field metadata.
+
 ## Buckets and pagination
 
 For bucket-returning fields, the schema registers list fields and page types. `PageInfo` exposes `total_count`, `current_page`, `total_pages`, and optional `page_size` so clients can implement cursor-less pagination quickly.

--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -25,13 +25,15 @@ Custom mutations use the `@graph_ql_mutation` decorator from `general_manager.ap
 
 Automatic GraphQL mutations accept relation inputs in the GraphQL-facing forms below and normalize them to the ORM mutation contract before persistence:
 
-- Single-valued relations: `<field>` or `<field>_id`
-- Many-valued relations: `<field>_list` or `<field>_id_list`
+- Single-valued relations: `<field>` or `<field>Id`
+- Many-valued relations: `<field>List` or `<field>IdList`
 
 Internally, GeneralManager treats the canonical mutation payload as:
 
 - Single-valued relations: `<field>_id`
 - Many-valued relations: `<field>_id_list`
+
+These public names assume Graphene's default `auto_camelcase=True`. If your schema disables auto-camelcase, the Python-side argument names remain available as `<field>`, `<field>_id`, `<field>_list`, and `<field>_id_list`.
 
 This keeps GraphQL mutations compatible with Graphene field naming while preserving a predictable backend contract for ORM-backed interfaces.
 

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -39,6 +39,7 @@ from general_manager.interface.base_interface import InterfaceBase
 from general_manager.logging import get_logger
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
+from general_manager.utils.type_checks import safe_issubclass
 
 from graphql import GraphQLError
 
@@ -404,7 +405,7 @@ class GraphQL:
             field_info,
         ) in generalManagerClass.Interface.get_attribute_types().items():
             field_type = field_info["type"]
-            if issubclass(field_type, GeneralManager):
+            if safe_issubclass(field_type, GeneralManager):
                 continue
             else:
                 sort_options.append(field_name)
@@ -546,9 +547,9 @@ class GraphQL:
         Returns:
             Any: Graphene field or type configured for the attribute.
         """
-        if issubclass(field_type, Measurement):
+        if safe_issubclass(field_type, Measurement):
             return graphene.Field(MeasurementType, target_unit=graphene.String())
-        elif issubclass(field_type, GeneralManager):
+        elif safe_issubclass(field_type, GeneralManager):
             if field_name.endswith("_list"):
                 attributes: dict[str, Any] = {
                     "reverse": graphene.Boolean(),
@@ -714,7 +715,7 @@ class GraphQL:
             input_field_name,
             input_field,
         ) in generalManagerClass.Interface.input_fields.items():
-            if issubclass(input_field.type, GeneralManager):
+            if safe_issubclass(input_field.type, GeneralManager):
                 key = f"{input_field_name}_id"
                 identification_fields[key] = graphene.Argument(
                     graphene.ID, required=input_field.required

--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -216,6 +216,11 @@ def generate_update_mutation_class(
         if manager_id is None:
             raise handle_graph_ql_error(MissingManagerIdentifierError())
         try:
+            kwargs = {
+                field_name: value
+                for field_name, value in kwargs.items()
+                if value is not NOT_PROVIDED
+            }
             kwargs = _normalize_mutation_kwargs_for_manager(generalManagerClass, kwargs)
             instance = generalManagerClass(id=manager_id).update(
                 creator_id=info.context.user.id, **kwargs

--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -19,6 +19,7 @@ from django.db.models import NOT_PROVIDED
 
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.utils.type_checks import safe_issubclass
 from general_manager.api.graphql_errors import (
     HANDLED_MANAGER_ERRORS,
     MissingManagerIdentifierError,
@@ -28,11 +29,6 @@ from general_manager.api.graphql_errors import (
 
 if TYPE_CHECKING:
     from graphene import ResolveInfo as GraphQLResolveInfo
-
-
-def _is_subclass(candidate: object, parent: type | tuple[type, ...]) -> bool:
-    """Return True when candidate is a class and a subclass of parent."""
-    return isinstance(candidate, type) and issubclass(candidate, parent)
 
 
 def _normalize_mutation_kwargs_for_manager(
@@ -58,7 +54,7 @@ def _normalize_mutation_kwargs_for_manager(
         if key.startswith("_") and not key.endswith("_id"):
             type_info = attribute_types.get(key)
             relation_type = type_info["type"] if type_info is not None else None
-            if _is_subclass(relation_type, GeneralManager):
+            if safe_issubclass(relation_type, GeneralManager):
                 normalized.setdefault(f"{key}_id", normalized[key])
                 normalized.pop(key, None)
 
@@ -99,7 +95,7 @@ def create_write_fields(interface_cls: InterfaceBase) -> dict[str, Any]:
         default = info["default"]
 
         fld: Any
-        if _is_subclass(typ, GeneralManager):
+        if safe_issubclass(typ, GeneralManager):
             if name.endswith("_list"):
                 fld = graphene.List(graphene.ID, required=req, default_value=default)
             else:

--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -30,6 +30,41 @@ if TYPE_CHECKING:
     from graphene import ResolveInfo as GraphQLResolveInfo
 
 
+def _is_subclass(candidate: object, parent: type | tuple[type, ...]) -> bool:
+    """Return True when candidate is a class and a subclass of parent."""
+    return isinstance(candidate, type) and issubclass(candidate, parent)
+
+
+def _normalize_mutation_kwargs_for_manager(
+    general_manager_class: type[GeneralManager],
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Normalize GraphQL relation aliases to the ORM mutation contract."""
+    interface_cls = getattr(general_manager_class, "Interface", None)
+    if interface_cls is None:
+        return dict(kwargs)
+
+    attribute_types = interface_cls.get_attribute_types()
+    normalized = dict(kwargs)
+
+    for key in list(kwargs.keys()):
+        if key.endswith("_list") and not key.endswith("_id_list"):
+            base_key = key.removesuffix("_list")
+            if base_key in attribute_types or key in attribute_types:
+                normalized.setdefault(f"{base_key}_id_list", normalized[key])
+                normalized.pop(key, None)
+                continue
+
+        if key.startswith("_") and not key.endswith("_id"):
+            type_info = attribute_types.get(key)
+            relation_type = type_info["type"] if type_info is not None else None
+            if _is_subclass(relation_type, GeneralManager):
+                normalized.setdefault(f"{key}_id", normalized[key])
+                normalized.pop(key, None)
+
+    return normalized
+
+
 # ---------------------------------------------------------------------------
 # Write-field helpers
 # ---------------------------------------------------------------------------
@@ -64,7 +99,7 @@ def create_write_fields(interface_cls: InterfaceBase) -> dict[str, Any]:
         default = info["default"]
 
         fld: Any
-        if issubclass(typ, GeneralManager):
+        if _is_subclass(typ, GeneralManager):
             if name.endswith("_list"):
                 fld = graphene.List(graphene.ID, required=req, default_value=default)
             else:
@@ -125,6 +160,7 @@ def generate_create_mutation_class(
                 for field_name, value in kwargs.items()
                 if value is not NOT_PROVIDED
             }
+            kwargs = _normalize_mutation_kwargs_for_manager(generalManagerClass, kwargs)
             instance = generalManagerClass.create(
                 **kwargs, creator_id=info.context.user.id
             )
@@ -184,6 +220,7 @@ def generate_update_mutation_class(
         if manager_id is None:
             raise handle_graph_ql_error(MissingManagerIdentifierError())
         try:
+            kwargs = _normalize_mutation_kwargs_for_manager(generalManagerClass, kwargs)
             instance = generalManagerClass(id=manager_id).update(
                 creator_id=info.context.user.id, **kwargs
             )

--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -46,7 +46,7 @@ def _normalize_mutation_kwargs_for_manager(
     for key in list(kwargs.keys()):
         if key.endswith("_list") and not key.endswith("_id_list"):
             base_key = key.removesuffix("_list")
-            if base_key in attribute_types or key in attribute_types:
+            if base_key in attribute_types:
                 normalized.setdefault(f"{base_key}_id_list", normalized[key])
                 normalized.pop(key, None)
                 continue

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -20,6 +20,7 @@ from general_manager.bucket.base_bucket import Bucket
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
 from general_manager.api.graphql_errors import get_read_permission_filter
+from general_manager.utils.type_checks import safe_issubclass
 
 if TYPE_CHECKING:
     from graphene import ResolveInfo as GraphQLResolveInfo
@@ -505,10 +506,10 @@ def create_resolver(field_name: str, field_type: type) -> Callable[..., Any]:
     :class:`~general_manager.measurement.Measurement` fields, and
     :func:`create_normal_resolver` for everything else.
     """
-    if field_name.endswith("_list") and issubclass(field_type, GeneralManager):
+    if field_name.endswith("_list") and safe_issubclass(field_type, GeneralManager):
         return create_list_resolver(
             lambda self, _include_inactive: getattr(self, field_name), field_type
         )
-    if issubclass(field_type, Measurement):
+    if safe_issubclass(field_type, Measurement):
         return create_measurement_resolver(field_name)
     return create_normal_resolver(field_name)

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -31,6 +31,7 @@ from django.utils import timezone
 from general_manager.logging import get_logger
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
+from general_manager.utils.type_checks import safe_issubclass
 from general_manager.search.backend_registry import get_search_backend
 from general_manager.search.registry import (
     get_search_config,
@@ -318,28 +319,30 @@ def get_filter_options(
         "endswith",
     ]
 
-    if issubclass(attribute_type, GeneralManager):
+    normalized_type = attribute_type if isinstance(attribute_type, type) else str
+
+    if safe_issubclass(normalized_type, GeneralManager):
         yield attribute_name, None
-    elif issubclass(attribute_type, Measurement):
+    elif safe_issubclass(normalized_type, Measurement):
         yield attribute_name, MeasurementScalar()
         for option in number_options:
             yield f"{attribute_name}__{option}", MeasurementScalar()
     else:
         yield (
             attribute_name,
-            map_field_to_graphene_read(attribute_type, attribute_name, attr_info),
+            map_field_to_graphene_read(normalized_type, attribute_name, attr_info),
         )
-        if issubclass(attribute_type, (int, float, Decimal, date, datetime)):
+        if safe_issubclass(normalized_type, (int, float, Decimal, date, datetime)):
             for option in number_options:
                 yield (
                     f"{attribute_name}__{option}",
                     map_field_to_graphene_read(
-                        attribute_type, attribute_name, attr_info
+                        normalized_type, attribute_name, attr_info
                     ),
                 )
-        elif issubclass(attribute_type, str):
+        elif safe_issubclass(normalized_type, str):
             base_type = map_field_to_graphene_base_type(
-                attribute_type,
+                normalized_type,
                 attr_info.get("graphql_scalar") if attr_info else None,
             )
             for option in string_options:
@@ -349,7 +352,7 @@ def get_filter_options(
                     yield (
                         f"{attribute_name}__{option}",
                         map_field_to_graphene_read(
-                            attribute_type, attribute_name, attr_info
+                            normalized_type, attribute_name, attr_info
                         ),
                     )
 

--- a/src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py
+++ b/src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py
@@ -56,8 +56,11 @@ class PayloadNormalizer:
             UnknownFieldError: If any key's base name is not an attribute of the model instance and not a model field name.
         """
         for key in kwargs:
-            base_key = _base_field_name(key)
-            if base_key not in self._attributes and base_key not in self._field_names:
+            candidate_key = self._key_for_validation(key)
+            if (
+                candidate_key not in self._attributes
+                and candidate_key not in self._field_names
+            ):
                 raise UnknownFieldError(key, self.model.__name__)
 
     def split_many_to_many(
@@ -77,7 +80,7 @@ class PayloadNormalizer:
         """
         many_kwargs: dict[str, Any] = {}
         for key, _value in list(kwargs.items()):
-            base_key = _base_field_name(key)
+            base_key = self._m2m_alias_base_key(key)
             if base_key in self._many_to_many_fields:
                 many_kwargs[f"{base_key}_id_list"] = kwargs.pop(key)
         return kwargs, many_kwargs
@@ -144,6 +147,15 @@ class PayloadNormalizer:
         return normalized
 
     # endregion
+
+    def _key_for_validation(self, key: str) -> str:
+        """Resolve relation list aliases only when they target real M2M fields."""
+        base_key = self._m2m_alias_base_key(key)
+        return base_key if base_key in self._many_to_many_fields else key
+
+    def _m2m_alias_base_key(self, key: str) -> str:
+        """Return the base key for M2M alias forms, or the original key."""
+        return _base_field_name(key)
 
     @staticmethod
     def _unwrap_manager(value: Any) -> Any:

--- a/src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py
+++ b/src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py
@@ -23,6 +23,11 @@ class PayloadNormalizer:
         self._attributes = set(vars(model).keys())
         self._field_names = {field.name for field in model._meta.get_fields()}
         self._many_to_many_fields = {field.name for field in model._meta.many_to_many}
+        self._relation_fields = {
+            field.name
+            for field in model._meta.get_fields()
+            if isinstance(field, (models.ForeignKey, models.OneToOneField))
+        }
 
     # region filter/exclude helpers
     def normalize_filter_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -51,7 +56,7 @@ class PayloadNormalizer:
             UnknownFieldError: If any key's base name is not an attribute of the model instance and not a model field name.
         """
         for key in kwargs:
-            base_key = key.split("_id_list")[0]
+            base_key = _base_field_name(key)
             if base_key not in self._attributes and base_key not in self._field_names:
                 raise UnknownFieldError(key, self.model.__name__)
 
@@ -72,9 +77,9 @@ class PayloadNormalizer:
         """
         many_kwargs: dict[str, Any] = {}
         for key, _value in list(kwargs.items()):
-            base_key = key.split("_id_list")[0]
+            base_key = _base_field_name(key)
             if base_key in self._many_to_many_fields:
-                many_kwargs[key] = kwargs.pop(key)
+                many_kwargs[f"{base_key}_id_list"] = kwargs.pop(key)
         return kwargs, many_kwargs
 
     def normalize_simple_values(self, kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -99,6 +104,13 @@ class PayloadNormalizer:
                 normalized_value = manager_value
             elif manager_value is not None:
                 normalized_value = manager_value
+            elif (
+                key in self._relation_fields
+                and not key.endswith("_id")
+                and not isinstance(value, models.Model)
+                and value is not None
+            ):
+                normalized_key = f"{key}_id"
             normalized[normalized_key] = normalized_value
         return normalized
 
@@ -200,3 +212,16 @@ def _general_manager_base() -> type | None:
     except ImportError:  # pragma: no cover - defensive
         return None
     return GeneralManager
+
+
+def _base_field_name(key: str) -> str:
+    """
+    Normalize payload key suffixes used for relation list fields.
+
+    Accepts both canonical (`*_id_list`) and GraphQL-facing (`*_list`) spellings.
+    """
+    if key.endswith("_id_list"):
+        return key[: -len("_id_list")]
+    if key.endswith("_list"):
+        return key[: -len("_list")]
+    return key

--- a/src/general_manager/utils/type_checks.py
+++ b/src/general_manager/utils/type_checks.py
@@ -1,0 +1,8 @@
+"""Type-checking helpers shared across the codebase."""
+
+from __future__ import annotations
+
+
+def safe_issubclass(candidate: object, parent: type | tuple[type, ...]) -> bool:
+    """Return True when *candidate* is a class and a subclass of *parent*."""
+    return isinstance(candidate, type) and issubclass(candidate, parent)

--- a/tests/integration/test_graphql_mutation_relation_aliases.py
+++ b/tests/integration/test_graphql_mutation_relation_aliases.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from django.db import models
+
+from general_manager.interface import DatabaseInterface
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.permission import ManagerBasedPermission
+from general_manager.utils.testing import GeneralManagerTransactionTestCase
+
+
+class TestGraphQLMutationRelationAliases(GeneralManagerTransactionTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        class TestPlant(GeneralManager):
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=100)
+
+                class Meta:
+                    app_label = "general_manager"
+                    use_soft_delete = True
+
+            class Permission(ManagerBasedPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+                __create__: ClassVar[list[str]] = ["public"]
+                __update__: ClassVar[list[str]] = ["public"]
+                __delete__: ClassVar[list[str]] = ["public"]
+
+        class TestTag(GeneralManager):
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=100)
+
+                class Meta:
+                    app_label = "general_manager"
+                    use_soft_delete = True
+
+            class Permission(ManagerBasedPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+                __create__: ClassVar[list[str]] = ["public"]
+                __update__: ClassVar[list[str]] = ["public"]
+                __delete__: ClassVar[list[str]] = ["public"]
+
+        class TestAsset(GeneralManager):
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=100)
+                _plant = models.ForeignKey(
+                    "general_manager.TestPlant", on_delete=models.CASCADE
+                )
+                tags = models.ManyToManyField("general_manager.TestTag", blank=True)
+
+                class Meta:
+                    app_label = "general_manager"
+                    use_soft_delete = True
+
+            class Permission(ManagerBasedPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+                __create__: ClassVar[list[str]] = ["public"]
+                __update__: ClassVar[list[str]] = ["public"]
+                __delete__: ClassVar[list[str]] = ["public"]
+
+        cls.TestPlant = TestPlant
+        cls.TestTag = TestTag
+        cls.TestAsset = TestAsset
+        cls.general_manager_classes = [TestPlant, TestTag, TestAsset]
+
+    def test_create_and_update_mutations_accept_relation_aliases(self) -> None:
+        plant_a = self.TestPlant.create(ignore_permission=True, name="Plant A")
+        plant_b = self.TestPlant.create(ignore_permission=True, name="Plant B")
+        tag_a = self.TestTag.create(ignore_permission=True, name="Tag A")
+        tag_b = self.TestTag.create(ignore_permission=True, name="Tag B")
+
+        create_mutation = """
+        mutation CreateAsset($name: String!, $Plant: ID!, $tagsList: [ID]) {
+            createTestAsset(name: $name, Plant: $Plant, tagsList: $tagsList) {
+                success
+                TestAsset { id name }
+            }
+        }
+        """
+        create_response = self.query(
+            create_mutation,
+            variables={
+                "name": "Asset 1",
+                "Plant": str(plant_a.id),
+                "tagsList": [str(tag_a.id)],
+            },
+        )
+        self.assertResponseNoErrors(create_response)
+        create_data = create_response.json()["data"]["createTestAsset"]
+        self.assertTrue(create_data["success"])
+        asset_id = int(create_data["TestAsset"]["id"])
+
+        update_mutation = """
+        mutation UpdateAsset($id: Int!, $name: String!, $Plant: ID!, $tagsList: [ID]) {
+            updateTestAsset(id: $id, name: $name, Plant: $Plant, tagsList: $tagsList) {
+                success
+                TestAsset { id name }
+            }
+        }
+        """
+        update_response = self.query(
+            update_mutation,
+            variables={
+                "id": asset_id,
+                "name": "Asset 1 Updated",
+                "Plant": str(plant_b.id),
+                "tagsList": [str(tag_a.id), str(tag_b.id)],
+            },
+        )
+        self.assertResponseNoErrors(update_response)
+        update_data = update_response.json()["data"]["updateTestAsset"]
+        self.assertTrue(update_data["success"])
+
+        db_asset = self.TestAsset.Interface._model.objects.get(pk=asset_id)
+        self.assertEqual(db_asset._plant_id, plant_b.id)
+        self.assertSetEqual(
+            set(db_asset.tags.values_list("id", flat=True)),
+            {tag_a.id, tag_b.id},
+        )

--- a/tests/unit/test_database_based_interface.py
+++ b/tests/unit/test_database_based_interface.py
@@ -1923,6 +1923,19 @@ def test_payload_normalizer_accepts_list_alias_suffix() -> None:
     normalizer.validate_keys({"tags_list": [1, 2]})
 
 
+def test_payload_normalizer_rejects_list_suffix_for_plain_field_name() -> None:
+    class WatchListModel(models.Model):
+        watch_list = models.CharField(max_length=32)
+
+        class Meta:
+            app_label = "test"
+
+    normalizer = PayloadNormalizer(WatchListModel)
+
+    with pytest.raises(UnknownFieldError):
+        normalizer.validate_keys({"watch_id_list": [1, 2]})
+
+
 def test_payload_normalizer_split_many_to_many_normalizes_list_alias_key() -> None:
     class AliasRelatedModel(models.Model):
         class Meta:
@@ -1944,6 +1957,21 @@ def test_payload_normalizer_split_many_to_many_normalizes_list_alias_key() -> No
     assert "name" in simple_kwargs
     assert "tags_list" not in simple_kwargs
     assert many_kwargs["tags_id_list"] == [1, 2]
+
+
+def test_payload_normalizer_split_many_to_many_keeps_plain_list_field() -> None:
+    class WatchListModel(models.Model):
+        watch_list = models.CharField(max_length=32)
+
+        class Meta:
+            app_label = "test"
+
+    normalizer = PayloadNormalizer(WatchListModel)
+
+    simple_kwargs, many_kwargs = normalizer.split_many_to_many({"watch_list": "daily"})
+
+    assert simple_kwargs == {"watch_list": "daily"}
+    assert many_kwargs == {}
 
 
 def test_payload_normalizer_normalize_simple_values_converts_fk_plain_id() -> None:

--- a/tests/unit/test_database_based_interface.py
+++ b/tests/unit/test_database_based_interface.py
@@ -1908,47 +1908,47 @@ def test_payload_normalizer_normalize_many_values_single_item():
 
 
 def test_payload_normalizer_accepts_list_alias_suffix() -> None:
-    class AliasRelatedModel(models.Model):
+    class AliasRelatedModelA(models.Model):
         class Meta:
-            app_label = "test"
+            app_label = "test_payload_alias_a"
 
-    class AliasModel(models.Model):
-        tags = models.ManyToManyField(AliasRelatedModel)
+    class AliasModelA(models.Model):
+        tags = models.ManyToManyField(AliasRelatedModelA)
 
         class Meta:
-            app_label = "test"
+            app_label = "test_payload_alias_a"
 
-    normalizer = PayloadNormalizer(AliasModel)
+    normalizer = PayloadNormalizer(AliasModelA)
 
     normalizer.validate_keys({"tags_list": [1, 2]})
 
 
 def test_payload_normalizer_rejects_list_suffix_for_plain_field_name() -> None:
-    class WatchListModel(models.Model):
+    class WatchListModelA(models.Model):
         watch_list = models.CharField(max_length=32)
 
         class Meta:
-            app_label = "test"
+            app_label = "test_payload_watchlist_a"
 
-    normalizer = PayloadNormalizer(WatchListModel)
+    normalizer = PayloadNormalizer(WatchListModelA)
 
     with pytest.raises(UnknownFieldError):
         normalizer.validate_keys({"watch_id_list": [1, 2]})
 
 
 def test_payload_normalizer_split_many_to_many_normalizes_list_alias_key() -> None:
-    class AliasRelatedModel(models.Model):
+    class AliasRelatedModelB(models.Model):
         class Meta:
-            app_label = "test"
+            app_label = "test_payload_alias_b"
 
-    class AliasModel(models.Model):
-        tags = models.ManyToManyField(AliasRelatedModel)
+    class AliasModelB(models.Model):
+        tags = models.ManyToManyField(AliasRelatedModelB)
         name = models.CharField(max_length=32, default="")
 
         class Meta:
-            app_label = "test"
+            app_label = "test_payload_alias_b"
 
-    normalizer = PayloadNormalizer(AliasModel)
+    normalizer = PayloadNormalizer(AliasModelB)
 
     simple_kwargs, many_kwargs = normalizer.split_many_to_many(
         {"name": "asset", "tags_list": [1, 2]}
@@ -1960,13 +1960,13 @@ def test_payload_normalizer_split_many_to_many_normalizes_list_alias_key() -> No
 
 
 def test_payload_normalizer_split_many_to_many_keeps_plain_list_field() -> None:
-    class WatchListModel(models.Model):
+    class WatchListModelB(models.Model):
         watch_list = models.CharField(max_length=32)
 
         class Meta:
-            app_label = "test"
+            app_label = "test_payload_watchlist_b"
 
-    normalizer = PayloadNormalizer(WatchListModel)
+    normalizer = PayloadNormalizer(WatchListModelB)
 
     simple_kwargs, many_kwargs = normalizer.split_many_to_many({"watch_list": "daily"})
 

--- a/tests/unit/test_database_based_interface.py
+++ b/tests/unit/test_database_based_interface.py
@@ -1907,6 +1907,80 @@ def test_payload_normalizer_normalize_many_values_single_item():
     assert result["field"] == [42]
 
 
+def test_payload_normalizer_accepts_list_alias_suffix() -> None:
+    class AliasRelatedModel(models.Model):
+        class Meta:
+            app_label = "test"
+
+    class AliasModel(models.Model):
+        tags = models.ManyToManyField(AliasRelatedModel)
+
+        class Meta:
+            app_label = "test"
+
+    normalizer = PayloadNormalizer(AliasModel)
+
+    normalizer.validate_keys({"tags_list": [1, 2]})
+
+
+def test_payload_normalizer_split_many_to_many_normalizes_list_alias_key() -> None:
+    class AliasRelatedModel(models.Model):
+        class Meta:
+            app_label = "test"
+
+    class AliasModel(models.Model):
+        tags = models.ManyToManyField(AliasRelatedModel)
+        name = models.CharField(max_length=32, default="")
+
+        class Meta:
+            app_label = "test"
+
+    normalizer = PayloadNormalizer(AliasModel)
+
+    simple_kwargs, many_kwargs = normalizer.split_many_to_many(
+        {"name": "asset", "tags_list": [1, 2]}
+    )
+
+    assert "name" in simple_kwargs
+    assert "tags_list" not in simple_kwargs
+    assert many_kwargs["tags_id_list"] == [1, 2]
+
+
+def test_payload_normalizer_normalize_simple_values_converts_fk_plain_id() -> None:
+    class PlantModel(models.Model):
+        class Meta:
+            app_label = "test"
+
+    class DerivativeModel(models.Model):
+        _plant = models.ForeignKey(PlantModel, on_delete=models.CASCADE)
+
+        class Meta:
+            app_label = "test"
+
+    normalizer = PayloadNormalizer(DerivativeModel)
+
+    normalized = normalizer.normalize_simple_values({"_plant": 7})
+
+    assert "_plant_id" in normalized
+    assert normalized["_plant_id"] == 7
+
+
+def test_payload_normalizer_normalize_simple_values_keeps_non_relation_scalar_keys() -> (
+    None
+):
+    class PlainModel(models.Model):
+        name = models.CharField(max_length=32)
+
+        class Meta:
+            app_label = "test"
+
+    normalizer = PayloadNormalizer(PlainModel)
+
+    normalized = normalizer.normalize_simple_values({"name": "asset"})
+
+    assert normalized == {"name": "asset"}
+
+
 def test_build_field_descriptors_translates_graphql_compatible_field_types():
     """Descriptor metadata maps GraphQL-compatible Django fields to usable Python types."""
 

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -17,6 +17,9 @@ from general_manager.api.graphql import (
     GraphQL,
     get_read_permission_filter,
 )
+from general_manager.api.graphql_mutations import (
+    _normalize_mutation_kwargs_for_manager,
+)
 from general_manager.api.graphql_view import GeneralManagerGraphQLView
 from general_manager.measurement.measurement import Measurement
 from general_manager.manager.general_manager import GeneralManager, GeneralManagerMeta
@@ -107,6 +110,29 @@ class GraphQLTests(TestCase):
             int, "large_value", {"graphql_scalar": "bigint"}
         )
         self.assertIsInstance(field, BigIntScalar)
+
+    def test_normalize_mutation_kwargs_does_not_rewrite_plain_list_field(self):
+        class DummyInterface:
+            @staticmethod
+            def get_attribute_types():
+                return {
+                    "watch_list": {
+                        "type": str,
+                        "is_required": False,
+                        "is_derived": False,
+                        "default": None,
+                        "is_editable": True,
+                    }
+                }
+
+        class DummyManager:
+            Interface = DummyInterface
+
+        normalized = _normalize_mutation_kwargs_for_manager(
+            DummyManager, {"watch_list": "daily"}
+        )
+
+        self.assertEqual(normalized, {"watch_list": "daily"})
 
     def test_map_field_to_graphene_handles_generic_alias_type(self):
         field = GraphQL._map_field_to_graphene_read(list[str], "labels")

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -7,7 +7,7 @@ import graphene
 from django.test import TestCase, override_settings
 from unittest.mock import MagicMock, patch
 from django.contrib.auth.models import AnonymousUser
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from general_manager import bootstrap as gm_bootstrap
 from general_manager.api.graphql import (
@@ -107,11 +107,31 @@ class GraphQLTests(TestCase):
         )
         self.assertIsInstance(field, BigIntScalar)
 
+    def test_map_field_to_graphene_handles_generic_alias_type(self):
+        field = GraphQL._map_field_to_graphene_read(list[str], "labels")
+        self.assertIsInstance(field, graphene.String)
+
+    def test_map_field_to_graphene_handles_any_type(self):
+        field = GraphQL._map_field_to_graphene_read(Any, "metadata")
+        self.assertIsInstance(field, graphene.String)
+
     def test_create_resolver_normal_case(self):
         mock_instance = MagicMock()
         mock_instance.some_field = "expected_value"
         resolver = GraphQL._create_resolver("some_field", str)
         self.assertEqual(resolver(mock_instance, self.info), "expected_value")
+
+    def test_create_resolver_handles_generic_alias_type(self):
+        mock_instance = MagicMock()
+        mock_instance.labels = ["a", "b"]
+        resolver = GraphQL._create_resolver("labels", list[str])
+        self.assertEqual(resolver(mock_instance, self.info), ["a", "b"])
+
+    def test_create_resolver_handles_any_type(self):
+        mock_instance = MagicMock()
+        mock_instance.metadata = {"a": 1}
+        resolver = GraphQL._create_resolver("metadata", Any)
+        self.assertEqual(resolver(mock_instance, self.info), {"a": 1})
 
     def test_create_resolver_measurement_case(self):
         mock_instance = MagicMock()
@@ -712,6 +732,62 @@ class TestGrapQlMutation(TestCase):
         self.assertIsNotNone(filter_type)
         self.assertIsInstance(filter_type.large_value, BigIntScalar)
         self.assertIsInstance(filter_type.large_value__gt, BigIntScalar)
+
+    def test_create_filter_options_handles_generic_alias_type(self):
+        class DummyInterface:
+            @staticmethod
+            def get_attribute_types():
+                return {
+                    "labels": {
+                        "type": list[str],
+                        "is_required": False,
+                        "is_derived": False,
+                        "default": None,
+                        "is_editable": True,
+                    }
+                }
+
+            @staticmethod
+            def get_graph_ql_properties():
+                return {}
+
+        class DummyManagerWithGenericAlias:
+            __name__ = "DummyManagerWithGenericAlias"
+            Interface = DummyInterface
+
+        GraphQL.graphql_filter_type_registry.clear()
+        filter_type = GraphQL._create_filter_options(DummyManagerWithGenericAlias)
+
+        self.assertIsNotNone(filter_type)
+        self.assertIsInstance(filter_type.labels, graphene.String)
+
+    def test_create_filter_options_handles_any_type(self):
+        class DummyInterface:
+            @staticmethod
+            def get_attribute_types():
+                return {
+                    "metadata": {
+                        "type": Any,
+                        "is_required": False,
+                        "is_derived": False,
+                        "default": None,
+                        "is_editable": True,
+                    }
+                }
+
+            @staticmethod
+            def get_graph_ql_properties():
+                return {}
+
+        class DummyManagerWithAny:
+            __name__ = "DummyManagerWithAny"
+            Interface = DummyInterface
+
+        GraphQL.graphql_filter_type_registry.clear()
+        filter_type = GraphQL._create_filter_options(DummyManagerWithAny)
+
+        self.assertIsNotNone(filter_type)
+        self.assertIsInstance(filter_type.metadata, graphene.String)
 
     def test_create_write_fields_with_manager(self):
         """

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from datetime import date, datetime
 import graphene
 from django.test import TestCase, override_settings
+from django.db.models import NOT_PROVIDED
 from unittest.mock import MagicMock, patch
 from django.contrib.auth.models import AnonymousUser
 from typing import Any, ClassVar
@@ -956,6 +957,47 @@ class TestGrapQlMutation(TestCase):
         info = None
         with self.assertRaises(GraphQLError):
             mutation_result = mutation_class.mutate(None, info, field1="test_value")
+
+    def test_generate_update_mutation_class_filters_not_provided(self):
+        class DummyManager:
+            def __init__(self, *_, **_kwargs):
+                pass
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @classmethod
+                def get_attribute_types(cls):
+                    return {
+                        "field1": {
+                            "type": str,
+                            "is_required": False,
+                            "is_editable": True,
+                            "is_derived": False,
+                            "default": None,
+                        }
+                    }
+
+            @classmethod
+            def update(cls, *_args, **_kwargs):
+                return DummyManager()
+
+        default_return_values = {
+            "success": graphene.Boolean(),
+            "instance": graphene.Field(DummyManager),
+        }
+        mutation_class = GraphQL.generate_update_mutation_class(
+            DummyManager, default_return_values
+        )
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        with patch.object(
+            DummyManager, "update", return_value=DummyManager()
+        ) as update_mock:
+            mutation_class.mutate(None, info, id="1", field1=NOT_PROVIDED)
+
+        update_mock.assert_called_once_with(creator_id=info.context.user.id)
 
     def test_generate_delete_mutation_class(self):
         """


### PR DESCRIPTION
## Summary
This PR hardens GraphQL correctness around relation mutations and schema/runtime edge cases.

It normalizes GraphQL-facing relation aliases to the canonical ORM mutation contract, adds regression coverage for relation payload normalization, and documents the accepted relation input forms and schema-generation expectations.

## What Changed
- normalize GraphQL relation mutation inputs like `<field>` / `<field>_list` to canonical `<field>_id` / `<field>_id_list`
- canonicalize ORM payload normalization for relation ids and many-to-many alias forms
- add integration coverage for GraphQL relation mutation aliases
- add unit coverage for payload normalization and GraphQL schema/runtime edge cases
- document the relation mutation contract and schema-generation behavior

## Why
Issue #193 expanded beyond the initial mutation fix. The GraphQL layer needed a clearly defined relation input contract, consistent relation normalization, and explicit regression coverage so startup/schema behavior stays predictable.

## Validation
- `python -m pytest tests/unit/test_graph_ql.py -q`
- `python -m pytest tests/unit/test_database_based_interface.py -q -k 'payload_normalizer and (list_alias_suffix or normalizes_list_alias_key or converts_fk_plain_id or keeps_non_relation_scalar_keys)'`
- `python -m pytest tests/integration/test_graphql_mutation_relation_aliases.py tests/integration/test_default_mutations.py tests/integration/test_custom_mutation.py -q`
- `ruff check src/general_manager/api/graphql_mutations.py src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py tests/integration/test_graphql_mutation_relation_aliases.py tests/unit/test_database_based_interface.py tests/unit/test_graph_ql.py`
- `mypy src`

## Notes
- The startup/schema hardening portion landed primarily as regression coverage and documentation; the current codebase already handled the tested non-class metadata edge cases.
- Focus remains intentionally narrow to GraphQL correctness and API clarity; no caching, MCP, or example-app changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation for GraphQL relation input aliases and schema‑generation fallbacks (BigInt, measurement mapping, edge cases).

* **Bug Fixes**
  * More defensive type handling across GraphQL generation and resolvers to avoid type-check errors.
  * Improved payload normalization to accept and normalize relation alias forms for FK and M2M inputs.

* **Tests**
  * New unit and integration tests covering relation-alias mutations and payload normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->