### PR TITLE
[codex] Fix premature manager lazy initialization

### DIFF
--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -395,6 +395,10 @@ class _FieldDescriptorBuilder:
         """
         if related_model == "self":
             return cast(type[models.Model], self.model)
+        if isinstance(related_model, type) and issubclass(related_model, models.Model):
+            return cast(type[models.Model], related_model)
+        if related_model is not None:
+            return None
         return cast(Optional[type[models.Model]], related_model)
 
 

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -99,7 +99,7 @@ class GeneralManagerMeta(type):
         fields override inherited names the same way bootstrap initialization
         does.
         """
-        if not attribute_name.startswith("_"):
+        if not attribute_name.startswith("_") and attribute_name != "Interface":
             manager_class = cast(Type["GeneralManager"], cls)
             GeneralManagerMeta.ensure_attributes_initialized(
                 manager_class, attribute_name

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -102,3 +102,30 @@ def test_build_field_descriptors_disambiguates_duplicate_reverse_relations() -> 
     assert relation_field_names == {"fk_a", "fk_b"}
     assert resolve_calls.count("fk_a") == 1
     assert resolve_calls.count("fk_b") == 1
+
+
+def test_build_field_descriptors_skips_unresolved_foreign_key_targets() -> None:
+    model = type("ModelUnderTest", (), {})
+    interface_cls = type("InterfaceUnderTest", (), {"_model": model})
+    unresolved_field = Mock(spec=models.Field)
+    unresolved_field.name = "owner"
+    unresolved_field.related_model = "accounts.User"
+    unresolved_field.null = False
+    unresolved_field.editable = True
+    unresolved_field.default = None
+
+    field_descriptors_module = (
+        "general_manager.interface.capabilities.orm_utils.field_descriptors"
+    )
+    with (
+        patch(f"{field_descriptors_module}._iter_model_fields", return_value=[]),
+        patch(f"{field_descriptors_module}._iter_many_to_many_fields", return_value=[]),
+        patch(f"{field_descriptors_module}._iter_reverse_relations", return_value=[]),
+        patch(
+            f"{field_descriptors_module}._iter_foreign_key_fields",
+            return_value=[unresolved_field],
+        ),
+    ):
+        descriptors = build_field_descriptors(interface_cls)
+
+    assert "owner" not in descriptors

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -508,6 +508,24 @@ class GeneralManagerMetaTests(SimpleTestCase):
             GeneralManagerMeta.pending_attribute_initialization,
         )
 
+    def test_accessing_interface_does_not_lazy_initialize_manager_attributes(self):
+        class LateImportedCalculation(GeneralManager):
+            user: int
+
+            class Interface(CalculationInterface):
+                user = GMInput(int, possible_values=[1, 2, 3])
+
+        self.assertNotIn("user", vars(LateImportedCalculation))
+
+        interface = LateImportedCalculation.Interface
+
+        self.assertIs(interface, LateImportedCalculation.Interface)
+        self.assertNotIn("user", vars(LateImportedCalculation))
+        self.assertIn(
+            LateImportedCalculation,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
     def test_late_imported_manager_still_raises_for_unknown_attribute(self):
         class LateImportedCalculation(GeneralManager):
             user: int


### PR DESCRIPTION
## Summary

- avoid lazy manager attribute initialization when reading `Manager.Interface`
- skip unresolved ForeignKey targets before descriptor metadata calls `issubclass()`
- add regression coverage for startup-safe Interface access and unresolved relation targets

## Root cause

The lazy initialization added after `0.38.0` ran from `GeneralManagerMeta.__getattribute__` for all public class attributes, including `Interface`. During Django startup this could evaluate `Interface.get_attributes()` while `apps.ready()` was still wiring managers, exposing unresolved relation metadata and crashing descriptor translation with `TypeError: issubclass() arg 1 must be a class`.

## Validation

- `python -m pytest tests/unit/test_general_manager_meta.py tests/unit/test_field_descriptors.py -q`
- `python -m pytest tests/unit/test_database_based_interface.py tests/unit/test_general_manager_meta.py tests/unit/test_field_descriptors.py -q`
- `ruff check src/general_manager/manager/meta.py src/general_manager/interface/capabilities/orm_utils/field_descriptors.py tests/unit/test_general_manager_meta.py tests/unit/test_field_descriptors.py`
- pre-commit on commit, including Ruff and mypy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience by properly handling unresolved model relationships to prevent potential errors
  * Optimized performance by preventing unnecessary descriptor and field initialization when accessing interface attributes

* **Tests**
  * Added unit tests to verify proper handling of unresolved model field references
  * Added unit tests to ensure attribute access optimization functions correctly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->