### PR TITLE
fix: bump Django, pytest, and black to resolve Dependabot vulnerabilities

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 asgiref==3.10.0
-Django==5.2.12
+Django==5.2.13
 django-simple-history==3.8.0
 exrex==0.12.0
 factory_boy==3.3.3

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -2,7 +2,7 @@
 -e .
 
 ipython==9.0.2
-pytest==8.4.0
+pytest==9.0.3
 pytest_django==4.11.1
 pytest_cov==4.1.0
 django-types==0.21.0
@@ -24,4 +24,4 @@ mkdocs-minify-plugin==0.8.0
 mkdocs-section-index==0.3.10
 mkdocstrings==0.30.1
 mkdocstrings-python==1.18.2
-black==25.9.0
+black==26.3.1


### PR DESCRIPTION
## Summary

- **Django 5.2.12 → 5.2.13**: resolves 5 Dependabot alerts
  - [#24] ASGI header spoofing via underscore/hyphen conflation (high)
  - [#22] WSGI requests bypassing `DATA_UPLOAD_MAX_MEMORY_SIZE` via missing/understated `Content-Length` (high)
  - [#23] DoS via MultiPartParser through crafted multipart uploads (medium)
  - [#25] Privilege abuse in `ModelAdmin.list_editable` (low)
  - [#26] Privilege abuse in `GenericInlineModelAdmin` (low)
- **pytest 8.4.0 → 9.0.3**: resolves [#27] vulnerable tmpdir handling (medium)
- **black 25.9.0 → 26.3.1**: resolves [#21] arbitrary file writes via unsanitized cache file names (high)

## Test plan

- [ ] `pip install -r requirements/development.txt` installs without conflicts
- [ ] `python -m pytest` passes
- [ ] `ruff check .` and `mypy .` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)