### PR TITLE
[codex] Enforce empty payload permission checks

### DIFF
--- a/src/general_manager/permission/base_permission.py
+++ b/src/general_manager/permission/base_permission.py
@@ -94,6 +94,20 @@ class BasePermission(ABC):
         """Return permission expressions associated with an action/attribute pair."""
         return ()
 
+    @abstractmethod
+    def describe_operation_permissions(
+        self,
+        action: Literal["create", "read", "update", "delete"],
+    ) -> tuple[str, ...]:
+        """Return permission expressions associated with an action-level check."""
+
+    @abstractmethod
+    def check_operation_permission(
+        self,
+        action: Literal["create", "read", "update", "delete"],
+    ) -> bool:
+        """Return whether an action without attribute payload is allowed."""
+
     def can_read_instance(self) -> bool:
         """Return whether the current user may see that the instance exists."""
         if self._is_superuser():
@@ -136,9 +150,12 @@ class BasePermission(ABC):
         request_user: UserLike | Any,
     ) -> None:
         """
-        Validate that the requesting user is allowed to create each attribute in the provided payload.
+        Validate that the requesting user is allowed to perform the create operation.
 
-        Checks create permission for every key in `data` using the given `manager`. If any attribute is not permitted, raises a PermissionCheckError that includes the evaluated user and a list of denial messages.
+        Checks create permission for every key in `data` using the given `manager`.
+        Empty payloads still evaluate the create-level permission gate once. If any
+        attribute is not permitted, raises a PermissionCheckError that includes the
+        evaluated user and a list of denial messages.
 
         Parameters:
             data (dict[str, Any]): Mapping of attribute names to the values intended for creation.
@@ -154,6 +171,20 @@ class BasePermission(ABC):
         manager_name = manager.__name__ if manager is not None else None
         if Permission._is_superuser():
             if audit_logging_enabled():
+                if not data:
+                    emit_permission_audit_event(
+                        PermissionAuditEvent(
+                            action="create",
+                            attributes=(),
+                            granted=True,
+                            user=request_user,
+                            manager=manager_name,
+                            permissions=Permission.describe_operation_permissions(
+                                "create"
+                            ),
+                            bypassed=True,
+                        )
+                    )
                 for key in data.keys():
                     emit_permission_audit_event(
                         PermissionAuditEvent(
@@ -170,6 +201,29 @@ class BasePermission(ABC):
 
         errors: list[str] = []
         user_identifier = getattr(request_user, "id", None)
+        if not data:
+            is_allowed = Permission.check_operation_permission("create")
+            if audit_logging_enabled():
+                emit_permission_audit_event(
+                    PermissionAuditEvent(
+                        action="create",
+                        attributes=(),
+                        granted=is_allowed,
+                        user=request_user,
+                        manager=manager_name,
+                        permissions=Permission.describe_operation_permissions("create"),
+                    )
+                )
+            if not is_allowed:
+                logger.info(
+                    "permission denied",
+                    context={
+                        "manager": manager_name,
+                        "action": "create",
+                        "user_id": user_identifier,
+                    },
+                )
+                errors.append("Create permission denied")
         for key in data.keys():
             is_allowed = Permission.check_permission("create", key)
             if audit_logging_enabled():
@@ -205,7 +259,11 @@ class BasePermission(ABC):
         request_user: UserLike | Any,
     ) -> None:
         """
-        Validate whether the request_user can update the given fields on an existing manager instance.
+        Validate whether the request_user can perform the update operation.
+
+        Checks update permission for every key in ``data`` against the existing
+        manager instance. Empty payloads still evaluate the update-level
+        permission gate once.
 
         Parameters:
             data (dict[str, Any]): Mapping of attribute names to new values to be applied.
@@ -223,6 +281,20 @@ class BasePermission(ABC):
         manager_name = old_manager_instance.__class__.__name__
         if Permission._is_superuser():
             if audit_logging_enabled():
