### PR TITLE
[codex] Expose GraphQL permission capabilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,5 @@ jobs:
         with:
           files: coverage.xml
           flags: unittests
+          version: v11.2.7
           fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ cython_debug/
 
 # todos:
 tasks/todo.md
+docs/superpowers/*

--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,4 @@ cython_debug/
 
 # todos:
 tasks/todo.md
-docs/superpowers/*
+docs/superpowers/

--- a/docs/adr/0007-graphql-capability-exposure.md
+++ b/docs/adr/0007-graphql-capability-exposure.md
@@ -1,0 +1,146 @@
+# ADR 0007: GraphQL capability exposure for frontend authorization
+
+## Status
+Proposed
+
+## Context
+GeneralManager already enforces backend authorization through manager
+permissions, GraphQL read filtering, and mutation checks. Frontends still need a
+safe way to ask business-oriented questions such as "can this user rename this
+project?" or "can this user create a derivative from this object?" without
+reading Django groups, permission strings, or role names.
+
+The GraphQL API needs this without weakening backend checks or adding N+1
+permission work in list queries. It also needs to avoid confusion with the
+existing interface capability system, which is an internal composition mechanism
+for interfaces.
+
+## Decision
+Add a dedicated GraphQL permission capability layer. Capability fields are
+advisory boolean hints for clients; real reads and writes continue to use the
+existing backend authorization path.
+
+### Declaration API
+Object capabilities are declared on a manager's nested `Permission` class:
+
+```python
+class Permission(AdditiveManagerPermission):
+    graphql_capabilities = (
+        permission_capability(Derivative, "create", name="canCreateDerivative"),
+        object_capability("canRename", can_rename_project),
+    )
+```
+
+The declarations live on `Permission`, not `Interface.configured_capabilities`,
+so frontend authorization metadata stays separate from interface composition
+capabilities.
+
+Provide three helpers:
+
+- `permission_capability(target, action, *, name=None, payload=None)` delegates
+  to the existing manager create/update/delete permission entrypoints.
+- `mutation_capability(mutation, *, name=None, payload=None)` delegates to the
+  real mutation permission path.
+- `object_capability(name, evaluator, *, batch_evaluator=None)` covers
+  domain-specific rules that cannot delegate to an existing operation.
+
+When omitted, helper-generated names use lower-camel business names such as
+`updateProject` or `renameProject`. Applications may override names whenever a
+more domain-specific label is clearer.
+
+### Current-user capabilities
+Global capabilities and current-user fields are supplied by an optional provider
+configured in Django settings:
+
+```python
+GENERAL_MANAGER = {
+    "GRAPHQL_GLOBAL_CAPABILITIES_PROVIDER": "my_app.auth.GraphQLCapabilities",
+}
+```
+
+The provider declares:
+
+- explicit whitelisted fields for `me`
+- global capability declarations for `me.capabilities`
+
+If no provider is configured, GraphQL does not expose a synthetic `me` object.
+There is no automatic exposure of the Django user model and no separate
+`user_capability(...)` helper.
+
+### GraphQL shape
+Managers with declared object capabilities get:
+
+```graphql
+Project {
+  capabilities: ProjectCapabilities!
+}
+```
+
+Configured global capabilities get:
+
+```graphql
+me: Me
+Me.capabilities: MeCapabilities!
+```
+
+Capability object types are generated and cached by the schema builder beside
+the existing generated GraphQL types.
+
+### Evaluation and caching
+Capability evaluation runs through an operation-scoped
+`CapabilityEvaluationContext`.
+
+- Query and mutation operations get a fresh context per operation.
+- Batched HTTP requests do not share capability cache entries between
+  operations.
+- Subscription events get a fresh context per emitted event to avoid stale
+  authorization results.
+
+Object cache keys use manager type, normalized interface identification, user
+identity, and capability name. They must not assume a single `id` field because
+GeneralManager supports composite and non-ORM identification.
+
+Capability evaluators are deny-on-error. Failures are logged, resolve to
+`false`, and are cached for the rest of the operation. Capability fields are
+non-null booleans, so clients never need to distinguish `false` from `null`.
+
+### List performance
+`object_capability(...)` may provide a `batch_evaluator`. List resolvers inspect
+the selected fields and warm capability results for the returned page when
+`capabilities` is requested.
+
+If no batch evaluator exists, or if batch evaluation fails, the resolver falls
+back to per-object evaluation through the same cached context.
+
+## Alternatives Considered
+### Expose raw groups, roles, or Django permissions
+Rejected. That would couple frontends to backend storage and policy details.
+
+### Auto-generate capability names from permission rules
+Rejected. The frontend contract should use stable domain language, not backend
+CRUD or field-level rule names.
+
+### Expose UI flags
+Rejected. Names such as `showAdminSidebarButton` encode presentation choices
+instead of authorization facts.
+
+### Resolve every row independently in lists
+Rejected. Lists need explicit batching and operation-scoped caching to avoid
+N+1 permission checks.
+
+## Consequences
+- Frontends get a stable, domain-oriented authorization contract.
+- Backend authorization remains the source of truth for all real operations.
+- Applications must explicitly declare the capability names they expose.
+- The GraphQL layer gains provider resolution, generated capability types,
+  resolver wiring, operation-scoped caching, and optional list warmup.
+
+## Implementation Plan
+1. Add declaration primitives, provider configuration, operation-scoped
+   evaluation context, and unit tests.
+2. Add the `Permission.graphql_capabilities` opt-in surface and public exports.
+3. Generate `me.capabilities` and per-object `capabilities` fields in GraphQL.
+4. Add resolver evaluation, selection-aware list warmup, deny-on-error logging,
+   and integration tests.
+5. Document declaration patterns, provider configuration, performance behavior,
+   and the advisory-only contract.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -8,3 +8,4 @@ This directory collects the Architecture Decision Records (ADRs) that document k
 - [ADR 0004: Capability-Driven Startup Hooks](0004-startup-hooks.md)
 - [ADR 0005: External search backends with unified search configuration](0005-search-backend.md)
 - [ADR 0006: Workflow engine architecture with pluggable backends](0006-workflow-engine-architecture.md)
+- [ADR 0007: GraphQL capability exposure for frontend authorization](0007-graphql-capability-exposure.md)

--- a/docs/api/permission.md
+++ b/docs/api/permission.md
@@ -22,6 +22,18 @@
 
 ::: general_manager.permission.permission_checks.permission_functions
 
+## GraphQL permission capabilities
+
+::: general_manager.permission.graphql_capabilities.object_capability
+
+::: general_manager.permission.graphql_capabilities.permission_capability
+
+::: general_manager.permission.graphql_capabilities.mutation_capability
+
+::: general_manager.permission.graphql_capabilities.CapabilityEvaluationContext
+
+::: general_manager.permission.graphql_capabilities.GraphQLPermissionCapability
+
 ## Audit logging
 
 ::: general_manager.permission.audit.AuditLogger

--- a/docs/concepts/graphql/security.md
+++ b/docs/concepts/graphql/security.md
@@ -58,12 +58,16 @@ GENERAL_MANAGER = {
 class GraphQLCapabilities:
     graphql_fields = {"username": str}
     graphql_capabilities = (
-        object_capability("canOpenAdmin", lambda _user, request_user: request_user.is_staff),
+        object_capability("canOpenAdmin", lambda instance, user: user.is_staff),
     )
 
     def resolve_username(self, user, info):
         return user.username
 ```
+
+For `object_capability`, the evaluator is called as `(instance, user)`, where
+`instance` is the provider or managed object and `user` is the requesting or
+resolved user.
 
 When no provider is configured, the schema does not expose `me`.
 

--- a/docs/concepts/graphql/security.md
+++ b/docs/concepts/graphql/security.md
@@ -7,8 +7,65 @@ Security in the GraphQL layer relies on permission checks and robust error handl
 - Every query obtains read filters from the manager's `Permission` class via `get_read_permission_filter()`.
 - Mutations invoke `check_create_permission`, `check_update_permission`, or `check_delete_permission` before executing. Permission errors translate into `success: false` responses with descriptive messages.
 - Attribute-level restrictions hide protected fields even when the user can access the object.
+- Optional GraphQL permission capabilities expose advisory boolean hints for clients. They do not replace read or mutation permission checks.
 
 Always execute GraphQL resolvers through managers; do not reach directly for Django models, or you will bypass permission rules.
+
+## Capability hints
+
+Declare object capability hints on the manager's nested `Permission` class:
+
+```python
+from general_manager.permission import AdditiveManagerPermission, object_capability
+
+
+def can_rename(project, user):
+    return project.status == "draft" and user.is_authenticated
+
+
+class Project(GeneralManager):
+    class Permission(AdditiveManagerPermission):
+        graphql_capabilities = (
+            object_capability("canRename", can_rename),
+        )
+```
+
+Managers with declarations expose a generated non-null capability object:
+
+```graphql
+query {
+  projectList {
+    items {
+      name
+      capabilities {
+        canRename
+      }
+    }
+  }
+}
+```
+
+Use `batch_evaluator=` on `object_capability(...)` for list pages that would otherwise repeat expensive policy checks. Batch warmup runs only when `items { capabilities { ... } }` is selected, and any evaluator exception is logged and resolved as `false`.
+
+Projects can also configure current-user capability hints:
+
+```python
+GENERAL_MANAGER = {
+    "GRAPHQL_GLOBAL_CAPABILITIES_PROVIDER": "my_app.auth.GraphQLCapabilities",
+}
+
+
+class GraphQLCapabilities:
+    graphql_fields = {"username": str}
+    graphql_capabilities = (
+        object_capability("canOpenAdmin", lambda _user, request_user: request_user.is_staff),
+    )
+
+    def resolve_username(self, user, info):
+        return user.username
+```
+
+When no provider is configured, the schema does not expose `me`.
 
 ## Authentication
 

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -1,3 +1,39 @@
 # Expose Managers via GraphQL
 
-TBD
+Managers with an `Interface` are registered during GeneralManager startup and receive generated query, mutation, and subscription fields based on their interface capabilities.
+
+## Expose authorization hints
+
+Use GraphQL permission capabilities when frontend code needs business-oriented authorization hints, such as whether the current user can rename a project. These fields are advisory only; backend permissions still enforce all reads and writes.
+
+```python
+from general_manager.permission import AdditiveManagerPermission, object_capability
+
+
+def can_rename_project(project, user):
+    return project.status == "draft" and user.is_authenticated
+
+
+class Project(GeneralManager):
+    class Permission(AdditiveManagerPermission):
+        graphql_capabilities = (
+            object_capability("canRename", can_rename_project),
+        )
+```
+
+Query the generated capability object:
+
+```graphql
+query {
+  projectList {
+    items {
+      name
+      capabilities {
+        canRename
+      }
+    }
+  }
+}
+```
+
+For list-heavy checks, pass `batch_evaluator=` to `object_capability(...)`. The list resolver warms capability values for the returned page only when `capabilities` is selected.

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -7,6 +7,7 @@ Managers with an `Interface` are registered during GeneralManager startup and re
 Use GraphQL permission capabilities when frontend code needs business-oriented authorization hints, such as whether the current user can rename a project. These fields are advisory only; backend permissions still enforce all reads and writes.
 
 ```python
+from general_manager import GeneralManager
 from general_manager.permission import AdditiveManagerPermission, object_capability
 
 

--- a/src/general_manager/_types/api.py
+++ b/src/general_manager/_types/api.py
@@ -14,6 +14,6 @@ __all__ = [
 from general_manager.api.graphql import GraphQL
 from general_manager.api.graphql import MeasurementScalar
 from general_manager.api.graphql import MeasurementType
-from general_manager.api.remote_invalidation_client import RemoteInvalidationClient
 from general_manager.api.mutation import graph_ql_mutation
 from general_manager.api.property import graph_ql_property
+from general_manager.api.remote_invalidation_client import RemoteInvalidationClient

--- a/src/general_manager/_types/api.py
+++ b/src/general_manager/_types/api.py
@@ -14,6 +14,6 @@ __all__ = [
 from general_manager.api.graphql import GraphQL
 from general_manager.api.graphql import MeasurementScalar
 from general_manager.api.graphql import MeasurementType
+from general_manager.api.remote_invalidation_client import RemoteInvalidationClient
 from general_manager.api.mutation import graph_ql_mutation
 from general_manager.api.property import graph_ql_property
-from general_manager.api.remote_invalidation_client import RemoteInvalidationClient

--- a/src/general_manager/_types/general_manager.py
+++ b/src/general_manager/_types/general_manager.py
@@ -7,45 +7,65 @@ __all__ = [
     "CalculationInterface",
     "DatabaseInterface",
     "ExistingModelInterface",
+    "FieldConfig",
     "GeneralManager",
     "GraphQL",
+    "IndexConfig",
     "Input",
     "ManagerBasedPermission",
     "OverrideManagerPermission",
     "ReadOnlyInterface",
+    "RemoteManagerInterface",
+    "RequestInterface",
     "Rule",
+    "SearchBackend",
+    "SearchConfigProtocol",
+    "SearchConfigSpec",
+    "SearchIndexer",
+    "configure_search_backend",
+    "configure_search_backend_from_settings",
     "get_logger",
+    "get_search_backend",
     "graph_ql_mutation",
     "graph_ql_property",
+    "iter_index_names",
     "permission_functions",
     "register_permission",
+    "resolve_search_config",
 ]
 
-from general_manager.interface.interfaces.calculation import (
-    CalculationInterface,
-)
-from general_manager.interface.interfaces.database import (
-    DatabaseInterface,
-)
-from general_manager.interface.interfaces.existing_model import (
-    ExistingModelInterface,
-)
-from general_manager.manager.general_manager import GeneralManager
-from general_manager.api.graphql import GraphQL
-from general_manager.manager.input import Input
 from general_manager.permission.manager_based_permission import (
     AdditiveManagerPermission,
 )
+from general_manager.interface.interfaces.calculation import CalculationInterface
+from general_manager.interface.interfaces.database import DatabaseInterface
+from general_manager.interface.interfaces.existing_model import ExistingModelInterface
+from general_manager.search.config import FieldConfig
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.api.graphql import GraphQL
+from general_manager.search.config import IndexConfig
+from general_manager.manager.input import Input
 from general_manager.permission.manager_based_permission import ManagerBasedPermission
 from general_manager.permission.manager_based_permission import (
     OverrideManagerPermission,
 )
-from general_manager.interface.interfaces.read_only import (
-    ReadOnlyInterface,
-)
+from general_manager.interface.interfaces.read_only import ReadOnlyInterface
+from general_manager.interface.interfaces.remote_manager import RemoteManagerInterface
+from general_manager.interface.interfaces.request import RequestInterface
 from general_manager.rule.rule import Rule
+from general_manager.search.backend import SearchBackend
+from general_manager.search.config import SearchConfigProtocol
+from general_manager.search.config import SearchConfigSpec
+from general_manager.search.indexer import SearchIndexer
+from general_manager.search.backend_registry import configure_search_backend
+from general_manager.search.backend_registry import (
+    configure_search_backend_from_settings,
+)
 from general_manager.logging import get_logger
+from general_manager.search.backend_registry import get_search_backend
 from general_manager.api.mutation import graph_ql_mutation
 from general_manager.api.property import graph_ql_property
+from general_manager.search.config import iter_index_names
 from general_manager.permission.permission_checks import permission_functions
 from general_manager.permission.permission_checks import register_permission
+from general_manager.search.config import resolve_search_config

--- a/src/general_manager/_types/general_manager.py
+++ b/src/general_manager/_types/general_manager.py
@@ -7,10 +7,8 @@ __all__ = [
     "CalculationInterface",
     "DatabaseInterface",
     "ExistingModelInterface",
-    "FieldConfig",
     "GeneralManager",
     "GraphQL",
-    "IndexConfig",
     "Input",
     "ManagerBasedPermission",
     "OverrideManagerPermission",
@@ -18,20 +16,11 @@ __all__ = [
     "RemoteManagerInterface",
     "RequestInterface",
     "Rule",
-    "SearchBackend",
-    "SearchConfigProtocol",
-    "SearchConfigSpec",
-    "SearchIndexer",
-    "configure_search_backend",
-    "configure_search_backend_from_settings",
     "get_logger",
-    "get_search_backend",
     "graph_ql_mutation",
     "graph_ql_property",
-    "iter_index_names",
     "permission_functions",
     "register_permission",
-    "resolve_search_config",
 ]
 
 from general_manager.permission.manager_based_permission import (
@@ -40,10 +29,8 @@ from general_manager.permission.manager_based_permission import (
 from general_manager.interface.interfaces.calculation import CalculationInterface
 from general_manager.interface.interfaces.database import DatabaseInterface
 from general_manager.interface.interfaces.existing_model import ExistingModelInterface
-from general_manager.search.config import FieldConfig
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.api.graphql import GraphQL
-from general_manager.search.config import IndexConfig
 from general_manager.manager.input import Input
 from general_manager.permission.manager_based_permission import ManagerBasedPermission
 from general_manager.permission.manager_based_permission import (
@@ -53,19 +40,8 @@ from general_manager.interface.interfaces.read_only import ReadOnlyInterface
 from general_manager.interface.interfaces.remote_manager import RemoteManagerInterface
 from general_manager.interface.interfaces.request import RequestInterface
 from general_manager.rule.rule import Rule
-from general_manager.search.backend import SearchBackend
-from general_manager.search.config import SearchConfigProtocol
-from general_manager.search.config import SearchConfigSpec
-from general_manager.search.indexer import SearchIndexer
-from general_manager.search.backend_registry import configure_search_backend
-from general_manager.search.backend_registry import (
-    configure_search_backend_from_settings,
-)
 from general_manager.logging import get_logger
-from general_manager.search.backend_registry import get_search_backend
 from general_manager.api.mutation import graph_ql_mutation
 from general_manager.api.property import graph_ql_property
-from general_manager.search.config import iter_index_names
 from general_manager.permission.permission_checks import permission_functions
 from general_manager.permission.permission_checks import register_permission
-from general_manager.search.config import resolve_search_config

--- a/src/general_manager/_types/interface.py
+++ b/src/general_manager/_types/interface.py
@@ -3,47 +3,85 @@ from __future__ import annotations
 """Type-only imports for public API re-exports."""
 
 __all__ = [
+    "BasicAuthProvider",
+    "BearerTokenAuthProvider",
     "CalculationInterface",
     "DatabaseInterface",
     "ExistingModelInterface",
+    "FieldMappingSerializer",
+    "HeaderApiKeyAuthProvider",
     "InterfaceBase",
+    "NoopRequestMetricsBackend",
+    "NoopRequestTraceBackend",
     "OrmInterfaceBase",
+    "QueryApiKeyAuthProvider",
     "ReadOnlyInterface",
     "RemoteManagerInterface",
+    "RequestAuthProvider",
+    "RequestAuthenticationError",
+    "RequestAuthorizationError",
+    "RequestConflictError",
     "RequestField",
     "RequestFilter",
     "RequestInterface",
+    "RequestMetricsBackend",
+    "RequestMutationOperation",
+    "RequestNotFoundError",
     "RequestQueryOperation",
     "RequestQueryPlan",
     "RequestQueryResult",
+    "RequestRateLimitedError",
+    "RequestRemoteError",
+    "RequestRetryPolicy",
+    "RequestSchemaError",
+    "RequestServerError",
+    "RequestTraceBackend",
+    "RequestTransportConfig",
+    "RequestTransportError",
+    "RequestTransportRequest",
+    "RequestTransportResponse",
+    "RequestTransportStatusError",
+    "SharedRequestTransport",
+    "UrllibRequestTransport",
 ]
 
-from general_manager.interface.interfaces.calculation import (
-    CalculationInterface,
-)
-from general_manager.interface.requests import (
-    RequestField,
-    RequestFilter,
-    RequestQueryOperation,
-    RequestQueryPlan,
-    RequestQueryResult,
-)
-from general_manager.interface.orm_interface import (
-    OrmInterfaceBase,
-)
-from general_manager.interface.interfaces.database import (
-    DatabaseInterface,
-)
-from general_manager.interface.interfaces.existing_model import (
-    ExistingModelInterface,
-)
+from general_manager.interface.requests import BasicAuthProvider
+from general_manager.interface.requests import BearerTokenAuthProvider
+from general_manager.interface.interfaces.calculation import CalculationInterface
+from general_manager.interface.interfaces.database import DatabaseInterface
+from general_manager.interface.interfaces.existing_model import ExistingModelInterface
+from general_manager.interface.requests import FieldMappingSerializer
+from general_manager.interface.requests import HeaderApiKeyAuthProvider
 from general_manager.interface.base_interface import InterfaceBase
-from general_manager.interface.interfaces.read_only import (
-    ReadOnlyInterface,
-)
-from general_manager.interface.interfaces.remote_manager import (
-    RemoteManagerInterface,
-)
-from general_manager.interface.interfaces.request import (
-    RequestInterface,
-)
+from general_manager.interface.requests import NoopRequestMetricsBackend
+from general_manager.interface.requests import NoopRequestTraceBackend
+from general_manager.interface.orm_interface import OrmInterfaceBase
+from general_manager.interface.requests import QueryApiKeyAuthProvider
+from general_manager.interface.interfaces.read_only import ReadOnlyInterface
+from general_manager.interface.interfaces.remote_manager import RemoteManagerInterface
+from general_manager.interface.requests import RequestAuthProvider
+from general_manager.interface.requests import RequestAuthenticationError
+from general_manager.interface.requests import RequestAuthorizationError
+from general_manager.interface.requests import RequestConflictError
+from general_manager.interface.requests import RequestField
+from general_manager.interface.requests import RequestFilter
+from general_manager.interface.interfaces.request import RequestInterface
+from general_manager.interface.requests import RequestMetricsBackend
+from general_manager.interface.requests import RequestMutationOperation
+from general_manager.interface.requests import RequestNotFoundError
+from general_manager.interface.requests import RequestQueryOperation
+from general_manager.interface.requests import RequestQueryPlan
+from general_manager.interface.requests import RequestQueryResult
+from general_manager.interface.requests import RequestRateLimitedError
+from general_manager.interface.requests import RequestRemoteError
+from general_manager.interface.requests import RequestRetryPolicy
+from general_manager.interface.requests import RequestSchemaError
+from general_manager.interface.requests import RequestServerError
+from general_manager.interface.requests import RequestTraceBackend
+from general_manager.interface.requests import RequestTransportConfig
+from general_manager.interface.requests import RequestTransportError
+from general_manager.interface.requests import RequestTransportRequest
+from general_manager.interface.requests import RequestTransportResponse
+from general_manager.interface.requests import RequestTransportStatusError
+from general_manager.interface.requests import SharedRequestTransport
+from general_manager.interface.requests import UrllibRequestTransport

--- a/src/general_manager/_types/manager.py
+++ b/src/general_manager/_types/manager.py
@@ -13,13 +13,11 @@ __all__ = [
     "graph_ql_property",
 ]
 
-from general_manager.manager.input import (
-    DateRangeDomain,
-    Input,
-    InputDomain,
-    NumericRangeDomain,
-)
+from general_manager.manager.input import DateRangeDomain
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.manager.group_manager import GroupManager
+from general_manager.manager.input import Input
+from general_manager.manager.input import InputDomain
+from general_manager.manager.input import NumericRangeDomain
 from general_manager.api.property import graph_ql_property

--- a/src/general_manager/_types/permission.py
+++ b/src/general_manager/_types/permission.py
@@ -6,14 +6,19 @@ __all__ = [
     "AdditiveManagerPermission",
     "AuditLogger",
     "BasePermission",
+    "CapabilityEvaluationContext",
     "DatabaseAuditLogger",
     "FileAuditLogger",
+    "GraphQLPermissionCapability",
     "ManagerBasedPermission",
     "MutationPermission",
     "OverrideManagerPermission",
     "PermissionAuditEvent",
     "configure_audit_logger",
     "configure_audit_logger_from_settings",
+    "mutation_capability",
+    "object_capability",
+    "permission_capability",
     "permission_functions",
     "register_permission",
 ]
@@ -23,15 +28,20 @@ from general_manager.permission.manager_based_permission import (
 )
 from general_manager.permission.audit import AuditLogger
 from general_manager.permission.base_permission import BasePermission
+from general_manager.permission.graphql_capabilities import CapabilityEvaluationContext
 from general_manager.permission.audit import DatabaseAuditLogger
 from general_manager.permission.audit import FileAuditLogger
+from general_manager.permission.graphql_capabilities import GraphQLPermissionCapability
 from general_manager.permission.manager_based_permission import ManagerBasedPermission
+from general_manager.permission.mutation_permission import MutationPermission
 from general_manager.permission.manager_based_permission import (
     OverrideManagerPermission,
 )
-from general_manager.permission.mutation_permission import MutationPermission
 from general_manager.permission.audit import PermissionAuditEvent
 from general_manager.permission.audit import configure_audit_logger
 from general_manager.permission.audit import configure_audit_logger_from_settings
+from general_manager.permission.graphql_capabilities import mutation_capability
+from general_manager.permission.graphql_capabilities import object_capability
+from general_manager.permission.graphql_capabilities import permission_capability
 from general_manager.permission.permission_checks import permission_functions
 from general_manager.permission.permission_checks import register_permission

--- a/src/general_manager/_types/search.py
+++ b/src/general_manager/_types/search.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Type-only imports for public API re-exports."""
+
+__all__ = [
+    "DevSearchBackend",
+    "FieldConfig",
+    "IndexConfig",
+    "MeilisearchBackend",
+    "OpenSearchBackend",
+    "SearchBackend",
+    "SearchBackendClientMissingError",
+    "SearchBackendError",
+    "SearchBackendNotConfiguredError",
+    "SearchBackendNotImplementedError",
+    "SearchConfigProtocol",
+    "SearchConfigSpec",
+    "SearchDocument",
+    "SearchHit",
+    "SearchIndexer",
+    "SearchResult",
+    "TypesenseBackend",
+    "configure_search_backend",
+    "configure_search_backend_from_settings",
+    "get_search_backend",
+    "iter_index_names",
+    "resolve_search_config",
+]
+
+from general_manager.search.backends.dev import DevSearchBackend
+from general_manager.search.config import FieldConfig
+from general_manager.search.config import IndexConfig
+from general_manager.search.backends.meilisearch import MeilisearchBackend
+from general_manager.search.backends.opensearch import OpenSearchBackend
+from general_manager.search.backend import SearchBackend
+from general_manager.search.backend import SearchBackendClientMissingError
+from general_manager.search.backend import SearchBackendError
+from general_manager.search.backend import SearchBackendNotConfiguredError
+from general_manager.search.backend import SearchBackendNotImplementedError
+from general_manager.search.config import SearchConfigProtocol
+from general_manager.search.config import SearchConfigSpec
+from general_manager.search.backend import SearchDocument
+from general_manager.search.backend import SearchHit
+from general_manager.search.indexer import SearchIndexer
+from general_manager.search.backend import SearchResult
+from general_manager.search.backends.typesense import TypesenseBackend
+from general_manager.search.backend_registry import configure_search_backend
+from general_manager.search.backend_registry import (
+    configure_search_backend_from_settings,
+)
+from general_manager.search.backend_registry import get_search_backend
+from general_manager.search.config import iter_index_names
+from general_manager.search.config import resolve_search_config

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -201,6 +201,7 @@ class GraphQL:
             subscription_payload_registry=dict(cls._subscription_payload_registry),
             graphql_type_registry=dict(cls.graphql_type_registry),
             graphql_filter_type_registry=dict(cls.graphql_filter_type_registry),
+            graphql_capability_type_registry=dict(cls.graphql_capability_type_registry),
             manager_registry=dict(cls.manager_registry),
             search_union=cls._search_union,
             search_result_type=cls._search_result_type,

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -43,6 +43,7 @@ from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
 from general_manager.permission.graphql_capabilities import (
     GraphQLPermissionCapability,
+    clear_capability_context,
     get_capability_context,
     get_graphql_capabilities,
 )
@@ -1167,6 +1168,7 @@ class GraphQL:
                     When the iterator is closed or exits, the background listener task is cancelled and the subscription's channel group memberships are discarded.
                 """
                 try:
+                    clear_capability_context(info)
                     yield SubscriptionEvent(item=instance, action="snapshot")
                     while True:
                         action = await queue.get()
@@ -1179,6 +1181,7 @@ class GraphQL:
                             )
                         except HANDLED_MANAGER_ERRORS:
                             item = None
+                        clear_capability_context(info)
                         yield SubscriptionEvent(item=item, action=action)
                 finally:
                     listener_task.cancel()

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -28,6 +28,7 @@ from typing import (
 import graphene  # type: ignore[import]
 from asgiref.sync import async_to_sync
 from channels.layers import BaseChannelLayer
+from django.utils.module_loading import import_string
 
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.bucket.group_bucket import GroupBucket
@@ -35,10 +36,16 @@ from general_manager.cache.dependency_index import (
     Dependency,
 )
 from general_manager.cache.signals import post_data_change
+from general_manager.conf import get_setting
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.logging import get_logger
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
+from general_manager.permission.graphql_capabilities import (
+    GraphQLPermissionCapability,
+    get_capability_context,
+    get_graphql_capabilities,
+)
 from general_manager.utils.type_checks import safe_issubclass
 
 from graphql import GraphQLError
@@ -127,6 +134,9 @@ class GraphQL:
     _subscription_payload_registry: ClassVar[dict[str, type[graphene.ObjectType]]] = {}
     graphql_type_registry: ClassVar[dict[str, type]] = {}
     graphql_filter_type_registry: ClassVar[dict[str, type]] = {}
+    graphql_capability_type_registry: ClassVar[
+        dict[str, type[graphene.ObjectType]]
+    ] = {}
     manager_registry: ClassVar[dict[str, type[GeneralManager]]] = {}
     _search_union: ClassVar[type[graphene.Union] | None] = None
     _search_result_type: ClassVar[type[graphene.ObjectType] | None] = None
@@ -164,6 +174,7 @@ class GraphQL:
         cls._subscription_payload_registry = {}
         cls.graphql_type_registry = {}
         cls.graphql_filter_type_registry = {}
+        cls.graphql_capability_type_registry = {}
         cls.manager_registry = {}
         cls._search_union = None
         cls._search_result_type = None
@@ -370,6 +381,23 @@ class GraphQL:
                 attr_name, resolved_type
             )
 
+        capability_declarations = get_graphql_capabilities(generalManagerClass)
+        if capability_declarations:
+            capability_type = cls._get_or_create_capability_type(
+                generalManagerClass,
+                capability_declarations,
+            )
+            fields["capabilities"] = graphene.Field(capability_type, required=True)
+
+            def resolve_capabilities(
+                manager_instance: GeneralManager,
+                info: GraphQLResolveInfo,
+            ) -> dict[str, GeneralManager]:
+                del info
+                return {"instance": manager_instance}
+
+            fields["resolve_capabilities"] = resolve_capabilities
+
         graphene_type = type(graphene_type_name, (graphene.ObjectType,), fields)
         cls.graphql_type_registry[generalManagerClass.__name__] = graphene_type
         cls.manager_registry[generalManagerClass.__name__] = generalManagerClass
@@ -385,6 +413,138 @@ class GraphQL:
                 "fields": exposed_fields,
             },
         )
+
+    @classmethod
+    def _get_or_create_capability_type(
+        cls,
+        generalManagerClass: type[GeneralManager],
+        declarations: tuple[GraphQLPermissionCapability, ...],
+    ) -> type[graphene.ObjectType]:
+        """Build or return the generated GraphQL capabilities type for a manager."""
+        type_name = f"{generalManagerClass.__name__}Capabilities"
+        if type_name in cls.graphql_capability_type_registry:
+            return cls.graphql_capability_type_registry[type_name]
+
+        fields: dict[str, Any] = {}
+        for declaration in declarations:
+            fields[declaration.name] = graphene.Boolean(required=True)
+
+            def resolver(
+                parent: dict[str, GeneralManager],
+                info: GraphQLResolveInfo,
+                *,
+                capability: GraphQLPermissionCapability = declaration,
+            ) -> bool:
+                return get_capability_context(info).evaluate(
+                    capability,
+                    parent["instance"],
+                )
+
+            fields[f"resolve_{declaration.name}"] = resolver
+
+        capability_type = type(type_name, (graphene.ObjectType,), fields)
+        cls.graphql_capability_type_registry[type_name] = capability_type
+        return capability_type
+
+    @classmethod
+    def register_current_user_capabilities(cls) -> None:
+        """Register the optional provider-backed ``me`` GraphQL field."""
+        provider = cls._get_current_user_capability_provider()
+        if provider is None:
+            return
+
+        me_fields: dict[str, Any] = {}
+        configured_fields = getattr(provider, "graphql_fields", {}) or {}
+        for field_name, field_type in configured_fields.items():
+            if isinstance(field_type, graphene.Field):
+                me_fields[field_name] = field_type
+            else:
+                me_fields[field_name] = cls._map_field_to_graphene_base_type(
+                    cast(type, field_type)
+                )()
+
+            def field_resolver(
+                user: Any,
+                info: GraphQLResolveInfo,
+                *,
+                provider_instance: Any = provider,
+                configured_name: str = field_name,
+            ) -> Any:
+                resolver = getattr(
+                    provider_instance,
+                    f"resolve_{configured_name}",
+                    None,
+                )
+                if callable(resolver):
+                    return resolver(user, info)
+                return getattr(user, configured_name)
+
+            me_fields[f"resolve_{field_name}"] = field_resolver
+
+        declarations = tuple(
+            declaration
+            for declaration in (getattr(provider, "graphql_capabilities", ()) or ())
+            if isinstance(declaration, GraphQLPermissionCapability)
+        )
+        if declarations:
+            capability_type = cls._get_or_create_current_user_capability_type(
+                declarations
+            )
+            me_fields["capabilities"] = graphene.Field(capability_type, required=True)
+
+            def resolve_capabilities(
+                user: Any, info: GraphQLResolveInfo
+            ) -> dict[str, Any]:
+                del info
+                return {"instance": user}
+
+            me_fields["resolve_capabilities"] = resolve_capabilities
+
+        me_type = type("Me", (graphene.ObjectType,), me_fields)
+        cls._query_fields["me"] = graphene.Field(me_type)
+
+        def resolve_me(_root: Any, info: GraphQLResolveInfo) -> Any:
+            return getattr(info.context, "user", None)
+
+        cls._query_fields["resolve_me"] = resolve_me
+
+    @classmethod
+    def _get_or_create_current_user_capability_type(
+        cls,
+        declarations: tuple[GraphQLPermissionCapability, ...],
+    ) -> type[graphene.ObjectType]:
+        type_name = "MeCapabilities"
+        if type_name in cls.graphql_capability_type_registry:
+            return cls.graphql_capability_type_registry[type_name]
+
+        fields: dict[str, Any] = {}
+        for declaration in declarations:
+            fields[declaration.name] = graphene.Boolean(required=True)
+
+            def resolver(
+                parent: dict[str, Any],
+                info: GraphQLResolveInfo,
+                *,
+                capability: GraphQLPermissionCapability = declaration,
+            ) -> bool:
+                return get_capability_context(info).evaluate(
+                    capability,
+                    parent["instance"],
+                )
+
+            fields[f"resolve_{declaration.name}"] = resolver
+
+        capability_type = type(type_name, (graphene.ObjectType,), fields)
+        cls.graphql_capability_type_registry[type_name] = capability_type
+        return capability_type
+
+    @staticmethod
+    def _get_current_user_capability_provider() -> Any | None:
+        provider_path = get_setting("GRAPHQL_GLOBAL_CAPABILITIES_PROVIDER")
+        if not provider_path:
+            return None
+        provider_class = import_string(provider_path)
+        return provider_class()
 
     @staticmethod
     def _sort_by_options(

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -484,15 +484,17 @@ def create_list_resolver(
 
         total_count = len(qs_grouped)
 
-        qs_paginated = apply_pagination(qs_grouped, page, page_size)
-        if not hasattr(qs_paginated, "groups") and selection_includes_path(
+        qs_paginated: Any = apply_pagination(qs_grouped, page, page_size)
+        if not hasattr(qs_paginated, "groups"):
+            qs_paginated = list(qs_paginated)
+        if isinstance(qs_paginated, list) and selection_includes_path(
             info, ("items", "capabilities")
         ):
             capability_declarations = get_graphql_capabilities(manager_class)
             if capability_declarations:
                 get_capability_context(info).warm(
                     capability_declarations,
-                    list(qs_paginated),
+                    qs_paginated,
                 )
 
         page_info = {
@@ -522,6 +524,7 @@ def selection_includes_path(
             getattr(field_node, "selection_set", None),
             path,
             info,
+            frozenset(),
         )
         for field_node in field_nodes
     )
@@ -531,6 +534,7 @@ def _selection_set_includes_path(
     selection_set: Any,
     path: tuple[str, ...],
     info: GraphQLResolveInfo,
+    visited: frozenset[str],
 ) -> bool:
     if selection_set is None or not path:
         return False
@@ -541,17 +545,31 @@ def _selection_set_includes_path(
                 continue
             if not rest:
                 return True
-            if _selection_set_includes_path(selection.selection_set, tuple(rest), info):
+            if _selection_set_includes_path(
+                selection.selection_set,
+                tuple(rest),
+                info,
+                visited,
+            ):
                 return True
         elif isinstance(selection, InlineFragmentNode):
-            if _selection_set_includes_path(selection.selection_set, path, info):
+            if _selection_set_includes_path(
+                selection.selection_set,
+                path,
+                info,
+                visited,
+            ):
                 return True
         elif isinstance(selection, FragmentSpreadNode):
-            fragment = info.fragments.get(selection.name.value)
+            fragment_name = selection.name.value
+            if fragment_name in visited:
+                continue
+            fragment = info.fragments.get(fragment_name)
             if fragment and _selection_set_includes_path(
                 fragment.selection_set,
                 path,
                 info,
+                visited | frozenset((fragment_name,)),
             ):
                 return True
     return False

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -14,12 +14,17 @@ from dataclasses import dataclass
 from typing import Any, Callable, Generic, TYPE_CHECKING, TypeVar, cast
 
 import graphene  # type: ignore[import]
+from graphql.language.ast import FieldNode, FragmentSpreadNode, InlineFragmentNode
 
 from general_manager.logging import get_logger
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
 from general_manager.api.graphql_errors import get_read_permission_filter
+from general_manager.permission.graphql_capabilities import (
+    get_capability_context,
+    get_graphql_capabilities,
+)
 from general_manager.utils.type_checks import safe_issubclass
 
 if TYPE_CHECKING:
@@ -480,6 +485,15 @@ def create_list_resolver(
         total_count = len(qs_grouped)
 
         qs_paginated = apply_pagination(qs_grouped, page, page_size)
+        if not hasattr(qs_paginated, "groups") and selection_includes_path(
+            info, ("items", "capabilities")
+        ):
+            capability_declarations = get_graphql_capabilities(manager_class)
+            if capability_declarations:
+                get_capability_context(info).warm(
+                    capability_declarations,
+                    list(qs_paginated),
+                )
 
         page_info = {
             "total_count": total_count,
@@ -495,6 +509,52 @@ def create_list_resolver(
         }
 
     return resolver
+
+
+def selection_includes_path(
+    info: GraphQLResolveInfo,
+    path: tuple[str, ...],
+) -> bool:
+    """Return whether the current field selection includes the nested path."""
+    field_nodes = getattr(info, "field_nodes", ())
+    return any(
+        _selection_set_includes_path(
+            getattr(field_node, "selection_set", None),
+            path,
+            info,
+        )
+        for field_node in field_nodes
+    )
+
+
+def _selection_set_includes_path(
+    selection_set: Any,
+    path: tuple[str, ...],
+    info: GraphQLResolveInfo,
+) -> bool:
+    if selection_set is None or not path:
+        return False
+    target, *rest = path
+    for selection in selection_set.selections:
+        if isinstance(selection, FieldNode):
+            if selection.name.value != target:
+                continue
+            if not rest:
+                return True
+            if _selection_set_includes_path(selection.selection_set, tuple(rest), info):
+                return True
+        elif isinstance(selection, InlineFragmentNode):
+            if _selection_set_includes_path(selection.selection_set, path, info):
+                return True
+        elif isinstance(selection, FragmentSpreadNode):
+            fragment = info.fragments.get(selection.name.value)
+            if fragment and _selection_set_includes_path(
+                fragment.selection_set,
+                path,
+                info,
+            ):
+                return True
+    return False
 
 
 def create_resolver(field_name: str, field_type: type) -> Callable[..., Any]:

--- a/src/general_manager/api/mutation.py
+++ b/src/general_manager/api/mutation.py
@@ -124,6 +124,7 @@ def graph_ql_mutation(
         Returns:
             Callable[..., Any]: Original function after registration.
         """
+        cast(Any, fn)._general_manager_mutation_permission = permission
         sig = inspect.signature(fn)
         hints = get_type_hints(fn)
 

--- a/src/general_manager/api/registry.py
+++ b/src/general_manager/api/registry.py
@@ -2,7 +2,7 @@
 GraphQLRegistry — a typed container for all mutable state managed by the
 ``GraphQL`` class.
 
-Extracting the 13 ``ClassVar`` registries into a single dataclass makes the
+Extracting the ``ClassVar`` registries into a single dataclass makes the
 state explicit, documentable, and resettable:
 
     from general_manager.api.graphql import GraphQL

--- a/src/general_manager/api/registry.py
+++ b/src/general_manager/api/registry.py
@@ -59,6 +59,9 @@ class GraphQLRegistry:
     )
     graphql_type_registry: dict[str, type] = field(default_factory=dict)
     graphql_filter_type_registry: dict[str, type] = field(default_factory=dict)
+    graphql_capability_type_registry: dict[str, type[graphene.ObjectType]] = field(
+        default_factory=dict
+    )
     manager_registry: dict[str, type[GeneralManager]] = field(default_factory=dict)
 
     # Search

--- a/src/general_manager/bootstrap.py
+++ b/src/general_manager/bootstrap.py
@@ -377,6 +377,7 @@ def handle_graph_ql(
         GraphQL.create_graphql_mutation(general_manager_class)
 
     GraphQL.register_search_query()
+    GraphQL.register_current_user_capabilities()
 
     query_class = type("Query", (graphene.ObjectType,), GraphQL._query_fields)
     GraphQL._query_class = query_class

--- a/src/general_manager/permission/graphql_capabilities.py
+++ b/src/general_manager/permission/graphql_capabilities.py
@@ -81,7 +81,9 @@ def mutation_capability(
     capability_name = name or _lower_camel(getattr(mutation, "__name__", "mutation"))
 
     def evaluator(instance: Any, user: Any) -> bool:
-        permission = getattr(mutation, "_general_manager_mutation_permission", mutation)
+        permission = getattr(mutation, "_general_manager_mutation_permission", None)
+        if permission is None and hasattr(mutation, "check"):
+            permission = mutation
         if permission is None:
             return True
         resolved_payload = _resolve_payload(payload, instance, user)
@@ -176,7 +178,7 @@ class CapabilityEvaluationContext:
                     self._cache[key] = normalized[identity]
             return
 
-        for instance, value in zip(instances, batch_result, strict=False):
+        for instance, value in zip(instances, batch_result, strict=True):
             self._cache[self._cache_key(declaration, instance)] = bool(value)
 
     def _cache_key(

--- a/src/general_manager/permission/graphql_capabilities.py
+++ b/src/general_manager/permission/graphql_capabilities.py
@@ -217,6 +217,16 @@ def get_capability_context(info: Any) -> CapabilityEvaluationContext:
     return contexts[operation_key]
 
 
+def clear_capability_context(info: Any) -> None:
+    """Discard cached capability values for the current GraphQL operation."""
+    request_context = getattr(info, "context", None)
+    operation_key = id(getattr(info, "operation", None))
+    storage_name = "_general_manager_graphql_capability_contexts"
+    contexts = getattr(request_context, storage_name, None)
+    if isinstance(contexts, dict):
+        contexts.pop(operation_key, None)
+
+
 def _resolve_payload(
     payload: CapabilityPayload | None,
     instance: Any,

--- a/src/general_manager/permission/graphql_capabilities.py
+++ b/src/general_manager/permission/graphql_capabilities.py
@@ -149,7 +149,13 @@ class CapabilityEvaluationContext:
                         "capability": declaration.name,
                         "manager": missing[0].__class__.__name__,
                         "error": type(exc).__name__,
+                        "message": str(exc),
                     },
+                )
+                self._store_batch_result(
+                    declaration,
+                    missing,
+                    [False for _instance in missing],
                 )
 
     def _store_batch_result(

--- a/src/general_manager/permission/graphql_capabilities.py
+++ b/src/general_manager/permission/graphql_capabilities.py
@@ -172,10 +172,10 @@ class CapabilityEvaluationContext:
                 for instance, value in batch_result.items()
             }
             for instance in instances:
-                key = self._cache_key(declaration, instance)
                 identity = _instance_identity(instance)
-                if identity in normalized:
-                    self._cache[key] = normalized[identity]
+                self._cache[self._cache_key(declaration, instance)] = bool(
+                    normalized.get(identity, False)
+                )
             return
 
         for instance, value in zip(instances, batch_result, strict=True):

--- a/src/general_manager/permission/graphql_capabilities.py
+++ b/src/general_manager/permission/graphql_capabilities.py
@@ -1,0 +1,263 @@
+"""GraphQL-facing permission capability declarations and evaluation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, cast
+
+from general_manager.logging import get_logger
+
+logger = get_logger("permission.graphql_capabilities")
+
+CapabilityAction = Literal["create", "update", "delete"]
+CapabilityPayload = Mapping[str, Any] | Callable[[Any, Any], Mapping[str, Any]]
+ObjectCapabilityEvaluator = Callable[[Any, Any], bool]
+BatchCapabilityEvaluator = Callable[
+    [Sequence[Any], Any], Mapping[Any, bool] | Sequence[bool]
+]
+
+
+@dataclass(frozen=True, slots=True)
+class GraphQLPermissionCapability:
+    """Declarative permission capability exposed as a GraphQL boolean field."""
+
+    name: str
+    evaluator: ObjectCapabilityEvaluator
+    batch_evaluator: BatchCapabilityEvaluator | None = None
+
+
+def object_capability(
+    name: str,
+    evaluator: ObjectCapabilityEvaluator,
+    *,
+    batch_evaluator: BatchCapabilityEvaluator | None = None,
+) -> GraphQLPermissionCapability:
+    """Declare a domain-specific object capability."""
+    return GraphQLPermissionCapability(
+        name=name,
+        evaluator=evaluator,
+        batch_evaluator=batch_evaluator,
+    )
+
+
+def permission_capability(
+    target: type[Any],
+    action: CapabilityAction,
+    *,
+    name: str | None = None,
+    payload: CapabilityPayload | None = None,
+) -> GraphQLPermissionCapability:
+    """Declare a capability backed by a manager Permission CRUD check."""
+    capability_name = name or _default_capability_name(action, target)
+
+    def evaluator(instance: Any, user: Any) -> bool:
+        permission_class = getattr(target, "Permission", None)
+        if not isinstance(permission_class, type):
+            return True
+        permission = cast(Any, permission_class)
+        resolved_payload = _resolve_payload(payload, instance, user)
+        try:
+            if action == "create":
+                permission.check_create_permission(resolved_payload, target, user)
+            elif action == "update":
+                permission.check_update_permission(resolved_payload, instance, user)
+            else:
+                permission.check_delete_permission(instance, user)
+        except PermissionError:
+            return False
+        return True
+
+    return object_capability(capability_name, evaluator)
+
+
+def mutation_capability(
+    mutation: type[Any],
+    *,
+    name: str | None = None,
+    payload: CapabilityPayload | None = None,
+) -> GraphQLPermissionCapability:
+    """Declare a capability backed by a custom MutationPermission class."""
+    capability_name = name or _lower_camel(getattr(mutation, "__name__", "mutation"))
+
+    def evaluator(instance: Any, user: Any) -> bool:
+        permission = getattr(mutation, "_general_manager_mutation_permission", mutation)
+        if permission is None:
+            return True
+        resolved_payload = _resolve_payload(payload, instance, user)
+        try:
+            permission.check(dict(resolved_payload), user)
+        except PermissionError:
+            return False
+        return True
+
+    return object_capability(capability_name, evaluator)
+
+
+class CapabilityEvaluationContext:
+    """Operation-scoped cache for GraphQL permission capability evaluation."""
+
+    def __init__(self, *, user: Any | None = None) -> None:
+        self.user = user if user is not None else _AnonymousUser()
+        self._cache: dict[tuple[str, str, str, str], bool] = {}
+
+    def evaluate(self, declaration: GraphQLPermissionCapability, instance: Any) -> bool:
+        """Evaluate a capability and cache deny-on-error results for the operation."""
+        cache_key = self._cache_key(declaration, instance)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+        try:
+            result = bool(declaration.evaluator(instance, self.user))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "graphql capability evaluation failed",
+                context={
+                    "capability": declaration.name,
+                    "manager": instance.__class__.__name__,
+                    "error": type(exc).__name__,
+                },
+            )
+            result = False
+        self._cache[cache_key] = result
+        return result
+
+    def warm(
+        self,
+        declarations: Sequence[GraphQLPermissionCapability],
+        instances: Sequence[Any],
+    ) -> None:
+        """Warm cached capability values for a page of instances when possible."""
+        if not instances:
+            return
+        for declaration in declarations:
+            if declaration.batch_evaluator is None:
+                continue
+            missing = [
+                instance
+                for instance in instances
+                if self._cache_key(declaration, instance) not in self._cache
+            ]
+            if not missing:
+                continue
+            try:
+                batch_result = declaration.batch_evaluator(missing, self.user)
+                self._store_batch_result(declaration, missing, batch_result)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "graphql capability batch evaluation failed",
+                    context={
+                        "capability": declaration.name,
+                        "manager": missing[0].__class__.__name__,
+                        "error": type(exc).__name__,
+                    },
+                )
+
+    def _store_batch_result(
+        self,
+        declaration: GraphQLPermissionCapability,
+        instances: Sequence[Any],
+        batch_result: Mapping[Any, bool] | Sequence[bool],
+    ) -> None:
+        if isinstance(batch_result, Mapping):
+            normalized = {
+                _instance_identity(instance): bool(value)
+                for instance, value in batch_result.items()
+            }
+            for instance in instances:
+                key = self._cache_key(declaration, instance)
+                identity = _instance_identity(instance)
+                if identity in normalized:
+                    self._cache[key] = normalized[identity]
+            return
+
+        for instance, value in zip(instances, batch_result, strict=False):
+            self._cache[self._cache_key(declaration, instance)] = bool(value)
+
+    def _cache_key(
+        self,
+        declaration: GraphQLPermissionCapability,
+        instance: Any,
+    ) -> tuple[str, str, str, str]:
+        return (
+            instance.__class__.__module__ + "." + instance.__class__.__qualname__,
+            _instance_identity(instance),
+            _user_identity(self.user),
+            declaration.name,
+        )
+
+
+def get_graphql_capabilities(
+    manager_class: type[Any],
+) -> tuple[GraphQLPermissionCapability, ...]:
+    """Return validated GraphQL capability declarations for a manager class."""
+    permission_class = getattr(manager_class, "Permission", None)
+    declarations = getattr(permission_class, "graphql_capabilities", ()) or ()
+    return tuple(
+        declaration
+        for declaration in declarations
+        if isinstance(declaration, GraphQLPermissionCapability)
+    )
+
+
+def get_capability_context(info: Any) -> CapabilityEvaluationContext:
+    """Return the operation-scoped capability context for a GraphQL resolver."""
+    request_context = getattr(info, "context", None)
+    user = getattr(request_context, "user", _AnonymousUser())
+    operation_key = id(getattr(info, "operation", None))
+    storage_name = "_general_manager_graphql_capability_contexts"
+    contexts = getattr(request_context, storage_name, None)
+    if contexts is None:
+        contexts = {}
+        try:
+            setattr(request_context, storage_name, contexts)
+        except Exception:  # noqa: BLE001
+            return CapabilityEvaluationContext(user=user)
+    if operation_key not in contexts:
+        contexts[operation_key] = CapabilityEvaluationContext(user=user)
+    return contexts[operation_key]
+
+
+def _resolve_payload(
+    payload: CapabilityPayload | None,
+    instance: Any,
+    user: Any,
+) -> dict[str, Any]:
+    if payload is None:
+        return {}
+    if callable(payload):
+        return dict(payload(instance, user))
+    return dict(payload)
+
+
+def _default_capability_name(action: str, target: type[Any]) -> str:
+    return _lower_camel(f"{action}_{target.__name__}")
+
+
+def _lower_camel(value: str) -> str:
+    parts = value.replace("-", "_").split("_")
+    if not parts:
+        return value
+    first, *rest = parts
+    return (
+        first[:1].lower()
+        + first[1:]
+        + "".join(part[:1].upper() + part[1:] for part in rest)
+    )
+
+
+def _instance_identity(instance: Any) -> str:
+    identification = getattr(instance, "identification", None)
+    if isinstance(identification, Mapping):
+        return repr(tuple(sorted(identification.items())))
+    return repr(getattr(instance, "pk", getattr(instance, "id", id(instance))))
+
+
+def _user_identity(user: Any) -> str:
+    return repr(getattr(user, "pk", getattr(user, "id", None)))
+
+
+class _AnonymousUser:
+    is_authenticated = False
+    is_superuser = False
+    pk = None
+    id = None

--- a/src/general_manager/public_api_registry.py
+++ b/src/general_manager/public_api_registry.py
@@ -216,6 +216,26 @@ PERMISSION_EXPORTS: LazyExportMap = {
         "PermissionAuditEvent",
     ),
     "AuditLogger": ("general_manager.permission.audit", "AuditLogger"),
+    "CapabilityEvaluationContext": (
+        "general_manager.permission.graphql_capabilities",
+        "CapabilityEvaluationContext",
+    ),
+    "GraphQLPermissionCapability": (
+        "general_manager.permission.graphql_capabilities",
+        "GraphQLPermissionCapability",
+    ),
+    "mutation_capability": (
+        "general_manager.permission.graphql_capabilities",
+        "mutation_capability",
+    ),
+    "object_capability": (
+        "general_manager.permission.graphql_capabilities",
+        "object_capability",
+    ),
+    "permission_capability": (
+        "general_manager.permission.graphql_capabilities",
+        "permission_capability",
+    ),
 }
 
 

--- a/src/general_manager/utils/testing.py
+++ b/src/general_manager/utils/testing.py
@@ -214,6 +214,7 @@ class GMTestCaseMeta(type):
             GraphQL._subscription_payload_registry = {}
             GraphQL._page_type_registry = {}
             GraphQL.manager_registry = {}
+            GraphQL.graphql_capability_type_registry = {}
             GraphQL._schema = None
             GraphQL._search_union = None
             GraphQL._search_result_type = None

--- a/src/general_manager/utils/testing.py
+++ b/src/general_manager/utils/testing.py
@@ -203,21 +203,7 @@ class GMTestCaseMeta(type):
 
             Resets GraphQL registries and schema/type state; optionally installs a fallback AppConfig lookup if configured; creates any missing database tables for models referenced by the test's GeneralManager interfaces (including their history models and models related via HistoricalChanges) and records created table names on cls._gm_created_tables; initializes GeneralManager classes and their GraphQL registrations (including installing the startup hook runner and registering system checks); clears the default GraphQL URL pattern; executes any user-defined setUpClass for the test class; and finally invokes the base GraphQLTransactionTestCase.setUpClass.
             """
-            GraphQL._query_class = None
-            GraphQL._mutation_class = None
-            GraphQL._subscription_class = None
-            GraphQL._mutations = {}
-            GraphQL._query_fields = {}
-            GraphQL._subscription_fields = {}
-            GraphQL.graphql_type_registry = {}
-            GraphQL.graphql_filter_type_registry = {}
-            GraphQL._subscription_payload_registry = {}
-            GraphQL._page_type_registry = {}
-            GraphQL.manager_registry = {}
-            GraphQL.graphql_capability_type_registry = {}
-            GraphQL._schema = None
-            GraphQL._search_union = None
-            GraphQL._search_result_type = None
+            GraphQL.reset_registry()
 
             if fallback_app is not None:
                 handler = create_fallback_get_app(fallback_app)

--- a/tests/integration/test_graphql_permission_capabilities.py
+++ b/tests/integration/test_graphql_permission_capabilities.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from django.contrib.auth import get_user_model
+from django.db.models import CharField
+from django.test import override_settings
+from django.utils.crypto import get_random_string
+
+from general_manager.api.mutation import graph_ql_mutation
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.interface import DatabaseInterface
+from general_manager.permission.manager_based_permission import (
+    AdditiveManagerPermission,
+)
+from general_manager.permission.mutation_permission import MutationPermission
+from general_manager.permission.graphql_capabilities import (
+    mutation_capability,
+    object_capability,
+    permission_capability,
+)
+from general_manager.utils.testing import GeneralManagerTransactionTestCase
+
+CapabilityProjectForMutation = GeneralManager
+
+
+class TestCapabilitiesProvider:
+    graphql_fields: ClassVar[dict[str, type]] = {"username": str}
+    graphql_capabilities: ClassVar[tuple] = (
+        object_capability(
+            "canOpenAdmin",
+            lambda _current_user, request_user: request_user.is_staff,
+        ),
+    )
+
+    def resolve_username(self, user: Any, info: Any) -> str:
+        return user.username
+
+
+class TestGraphQLPermissionCapabilities(GeneralManagerTransactionTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rename_calls = 0
+        cls.batch_calls = 0
+
+        def can_rename(project: Any, user: Any) -> bool:
+            cls.rename_calls += 1
+            return project.status == "draft" and user.is_authenticated
+
+        def can_rename_batch(projects: list[Any], user: Any) -> list[bool]:
+            cls.batch_calls += 1
+            return [
+                project.status == "draft" and user.is_authenticated
+                for project in projects
+            ]
+
+        class ArchiveProjectPermission(MutationPermission):
+            __mutate__: ClassVar[list[str]] = ["isAuthenticated"]
+            status: ClassVar[list[str]] = ["matches:status:draft"]
+
+        class Project(GeneralManager):
+            class Interface(DatabaseInterface):
+                name = CharField(max_length=100)
+                status = CharField(max_length=20)
+
+            class Permission(AdditiveManagerPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+                __create__: ClassVar[list[str]] = ["public"]
+                __update__: ClassVar[list[str]] = ["isAuthenticated"]
+                __delete__: ClassVar[list[str]] = ["isAuthenticated"]
+                graphql_capabilities = (
+                    object_capability(
+                        "canRename",
+                        can_rename,
+                        batch_evaluator=can_rename_batch,
+                    ),
+                )
+
+        globals()["CapabilityProjectForMutation"] = Project
+
+        @graph_ql_mutation(permission=ArchiveProjectPermission)
+        def archive_project(info: Any, status: str) -> CapabilityProjectForMutation:
+            del info
+            return Project(name="preview", status=status)
+
+        Project.Permission.graphql_capabilities = (
+            *Project.Permission.graphql_capabilities,
+            permission_capability(
+                Project,
+                "update",
+                name="canUpdateProject",
+            ),
+            mutation_capability(
+                archive_project,
+                name="canArchiveProject",
+                payload=lambda project, _user: {"status": project.status},
+            ),
+        )
+        cls.Project = Project
+        cls.general_manager_classes = [Project]
+
+    def setUp(self) -> None:
+        super().setUp()
+        password = get_random_string(12)
+        self.user = get_user_model().objects.create_user(
+            username="capability-user",
+            password=password,
+        )
+        self.client.login(username="capability-user", password=password)
+        self.Project.create(
+            creator_id=None,
+            name="Apollo",
+            status="draft",
+            ignore_permission=True,
+        )
+        self.Project.create(
+            creator_id=None,
+            name="Zeus",
+            status="locked",
+            ignore_permission=True,
+        )
+        type(self).rename_calls = 0
+        type(self).batch_calls = 0
+
+    def test_object_capabilities_are_exposed_on_list_items_and_batch_warmed(
+        self,
+    ) -> None:
+        query = """
+        query {
+            projectList(sortBy: name) {
+                items {
+                    name
+                    capabilities {
+                        canRename
+                    }
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        items = response.json()["data"]["projectList"]["items"]
+        self.assertEqual(
+            items,
+            [
+                {"name": "Apollo", "capabilities": {"canRename": True}},
+                {"name": "Zeus", "capabilities": {"canRename": False}},
+            ],
+        )
+        self.assertEqual(type(self).batch_calls, 1)
+        self.assertEqual(type(self).rename_calls, 0)
+
+    def test_permission_and_mutation_capability_helpers_are_exposed(self) -> None:
+        query = """
+        query {
+            projectList(sortBy: name) {
+                items {
+                    name
+                    capabilities {
+                        canUpdateProject
+                        canArchiveProject
+                    }
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        items = response.json()["data"]["projectList"]["items"]
+        self.assertEqual(
+            items,
+            [
+                {
+                    "name": "Apollo",
+                    "capabilities": {
+                        "canUpdateProject": True,
+                        "canArchiveProject": True,
+                    },
+                },
+                {
+                    "name": "Zeus",
+                    "capabilities": {
+                        "canUpdateProject": True,
+                        "canArchiveProject": False,
+                    },
+                },
+            ],
+        )
+
+    def test_list_query_does_not_warm_capabilities_when_unselected(self) -> None:
+        query = """
+        query {
+            projectList(sortBy: name) {
+                items {
+                    name
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        self.assertEqual(type(self).batch_calls, 0)
+        self.assertEqual(type(self).rename_calls, 0)
+
+
+class TestGraphQLCurrentUserCapabilities(GeneralManagerTransactionTestCase):
+    general_manager_classes: ClassVar[list[type[GeneralManager]]] = []
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.settings_override = override_settings(
+            GENERAL_MANAGER={
+                "GRAPHQL_GLOBAL_CAPABILITIES_PROVIDER": (
+                    "tests.integration.test_graphql_permission_capabilities."
+                    "TestCapabilitiesProvider"
+                )
+            }
+        )
+        cls.settings_override.enable()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.settings_override.disable()
+
+    def setUp(self) -> None:
+        super().setUp()
+        password = get_random_string(12)
+        self.user = get_user_model().objects.create_user(
+            username="staff-user",
+            password=password,
+            is_staff=True,
+        )
+        self.client.login(username="staff-user", password=password)
+
+    def test_provider_exposes_me_capabilities(self) -> None:
+        query = """
+        query {
+            me {
+                username
+                capabilities {
+                    canOpenAdmin
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        self.assertEqual(
+            response.json()["data"]["me"],
+            {
+                "username": "staff-user",
+                "capabilities": {"canOpenAdmin": True},
+            },
+        )

--- a/tests/integration/test_graphql_permission_capabilities.py
+++ b/tests/integration/test_graphql_permission_capabilities.py
@@ -40,6 +40,7 @@ class TestCapabilitiesProvider:
 class TestGraphQLPermissionCapabilities(GeneralManagerTransactionTestCase):
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         cls.rename_calls = 0
         cls.batch_calls = 0
 
@@ -208,12 +209,61 @@ class TestGraphQLPermissionCapabilities(GeneralManagerTransactionTestCase):
         self.assertEqual(type(self).batch_calls, 0)
         self.assertEqual(type(self).rename_calls, 0)
 
+    def test_batch_capability_failure_is_cached_as_deny(self) -> None:
+        original_capabilities = self.Project.Permission.graphql_capabilities
+
+        def can_fail(_project: Any, _user: Any) -> bool:
+            type(self).rename_calls += 1
+            return True
+
+        def can_fail_batch(_projects: list[Any], _user: Any) -> list[bool]:
+            type(self).batch_calls += 1
+            raise RuntimeError
+
+        self.Project.Permission.graphql_capabilities = (
+            object_capability(
+                "canRename",
+                can_fail,
+                batch_evaluator=can_fail_batch,
+            ),
+        )
+        try:
+            query = """
+            query {
+                projectList(sortBy: name) {
+                    items {
+                        name
+                        capabilities {
+                            canRename
+                        }
+                    }
+                }
+            }
+            """
+
+            response = self.query(query)
+
+            self.assertResponseNoErrors(response)
+            items = response.json()["data"]["projectList"]["items"]
+            self.assertEqual(
+                items,
+                [
+                    {"name": "Apollo", "capabilities": {"canRename": False}},
+                    {"name": "Zeus", "capabilities": {"canRename": False}},
+                ],
+            )
+            self.assertEqual(type(self).batch_calls, 1)
+            self.assertEqual(type(self).rename_calls, 0)
+        finally:
+            self.Project.Permission.graphql_capabilities = original_capabilities
+
 
 class TestGraphQLCurrentUserCapabilities(GeneralManagerTransactionTestCase):
     general_manager_classes: ClassVar[list[type[GeneralManager]]] = []
 
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         cls.settings_override = override_settings(
             GENERAL_MANAGER={
                 "GRAPHQL_GLOBAL_CAPABILITIES_PROVIDER": (
@@ -226,8 +276,12 @@ class TestGraphQLCurrentUserCapabilities(GeneralManagerTransactionTestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        super().tearDownClass()
-        cls.settings_override.disable()
+        try:
+            settings_override = getattr(cls, "settings_override", None)
+            if settings_override is not None:
+                settings_override.disable()
+        finally:
+            super().tearDownClass()
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/snapshots/public_api_exports.json
+++ b/tests/snapshots/public_api_exports.json
@@ -1,5 +1,9 @@
 {
   "general_manager": {
+    "AdditiveManagerPermission": [
+      "general_manager.permission.manager_based_permission",
+      "AdditiveManagerPermission"
+    ],
     "CalculationInterface": [
       "general_manager.interface.interfaces.calculation",
       "CalculationInterface"
@@ -7,10 +11,6 @@
     "DatabaseInterface": [
       "general_manager.interface.interfaces.database",
       "DatabaseInterface"
-    ],
-    "AdditiveManagerPermission": [
-      "general_manager.permission.manager_based_permission",
-      "AdditiveManagerPermission"
     ],
     "ExistingModelInterface": [
       "general_manager.interface.interfaces.existing_model",
@@ -39,6 +39,10 @@
     "ManagerBasedPermission": [
       "general_manager.permission.manager_based_permission",
       "ManagerBasedPermission"
+    ],
+    "OverrideManagerPermission": [
+      "general_manager.permission.manager_based_permission",
+      "OverrideManagerPermission"
     ],
     "ReadOnlyInterface": [
       "general_manager.interface.interfaces.read_only",
@@ -103,10 +107,6 @@
     "permission_functions": [
       "general_manager.permission.permission_checks",
       "permission_functions"
-    ],
-    "OverrideManagerPermission": [
-      "general_manager.permission.manager_based_permission",
-      "OverrideManagerPermission"
     ],
     "register_permission": [
       "general_manager.permission.permission_checks",
@@ -492,6 +492,10 @@
       "general_manager.permission.base_permission",
       "BasePermission"
     ],
+    "CapabilityEvaluationContext": [
+      "general_manager.permission.graphql_capabilities",
+      "CapabilityEvaluationContext"
+    ],
     "DatabaseAuditLogger": [
       "general_manager.permission.audit",
       "DatabaseAuditLogger"
@@ -500,6 +504,10 @@
       "general_manager.permission.audit",
       "FileAuditLogger"
     ],
+    "GraphQLPermissionCapability": [
+      "general_manager.permission.graphql_capabilities",
+      "GraphQLPermissionCapability"
+    ],
     "ManagerBasedPermission": [
       "general_manager.permission.manager_based_permission",
       "ManagerBasedPermission"
@@ -507,6 +515,10 @@
     "MutationPermission": [
       "general_manager.permission.mutation_permission",
       "MutationPermission"
+    ],
+    "OverrideManagerPermission": [
+      "general_manager.permission.manager_based_permission",
+      "OverrideManagerPermission"
     ],
     "PermissionAuditEvent": [
       "general_manager.permission.audit",
@@ -520,13 +532,21 @@
       "general_manager.permission.audit",
       "configure_audit_logger_from_settings"
     ],
+    "mutation_capability": [
+      "general_manager.permission.graphql_capabilities",
+      "mutation_capability"
+    ],
+    "object_capability": [
+      "general_manager.permission.graphql_capabilities",
+      "object_capability"
+    ],
+    "permission_capability": [
+      "general_manager.permission.graphql_capabilities",
+      "permission_capability"
+    ],
     "permission_functions": [
       "general_manager.permission.permission_checks",
       "permission_functions"
-    ],
-    "OverrideManagerPermission": [
-      "general_manager.permission.manager_based_permission",
-      "OverrideManagerPermission"
     ],
     "register_permission": [
       "general_manager.permission.permission_checks",

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -183,6 +183,7 @@ class GraphQLHelperTests(SimpleTestCase):
         Verify registry snapshots include generated capability GraphQL types.
         """
         capability_type = type("CapabilityType", (graphene.ObjectType,), {})
+        original_registry = GraphQL.graphql_capability_type_registry
         GraphQL.graphql_capability_type_registry = {"Capability": capability_type}
         try:
             snapshot = GraphQL.get_registry_snapshot()
@@ -194,7 +195,7 @@ class GraphQLHelperTests(SimpleTestCase):
                 GraphQL.graphql_capability_type_registry
             )
         finally:
-            GraphQL.graphql_capability_type_registry = {}
+            GraphQL.graphql_capability_type_registry = original_registry
 
     def test_measurement_scalar_parse_literal(self) -> None:
         node = StringValueNode(value="10 m")

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+import graphene  # type: ignore[import]
 from django.test import SimpleTestCase
 from graphql import parse
 from graphql.language.ast import (
@@ -176,6 +177,24 @@ class GraphQLHelperTests(SimpleTestCase):
         """
         with pytest.raises(InvalidMeasurementValueError):
             MeasurementScalar.serialize("not-a-measurement")  # type: ignore[arg-type]
+
+    def test_registry_snapshot_includes_capability_type_registry(self) -> None:
+        """
+        Verify registry snapshots include generated capability GraphQL types.
+        """
+        capability_type = type("CapabilityType", (graphene.ObjectType,), {})
+        GraphQL.graphql_capability_type_registry = {"Capability": capability_type}
+        try:
+            snapshot = GraphQL.get_registry_snapshot()
+
+            assert snapshot.graphql_capability_type_registry == {
+                "Capability": capability_type
+            }
+            assert snapshot.graphql_capability_type_registry is not (
+                GraphQL.graphql_capability_type_registry
+            )
+        finally:
+            GraphQL.graphql_capability_type_registry = {}
 
     def test_measurement_scalar_parse_literal(self) -> None:
         node = StringValueNode(value="10 m")
@@ -404,6 +423,26 @@ class GraphQLHelperTests(SimpleTestCase):
         )
 
         assert selection_includes_path(info, ("items", "capabilities")) is True
+
+    def test_selection_includes_path_skips_fragment_cycles(self) -> None:
+        """
+        Verify cyclic named fragments do not recurse indefinitely.
+        """
+        info = _selection_info(
+            """
+            query {
+                projectList {
+                    ...ProjectPageFields
+                }
+            }
+
+            fragment ProjectPageFields on ProjectPage {
+                ...ProjectPageFields
+            }
+            """
+        )
+
+        assert selection_includes_path(info, ("items", "capabilities")) is False
 
     def test_selection_includes_path_handles_empty_or_missing_selections(self) -> None:
         """

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -133,6 +133,12 @@ class _Info:
 
 
 def _selection_info(query: str) -> object:
+    """
+    Build a lightweight GraphQL resolver info object from a query document.
+
+    The returned object provides `field_nodes` and `fragments`, matching the
+    attributes consumed by selection traversal helpers.
+    """
     document = parse(query)
     fragments = {
         definition.name.value: definition
@@ -353,6 +359,9 @@ class GraphQLHelperTests(SimpleTestCase):
         assert CountingPermission.check_count == 2
 
     def test_selection_includes_path_handles_direct_nested_fields(self) -> None:
+        """
+        Verify selection path detection works for directly nested list fields.
+        """
         info = _selection_info(
             """
             query {
@@ -371,6 +380,9 @@ class GraphQLHelperTests(SimpleTestCase):
         assert selection_includes_path(info, ("items", "missing")) is False
 
     def test_selection_includes_path_handles_fragments(self) -> None:
+        """
+        Verify selection path detection follows named and inline fragments.
+        """
         info = _selection_info(
             """
             query {
@@ -394,6 +406,9 @@ class GraphQLHelperTests(SimpleTestCase):
         assert selection_includes_path(info, ("items", "capabilities")) is True
 
     def test_selection_includes_path_handles_empty_or_missing_selections(self) -> None:
+        """
+        Verify selection path detection returns false for empty or absent selections.
+        """
         info = type("SelectionInfo", (), {})()
 
         assert selection_includes_path(info, ("items", "capabilities")) is False

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -4,7 +4,13 @@ from unittest import mock
 
 import pytest
 from django.test import SimpleTestCase
-from graphql.language.ast import IntValueNode, StringValueNode
+from graphql import parse
+from graphql.language.ast import (
+    FragmentDefinitionNode,
+    IntValueNode,
+    OperationDefinitionNode,
+    StringValueNode,
+)
 
 from general_manager.api.graphql import (
     BigIntScalar,
@@ -26,7 +32,10 @@ from general_manager.permission.base_permission import (
     BasePermission,
     ReadPermissionPlan,
 )
-from general_manager.api.graphql_resolvers import resolve_instance_check_reasons
+from general_manager.api.graphql_resolvers import (
+    resolve_instance_check_reasons,
+    selection_includes_path,
+)
 from tests.utils.simple_manager_interface import BaseTestInterface, SimpleBucket
 
 
@@ -121,6 +130,24 @@ class _Info:
         Sets self.context to a lightweight object with a single attribute `user` initialized to a generic object instance.
         """
         self.context = type("Context", (), {"user": object()})()
+
+
+def _selection_info(query: str) -> object:
+    document = parse(query)
+    fragments = {
+        definition.name.value: definition
+        for definition in document.definitions
+        if isinstance(definition, FragmentDefinitionNode)
+    }
+    field_nodes = [
+        selection
+        for definition in document.definitions
+        if isinstance(definition, OperationDefinitionNode)
+        for selection in definition.selection_set.selections
+    ]
+    return type(
+        "SelectionInfo", (), {"field_nodes": field_nodes, "fragments": fragments}
+    )()
 
 
 class GraphQLHelperTests(SimpleTestCase):
@@ -324,6 +351,55 @@ class GraphQLHelperTests(SimpleTestCase):
 
         assert result["pageInfo"]["total_count"] == 2
         assert CountingPermission.check_count == 2
+
+    def test_selection_includes_path_handles_direct_nested_fields(self) -> None:
+        info = _selection_info(
+            """
+            query {
+                projectList {
+                    items {
+                        capabilities {
+                            canRename
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert selection_includes_path(info, ("items", "capabilities")) is True
+        assert selection_includes_path(info, ("items", "missing")) is False
+
+    def test_selection_includes_path_handles_fragments(self) -> None:
+        info = _selection_info(
+            """
+            query {
+                projectList {
+                    ...ProjectPageFields
+                }
+            }
+
+            fragment ProjectPageFields on ProjectPage {
+                items {
+                    ... on ProjectType {
+                        capabilities {
+                            canRename
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert selection_includes_path(info, ("items", "capabilities")) is True
+
+    def test_selection_includes_path_handles_empty_or_missing_selections(self) -> None:
+        info = type("SelectionInfo", (), {})()
+
+        assert selection_includes_path(info, ("items", "capabilities")) is False
+        assert selection_includes_path(
+            _selection_info("query { projectList }"), ()
+        ) is (False)
 
     def test_graphql_error_types(self) -> None:
         """

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -452,9 +452,10 @@ class GraphQLHelperTests(SimpleTestCase):
         info = type("SelectionInfo", (), {})()
 
         assert selection_includes_path(info, ("items", "capabilities")) is False
-        assert selection_includes_path(
-            _selection_info("query { projectList }"), ()
-        ) is (False)
+        assert (
+            selection_includes_path(_selection_info("query { projectList }"), ())
+            is False
+        )
 
     def test_graphql_error_types(self) -> None:
         """

--- a/tests/unit/test_graphql_permission_capabilities.py
+++ b/tests/unit/test_graphql_permission_capabilities.py
@@ -138,6 +138,43 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertTrue(context.evaluate(declaration, second))
         self.assertEqual(calls, [["ALPHA", "BETA"]])
 
+    def test_object_capability_batch_mapping_missing_entries_deny(self) -> None:
+        """
+        Verify missing mapping entries are cached as deny results after warmup.
+        """
+        calls = 0
+
+        def can_rename_batch(
+            instances: Sequence[Any],
+            user: Any,
+        ) -> dict[DummyManager, bool]:
+            """Allow only the first provided instance in the batch result."""
+            del user
+            managers = cast(Sequence[DummyManager], instances)
+            return {managers[0]: True}
+
+        def can_rename(instance: DummyManager, user: Any) -> bool:
+            """Count fallback evaluations and allow the capability."""
+            nonlocal calls
+            del instance, user
+            calls += 1
+            return True
+
+        declaration = object_capability(
+            "canRename",
+            can_rename,
+            batch_evaluator=can_rename_batch,
+        )
+        first = DummyManager({"code": "ALPHA"})
+        second = DummyManager({"code": "BETA"})
+        context = CapabilityEvaluationContext(user=AnonymousUser())
+
+        context.warm([declaration], [first, second])
+
+        self.assertTrue(context.evaluate(declaration, first))
+        self.assertFalse(context.evaluate(declaration, second))
+        self.assertEqual(calls, 0)
+
     def test_permission_capability_allows_manager_without_permission(self) -> None:
         """
         Verify permission-backed capabilities allow managers without Permission classes.

--- a/tests/unit/test_graphql_permission_capabilities.py
+++ b/tests/unit/test_graphql_permission_capabilities.py
@@ -255,7 +255,6 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
             """Mutation stub used to carry GraphQL mutation metadata."""
             return None
 
-        archive_project._general_manager_mutation_permission = None  # type: ignore[attr-defined]
         declaration = mutation_capability(cast(type[Any], archive_project))
 
         self.assertEqual(declaration.name, "archiveProject")
@@ -323,6 +322,45 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
 
         self.assertEqual(batch_calls, 1)
         self.assertTrue(context.evaluate(with_batch, instance))
+
+    def test_batch_warm_mismatched_result_length_caches_deny(self) -> None:
+        """
+        Verify mismatched batch result lengths fail closed for all missing rows.
+        """
+        calls = 0
+
+        def short_batch(instances: Sequence[Any], user: Any) -> list[bool]:
+            """Return too few batch results for the provided instances."""
+            del instances, user
+            return [True]
+
+        def evaluator(instance: DummyManager, user: Any) -> bool:
+            """Count fallback object evaluations and allow the capability."""
+            nonlocal calls
+            del instance, user
+            calls += 1
+            return True
+
+        declaration = object_capability(
+            "canRename",
+            evaluator,
+            batch_evaluator=short_batch,
+        )
+        instances = [
+            DummyManager({"code": "ALPHA"}),
+            DummyManager({"code": "BETA"}),
+        ]
+        context = CapabilityEvaluationContext(user=AnonymousUser())
+
+        with mock.patch(
+            "general_manager.permission.graphql_capabilities.logger"
+        ) as logger_mock:
+            context.warm([declaration], instances)
+
+        logger_mock.warning.assert_called_once()
+        self.assertFalse(context.evaluate(declaration, instances[0]))
+        self.assertFalse(context.evaluate(declaration, instances[1]))
+        self.assertEqual(calls, 0)
 
     def test_batch_warm_logs_and_caches_deny_after_batch_errors(self) -> None:
         """
@@ -450,20 +488,26 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
 
         declaration = object_capability("canView", lambda _instance, _user: True)
         GraphQL.reset_registry()
+        try:
+            capability_type = GraphQL._get_or_create_capability_type(
+                Project,
+                (declaration,),
+            )
+            cached_type = GraphQL._get_or_create_capability_type(
+                Project, (declaration,)
+            )
+            resolver = capability_type.resolve_canView
+            info = SimpleNamespace(
+                context=SimpleNamespace(user=AnonymousUser()),
+                operation=object(),
+            )
 
-        capability_type = GraphQL._get_or_create_capability_type(
-            Project,
-            (declaration,),
-        )
-        cached_type = GraphQL._get_or_create_capability_type(Project, (declaration,))
-        resolver = capability_type.resolve_canView
-        info = SimpleNamespace(
-            context=SimpleNamespace(user=AnonymousUser()),
-            operation=object(),
-        )
-
-        self.assertIs(capability_type, cached_type)
-        self.assertTrue(resolver({"instance": DummyManager({"code": "ALPHA"})}, info))
+            self.assertIs(capability_type, cached_type)
+            self.assertTrue(
+                resolver({"instance": DummyManager({"code": "ALPHA"})}, info)
+            )
+        finally:
+            GraphQL.reset_registry()
 
     def test_current_user_capability_type_is_cached_and_resolves_declaration(
         self,
@@ -477,18 +521,22 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
             lambda current_user, request_user: current_user is request_user,
         )
         GraphQL.reset_registry()
+        try:
+            capability_type = GraphQL._get_or_create_current_user_capability_type(
+                (declaration,)
+            )
+            cached_type = GraphQL._get_or_create_current_user_capability_type(
+                (declaration,)
+            )
+            resolver = capability_type.resolve_canViewProfile
+            info = SimpleNamespace(
+                context=SimpleNamespace(user=user), operation=object()
+            )
 
-        capability_type = GraphQL._get_or_create_current_user_capability_type(
-            (declaration,)
-        )
-        cached_type = GraphQL._get_or_create_current_user_capability_type(
-            (declaration,)
-        )
-        resolver = capability_type.resolve_canViewProfile
-        info = SimpleNamespace(context=SimpleNamespace(user=user), operation=object())
-
-        self.assertIs(capability_type, cached_type)
-        self.assertTrue(resolver({"instance": user}, info))
+            self.assertIs(capability_type, cached_type)
+            self.assertTrue(resolver({"instance": user}, info))
+        finally:
+            GraphQL.reset_registry()
 
     @override_settings(GENERAL_MANAGER={})
     def test_current_user_capability_provider_is_optional(self) -> None:
@@ -511,17 +559,20 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         """
         user = SimpleNamespace(email="apollo@example.com")
         GraphQL.reset_registry()
+        try:
+            GraphQL.register_current_user_capabilities()
+            me_resolver = GraphQL._query_fields["resolve_me"]
+            me_field_resolver = GraphQL._query_fields["me"].type.resolve_email
 
-        GraphQL.register_current_user_capabilities()
-        me_resolver = GraphQL._query_fields["resolve_me"]
-        me_field_resolver = GraphQL._query_fields["me"].type.resolve_email
-
-        self.assertIs(
-            me_resolver(None, SimpleNamespace(context=SimpleNamespace(user=user))), user
-        )
-        self.assertEqual(
-            me_field_resolver(
-                user, SimpleNamespace(context=SimpleNamespace(user=user))
-            ),
-            "apollo@example.com",
-        )
+            self.assertIs(
+                me_resolver(None, SimpleNamespace(context=SimpleNamespace(user=user))),
+                user,
+            )
+            self.assertEqual(
+                me_field_resolver(
+                    user, SimpleNamespace(context=SimpleNamespace(user=user))
+                ),
+                "apollo@example.com",
+            )
+        finally:
+            GraphQL.reset_registry()

--- a/tests/unit/test_graphql_permission_capabilities.py
+++ b/tests/unit/test_graphql_permission_capabilities.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from types import SimpleNamespace
+from collections.abc import Sequence
+from typing import Any, ClassVar, cast
+from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
+from general_manager.api.graphql import GraphQL
+from general_manager.manager.general_manager import GeneralManager
 from general_manager.permission.graphql_capabilities import (
     CapabilityEvaluationContext,
+    GraphQLPermissionCapability,
+    clear_capability_context,
+    get_capability_context,
+    get_graphql_capabilities,
+    mutation_capability,
     object_capability,
+    permission_capability,
 )
 
 
@@ -22,6 +33,19 @@ class DummyManager:
 
 class PolicyBackendUnavailable(RuntimeError):
     pass
+
+
+class DeniedPermission(PermissionError):
+    pass
+
+
+class TestCurrentUserCapabilityProvider:
+    graphql_fields: ClassVar[dict[str, type]] = {"email": str}
+    graphql_capabilities: ClassVar[tuple[GraphQLPermissionCapability, ...]] = (
+        object_capability(
+            "canViewProfile", lambda user, request_user: user is request_user
+        ),
+    )
 
 
 class GraphQLPermissionCapabilityTests(SimpleTestCase):
@@ -67,11 +91,12 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         calls: list[list[str]] = []
 
         def can_rename_batch(
-            instances: list[DummyManager],
+            instances: Sequence[Any],
             user: Any,
         ) -> dict[DummyManager, bool]:
-            calls.append([instance.identification["code"] for instance in instances])
-            return {instance: True for instance in instances}
+            managers = cast(Sequence[DummyManager], instances)
+            calls.append([instance.identification["code"] for instance in managers])
+            return {instance: True for instance in managers}
 
         declaration = object_capability(
             "canRename",
@@ -87,3 +112,303 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertTrue(context.evaluate(declaration, first))
         self.assertTrue(context.evaluate(declaration, second))
         self.assertEqual(calls, [["ALPHA", "BETA"]])
+
+    def test_permission_capability_allows_manager_without_permission(self) -> None:
+        class UnprotectedManager:
+            pass
+
+        declaration = permission_capability(UnprotectedManager, "create")
+
+        self.assertEqual(declaration.name, "createUnprotectedManager")
+        self.assertTrue(
+            declaration.evaluator(DummyManager({"code": "ALPHA"}), AnonymousUser())
+        )
+
+    def test_permission_capability_delegates_create_update_and_delete(self) -> None:
+        calls: list[tuple[str, dict[str, Any]]] = []
+
+        class ProtectedManager:
+            class Permission:
+                @staticmethod
+                def check_create_permission(
+                    payload: dict[str, Any],
+                    target: type[Any],
+                    user: Any,
+                ) -> None:
+                    del target, user
+                    calls.append(("create", payload))
+
+                @staticmethod
+                def check_update_permission(
+                    payload: dict[str, Any],
+                    instance: Any,
+                    user: Any,
+                ) -> None:
+                    del instance, user
+                    calls.append(("update", payload))
+
+                @staticmethod
+                def check_delete_permission(instance: Any, user: Any) -> None:
+                    del instance, user
+                    calls.append(("delete", {}))
+
+        instance = DummyManager({"code": "ALPHA"})
+        user = AnonymousUser()
+
+        create_capability = permission_capability(
+            ProtectedManager,
+            "create",
+            payload={"name": "Apollo"},
+        )
+        update_capability = permission_capability(
+            ProtectedManager,
+            "update",
+            payload=lambda target, _user: {"code": target.identification["code"]},
+        )
+        delete_capability = permission_capability(ProtectedManager, "delete")
+
+        self.assertTrue(create_capability.evaluator(instance, user))
+        self.assertTrue(update_capability.evaluator(instance, user))
+        self.assertTrue(delete_capability.evaluator(instance, user))
+        self.assertEqual(
+            calls,
+            [
+                ("create", {"name": "Apollo"}),
+                ("update", {"code": "ALPHA"}),
+                ("delete", {}),
+            ],
+        )
+
+    def test_permission_capability_denies_permission_errors(self) -> None:
+        class ProtectedManager:
+            class Permission:
+                @staticmethod
+                def check_delete_permission(instance: Any, user: Any) -> None:
+                    del instance, user
+                    raise DeniedPermission
+
+        declaration = permission_capability(ProtectedManager, "delete")
+
+        self.assertFalse(
+            declaration.evaluator(DummyManager({"code": "ALPHA"}), AnonymousUser())
+        )
+
+    def test_mutation_capability_allows_unguarded_mutation(self) -> None:
+        def archive_project() -> None:
+            return None
+
+        archive_project._general_manager_mutation_permission = None  # type: ignore[attr-defined]
+        declaration = mutation_capability(cast(type[Any], archive_project))
+
+        self.assertEqual(declaration.name, "archiveProject")
+        self.assertTrue(
+            declaration.evaluator(DummyManager({"code": "ALPHA"}), AnonymousUser())
+        )
+
+    def test_mutation_capability_denies_permission_errors(self) -> None:
+        class ArchivePermission:
+            @staticmethod
+            def check(payload: dict[str, Any], user: Any) -> None:
+                del payload, user
+                raise DeniedPermission
+
+        def archive_project() -> None:
+            return None
+
+        archive_project._general_manager_mutation_permission = ArchivePermission  # type: ignore[attr-defined]
+        declaration = mutation_capability(
+            cast(type[Any], archive_project),
+            payload={"status": "locked"},
+        )
+
+        self.assertFalse(
+            declaration.evaluator(DummyManager({"code": "ALPHA"}), AnonymousUser())
+        )
+
+    def test_batch_warm_skips_empty_uncacheable_and_cached_inputs(self) -> None:
+        batch_calls = 0
+
+        def can_rename_batch(
+            instances: Sequence[Any],
+            user: Any,
+        ) -> list[bool]:
+            nonlocal batch_calls
+            del instances, user
+            batch_calls += 1
+            return [True]
+
+        no_batch = object_capability("canView", lambda _instance, _user: True)
+        with_batch = object_capability(
+            "canRename",
+            lambda _instance, _user: False,
+            batch_evaluator=can_rename_batch,
+        )
+        instance = DummyManager({"code": "ALPHA"})
+        context = CapabilityEvaluationContext(user=AnonymousUser())
+
+        context.warm([with_batch], [])
+        context.warm([no_batch], [instance])
+        context.warm([with_batch], [instance])
+        context.warm([with_batch], [instance])
+
+        self.assertEqual(batch_calls, 1)
+        self.assertTrue(context.evaluate(with_batch, instance))
+
+    def test_batch_warm_logs_and_falls_back_after_batch_errors(self) -> None:
+        calls = 0
+
+        def broken_batch(instances: Sequence[Any], user: Any) -> list[bool]:
+            del instances, user
+            raise PolicyBackendUnavailable
+
+        def evaluator(instance: DummyManager, user: Any) -> bool:
+            nonlocal calls
+            del instance, user
+            calls += 1
+            return True
+
+        declaration = object_capability(
+            "canRename",
+            evaluator,
+            batch_evaluator=broken_batch,
+        )
+        instance = DummyManager({"code": "ALPHA"})
+        context = CapabilityEvaluationContext(user=AnonymousUser())
+
+        with mock.patch(
+            "general_manager.permission.graphql_capabilities.logger"
+        ) as logger_mock:
+            context.warm([declaration], [instance])
+
+        logger_mock.warning.assert_called_once()
+        self.assertTrue(context.evaluate(declaration, instance))
+        self.assertEqual(calls, 1)
+
+    def test_get_graphql_capabilities_filters_invalid_declarations(self) -> None:
+        valid = object_capability("canRename", lambda _instance, _user: True)
+
+        class Project:
+            class Permission:
+                graphql_capabilities = (valid, object())
+
+        self.assertEqual(get_graphql_capabilities(Project), (valid,))
+
+    def test_get_and_clear_capability_context_share_operation_storage(self) -> None:
+        info = SimpleNamespace(
+            context=SimpleNamespace(user=AnonymousUser()),
+            operation=object(),
+        )
+
+        first = get_capability_context(info)
+        second = get_capability_context(info)
+        clear_capability_context(info)
+        third = get_capability_context(info)
+
+        self.assertIs(first, second)
+        self.assertIsNot(first, third)
+
+    def test_get_capability_context_returns_uncached_context_when_storage_fails(
+        self,
+    ) -> None:
+        class FrozenContext:
+            user = AnonymousUser()
+
+            def __setattr__(self, name: str, value: Any) -> None:
+                del name, value
+                raise RuntimeError("frozen")
+
+        info = SimpleNamespace(context=FrozenContext(), operation=object())
+
+        first = get_capability_context(info)
+        second = get_capability_context(info)
+
+        self.assertIsInstance(first, CapabilityEvaluationContext)
+        self.assertIsInstance(second, CapabilityEvaluationContext)
+        self.assertIsNot(first, second)
+
+    def test_clear_capability_context_ignores_missing_storage(self) -> None:
+        info = SimpleNamespace(context=SimpleNamespace(), operation=object())
+
+        clear_capability_context(info)
+
+    def test_anonymous_context_default_user_identity(self) -> None:
+        context = CapabilityEvaluationContext()
+        declaration = GraphQLPermissionCapability(
+            "canView",
+            lambda _instance, user: not user.is_authenticated,
+        )
+
+        self.assertTrue(context.evaluate(declaration, DummyManager({"code": "ALPHA"})))
+
+    def test_graphql_capability_type_is_cached_and_resolves_declaration(self) -> None:
+        class Project(GeneralManager):
+            pass
+
+        declaration = object_capability("canView", lambda _instance, _user: True)
+        GraphQL.reset_registry()
+
+        capability_type = GraphQL._get_or_create_capability_type(
+            Project,
+            (declaration,),
+        )
+        cached_type = GraphQL._get_or_create_capability_type(Project, (declaration,))
+        resolver = capability_type.resolve_canView
+        info = SimpleNamespace(
+            context=SimpleNamespace(user=AnonymousUser()),
+            operation=object(),
+        )
+
+        self.assertIs(capability_type, cached_type)
+        self.assertTrue(resolver({"instance": DummyManager({"code": "ALPHA"})}, info))
+
+    def test_current_user_capability_type_is_cached_and_resolves_declaration(
+        self,
+    ) -> None:
+        user = AnonymousUser()
+        declaration = object_capability(
+            "canViewProfile",
+            lambda current_user, request_user: current_user is request_user,
+        )
+        GraphQL.reset_registry()
+
+        capability_type = GraphQL._get_or_create_current_user_capability_type(
+            (declaration,)
+        )
+        cached_type = GraphQL._get_or_create_current_user_capability_type(
+            (declaration,)
+        )
+        resolver = capability_type.resolve_canViewProfile
+        info = SimpleNamespace(context=SimpleNamespace(user=user), operation=object())
+
+        self.assertIs(capability_type, cached_type)
+        self.assertTrue(resolver({"instance": user}, info))
+
+    @override_settings(GENERAL_MANAGER={})
+    def test_current_user_capability_provider_is_optional(self) -> None:
+        self.assertIsNone(GraphQL._get_current_user_capability_provider())
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_GLOBAL_CAPABILITIES_PROVIDER": (
+                "tests.unit.test_graphql_permission_capabilities."
+                "TestCurrentUserCapabilityProvider"
+            )
+        }
+    )
+    def test_register_current_user_capabilities_uses_provider_fields(self) -> None:
+        user = SimpleNamespace(email="apollo@example.com")
+        GraphQL.reset_registry()
+
+        GraphQL.register_current_user_capabilities()
+        me_resolver = GraphQL._query_fields["resolve_me"]
+        me_field_resolver = GraphQL._query_fields["me"].type.resolve_email
+
+        self.assertIs(
+            me_resolver(None, SimpleNamespace(context=SimpleNamespace(user=user))), user
+        )
+        self.assertEqual(
+            me_field_resolver(
+                user, SimpleNamespace(context=SimpleNamespace(user=user))
+            ),
+            "apollo@example.com",
+        )

--- a/tests/unit/test_graphql_permission_capabilities.py
+++ b/tests/unit/test_graphql_permission_capabilities.py
@@ -324,9 +324,9 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertEqual(batch_calls, 1)
         self.assertTrue(context.evaluate(with_batch, instance))
 
-    def test_batch_warm_logs_and_falls_back_after_batch_errors(self) -> None:
+    def test_batch_warm_logs_and_caches_deny_after_batch_errors(self) -> None:
         """
-        Verify batch warmup logs failures and leaves per-object fallback available.
+        Verify batch warmup logs failures and caches deny results.
         """
         calls = 0
 
@@ -356,8 +356,8 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
             context.warm([declaration], [instance])
 
         logger_mock.warning.assert_called_once()
-        self.assertTrue(context.evaluate(declaration, instance))
-        self.assertEqual(calls, 1)
+        self.assertFalse(context.evaluate(declaration, instance))
+        self.assertEqual(calls, 0)
 
     def test_get_graphql_capabilities_filters_invalid_declarations(self) -> None:
         """

--- a/tests/unit/test_graphql_permission_capabilities.py
+++ b/tests/unit/test_graphql_permission_capabilities.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import SimpleTestCase
+
+from general_manager.permission.graphql_capabilities import (
+    CapabilityEvaluationContext,
+    object_capability,
+)
+
+
+@dataclass
+class DummyManager:
+    identification: dict[str, Any]
+
+    def __hash__(self) -> int:
+        return hash(self.identification["code"])
+
+
+class PolicyBackendUnavailable(RuntimeError):
+    pass
+
+
+class GraphQLPermissionCapabilityTests(SimpleTestCase):
+    def test_object_capability_is_public_permission_api(self) -> None:
+        from general_manager.permission import object_capability as public_helper
+
+        self.assertIs(public_helper, object_capability)
+
+    def test_object_capability_evaluates_once_per_operation_cache_key(self) -> None:
+        calls: list[str] = []
+
+        def can_rename(instance: DummyManager, user: Any) -> bool:
+            calls.append(instance.identification["code"])
+            return True
+
+        declaration = object_capability("canRename", can_rename)
+        instance = DummyManager({"code": "ALPHA"})
+        context = CapabilityEvaluationContext(user=AnonymousUser())
+
+        self.assertTrue(context.evaluate(declaration, instance))
+        self.assertTrue(context.evaluate(declaration, instance))
+
+        self.assertEqual(calls, ["ALPHA"])
+
+    def test_object_capability_denies_and_caches_evaluator_errors(self) -> None:
+        calls = 0
+
+        def broken_evaluator(instance: DummyManager, user: Any) -> bool:
+            nonlocal calls
+            calls += 1
+            raise PolicyBackendUnavailable
+
+        declaration = object_capability("canRename", broken_evaluator)
+        instance = DummyManager({"code": "ALPHA"})
+        context = CapabilityEvaluationContext(user=AnonymousUser())
+
+        self.assertFalse(context.evaluate(declaration, instance))
+        self.assertFalse(context.evaluate(declaration, instance))
+
+        self.assertEqual(calls, 1)
+
+    def test_object_capability_batch_evaluator_warms_cache(self) -> None:
+        calls: list[list[str]] = []
+
+        def can_rename_batch(
+            instances: list[DummyManager],
+            user: Any,
+        ) -> dict[DummyManager, bool]:
+            calls.append([instance.identification["code"] for instance in instances])
+            return {instance: True for instance in instances}
+
+        declaration = object_capability(
+            "canRename",
+            lambda _instance, _user: False,
+            batch_evaluator=can_rename_batch,
+        )
+        first = DummyManager({"code": "ALPHA"})
+        second = DummyManager({"code": "BETA"})
+        context = CapabilityEvaluationContext(user=AnonymousUser())
+
+        context.warm([declaration], [first, second])
+
+        self.assertTrue(context.evaluate(declaration, first))
+        self.assertTrue(context.evaluate(declaration, second))
+        self.assertEqual(calls, [["ALPHA", "BETA"]])

--- a/tests/unit/test_graphql_permission_capabilities.py
+++ b/tests/unit/test_graphql_permission_capabilities.py
@@ -28,6 +28,7 @@ class DummyManager:
     identification: dict[str, Any]
 
     def __hash__(self) -> int:
+        """Return a stable hash derived from the test identification code."""
         return hash(self.identification["code"])
 
 
@@ -50,14 +51,24 @@ class TestCurrentUserCapabilityProvider:
 
 class GraphQLPermissionCapabilityTests(SimpleTestCase):
     def test_object_capability_is_public_permission_api(self) -> None:
+        """
+        Verify the public permission package re-exports the object capability helper.
+        """
         from general_manager.permission import object_capability as public_helper
 
         self.assertIs(public_helper, object_capability)
 
     def test_object_capability_evaluates_once_per_operation_cache_key(self) -> None:
+        """
+        Verify object capability results are cached per operation identity.
+
+        The evaluator records each invocation so the assertion can prove repeated
+        evaluations for the same declaration and instance reuse the cached result.
+        """
         calls: list[str] = []
 
         def can_rename(instance: DummyManager, user: Any) -> bool:
+            """Record the evaluated manager code and allow the capability."""
             calls.append(instance.identification["code"])
             return True
 
@@ -71,9 +82,16 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertEqual(calls, ["ALPHA"])
 
     def test_object_capability_denies_and_caches_evaluator_errors(self) -> None:
+        """
+        Verify evaluator exceptions deny the capability and are cached.
+
+        The broken evaluator increments a counter before raising so repeated
+        evaluations can prove the deny-on-error result is stored.
+        """
         calls = 0
 
         def broken_evaluator(instance: DummyManager, user: Any) -> bool:
+            """Count the evaluation attempt and simulate a policy backend failure."""
             nonlocal calls
             calls += 1
             raise PolicyBackendUnavailable
@@ -88,12 +106,19 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertEqual(calls, 1)
 
     def test_object_capability_batch_evaluator_warms_cache(self) -> None:
+        """
+        Verify batch evaluators can populate cached object capability results.
+
+        The per-object evaluator returns false, so true results after warmup show
+        that the batch output was used instead of falling back.
+        """
         calls: list[list[str]] = []
 
         def can_rename_batch(
             instances: Sequence[Any],
             user: Any,
         ) -> dict[DummyManager, bool]:
+            """Record the warmed manager codes and allow each provided instance."""
             managers = cast(Sequence[DummyManager], instances)
             calls.append([instance.identification["code"] for instance in managers])
             return {instance: True for instance in managers}
@@ -114,7 +139,13 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertEqual(calls, [["ALPHA", "BETA"]])
 
     def test_permission_capability_allows_manager_without_permission(self) -> None:
+        """
+        Verify permission-backed capabilities allow managers without Permission classes.
+        """
+
         class UnprotectedManager:
+            """Manager stub with no nested Permission class."""
+
             pass
 
         declaration = permission_capability(UnprotectedManager, "create")
@@ -125,16 +156,27 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         )
 
     def test_permission_capability_delegates_create_update_and_delete(self) -> None:
+        """
+        Verify CRUD permission capabilities call the matching permission entrypoint.
+
+        The test manager records create, update, and delete calls to prove payload
+        resolution and action dispatch are wired through the real helper.
+        """
         calls: list[tuple[str, dict[str, Any]]] = []
 
         class ProtectedManager:
+            """Manager stub with a recording Permission class."""
+
             class Permission:
+                """Permission stub that records CRUD checks for assertions."""
+
                 @staticmethod
                 def check_create_permission(
                     payload: dict[str, Any],
                     target: type[Any],
                     user: Any,
                 ) -> None:
+                    """Record create permission payloads."""
                     del target, user
                     calls.append(("create", payload))
 
@@ -144,11 +186,13 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
                     instance: Any,
                     user: Any,
                 ) -> None:
+                    """Record update permission payloads."""
                     del instance, user
                     calls.append(("update", payload))
 
                 @staticmethod
                 def check_delete_permission(instance: Any, user: Any) -> None:
+                    """Record delete permission checks."""
                     del instance, user
                     calls.append(("delete", {}))
 
@@ -180,10 +224,19 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         )
 
     def test_permission_capability_denies_permission_errors(self) -> None:
+        """
+        Verify permission-backed capabilities return false when permissions fail.
+        """
+
         class ProtectedManager:
+            """Manager stub with a denying Permission class."""
+
             class Permission:
+                """Permission stub that denies delete checks."""
+
                 @staticmethod
                 def check_delete_permission(instance: Any, user: Any) -> None:
+                    """Raise a permission denial for delete operations."""
                     del instance, user
                     raise DeniedPermission
 
@@ -194,7 +247,12 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         )
 
     def test_mutation_capability_allows_unguarded_mutation(self) -> None:
+        """
+        Verify mutation-backed capabilities allow mutations with no permission class.
+        """
+
         def archive_project() -> None:
+            """Mutation stub used to carry GraphQL mutation metadata."""
             return None
 
         archive_project._general_manager_mutation_permission = None  # type: ignore[attr-defined]
@@ -206,13 +264,21 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         )
 
     def test_mutation_capability_denies_permission_errors(self) -> None:
+        """
+        Verify mutation-backed capabilities return false on permission errors.
+        """
+
         class ArchivePermission:
+            """Mutation permission stub that always denies."""
+
             @staticmethod
             def check(payload: dict[str, Any], user: Any) -> None:
+                """Raise a permission denial for the provided payload."""
                 del payload, user
                 raise DeniedPermission
 
         def archive_project() -> None:
+            """Mutation stub used to carry GraphQL mutation metadata."""
             return None
 
         archive_project._general_manager_mutation_permission = ArchivePermission  # type: ignore[attr-defined]
@@ -226,12 +292,16 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         )
 
     def test_batch_warm_skips_empty_uncacheable_and_cached_inputs(self) -> None:
+        """
+        Verify warmup skips empty inputs, unbatchable declarations, and cached rows.
+        """
         batch_calls = 0
 
         def can_rename_batch(
             instances: Sequence[Any],
             user: Any,
         ) -> list[bool]:
+            """Count batch evaluations and return an allow result."""
             nonlocal batch_calls
             del instances, user
             batch_calls += 1
@@ -255,13 +325,18 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertTrue(context.evaluate(with_batch, instance))
 
     def test_batch_warm_logs_and_falls_back_after_batch_errors(self) -> None:
+        """
+        Verify batch warmup logs failures and leaves per-object fallback available.
+        """
         calls = 0
 
         def broken_batch(instances: Sequence[Any], user: Any) -> list[bool]:
+            """Simulate a failing batch policy backend."""
             del instances, user
             raise PolicyBackendUnavailable
 
         def evaluator(instance: DummyManager, user: Any) -> bool:
+            """Count fallback object evaluations and allow the capability."""
             nonlocal calls
             del instance, user
             calls += 1
@@ -285,15 +360,25 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertEqual(calls, 1)
 
     def test_get_graphql_capabilities_filters_invalid_declarations(self) -> None:
+        """
+        Verify capability discovery returns only valid GraphQL capability declarations.
+        """
         valid = object_capability("canRename", lambda _instance, _user: True)
 
         class Project:
+            """Manager stub with mixed valid and invalid capability declarations."""
+
             class Permission:
+                """Permission stub exposing GraphQL capability declarations."""
+
                 graphql_capabilities = (valid, object())
 
         self.assertEqual(get_graphql_capabilities(Project), (valid,))
 
     def test_get_and_clear_capability_context_share_operation_storage(self) -> None:
+        """
+        Verify operation contexts are reused until explicitly cleared.
+        """
         info = SimpleNamespace(
             context=SimpleNamespace(user=AnonymousUser()),
             operation=object(),
@@ -310,10 +395,17 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
     def test_get_capability_context_returns_uncached_context_when_storage_fails(
         self,
     ) -> None:
+        """
+        Verify context creation falls back when request context storage is immutable.
+        """
+
         class FrozenContext:
+            """Context stub that rejects dynamic attribute storage."""
+
             user = AnonymousUser()
 
             def __setattr__(self, name: str, value: Any) -> None:
+                """Reject attempts to store operation-scoped cache state."""
                 del name, value
                 raise RuntimeError("frozen")
 
@@ -327,11 +419,17 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertIsNot(first, second)
 
     def test_clear_capability_context_ignores_missing_storage(self) -> None:
+        """
+        Verify clearing capability context is a no-op when storage is absent.
+        """
         info = SimpleNamespace(context=SimpleNamespace(), operation=object())
 
         clear_capability_context(info)
 
     def test_anonymous_context_default_user_identity(self) -> None:
+        """
+        Verify an omitted user defaults to an anonymous capability user.
+        """
         context = CapabilityEvaluationContext()
         declaration = GraphQLPermissionCapability(
             "canView",
@@ -341,7 +439,13 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         self.assertTrue(context.evaluate(declaration, DummyManager({"code": "ALPHA"})))
 
     def test_graphql_capability_type_is_cached_and_resolves_declaration(self) -> None:
+        """
+        Verify generated object capability GraphQL types are cached and resolvable.
+        """
+
         class Project(GeneralManager):
+            """Manager stub used for generated object capability type naming."""
+
             pass
 
         declaration = object_capability("canView", lambda _instance, _user: True)
@@ -364,6 +468,9 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
     def test_current_user_capability_type_is_cached_and_resolves_declaration(
         self,
     ) -> None:
+        """
+        Verify generated current-user capability types are cached and resolvable.
+        """
         user = AnonymousUser()
         declaration = object_capability(
             "canViewProfile",
@@ -385,6 +492,9 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={})
     def test_current_user_capability_provider_is_optional(self) -> None:
+        """
+        Verify current-user capability provider lookup returns none when unset.
+        """
         self.assertIsNone(GraphQL._get_current_user_capability_provider())
 
     @override_settings(
@@ -396,6 +506,9 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         }
     )
     def test_register_current_user_capabilities_uses_provider_fields(self) -> None:
+        """
+        Verify provider-backed `me` fields resolve through generated query fields.
+        """
         user = SimpleNamespace(email="apollo@example.com")
         GraphQL.reset_registry()
 

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -18,6 +18,7 @@ import unittest
 from general_manager.api.graphql import GraphQL
 from general_manager.interface import DatabaseInterface
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.permission import AdditiveManagerPermission, object_capability
 from general_manager.utils.testing import GeneralManagerTransactionTestCase
 from tests.utils.simple_manager_interface import BaseTestInterface
 
@@ -56,6 +57,15 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         class Employee(GeneralManager):
             class Interface(DatabaseInterface):
                 name = CharField(max_length=120)
+
+            class Permission(AdditiveManagerPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+                graphql_capabilities = (
+                    object_capability(
+                        "canKeepName",
+                        lambda employee, _user: employee.name == "Alice",
+                    ),
+                )
 
         cls.general_manager_classes = [Employee]
         cls.Employee = Employee
@@ -157,6 +167,55 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         update = second_event.data["onEmployeeChange"]
         self.assertEqual(update["action"], "update")
         self.assertEqual(update["item"]["name"], "Bob")
+
+    def test_subscription_capabilities_are_recomputed_for_each_event(self) -> None:
+        employee = self.Employee.create(name="Alice", creator_id=self.user.id)
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription ($id: ID!) {
+                onEmployeeChange(id: $id) {
+                    action
+                    item {
+                        id
+                        name
+                        capabilities {
+                            canKeepName
+                        }
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> tuple[object, object]:
+            generator = await schema.subscribe(
+                subscription,
+                variable_values={"id": employee.id},
+                context_value=context,
+            )
+            try:
+                first = await generator.__anext__()
+                await asyncio.to_thread(
+                    lambda: employee.update(
+                        name="Bob",
+                        creator_id=self.user.id,
+                    )
+                )
+                second = await generator.__anext__()
+            finally:
+                await generator.aclose()
+            return first, second
+
+        first_event, second_event = asyncio.run(run_subscription())
+
+        self.assertIsNone(first_event.errors)
+        self.assertTrue(
+            first_event.data["onEmployeeChange"]["item"]["capabilities"]["canKeepName"]
+        )
+        self.assertIsNone(second_event.errors)
+        self.assertFalse(
+            second_event.data["onEmployeeChange"]["item"]["capabilities"]["canKeepName"]
+        )
 
 
 class GraphQLSubscriptionPropertySelectionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add GraphQL permission capability declarations for object, manager permission, and mutation-backed capability hints.
- Generate per-manager `capabilities` fields and optional provider-backed `me.capabilities` fields.
- Warm object capability batches only when capability fields are selected, with operation-scoped caching and deny-on-error behavior.
- Add unit/integration coverage and documentation for the new advisory authorization hints.

## Validation
- `python -m pytest` (2236 passed, 5 skipped, 1 warning)
- `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add GraphQL permission capabilities and optional current-user capability provider; selection-driven warming preloads capability hints for lists.

* **Documentation**
  * Add ADR 0007, API docs, concept guides, and a how‑to for GraphQL capability exposure.

* **Tests**
  * Add extensive unit and integration tests covering capability helpers, warming, caching, subscription behavior, and current-user capabilities.

* **Chores**
  * Update ignore rules and CI upload metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->