### PR TITLE
[codex] Lazily initialize late manager attributes

### DIFF
--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -77,6 +77,21 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         """Return a detailed representation of the manager instance."""
         return f"{self.__class__.__name__}(**{self.__id})"
 
+    def __getattr__(self, attribute_name: str) -> Any:
+        """
+        Lazily install descriptors for declared fields on late-imported managers.
+
+        Manager classes imported after Django app startup are registered but have
+        not yet had descriptor properties attached. Falling back here lets
+        interactive and test-only managers behave like startup-loaded managers
+        while preserving normal ``AttributeError`` behavior for unknown names.
+        """
+        if GeneralManagerMeta.ensure_attributes_initialized(
+            self.__class__, attribute_name
+        ):
+            return object.__getattribute__(self, attribute_name)
+        raise AttributeError(attribute_name)
+
     def __reduce__(self) -> str | tuple[Any, ...]:
         """
         Provide pickling support for the manager instance.

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any, ClassVar, Iterable, Type, TypeVar, cast
 
 from general_manager.interface.base_interface import InterfaceBase
@@ -86,7 +87,24 @@ class GeneralManagerMeta(type):
     read_only_classes: ClassVar[list[Type[GeneralManager]]] = []
     pending_graphql_interfaces: ClassVar[list[Type[GeneralManager]]] = []
     pending_attribute_initialization: ClassVar[list[Type[GeneralManager]]] = []
+    _attribute_initialization_lock: ClassVar[Any] = threading.Lock()
     Interface: type[InterfaceBase]
+
+    def __getattribute__(cls, attribute_name: str) -> Any:
+        """
+        Initialize late-imported field descriptors before class attribute lookup.
+
+        ``__getattr__`` is only reached for missing names, so inherited
+        ``GeneralManager`` attributes must pass through here to let declared
+        fields override inherited names the same way bootstrap initialization
+        does.
+        """
+        if not attribute_name.startswith("_"):
+            manager_class = cast(Type["GeneralManager"], cls)
+            GeneralManagerMeta.ensure_attributes_initialized(
+                manager_class, attribute_name
+            )
+        return type.__getattribute__(cls, attribute_name)
 
     def __getattr__(cls, attribute_name: str) -> Any:
         """
@@ -124,25 +142,35 @@ class GeneralManagerMeta(type):
             return False
         if not hasattr(interface, "get_attributes"):
             return False
-        if "_attributes" in vars(manager_class):
-            attributes = manager_class._attributes
+
+        with GeneralManagerMeta._attribute_initialization_lock:
+            if "_attributes" in vars(manager_class):
+                attributes = manager_class._attributes
+                if attribute_name is not None and attribute_name not in attributes:
+                    return False
+                if attribute_name is None or attribute_name not in vars(manager_class):
+                    GeneralManagerMeta.create_at_properties_for_attributes(
+                        attributes.keys(), manager_class
+                    )
+                return True
+
+            try:
+                attributes = interface.get_attributes()
+            except NotImplementedError:
+                return False
             if attribute_name is not None and attribute_name not in attributes:
                 return False
