### PR TITLE
[codex] Fix reverse relation bucket naming conventions

### DIFF
--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+import re
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, cast
 from uuid import UUID
 
@@ -73,6 +74,13 @@ def _graphql_scalar_hint(raw_type: type) -> str | None:
     if issubclass(raw_type, models.BigIntegerField):
         return "bigint"
     return None
+
+
+def _to_snake_case(name: str) -> str:
+    """Convert a CamelCase class name into snake_case."""
+    snake = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    snake = re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake)
+    return snake.lower()
 
 
 def build_field_descriptors(
@@ -214,9 +222,21 @@ class _FieldDescriptorBuilder:
             accessor_name = (
                 reverse_relation.get_accessor_name() or reverse_relation.name
             )
+            explicit_accessor = getattr(reverse_relation.field, "_related_name", None)
+            related_model = getattr(reverse_relation, "related_model", None)
+            if (
+                isinstance(explicit_accessor, str)
+                and explicit_accessor
+                and explicit_accessor != "+"
+            ):
+                base_name = explicit_accessor
+            elif related_model is not None:
+                base_name = _to_snake_case(related_model.__name__)
+            else:
+                base_name = reverse_relation.name
             self._register_collection_field(
                 field=reverse_relation,
-                base_name=reverse_relation.name,
+                base_name=base_name,
                 accessor_name=accessor_name,
                 relation_field_name=getattr(reverse_relation.field, "name", None),
             )

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -342,6 +342,12 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
                 change_request_feasibility_list__id=self.change_request_feasibility.id
             )
 
+    def test_reverse_relation_bucket_uses_snake_case_attribute_name(self):
+        bucket = self.change_request.change_request_feasibility_list
+
+        self.assertEqual(len(bucket), 1)
+        self.assertEqual(bucket[0].id, self.change_request_feasibility.id)
+
     def test_filter_with_search_date_returns_historical_state(self):
         base_time = timezone.now() - timedelta(days=10)
 

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -91,7 +91,7 @@ def test_build_field_descriptors_disambiguates_duplicate_reverse_relations() -> 
             resolve_many=lambda *_args: None,
         )
 
-    assert "relatedmodel_list" in descriptors
+    assert "related_model_list" in descriptors
     assert "relatedmodel_set_list" in descriptors
 
     relation_field_names = {


### PR DESCRIPTION
## Summary
- align reverse relation bucket descriptor names with the existing snake_case naming convention
- preserve explicit `related_name` values while using snake_case related model names for default reverse bucket accessors
- add regression coverage for manager instance access and descriptor naming

## Root cause
Reverse relation bucket field names were derived from Django's raw reverse lookup roots, which collapsed words for default relations and exposed attributes like `changerequestfeasibility_list` instead of the expected `change_request_feasibility_list`.

## Validation
- `PYTHONPATH=src python -m pytest`
- `PYTHONPATH=src pre-commit run --all-files`

Fixes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reverse relation attributes to consistently use snake_case naming convention, improving consistency with application naming standards.

* **Tests**
  * Added integration test to verify reverse relation naming behavior follows expected conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->