+                if not data:
+                    emit_permission_audit_event(
+                        PermissionAuditEvent(
+                            action="update",
+                            attributes=(),
+                            granted=True,
+                            user=request_user,
+                            manager=manager_name,
+                            permissions=Permission.describe_operation_permissions(
+                                "update"
+                            ),
+                            bypassed=True,
+                        )
+                    )
                 for key in data.keys():
                     emit_permission_audit_event(
                         PermissionAuditEvent(
@@ -239,6 +311,29 @@ class BasePermission(ABC):
 
         errors: list[str] = []
         user_identifier = getattr(request_user, "id", None)
+        if not data:
+            is_allowed = Permission.check_operation_permission("update")
+            if audit_logging_enabled():
+                emit_permission_audit_event(
+                    PermissionAuditEvent(
+                        action="update",
+                        attributes=(),
+                        granted=is_allowed,
+                        user=request_user,
+                        manager=manager_name,
+                        permissions=Permission.describe_operation_permissions("update"),
+                    )
+                )
+            if not is_allowed:
+                logger.info(
+                    "permission denied",
+                    context={
+                        "manager": manager_name,
+                        "action": "update",
+                        "user_id": user_identifier,
+                    },
+                )
+                errors.append("Update permission denied")
         for key in data.keys():
             is_allowed = Permission.check_permission("update", key)
             if audit_logging_enabled():

--- a/src/general_manager/permission/manager_based_permission.py
+++ b/src/general_manager/permission/manager_based_permission.py
@@ -360,6 +360,28 @@ class _ConfiguredManagerPermission(BasePermission):
     def _check_permission_list(self, permissions: list[str]) -> bool:
         return self.__check_specific_permission(permissions)
 
+    def check_operation_permission(self, action: permission_type) -> bool:
+        """Evaluate the CRUD-level permission for an operation without field data."""
+        base_permissions = self._get_base_permissions(action)
+        if self._is_superuser():
+            self.__overall_results[action] = True
+            return True
+        if self.__based_on_permission is not None and not (
+            self.__based_on_permission.check_operation_permission(action)
+        ):
+            return False
+
+        can_use_action_cache = self.__based_on_permission is None
+        if can_use_action_cache:
+            last_result = self.__overall_results.get(action)
+            if last_result is not None:
+                return last_result
+
+        permission = self._check_permission_list(base_permissions)
+        if can_use_action_cache:
+            self.__overall_results[action] = permission
+        return permission
+
     def get_permission_filter(
         self,
     ) -> list[dict[Literal["filter", "exclude"], dict[str, str]]]:
@@ -511,6 +533,17 @@ class _ConfiguredManagerPermission(BasePermission):
         if self.__based_on_permission is not None:
             combined += self.__based_on_permission.describe_permissions(
                 action, attribute
+            )
+        return combined
+
+    def describe_operation_permissions(
+        self,
+        action: permission_type,
+    ) -> tuple[str, ...]:
+        combined = tuple(self._get_base_permissions(action))
+        if self.__based_on_permission is not None:
+            combined += self.__based_on_permission.describe_operation_permissions(
+                action
             )
         return combined
 

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from django.db import models
 from django.core.exceptions import ValidationError
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.utils.crypto import get_random_string
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface import DatabaseInterface
@@ -74,10 +74,42 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
                 __update__: ClassVar[list[str]] = ["public"]
                 __delete__: ClassVar[list[str]] = ["public"]
 
+        class EmptyPayloadProject1(GeneralManager):
+            name: str
+
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=50, default="Untitled")
+
+            class Permission(ManagerBasedPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+                __create__: ClassVar[list[str]] = ["isAdmin"]
+                __update__: ClassVar[list[str]] = ["isAdmin"]
+                __delete__: ClassVar[list[str]] = ["public"]
+
+        class InGroupEmptyPayloadProject1(GeneralManager):
+            name: str
+
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=50, default="Grouped")
+
+            class Permission(ManagerBasedPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+                __create__: ClassVar[list[str]] = ["inGroup:Test"]
+                __update__: ClassVar[list[str]] = ["inGroup:Test"]
+                __delete__: ClassVar[list[str]] = ["public"]
+
         cls.TestCountry = TestCountry1
         cls.TestHuman = TestHuman1
         cls.TestFamily = TestFamily1
-        cls.general_manager_classes = [TestCountry1, TestHuman1, TestFamily1]
+        cls.EmptyPayloadProject = EmptyPayloadProject1
+        cls.InGroupEmptyPayloadProject = InGroupEmptyPayloadProject1
+        cls.general_manager_classes = [
+            TestCountry1,
+            TestHuman1,
+            TestFamily1,
+            EmptyPayloadProject1,
+            InGroupEmptyPayloadProject1,
+        ]
 
     def setUp(self):
         """
@@ -90,6 +122,19 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.user: User = User.objects.create_user(
             username="testuser", password=password, email="testuser@example.com"
         )
+        self.admin_user: User = User.objects.create_user(
+            username="adminuser",
+            password=password,
+            email="adminuser@example.com",
+            is_staff=True,
+        )
+        self.group_user: User = User.objects.create_user(
+            username="groupuser",
+            password=password,
+            email="groupuser@example.com",
+        )
+        self.test_group = Group.objects.create(name="Test")
+        self.group_user.groups.add(self.test_group)
         self.us = self.TestCountry.create(
             creator_id=None,
             code="US",
@@ -194,6 +239,28 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(human_without_country.name, "Eva")
         self.assertIsNone(human_without_country.country)
 
+    def test_create_without_kwargs_checks_create_permission(self):
+        """
+        Creating with no field kwargs should still enforce class-level create permissions.
+        """
+        with self.assertRaises(PermissionError):
+            self.EmptyPayloadProject.create(creator_id=self.user.id)
+
+        project = self.EmptyPayloadProject.create(creator_id=self.admin_user.id)
+
+        self.assertEqual(project.name, "Untitled")
+
+    def test_create_without_kwargs_checks_group_create_permission(self):
+        """
+        Empty create payloads should enforce group-based create permissions.
+        """
+        with self.assertRaises(PermissionError):
+            self.InGroupEmptyPayloadProject.create(creator_id=self.user.id)
+
+        project = self.InGroupEmptyPayloadProject.create(creator_id=self.group_user.id)
+
+        self.assertEqual(project.name, "Grouped")
+
     def test_update_with_permission_validation(self):
         """
         Test updating a human's country association with permission enforcement.
@@ -212,6 +279,38 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             updated_human = updated_human.update(country=None)
         updated_human = updated_human.update(country=None, creator_id=self.user.id)  # type: ignore
         self.assertIsNone(updated_human.country)
+
+    def test_update_without_kwargs_checks_update_permission(self):
+        """
+        Updating with no field kwargs should still enforce class-level update permissions.
+        """
+        project = self.EmptyPayloadProject.create(
+            creator_id=self.admin_user.id,
+            ignore_permission=True,
+        )
+
+        with self.assertRaises(PermissionError):
+            project.update(creator_id=self.user.id)
+
+        updated_project = project.update(creator_id=self.admin_user.id)
+
+        self.assertEqual(updated_project.name, "Untitled")
+
+    def test_update_without_kwargs_checks_group_update_permission(self):
+        """
+        Empty update payloads should enforce group-based update permissions.
+        """
+        project = self.InGroupEmptyPayloadProject.create(
+            creator_id=self.group_user.id,
+            ignore_permission=True,
+        )
+
+        with self.assertRaises(PermissionError):
+            project.update(creator_id=self.user.id)
+
+        updated_project = project.update(creator_id=self.group_user.id)
+
+        self.assertEqual(updated_project.name, "Grouped")
 
     def test_delete_with_permissions(self):
         """

--- a/tests/unit/test_base_permission.py
+++ b/tests/unit/test_base_permission.py
@@ -68,6 +68,37 @@ class DummyPermission(BasePermission):
             return True
         return self.validate_permission_string(configured_permission)
 
+    def check_operation_permission(
+        self,
+        action: Literal["create", "read", "update", "delete"],
+    ) -> bool:
+        permission_map: dict[str, dict[str, str]] = {
+            "create": self.__class__.create_permissions,
+            "read": self.__class__.read_permissions,
+            "update": self.__class__.update_permissions,
+            "delete": self.__class__.delete_permissions,
+        }
+        configured_permission = permission_map.get(action, {}).get("")
+        if configured_permission is None:
+            return True
+        return self.validate_permission_string(configured_permission)
+
+    def describe_operation_permissions(
+        self,
+        action: Literal["create", "read", "update", "delete"],
+    ) -> tuple[str, ...]:
+        permission_map: dict[str, dict[str, str]] = {
+            "create": self.__class__.create_permissions,
+            "read": self.__class__.read_permissions,
+            "update": self.__class__.update_permissions,
+            "delete": self.__class__.delete_permissions,
+        }
+        return tuple(
+            permission
+            for permission in permission_map.get(action, {}).values()
+            if isinstance(permission, str)
+        )
+
     def get_permission_filter(
         self,
     ) -> list[dict[Literal["filter", "exclude"], dict[str, str]]]:
@@ -327,9 +358,8 @@ class BasePermissionTests(TestCase):
         self.assertIn("field2", error_str)
         self.assertIn("field3", error_str)
 
-    def test_permission_with_empty_data(self):
-        """Test permission checks with empty data dictionaries."""
-        # Should not raise any errors
+    def test_permission_with_empty_data_and_no_restrictions(self):
+        """Test empty create and update data pass when no rules deny them."""
         DummyPermission.check_create_permission({}, None, self.dummy_user)
         with patch(
             "general_manager.permission.base_permission.PermissionDataManager.for_update"

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -92,6 +92,12 @@ class _DummyPermission(BasePermission):
         """
         return None
 
+    def check_operation_permission(self, *args, **kwargs) -> bool:
+        return True
+
+    def describe_operation_permissions(self, *args, **kwargs) -> tuple[str, ...]:
+        return ()
+
     def get_permission_filter(self):
         """
         Provide the permission filter used for read operations.
@@ -175,6 +181,14 @@ class GraphQLHelperTests(SimpleTestCase):
             def check_permission(self, *args, **kwargs) -> bool:
                 return False
 
+            def check_operation_permission(self, *args, **kwargs) -> bool:
+                return False
+
+            def describe_operation_permissions(
+                self, *args, **kwargs
+            ) -> tuple[str, ...]:
+                return ()
+
             def can_read_instance(self) -> bool:
                 return False
 
@@ -202,6 +216,14 @@ class GraphQLHelperTests(SimpleTestCase):
         class AdminOnlyPermission(BasePermission):
             def check_permission(self, *args, **kwargs) -> bool:
                 return False
+
+            def check_operation_permission(self, *args, **kwargs) -> bool:
+                return False
+
+            def describe_operation_permissions(
+                self, *args, **kwargs
+            ) -> tuple[str, ...]:
+                return ()
 
             def can_read_instance(self) -> bool:
                 return False
@@ -263,6 +285,14 @@ class GraphQLHelperTests(SimpleTestCase):
 
             def check_permission(self, *args, **kwargs) -> bool:
                 return True
+
+            def check_operation_permission(self, *args, **kwargs) -> bool:
+                return True
+
+            def describe_operation_permissions(
+                self, *args, **kwargs
+            ) -> tuple[str, ...]:
+                return ()
 
             def can_read_instance(self) -> bool:
                 type(self).check_count += 1

--- a/tests/unit/test_graphql_search.py
+++ b/tests/unit/test_graphql_search.py
@@ -100,6 +100,12 @@ class ProjectPermission(BasePermission):
         """
         return True
 
+    def check_operation_permission(self, action):
+        return True
+
+    def describe_operation_permissions(self, action):
+        return ()
+
     def get_permission_filter(self):
         """
         Provide permission filters that restrict results to items with status "public".
@@ -345,6 +351,12 @@ class GraphQLSearchTests(SimpleTestCase):
                         `True` if the action is permitted (this permission always grants access), `False` otherwise.
                 """
                 return True
+
+            def check_operation_permission(self, action):
+                return True
+
+            def describe_operation_permissions(self, action):
+                return ()
 
             def get_permission_filter(self):
                 """

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -115,6 +115,12 @@ def test_general_manager_logging_for_create_and_queries() -> None:
         def check_permission(self, action: str, attribute: str) -> bool:  # type: ignore[override]
             return True
 
+        def check_operation_permission(self, action: str) -> bool:  # type: ignore[override]
+            return True
+
+        def describe_operation_permissions(self, action: str) -> tuple[str, ...]:  # type: ignore[override]
+            return ()
+
     original_interface = getattr(GeneralManager, "Interface", None)
     original_permission = getattr(GeneralManager, "Permission", None)
     original_attributes = getattr(GeneralManager, "_attributes", None)
@@ -206,6 +212,12 @@ def test_permission_check_logs_denial() -> None:
     class AlwaysDenyPermission(BasePermission):
         def check_permission(self, action: str, attribute: str) -> bool:  # type: ignore[override]
             return False
+
+        def check_operation_permission(self, action: str) -> bool:  # type: ignore[override]
+            return False
+
+        def describe_operation_permissions(self, action: str) -> tuple[str, ...]:  # type: ignore[override]
+            return ()
 
     user = AnonymousUser()
 

--- a/tests/unit/test_manager_based_permission.py
+++ b/tests/unit/test_manager_based_permission.py
@@ -30,6 +30,18 @@ class DummyPermission(BasePermission):
     ) -> bool:
         return True
 
+    def check_operation_permission(
+        self,
+        action: Literal["create", "read", "update", "delete"],
+    ) -> bool:
+        return True
+
+    def describe_operation_permissions(
+        self,
+        action: Literal["create", "read", "update", "delete"],
+    ) -> tuple[str, ...]:
+        return ()
+
     def get_permission_filter(
         self,
     ) -> list[dict[Literal["filter", "exclude"], dict[str, str]]]:
@@ -717,6 +729,62 @@ class ManagerBasedPermissionTests(TestCase):
 
         result = permission.check_permission("update", "non_specific_attr")
         self.assertFalse(result)
+
+    def test_operation_permission_uses_base_rule(self) -> None:
+        """Operation checks should evaluate the CRUD-level rule directly."""
+        permission = CustomManagerBasedPermission(self.mock_instance, self.user)
+
+        self.assertTrue(permission.check_operation_permission("create"))
+        self.assertFalse(permission.check_operation_permission("update"))
+
+    def test_operation_permission_uses_cached_result_without_based_on(self) -> None:
+        """Operation checks without delegation should cache per action."""
+
+        class AdminUpdatePermission(ManagerBasedPermission):
+            __based_on__: ClassVar[Optional[str]] = None
+            __update__: ClassVar[list[str]] = ["isAdmin"]
+
+        permission = AdminUpdatePermission(self.mock_instance, self.admin_user)
+
+        with patch.object(
+            AdminUpdatePermission,
+            "validate_permission_string",
+            return_value=True,
+        ) as mock_validate:
+            self.assertTrue(permission.check_operation_permission("update"))
+            self.assertTrue(permission.check_operation_permission("update"))
+
+        self.assertEqual(mock_validate.call_count, 1)
+
+    def test_operation_permission_with_superuser_bypasses_rules(self) -> None:
+        """Superusers should bypass operation-level rules."""
+        permission = CustomManagerBasedPermission(self.mock_instance, self.superuser)
+
+        self.assertTrue(permission.check_operation_permission("update"))
+
+    def test_operation_permission_with_based_on_denial(self) -> None:
+        """Delegated operation denial should block local operation permission."""
+        based_on_permission = Mock()
+        based_on_permission.check_operation_permission.return_value = False
+        self.mock_check.return_value = based_on_permission
+
+        permission = CustomManagerBasedPermission(self.mock_instance, self.admin_user)
+
+        self.assertFalse(permission.check_operation_permission("update"))
+        based_on_permission.check_operation_permission.assert_called_once_with("update")
+
+    def test_describe_operation_permissions_includes_based_on(self) -> None:
+        """Operation permission descriptions should include delegated rules."""
+        based_on_permission = Mock()
+        based_on_permission.describe_operation_permissions.return_value = ("delegated",)
+        self.mock_check.return_value = based_on_permission
+
+        permission = CustomManagerBasedPermission(self.mock_instance, self.user)
+
+        self.assertEqual(
+            permission.describe_operation_permissions("create"),
+            ("isAuthenticated", "delegated"),
+        )
 
     def test_override_describe_permissions_reports_effective_attribute_rule(
         self,

--- a/tests/unit/test_permission_audit.py
+++ b/tests/unit/test_permission_audit.py
@@ -54,6 +54,12 @@ class AuditDummyPermission(BasePermission):
     ) -> tuple[str, ...]:
         return (f"{action}:{attribute}",)
 
+    def check_operation_permission(self, action: str) -> bool:
+        return True
+
+    def describe_operation_permissions(self, action: str) -> tuple[str, ...]:
+        return (f"{action}:operation",)
+
 
 class AuditMutationPermission(MutationPermission):
     __mutate__: ClassVar[list[str]] = ["public"]
@@ -314,6 +320,84 @@ class PermissionAuditTests(TransactionTestCase):
         self.assertEqual(event.attributes, ("field",))
         self.assertTrue(event.granted)
         self.assertFalse(event.bypassed)
+
+    def test_audit_event_emitted_for_empty_create_payload(self) -> None:
+        """Empty create payloads should log an operation-level audit event."""
+        logger = RecordingAuditLogger()
+        configure_audit_logger(logger)
+
+        class DummyManager:
+            __name__ = "DummyManager"
+
+        AuditDummyPermission.check_create_permission({}, DummyManager, self.user)
+
+        self.assertEqual(len(logger.events), 1)
+        event = logger.events[0]
+        self.assertEqual(event.action, "create")
+        self.assertEqual(event.attributes, ())
+        self.assertEqual(event.permissions, ("create:operation",))
+        self.assertTrue(event.granted)
+        self.assertFalse(event.bypassed)
+
+    def test_audit_event_emitted_for_empty_update_payload(self) -> None:
+        """Empty update payloads should log an operation-level audit event."""
+        logger = RecordingAuditLogger()
+        configure_audit_logger(logger)
+
+        permission_data_manager = PermissionDataManager({}, None)
+        old_instance = type("DummyManager", (), {})()
+        with patch(
+            "general_manager.permission.base_permission.PermissionDataManager.for_update",
+            return_value=permission_data_manager,
+        ):
+            AuditDummyPermission.check_update_permission({}, old_instance, self.user)
+
+        self.assertEqual(len(logger.events), 1)
+        event = logger.events[0]
+        self.assertEqual(event.action, "update")
+        self.assertEqual(event.attributes, ())
+        self.assertEqual(event.permissions, ("update:operation",))
+        self.assertTrue(event.granted)
+        self.assertFalse(event.bypassed)
+
+    def test_superuser_empty_create_payload_bypass_logged(self) -> None:
+        """Superuser empty create payload bypasses should be audited."""
+        logger = RecordingAuditLogger()
+        configure_audit_logger(logger)
+
+        class DummyManager:
+            __name__ = "DummyManager"
+
+        AuditDummyPermission.check_create_permission({}, DummyManager, self.superuser)
+
+        self.assertEqual(len(logger.events), 1)
+        event = logger.events[0]
+        self.assertEqual(event.action, "create")
+        self.assertEqual(event.attributes, ())
+        self.assertTrue(event.bypassed)
+        self.assertTrue(event.granted)
+
+    def test_superuser_empty_update_payload_bypass_logged(self) -> None:
+        """Superuser empty update payload bypasses should be audited."""
+        logger = RecordingAuditLogger()
+        configure_audit_logger(logger)
+
+        permission_data_manager = PermissionDataManager({}, None)
+        old_instance = type("DummyManager", (), {})()
+        with patch(
+            "general_manager.permission.base_permission.PermissionDataManager.for_update",
+            return_value=permission_data_manager,
+        ):
+            AuditDummyPermission.check_update_permission(
+                {}, old_instance, self.superuser
+            )
+
+        self.assertEqual(len(logger.events), 1)
+        event = logger.events[0]
+        self.assertEqual(event.action, "update")
+        self.assertEqual(event.attributes, ())
+        self.assertTrue(event.bypassed)
+        self.assertTrue(event.granted)
 
     def test_audit_event_emitted_for_delete(self) -> None:
         """Test audit event emission for delete operations."""


### PR DESCRIPTION
## Summary

- Enforce CRUD-level create/update permission rules when `GeneralManager.create()` or `.update()` is called without field kwargs.
- Add operation-level permission methods to the base permission contract and implement them for manager-based permissions, including `__based_on__` delegation.
- Add integration coverage for no-kwargs create/update with `isAdmin` and `inGroup:Test` permissions.

## Root cause

`check_create_permission()` and `check_update_permission()` only iterated submitted payload keys. Empty payloads therefore skipped class-level permission gates such as `__create__` and `__update__`.

Fixes #200

## Validation

- `PYTHONPATH=src python -m pytest tests/integration/test_manager_based_permission.py tests/unit/test_base_permission.py tests/unit/test_manager_based_permission.py tests/unit/test_permission_audit.py tests/unit/test_graphql_search.py tests/unit/test_graphql_helpers.py tests/unit/test_logging.py`
- pre-commit during commit: ruff, formatting, whitespace checks, merge-conflict/debug checks, mypy
- `ruff check src/general_manager/permission/base_permission.py tests/unit/test_base_permission.py tests/unit/test_permission_audit.py tests/unit/test_manager_based_permission.py tests/unit/test_graphql_search.py tests/unit/test_graphql_helpers.py tests/unit/test_logging.py`
- `ruff format --check src/general_manager/permission/base_permission.py tests/unit/test_base_permission.py tests/unit/test_permission_audit.py tests/unit/test_manager_based_permission.py tests/unit/test_graphql_search.py tests/unit/test_graphql_helpers.py tests/unit/test_logging.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operation-level permission checks for CRUD actions, enabling more granular permission control when operations are performed without field data.

* **Improvements**
  * Enhanced permission denial messages for create and update operations with empty payloads.
  * Refined audit logging for permission evaluation on operations lacking field attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->