-            if attribute_name is None or attribute_name not in vars(manager_class):
-                GeneralManagerMeta.create_at_properties_for_attributes(
-                    attributes.keys(), manager_class
+            manager_class._attributes = attributes
+            GeneralManagerMeta.create_at_properties_for_attributes(
+                attributes.keys(), manager_class
+            )
+            try:
+                GeneralManagerMeta.pending_attribute_initialization.remove(
+                    manager_class
                 )
+            except ValueError:
+                pass
             return True
-        attributes = interface.get_attributes()
-        if attribute_name is not None and attribute_name not in attributes:
-            return False
-        manager_class._attributes = attributes
-        GeneralManagerMeta.create_at_properties_for_attributes(
-            attributes.keys(), manager_class
-        )
-        if manager_class in GeneralManagerMeta.pending_attribute_initialization:
-            GeneralManagerMeta.pending_attribute_initialization.remove(manager_class)
-        return True
 
     @staticmethod
     def ensure_manager_is_valid(

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -88,6 +88,62 @@ class GeneralManagerMeta(type):
     pending_attribute_initialization: ClassVar[list[Type[GeneralManager]]] = []
     Interface: type[InterfaceBase]
 
+    def __getattr__(cls, attribute_name: str) -> Any:
+        """
+        Lazily install field descriptors for manager classes imported after startup.
+
+        Django app initialization wires descriptors for managers known at startup.
+        Managers defined later, for example in an interactive shell or a test scratch
+        module, still register with this metaclass but have not had descriptors
+        attached yet. If the missing class attribute is a declared manager field,
+        initialize the class and retry the lookup.
+        """
+        manager_class = cast(Type["GeneralManager"], cls)
+        if GeneralManagerMeta.ensure_attributes_initialized(
+            manager_class, attribute_name
+        ):
+            return getattr(cls, attribute_name)
+        raise AttributeError(attribute_name)
+
+    @staticmethod
+    def ensure_attributes_initialized(
+        manager_class: Type["GeneralManager"],
+        attribute_name: str | None = None,
+    ) -> bool:
+        """
+        Ensure descriptor-backed fields are installed for ``manager_class``.
+
+        Returns ``True`` when the class exposes ``attribute_name`` after
+        initialization, or when no specific attribute was requested and
+        descriptors were installed. Returns ``False`` for unknown attributes or
+        classes that do not expose interface-backed fields.
+        """
+        try:
+            interface = type.__getattribute__(manager_class, "Interface")
+        except AttributeError:
+            return False
+        if not hasattr(interface, "get_attributes"):
+            return False
+        if "_attributes" in vars(manager_class):
+            attributes = manager_class._attributes
+            if attribute_name is not None and attribute_name not in attributes:
+                return False
+            if attribute_name is None or attribute_name not in vars(manager_class):
+                GeneralManagerMeta.create_at_properties_for_attributes(
+                    attributes.keys(), manager_class
+                )
+            return True
+        attributes = interface.get_attributes()
+        if attribute_name is not None and attribute_name not in attributes:
+            return False
+        manager_class._attributes = attributes
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            attributes.keys(), manager_class
+        )
+        if manager_class in GeneralManagerMeta.pending_attribute_initialization:
+            GeneralManagerMeta.pending_attribute_initialization.remove(manager_class)
+        return True
+
     @staticmethod
     def ensure_manager_is_valid(
         instance: "GeneralManager",

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -7,6 +7,8 @@ from general_manager.interface.base_interface import InterfaceBase
 from general_manager.interface.interfaces.calculation import (
     CalculationInterface,
 )
+from general_manager.bootstrap import initialize_general_manager_classes
+from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.input import Input as GMInput
 
 
@@ -476,6 +478,116 @@ class GeneralManagerMetaTests(SimpleTestCase):
             hasattr(MyManager, "post_mark") and MyManager.post_mark is True,  # type: ignore
             msg="MyManager.post_mark should be True set by the DummyInterface post_creation hook.",
         )
+
+    def test_late_imported_manager_initializes_declared_field_on_access(self):
+        """
+        Managers imported after app startup should still expose declared fields.
+
+        This mirrors shell/test scratch modules: the class is registered by the
+        metaclass, but the startup bootstrap has not installed descriptors yet.
+        """
+
+        class LateImportedCalculation(GeneralManager):
+            user: int
+
+            class Interface(CalculationInterface):
+                user = GMInput(int, possible_values=[1, 2, 3])
+
+        self.assertNotIn("user", vars(LateImportedCalculation))
+        manager = LateImportedCalculation(user="1")
+
+        self.assertEqual(manager.user, 1)
+        self.assertIs(LateImportedCalculation.user, int)
+        self.assertNotIn(
+            LateImportedCalculation,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
+    def test_late_imported_manager_still_raises_for_unknown_attribute(self):
+        class LateImportedCalculation(GeneralManager):
+            user: int
+
+            class Interface(CalculationInterface):
+                user = GMInput(int, possible_values=[1, 2, 3])
+
+        manager = LateImportedCalculation(user=1)
+
+        missing_attribute = "organization"
+        with self.assertRaises(AttributeError):
+            getattr(manager, missing_attribute)
+
+    def test_lazy_initialized_manager_does_not_block_bootstrap_initialization(self):
+        class LazyCalculation(GeneralManager):
+            user: int
+
+            class Interface(CalculationInterface):
+                user = GMInput(int, possible_values=[1, 2, 3])
+
+        class PendingCalculation(GeneralManager):
+            project: int
+
+            class Interface(CalculationInterface):
+                project = GMInput(int, possible_values=[10, 20])
+
+        lazy_manager = LazyCalculation(user=1)
+
+        self.assertEqual(lazy_manager.user, 1)
+        self.assertNotIn(
+            LazyCalculation,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+        self.assertIn(
+            PendingCalculation,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
+        initialize_general_manager_classes(
+            GeneralManagerMeta.pending_attribute_initialization,
+            GeneralManagerMeta.all_classes,
+        )
+
+        self.assertIs(LazyCalculation.user, int)
+        self.assertIs(PendingCalculation.project, int)
+        self.assertEqual(PendingCalculation(project=10).project, 10)
+
+    def test_late_imported_manager_initializes_non_calculation_field_on_access(self):
+        class LateImportedInterface(DummyInterface):
+            input_fields: ClassVar[dict[str, GMInput]] = {"slug": GMInput(str)}
+
+            @classmethod
+            def get_attributes(cls) -> dict[str, object]:
+                return {
+                    "display_name": lambda interface: interface.identification["slug"]
+                }
+
+            @classmethod
+            def get_field_type(cls, field_name: str) -> type:
+                if field_name == "display_name":
+                    return str
+                return super().get_field_type(field_name)
+
+            @classmethod
+            def handle_interface(cls):
+                def pre_creation(name, attrs, interface):
+                    attrs["Interface"] = interface
+                    return attrs, interface, None
+
+                def post_creation(new_cls, interface_cls, model):
+                    return None
+
+                return pre_creation, post_creation
+
+        class LateImportedPlainManager(GeneralManager):
+            display_name: str
+
+            class Interface(LateImportedInterface):
+                pass
+
+        self.assertNotIn("display_name", vars(LateImportedPlainManager))
+        manager = LateImportedPlainManager(slug="falcon")
+
+        self.assertEqual(manager.display_name, "falcon")
+        self.assertIs(LateImportedPlainManager.display_name, str)
 
     def test_invalid_interface_raises_type_error(self):
         """

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -494,6 +494,11 @@ class GeneralManagerMetaTests(SimpleTestCase):
                 user = GMInput(int, possible_values=[1, 2, 3])
 
         self.assertNotIn("user", vars(LateImportedCalculation))
+        self.assertIs(LateImportedCalculation.user, int)
+        self.assertNotIn(
+            LateImportedCalculation,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
         manager = LateImportedCalculation(user="1")
 
         self.assertEqual(manager.user, 1)
@@ -588,6 +593,49 @@ class GeneralManagerMetaTests(SimpleTestCase):
 
         self.assertEqual(manager.display_name, "falcon")
         self.assertIs(LateImportedPlainManager.display_name, str)
+
+    def test_late_imported_manager_declared_field_overrides_inherited_attribute(self):
+        class LateImportedCalculation(GeneralManager):
+            create: int
+
+            class Interface(CalculationInterface):
+                create = GMInput(int, possible_values=[1, 2, 3])
+
+        self.assertNotIn("create", vars(LateImportedCalculation))
+
+        self.assertIs(LateImportedCalculation.create, int)
+        self.assertEqual(LateImportedCalculation(create=2).create, 2)
+
+    def test_late_imported_manager_without_read_attributes_raises_attribute_error(self):
+        class LateImportedInterface(DummyInterface):
+            input_fields: ClassVar[dict[str, GMInput]] = {"slug": GMInput(str)}
+
+            @classmethod
+            def get_attributes(cls) -> dict[str, object]:
+                raise NotImplementedError
+
+            @classmethod
+            def handle_interface(cls):
+                def pre_creation(name, attrs, interface):
+                    attrs["Interface"] = interface
+                    return attrs, interface, None
+
+                def post_creation(new_cls, interface_cls, model):
+                    return None
+
+                return pre_creation, post_creation
+
+        class LateImportedPlainManager(GeneralManager):
+            missing: str
+
+            class Interface(LateImportedInterface):
+                pass
+
+        manager = LateImportedPlainManager(slug="falcon")
+
+        missing_attribute = "missing"
+        with self.assertRaises(AttributeError):
+            getattr(manager, missing_attribute)
 
     def test_invalid_interface_raises_type_error(self):
         """


### PR DESCRIPTION
## Summary

Adds lazy descriptor initialization for `GeneralManager` subclasses that are imported after Django startup, so declared interface fields are available on first class or instance access.

## Details

- Adds a shared metaclass helper to install descriptor-backed manager fields when a declared attribute is first requested.
- Adds instance-level fallback access so late-imported managers behave like startup-initialized managers.
- Preserves normal `AttributeError` behavior for unknown attributes.
- Covers late calculation managers, non-calculation managers, and interaction with the normal bootstrap initializer.

## Validation

- `python -m pytest tests/unit/test_general_manager_meta.py`
- `ruff check src/general_manager/manager/general_manager.py src/general_manager/manager/meta.py tests/unit/test_general_manager_meta.py`
- `mypy src/general_manager/manager/general_manager.py src/general_manager/manager/meta.py`
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manager classes can now be registered after Django app startup with automatic field descriptor initialization on first access.

* **Tests**
  * Added unit tests validating proper initialization of declared field descriptors for post-startup manager class registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->