### PR TITLE
Add class-wide GraphQL subscriptions

### DIFF
--- a/docs/concepts/graphql/subscriptions.md
+++ b/docs/concepts/graphql/subscriptions.md
@@ -23,6 +23,22 @@ subscription ($id: ID!) {
 }
 ```
 
+For class-wide streams, GraphQL also exposes `on<ManagerClass>ClassChange` (e.g. `onProjectClassChange`). This field takes no identification arguments and emits one changed item per event:
+
+```graphql
+subscription {
+  onProjectClassChange {
+    action
+    item {
+      id
+      name
+    }
+  }
+}
+```
+
+Class-wide subscriptions do not emit an initial `snapshot`, because there is no single current item to return. They only stream future changes that happen after the subscription is active.
+
 Each event has two fields:
 
 - `action`: describes what triggered the update (`snapshot`, `update`, `delete`, custom signals).
@@ -31,7 +47,7 @@ Each event has two fields:
 ### Signals and channels
 
 - Subscriptions require Django Channels. If `get_channel_layer()` returns `None`, the resolver raises a descriptive GraphQL error explaining that `CHANNEL_LAYERS` must be configured.
-- Managers are automatically decorated with `@data_change` and emit `pre_data_change` and `post_data_change` signals. GraphQL listens to `post_data_change` and forwards the event to the relevant channel group (`gm_subscriptions.<Manager>.<digest>`).
+- Managers are automatically decorated with `@data_change` and emit `pre_data_change` and `post_data_change` signals. GraphQL listens to `post_data_change` and forwards the event to the relevant instance channel group (`gm_subscriptions.<Manager>.<digest>`) and class channel group (`gm_subscriptions.<Manager>.__class__`).
 
 ### Identification helpers
 
@@ -61,6 +77,8 @@ No additional configuration is necessary. Continue to annotate computed fields w
 
 - Missing channel layer configuration produces a GraphQL error instructing the operator to configure `CHANNEL_LAYERS`.
 - If instantiating the manager or a dependency fails during an update, the subscription sends an event with `item = null` and the incoming `action`. Clients can use this to show a placeholder while retrying the fetch.
+- Class-wide subscriptions check object-level read permission before yielding each event. If the requesting user cannot read the changed object, the event is suppressed entirely so the stream does not reveal hidden object IDs or change timing.
+- If a class-wide event cannot be rehydrated, such as a hard-deleted object that no longer exists, the event is suppressed rather than sent with `item = null`.
 
 ## Testing tips
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+pythonpath = src
 DJANGO_SETTINGS_MODULE = tests.test_settings
 django_find_project = false
 python_files = test_*.py *_test.py

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -28,6 +28,7 @@ from typing import (
 import graphene  # type: ignore[import]
 from asgiref.sync import async_to_sync
 from channels.layers import BaseChannelLayer
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.module_loading import import_string
 
 from general_manager.bucket.base_bucket import Bucket
@@ -120,6 +121,10 @@ if TYPE_CHECKING:
     from graphene import ResolveInfo as GraphQLResolveInfo
 
 logger = get_logger("api.graphql")
+SUBSCRIPTION_HYDRATION_ERRORS: tuple[type[Exception], ...] = (
+    *HANDLED_MANAGER_ERRORS,
+    ObjectDoesNotExist,
+)
 
 
 GeneralManagerT = TypeVar("GeneralManagerT", bound=GeneralManager)
@@ -1202,7 +1207,7 @@ class GraphQL:
                                 identification_copy,
                                 property_names=property_names,
                             )
-                        except HANDLED_MANAGER_ERRORS:
+                        except SUBSCRIPTION_HYDRATION_ERRORS:
                             item = None
                         clear_capability_context(info)
                         yield SubscriptionEvent(item=item, action=action)
@@ -1278,7 +1283,7 @@ class GraphQL:
                                 cast(type[GeneralManager], generalManagerClass),
                                 identification_copy,
                             )
-                        except HANDLED_MANAGER_ERRORS:
+                        except SUBSCRIPTION_HYDRATION_ERRORS:
                             continue
                         if not _can_read_instance_fn(item, info):
                             continue
@@ -1350,6 +1355,8 @@ class GraphQL:
         sender: type[GeneralManager] | GeneralManager,
         instance: GeneralManager | None,
         action: str,
+        previous_instance: GeneralManager | None = None,
+        identification: dict[str, Any] | None = None,
         **_: Any,
     ) -> None:
         """
@@ -1362,13 +1369,14 @@ class GraphQL:
             instance (GeneralManager | None): The GeneralManager instance that changed.
             action (str): A string describing the change action (e.g., "created", "updated", "deleted").
         """
-        if instance is None or not isinstance(instance, GeneralManager):
+        event_instance = instance if instance is not None else previous_instance
+        if event_instance is None or not isinstance(event_instance, GeneralManager):
             return
 
         if isinstance(sender, type) and issubclass(sender, GeneralManager):
             manager_class: type[GeneralManager] = sender
         else:
-            manager_class = instance.__class__
+            manager_class = event_instance.__class__
 
         if manager_class.__name__ not in cls.manager_registry:
             logger.debug(
@@ -1391,13 +1399,18 @@ class GraphQL:
             )
             return
 
-        group_name = cls._group_name(manager_class, instance.identification)
+        event_identification = (
+            deepcopy(identification)
+            if identification is not None
+            else deepcopy(event_instance.identification)
+        )
+        group_name = cls._group_name(manager_class, event_identification)
         class_group_name = cls._class_group_name(manager_class)
         message = {
             "type": "gm.subscription.event",
             "action": action,
             "manager": manager_class.__name__,
-            "identification": deepcopy(instance.identification),
+            "identification": event_identification,
         }
         group_send = async_to_sync(channel_layer.group_send)
         group_send(group_name, message)

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -1413,8 +1413,20 @@ class GraphQL:
             "identification": event_identification,
         }
         group_send = async_to_sync(channel_layer.group_send)
-        group_send(group_name, message)
-        group_send(class_group_name, message)
+        for target_group_name in (group_name, class_group_name):
+            try:
+                group_send(target_group_name, message)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "failed to dispatch subscription event",
+                    context={
+                        "manager": manager_class.__name__,
+                        "action": action,
+                        "group": target_group_name,
+                        "message": message,
+                    },
+                    exc_info=exc,
+                )
         logger.debug(
             "dispatched subscription event",
             context={

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -85,6 +85,7 @@ from general_manager.api.graphql_resolvers import (
     apply_pagination as _apply_pagination_fn,
     apply_grouping as _apply_grouping_fn,
     check_read_permission as _check_read_permission_fn,
+    can_read_instance as _can_read_instance_fn,
     create_measurement_resolver as _create_measurement_resolver_fn,
     create_normal_resolver as _create_normal_resolver_fn,
     create_list_resolver as _create_list_resolver_fn,
@@ -104,7 +105,9 @@ from general_manager.api.graphql_search import (
 from general_manager.api.graphql_subscriptions import (
     get_channel_layer_safe as _get_channel_layer_fn,
     group_name as _group_name_fn,
+    class_group_name as _class_group_name_fn,
     channel_listener as _channel_listener_fn,
+    channel_message_listener as _channel_message_listener_fn,
     prime_graphql_properties as _prime_graphql_properties_fn,
     dependencies_from_tracker as _dependencies_from_tracker_fn,
     subscription_property_names as _subscription_property_names_fn,
@@ -215,6 +218,11 @@ class GraphQL:
         return _group_name_fn(manager_class, identification)
 
     @staticmethod
+    def _class_group_name(manager_class: type[GeneralManager]) -> str:
+        """Build class-wide channel group name."""
+        return _class_group_name_fn(manager_class)
+
+    @staticmethod
     async def _channel_listener(
         channel_layer: BaseChannelLayer,
         channel_name: str,
@@ -222,6 +230,15 @@ class GraphQL:
     ) -> None:
         """Listen for subscription events. See ``graphql_subscriptions.channel_listener``."""
         await _channel_listener_fn(channel_layer, channel_name, queue)
+
+    @staticmethod
+    async def _channel_message_listener(
+        channel_layer: BaseChannelLayer,
+        channel_name: str,
+        queue: asyncio.Queue[dict[str, Any]],
+    ) -> None:
+        """Listen for complete subscription event messages."""
+        await _channel_message_listener_fn(channel_layer, channel_name, queue)
 
     @classmethod
     def create_graphql_mutation(cls, generalManagerClass: type[GeneralManager]) -> None:
@@ -1073,7 +1090,11 @@ class GraphQL:
         - On termination the subscription cleans up listener tasks and unsubscribes from channel groups.
         """
         field_name = f"on_{generalManagerClass.__name__.lower()}_change"
-        if field_name in cls._subscription_fields:
+        class_field_name = f"on_{generalManagerClass.__name__.lower()}_class_change"
+        if (
+            field_name in cls._subscription_fields
+            and class_field_name in cls._subscription_fields
+        ):
             return
 
         payload_type = cls._subscription_payload_registry.get(
@@ -1094,6 +1115,7 @@ class GraphQL:
 
         identification_args = cls._build_identification_arguments(generalManagerClass)
         subscription_field = graphene.Field(payload_type, **identification_args)
+        class_subscription_field = graphene.Field(payload_type)
 
         async def subscribe(
             _root: Any,
@@ -1210,9 +1232,74 @@ class GraphQL:
             """
             return payload
 
-        cls._subscription_fields[field_name] = subscription_field
-        cls._subscription_fields[f"subscribe_{field_name}"] = subscribe
-        cls._subscription_fields[f"resolve_{field_name}"] = resolve
+        async def subscribe_class(
+            _root: Any,
+            info: GraphQLResolveInfo,
+            **_: Any,
+        ) -> AsyncIterator[SubscriptionEvent]:
+            """
+            Stream future authorized change events for any instance of a manager class.
+
+            Unlike single-entity subscriptions, class-wide subscriptions do not
+            yield an initial snapshot. Each channel event is hydrated and
+            checked against the request user's object-level read permission
+            before it is yielded.
+            """
+            try:
+                channel_layer = cast(
+                    BaseChannelLayer, cls._get_channel_layer(strict=True)
+                )
+            except RuntimeError as exc:
+                raise GraphQLError(str(exc)) from exc
+            channel_name = cast(str, await channel_layer.new_channel())
+            queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+            group_name = cls._class_group_name(
+                cast(type[GeneralManager], generalManagerClass)
+            )
+            await channel_layer.group_add(group_name, channel_name)
+            listener_task = asyncio.create_task(
+                cls._channel_message_listener(channel_layer, channel_name, queue)
+            )
+
+            async def event_stream() -> AsyncIterator[SubscriptionEvent]:
+                try:
+                    while True:
+                        message = await queue.get()
+                        if message.get("manager") != generalManagerClass.__name__:
+                            continue
+                        action = cast(str | None, message.get("action"))
+                        identification = message.get("identification")
+                        if action is None or not isinstance(identification, dict):
+                            continue
+                        identification_copy = deepcopy(identification)
+                        try:
+                            item, _ = await asyncio.to_thread(
+                                cls._instantiate_manager,
+                                cast(type[GeneralManager], generalManagerClass),
+                                identification_copy,
+                            )
+                        except HANDLED_MANAGER_ERRORS:
+                            continue
+                        if not _can_read_instance_fn(item, info):
+                            continue
+                        clear_capability_context(info)
+                        yield SubscriptionEvent(item=item, action=action)
+                finally:
+                    listener_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await listener_task
+                    await channel_layer.group_discard(group_name, channel_name)
+
+            return event_stream()
+
+        if field_name not in cls._subscription_fields:
+            cls._subscription_fields[field_name] = subscription_field
+            cls._subscription_fields[f"subscribe_{field_name}"] = subscribe
+            cls._subscription_fields[f"resolve_{field_name}"] = resolve
+        if class_field_name not in cls._subscription_fields:
+            cls._subscription_fields[class_field_name] = class_subscription_field
+            cls._subscription_fields[f"subscribe_{class_field_name}"] = subscribe_class
+            cls._subscription_fields[f"resolve_{class_field_name}"] = resolve
 
     @classmethod
     def create_write_fields(cls, interface_cls: InterfaceBase) -> dict[str, Any]:
@@ -1305,19 +1392,22 @@ class GraphQL:
             return
 
         group_name = cls._group_name(manager_class, instance.identification)
-        async_to_sync(channel_layer.group_send)(
-            group_name,
-            {
-                "type": "gm.subscription.event",
-                "action": action,
-            },
-        )
+        class_group_name = cls._class_group_name(manager_class)
+        message = {
+            "type": "gm.subscription.event",
+            "action": action,
+            "manager": manager_class.__name__,
+            "identification": deepcopy(instance.identification),
+        }
+        group_send = async_to_sync(channel_layer.group_send)
+        group_send(group_name, message)
+        group_send(class_group_name, message)
         logger.debug(
             "dispatched subscription event",
             context={
                 "manager": manager_class.__name__,
                 "action": action,
-                "group": group_name,
+                "groups": [group_name, class_group_name],
             },
         )
 

--- a/src/general_manager/api/graphql_subscriptions.py
+++ b/src/general_manager/api/graphql_subscriptions.py
@@ -87,6 +87,19 @@ def group_name(
     return f"gm_subscriptions.{manager_class.__name__}.{digest}"
 
 
+def class_group_name(manager_class: type[GeneralManager]) -> str:
+    """
+    Build a deterministic channel-group name for all instances of a manager.
+
+    Parameters:
+        manager_class: Manager class used to namespace the group.
+
+    Returns:
+        A stable group identifier for class-wide subscriptions.
+    """
+    return f"gm_subscriptions.{manager_class.__name__}.__class__"
+
+
 async def channel_listener(
     channel_layer: BaseChannelLayer,
     channel_name: str,
@@ -111,6 +124,28 @@ async def channel_listener(
             action = cast(str | None, message.get("action"))
             if action is not None:
                 await queue.put(action)
+    except asyncio.CancelledError:
+        pass
+
+
+async def channel_message_listener(
+    channel_layer: BaseChannelLayer,
+    channel_name: str,
+    queue: asyncio.Queue[dict[str, Any]],
+) -> None:
+    """
+    Listen for subscription event messages and enqueue complete messages.
+
+    Class-wide subscriptions need the event identification, not only the action,
+    so this listener preserves the full channel-layer payload.
+    """
+    try:
+        while True:
+            message = cast(dict[str, Any], await channel_layer.receive(channel_name))
+            if message.get("type") != "gm.subscription.event":
+                continue
+            if message.get("action") is not None:
+                await queue.put(message)
     except asyncio.CancelledError:
         pass
 

--- a/src/general_manager/api/remote_invalidation.py
+++ b/src/general_manager/api/remote_invalidation.py
@@ -64,6 +64,7 @@ def emit_remote_invalidation(
     sender: type["GeneralManager"],
     *,
     instance: "GeneralManager | None" = None,
+    identification: dict[str, Any] | None = None,
     action: str,
     **_: Any,
 ) -> None:
@@ -73,14 +74,17 @@ def emit_remote_invalidation(
     channel_layer = _get_channel_layer_safe()
     if channel_layer is None:
         return
+    event_identification = identification
+    if event_identification is None and instance is not None:
+        event_identification = dict(instance.identification)
     payload = {
         "type": "gm.remote.invalidation",
         "protocol_version": config.protocol_version,
         "base_path": config.base_path,
         "resource_name": config.resource_name,
         "action": action,
-        "identification": _json_safe_identification(dict(instance.identification))
-        if instance is not None
+        "identification": _json_safe_identification(event_identification)
+        if event_identification is not None
         else None,
         "event_id": str(uuid4()),
     }

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -1,5 +1,6 @@
 """Signals and decorators for tracking GeneralManager data changes."""
 
+from copy import deepcopy
 from django.dispatch import Signal
 from typing import Callable, TypeVar, ParamSpec, cast
 
@@ -53,6 +54,7 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
             **kwargs,
         )
         old_relevant_values = getattr(instance_before, "_old_values", {})
+        pre_identification = deepcopy(getattr(instance_before, "identification", None))
         if isinstance(func, classmethod):
             inner = cast(Callable[P, R], func.__func__)
             result = inner(*args, **kwargs)
@@ -62,7 +64,7 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
         instance = result
         identification = getattr(instance, "identification", None)
         if identification is None:
-            identification = getattr(instance_before, "identification", None)
+            identification = pre_identification
 
         post_data_change.send(
             sender=sender,

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -59,11 +59,16 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
         else:
             result = func(*args, **kwargs)
 
-        instance = result if result is not None else instance_before
+        instance = result
+        identification = getattr(instance, "identification", None)
+        if identification is None:
+            identification = getattr(instance_before, "identification", None)
 
         post_data_change.send(
             sender=sender,
             instance=instance,
+            previous_instance=instance_before,
+            identification=identification,
             action=action,
             old_relevant_values=old_relevant_values,
             **kwargs,

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -59,7 +59,7 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
         else:
             result = func(*args, **kwargs)
 
-        instance = result
+        instance = result if result is not None else instance_before
 
         post_data_change.send(
             sender=sender,

--- a/src/general_manager/workflow/signal_bridge.py
+++ b/src/general_manager/workflow/signal_bridge.py
@@ -22,7 +22,14 @@ _SETTINGS_KEY = "GENERAL_MANAGER"
 _WORKFLOW_SIGNAL_BRIDGE_KEY = "WORKFLOW_SIGNAL_BRIDGE"
 _DISPATCH_UID = "general_manager_workflow_signal_bridge"
 
-_RESERVED_KEYS = {"creator_id", "history_comment", "ignore_permission", "signal"}
+_RESERVED_KEYS = {
+    "creator_id",
+    "history_comment",
+    "identification",
+    "ignore_permission",
+    "previous_instance",
+    "signal",
+}
 
 
 class _CommonEventKwargs(TypedDict):
@@ -105,8 +112,11 @@ def _handle_post_data_change(
     **kwargs: Any,
 ) -> None:
     del sender
+    event_instance = (
+        instance if instance is not None else kwargs.get("previous_instance")
+    )
     event = _manager_change_to_event(
-        instance=instance,
+        instance=event_instance,
         action=action,
         old_relevant_values=old_relevant_values,
         kwargs=kwargs,

--- a/src/general_manager/workflow/signal_bridge.py
+++ b/src/general_manager/workflow/signal_bridge.py
@@ -74,9 +74,12 @@ def _manager_change_to_event(
     if action in {"create", "update"} and not relevant_fields:
         return None
 
+    identification = kwargs.get("identification")
+    if identification is None:
+        identification = instance.identification
     common_kwargs: _CommonEventKwargs = {
         "manager": instance.__class__.__name__,
-        "identification": instance.identification,
+        "identification": identification,
         "source": "general_manager.cache.signals.post_data_change",
         "metadata": {"action": action},
         "event_name": "manager_updated",

--- a/tests/integration/test_workflow_signal_integration.py
+++ b/tests/integration/test_workflow_signal_integration.py
@@ -195,3 +195,23 @@ class WorkflowSignalIntegrationTests(GeneralManagerTransactionTestCase):
         assert len(self.executions) == 1
         assert self.executions[0].workflow_id == "project_status_email"
         assert self.executions[0].state == "completed"
+
+    def test_manager_delete_signal_includes_identification_in_workflow_event(
+        self,
+    ) -> None:
+        deleted_events: list[WorkflowEvent] = []
+        self.event_registry.register(
+            "manager_deleted",
+            handler=deleted_events.append,
+        )
+        project = self.Project.create(
+            name="Delta",
+            status="draft",
+            ignore_permission=True,
+        )
+        identification = dict(project.identification)
+
+        project.delete(ignore_permission=True)
+
+        assert len(deleted_events) == 1
+        assert deleted_events[0].payload["identification"] == identification

--- a/tests/integration/test_workflow_signal_integration.py
+++ b/tests/integration/test_workflow_signal_integration.py
@@ -209,9 +209,12 @@ class WorkflowSignalIntegrationTests(GeneralManagerTransactionTestCase):
             status="draft",
             ignore_permission=True,
         )
-        identification = dict(project.identification)
+        identification_before = dict(project.identification)
+        project.identification["delete_marker"] = "current"
+        current_identification = dict(project.identification)
 
         project.delete(ignore_permission=True)
 
         assert len(deleted_events) == 1
-        assert deleted_events[0].payload["identification"] == identification
+        assert current_identification != identification_before
+        assert deleted_events[0].payload["identification"] == current_identification

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -359,7 +359,9 @@ class GeneralManagerTestCase(TestCase):
 
             self.assertEqual(len(self.post_list), 1)
             self.assertEqual(self.post_list[0]["action"], "delete")
-            self.assertIs(self.post_list[0]["instance"], manager_obj)
+            self.assertIsNone(self.post_list[0]["instance"])
+            self.assertIs(self.post_list[0]["previous_instance"], manager_obj)
+            self.assertEqual(self.post_list[0]["identification"], {"id": "dummy_id"})
 
     def test_delete_returns_none_when_hard_delete(self):
         """Deletes should return None from the manager API even when the interface returns identifiers."""

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -359,7 +359,7 @@ class GeneralManagerTestCase(TestCase):
 
             self.assertEqual(len(self.post_list), 1)
             self.assertEqual(self.post_list[0]["action"], "delete")
-            self.assertIsNone(self.post_list[0]["instance"])
+            self.assertIs(self.post_list[0]["instance"], manager_obj)
 
     def test_delete_returns_none_when_hard_delete(self):
         """Deletes should return None from the manager API even when the interface returns identifiers."""

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -67,6 +67,9 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
                     ),
                 )
 
+                def can_read_instance(self) -> bool:
+                    return self.instance.name != "Hidden"
+
         cls.general_manager_classes = [Employee]
         cls.Employee = Employee
 
@@ -216,6 +219,133 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         self.assertFalse(
             second_event.data["onEmployeeChange"]["item"]["capabilities"]["canKeepName"]
         )
+
+    def test_class_subscription_emits_create_without_initial_snapshot(self) -> None:
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> object:
+            generator = await schema.subscribe(subscription, context_value=context)
+            if hasattr(generator, "errors"):
+                raise AssertionError(generator.errors)
+            try:
+                next_event = asyncio.create_task(generator.__anext__())
+                await asyncio.sleep(0.02)
+                self.assertFalse(next_event.done())
+                await asyncio.to_thread(
+                    lambda: self.Employee.create(
+                        name="Class Alice",
+                        creator_id=self.user.id,
+                    )
+                )
+                return await next_event
+            finally:
+                await generator.aclose()
+
+        event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        payload = event.data["onEmployeeClassChange"]
+        self.assertEqual(payload["action"], "create")
+        self.assertEqual(payload["item"]["name"], "Class Alice")
+
+    def test_class_subscription_suppresses_unreadable_events(self) -> None:
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> object:
+            generator = await schema.subscribe(subscription, context_value=context)
+            if hasattr(generator, "errors"):
+                raise AssertionError(generator.errors)
+            try:
+                next_event = asyncio.create_task(generator.__anext__())
+                await asyncio.to_thread(
+                    lambda: self.Employee.create(
+                        name="Hidden",
+                        creator_id=self.user.id,
+                    )
+                )
+                await asyncio.sleep(0.02)
+                self.assertFalse(next_event.done())
+                await asyncio.to_thread(
+                    lambda: self.Employee.create(
+                        name="Visible",
+                        creator_id=self.user.id,
+                    )
+                )
+                return await next_event
+            finally:
+                await generator.aclose()
+
+        event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        payload = event.data["onEmployeeClassChange"]
+        self.assertEqual(payload["action"], "create")
+        self.assertEqual(payload["item"]["name"], "Visible")
+
+    def test_class_subscription_emits_update_events(self) -> None:
+        employee = self.Employee.create(name="Before", creator_id=self.user.id)
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> object:
+            generator = await schema.subscribe(subscription, context_value=context)
+            if hasattr(generator, "errors"):
+                raise AssertionError(generator.errors)
+            try:
+                next_event = asyncio.create_task(generator.__anext__())
+                await asyncio.sleep(0.02)
+                self.assertFalse(next_event.done())
+                await asyncio.to_thread(
+                    lambda: employee.update(
+                        name="After",
+                        creator_id=self.user.id,
+                    )
+                )
+                return await next_event
+            finally:
+                await generator.aclose()
+
+        event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        payload = event.data["onEmployeeClassChange"]
+        self.assertEqual(payload["action"], "update")
+        self.assertEqual(payload["item"]["name"], "After")
 
 
 class GraphQLSubscriptionPropertySelectionTests(unittest.TestCase):
@@ -563,6 +693,17 @@ class GraphQLGroupNameTests(unittest.TestCase):
         self.assertIsInstance(name, str)
         self.assertTrue(name.startswith("gm_subscriptions."))
 
+    def test_class_group_name_is_deterministic(self) -> None:
+        """Verify _class_group_name produces a stable class-level group."""
+
+        class TestManager(GeneralManager):
+            pass
+
+        name1 = GraphQL._class_group_name(TestManager)
+        name2 = GraphQL._class_group_name(TestManager)
+        self.assertEqual(name1, name2)
+        self.assertEqual(name1, "gm_subscriptions.TestManager.__class__")
+
 
 class GraphQLPrimePropertiesEdgeCaseTests(unittest.TestCase):
     """Test edge cases in property priming."""
@@ -880,6 +1021,70 @@ class GraphQLBuildIdentificationArgumentsTests(unittest.TestCase):
         self.assertEqual(len(args), 3)
 
 
+class GraphQLAddSubscriptionFieldTests(unittest.TestCase):
+    """Test generated GraphQL subscription field registration."""
+
+    def setUp(self) -> None:
+        self._snapshot = GraphQL.get_registry_snapshot()
+        GraphQL.reset_registry()
+
+    def tearDown(self) -> None:
+        GraphQL._query_class = self._snapshot.query_class
+        GraphQL._mutation_class = self._snapshot.mutation_class
+        GraphQL._subscription_class = self._snapshot.subscription_class
+        GraphQL._schema = self._snapshot.schema
+        GraphQL._mutations = self._snapshot.mutations
+        GraphQL._query_fields = self._snapshot.query_fields
+        GraphQL._subscription_fields = self._snapshot.subscription_fields
+        GraphQL._page_type_registry = self._snapshot.page_type_registry
+        GraphQL._subscription_payload_registry = (
+            self._snapshot.subscription_payload_registry
+        )
+        GraphQL.graphql_type_registry = self._snapshot.graphql_type_registry
+        GraphQL.graphql_filter_type_registry = (
+            self._snapshot.graphql_filter_type_registry
+        )
+        GraphQL.graphql_capability_type_registry = (
+            self._snapshot.graphql_capability_type_registry
+        )
+        GraphQL.manager_registry = self._snapshot.manager_registry
+        GraphQL._search_union = self._snapshot.search_union
+        GraphQL._search_result_type = self._snapshot.search_result_type
+
+    def test_add_subscription_field_registers_entity_and_class_fields(self) -> None:
+        class TestInterface(BaseTestInterface):
+            input_fields: ClassVar[dict[str, object]] = {
+                "id": SimpleNamespace(type=int, required=True),
+            }
+
+        class TestManager(GeneralManager):
+            Interface = TestInterface
+
+        graphene_type = type(
+            "TestManagerType",
+            (graphene.ObjectType,),
+            {"id": graphene.ID()},
+        )
+
+        GraphQL._add_subscription_field(graphene_type, TestManager)
+
+        self.assertIn("on_testmanager_change", GraphQL._subscription_fields)
+        self.assertIn("subscribe_on_testmanager_change", GraphQL._subscription_fields)
+        self.assertIn("resolve_on_testmanager_change", GraphQL._subscription_fields)
+        self.assertIn("on_testmanager_class_change", GraphQL._subscription_fields)
+        self.assertIn(
+            "subscribe_on_testmanager_class_change", GraphQL._subscription_fields
+        )
+        self.assertIn(
+            "resolve_on_testmanager_class_change", GraphQL._subscription_fields
+        )
+
+        entity_field = GraphQL._subscription_fields["on_testmanager_change"]
+        class_field = GraphQL._subscription_fields["on_testmanager_class_change"]
+        self.assertIn("id", entity_field.args)
+        self.assertEqual(class_field.args, {})
+
+
 class GraphQLHandleDataChangeTests(unittest.TestCase):
     """Test signal handler for subscription data changes."""
 
@@ -945,8 +1150,8 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
                 sender=RegisteredManager, instance=instance, action="test"
             )
 
-    def test_handle_data_change_sends_to_channel_group(self) -> None:
-        """Verify _handle_data_change sends message to correct channel group."""
+    def test_handle_data_change_sends_to_instance_and_class_groups(self) -> None:
+        """Verify _handle_data_change sends a rich message to both groups."""
 
         class RegisteredManager(GeneralManager):
             identification: ClassVar[dict[str, int]] = {"id": 1}
@@ -973,16 +1178,20 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
                 # Verify group_send was wrapped with async_to_sync
                 mock_async_to_sync.assert_called_once_with(mock_layer.group_send)
 
-                # Verify the send was called with correct arguments
-                self.assertEqual(mock_send.call_count, 1)
-                call_args = mock_send.call_args[0]
-                group_name = call_args[0]
-                message = call_args[1]
+                self.assertEqual(mock_send.call_count, 2)
+                sent_groups = {call.args[0] for call in mock_send.call_args_list}
+                instance_group = GraphQL._group_name(
+                    RegisteredManager, instance.identification
+                )
+                class_group = GraphQL._class_group_name(RegisteredManager)
+                self.assertEqual(sent_groups, {instance_group, class_group})
 
-                self.assertIsInstance(group_name, str)
-                self.assertTrue(group_name.startswith("gm_subscriptions."))
-                self.assertEqual(message["type"], "gm.subscription.event")
-                self.assertEqual(message["action"], "update")
+                for call in mock_send.call_args_list:
+                    message = call.args[1]
+                    self.assertEqual(message["type"], "gm.subscription.event")
+                    self.assertEqual(message["action"], "update")
+                    self.assertEqual(message["manager"], "RegisteredManager")
+                    self.assertEqual(message["identification"], {"id": 1})
 
 
 class GraphQLInstantiateManagerTests(GeneralManagerTransactionTestCase):
@@ -1246,6 +1455,62 @@ class GraphQLSubscriptionChannelListenerTests(unittest.TestCase):
 
         # Should complete without hanging
         asyncio.run(test_cancellation())
+
+    def test_channel_message_listener_enqueues_full_messages(self) -> None:
+        """Verify _channel_message_listener preserves subscription messages."""
+
+        async def test_listener() -> list[dict[str, Any]]:
+            mock_layer = MagicMock()
+            messages = [
+                {
+                    "type": "gm.subscription.event",
+                    "action": "update",
+                    "manager": "Project",
+                    "identification": {"id": 1},
+                },
+                {"type": "other.message", "action": "ignored"},
+                {"type": "gm.subscription.event"},
+            ]
+            message_iter = iter(messages)
+
+            async def mock_receive(_channel: str) -> dict[str, Any]:
+                try:
+                    await asyncio.sleep(0.001)
+                    return next(message_iter)
+                except StopIteration as err:
+                    await asyncio.sleep(10)
+                    raise AssertionError("Cancelled") from err
+
+            mock_layer.receive = mock_receive
+
+            queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+            listener_task = asyncio.create_task(
+                GraphQL._channel_message_listener(mock_layer, "test_channel", queue)
+            )
+            await asyncio.sleep(0.01)
+            listener_task.cancel()
+            try:
+                await listener_task
+            except asyncio.CancelledError:
+                pass
+
+            queued = []
+            while not queue.empty():
+                queued.append(await queue.get())
+            return queued
+
+        queued_messages = asyncio.run(test_listener())
+        self.assertEqual(
+            queued_messages,
+            [
+                {
+                    "type": "gm.subscription.event",
+                    "action": "update",
+                    "manager": "Project",
+                    "identification": {"id": 1},
+                }
+            ],
+        )
 
 
 class GraphQLSchemaAccessTests(unittest.TestCase):

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -2,6 +2,7 @@
 
 
 import asyncio
+import contextlib
 import os
 from types import SimpleNamespace
 from typing import Any, ClassVar
@@ -70,8 +71,19 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
                 def can_read_instance(self) -> bool:
                     return self.instance.name != "Hidden"
 
-        cls.general_manager_classes = [Employee]
+        class SoftEmployee(GeneralManager):
+            class Interface(DatabaseInterface):
+                name = CharField(max_length=120)
+
+                class Meta:
+                    use_soft_delete = True
+
+            class Permission(AdditiveManagerPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+
+        cls.general_manager_classes = [Employee, SoftEmployee]
         cls.Employee = Employee
+        cls.SoftEmployee = SoftEmployee
 
     def setUp(self) -> None:
         """
@@ -346,6 +358,87 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         payload = event.data["onEmployeeClassChange"]
         self.assertEqual(payload["action"], "update")
         self.assertEqual(payload["item"]["name"], "After")
+
+    def test_class_subscription_emits_soft_delete_events(self) -> None:
+        employee = self.SoftEmployee.create(name="Soft", creator_id=self.user.id)
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onSoftemployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> object:
+            generator = await schema.subscribe(subscription, context_value=context)
+            if hasattr(generator, "errors"):
+                raise AssertionError(generator.errors)
+            try:
+                next_event = asyncio.create_task(generator.__anext__())
+                await asyncio.sleep(0.02)
+                self.assertFalse(next_event.done())
+                await asyncio.to_thread(
+                    lambda: employee.delete(
+                        creator_id=self.user.id,
+                        ignore_permission=True,
+                    )
+                )
+                return await next_event
+            finally:
+                await generator.aclose()
+
+        event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        payload = event.data["onSoftemployeeClassChange"]
+        self.assertEqual(payload["action"], "delete")
+        self.assertEqual(payload["item"]["name"], "Soft")
+
+    def test_class_subscription_suppresses_hard_delete_events(self) -> None:
+        employee = self.Employee.create(name="Hard", creator_id=self.user.id)
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> None:
+            generator = await schema.subscribe(subscription, context_value=context)
+            if hasattr(generator, "errors"):
+                raise AssertionError(generator.errors)
+            next_event = asyncio.create_task(generator.__anext__())
+            try:
+                await asyncio.sleep(0.02)
+                self.assertFalse(next_event.done())
+                await asyncio.to_thread(
+                    lambda: employee.delete(
+                        creator_id=self.user.id,
+                        ignore_permission=True,
+                    )
+                )
+                await asyncio.sleep(0.02)
+                self.assertFalse(next_event.done())
+            finally:
+                next_event.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await next_event
+                await generator.aclose()
+
+        asyncio.run(run_subscription())
 
 
 class GraphQLSubscriptionPropertySelectionTests(unittest.TestCase):

--- a/tests/unit/test_grapql_subscription_helper.py
+++ b/tests/unit/test_grapql_subscription_helper.py
@@ -660,8 +660,8 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
                     sender=instance, instance=instance, action="test"
                 )
 
-                # Should still work correctly
-                mock_send.assert_called_once()
+                # Should send to the instance and class-level groups.
+                self.assertEqual(mock_send.call_count, 2)
 
     def test_handle_data_change_with_subclass(self) -> None:
         """Verify _handle_data_change works with GeneralManager subclasses."""
@@ -689,4 +689,4 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
                     sender=DerivedManager, instance=instance, action="test"
                 )
 
-                mock_send.assert_called_once()
+                self.assertEqual(mock_send.call_count, 2)

--- a/tests/unit/test_grapql_subscription_helper.py
+++ b/tests/unit/test_grapql_subscription_helper.py
@@ -697,3 +697,42 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
                 )
 
                 self.assertEqual(mock_send.call_count, 2)
+
+    def test_handle_data_change_continues_when_instance_group_send_fails(
+        self,
+    ) -> None:
+        """Verify class-level dispatch still runs when instance dispatch fails."""
+
+        class TestManager(GeneralManager):
+            identification: ClassVar = {"id": 1}
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {"TestManager": TestManager}
+        instance = TestManager()
+        mock_layer = MagicMock()
+
+        with (
+            patch(
+                "general_manager.api.graphql.GraphQL._get_channel_layer",
+                return_value=mock_layer,
+            ),
+            patch("general_manager.api.graphql.async_to_sync") as mock_async,
+            patch("general_manager.api.graphql.logger") as mock_logger,
+        ):
+            mock_send = MagicMock(side_effect=[RuntimeError("send failed"), None])
+            mock_async.return_value = mock_send
+
+            GraphQL._handle_data_change(
+                sender=TestManager,
+                instance=instance,
+                action="test",
+            )
+
+        self.assertEqual(
+            [call.args[0] for call in mock_send.call_args_list],
+            [
+                GraphQL._group_name(TestManager, instance.identification),
+                GraphQL._class_group_name(TestManager),
+            ],
+        )
+        mock_logger.warning.assert_called_once()

--- a/tests/unit/test_grapql_subscription_helper.py
+++ b/tests/unit/test_grapql_subscription_helper.py
@@ -662,6 +662,13 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
 
                 # Should send to the instance and class-level groups.
                 self.assertEqual(mock_send.call_count, 2)
+                self.assertEqual(
+                    {call.args[0] for call in mock_send.call_args_list},
+                    {
+                        GraphQL._group_name(TestManager, instance.identification),
+                        GraphQL._class_group_name(TestManager),
+                    },
+                )
 
     def test_handle_data_change_with_subclass(self) -> None:
         """Verify _handle_data_change works with GeneralManager subclasses."""

--- a/tests/unit/test_remote_invalidation.py
+++ b/tests/unit/test_remote_invalidation.py
@@ -143,3 +143,40 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
         self.assertEqual(payload["identification"]["start_date"], "2026-03-18")
         self.assertEqual(payload["identification"]["updated_at"], "2026-03-18T12:30:00")
         self.assertEqual(payload["identification"]["name"], "Alpha")
+
+    def test_emit_remote_invalidation_uses_delete_identification_metadata(
+        self,
+    ) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        channel_layer = SimpleNamespace(group_send=MagicMock())
+
+        with (
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe",
+                return_value=channel_layer,
+            ),
+            patch(
+                "general_manager.api.remote_invalidation.async_to_sync",
+                side_effect=lambda fn: fn,
+            ),
+        ):
+            emit_remote_invalidation(
+                Project,
+                instance=None,
+                identification={"id": UUID("12345678-1234-5678-1234-567812345678")},
+                action="delete",
+            )
+
+        _, payload = channel_layer.group_send.call_args.args
+        self.assertEqual(payload["action"], "delete")
+        self.assertEqual(
+            payload["identification"],
+            {"id": "12345678-1234-5678-1234-567812345678"},
+        )

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -47,6 +47,19 @@ class Dummy:
         return None
 
 
+class InvalidatingDummy:
+    """Test helper that invalidates identification during delete."""
+
+    def __init__(self):
+        self.identification = {"id": "before"}
+
+    @data_change
+    def delete(self):
+        self.identification["id"] = "after"
+        self.identification = None
+        return None
+
+
 class DataChangeSignalTests(TestCase):
     def setUp(self):
         # Preserve existing receivers so they can be restored after the test run
@@ -132,3 +145,12 @@ class DataChangeSignalTests(TestCase):
         self.assertIs(post["previous_instance"], inst)
         self.assertIsNone(post["identification"])
         self.assertEqual(post["action"], "delete")
+
+    def test_delete_identification_uses_pre_mutation_snapshot(self):
+        inst = InvalidatingDummy()
+
+        with capture_signal(post_data_change) as post_calls:
+            inst.delete()
+
+        self.assertEqual(len(post_calls), 1)
+        self.assertEqual(post_calls[0]["identification"], {"id": "before"})

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -118,7 +118,7 @@ class DataChangeSignalTests(TestCase):
         self.assertIsInstance(result, Dummy)
         self.assertEqual(result.value, "baz")
 
-    def test_delete_returning_none_sends_pre_change_instance_to_post_signal(self):
+    def test_delete_returning_none_sends_delete_metadata_to_post_signal(self):
         inst = Dummy()
 
         with capture_signal(post_data_change) as post_calls:
@@ -128,5 +128,7 @@ class DataChangeSignalTests(TestCase):
         self.assertEqual(len(post_calls), 1)
         post = post_calls[0]
         self.assertIs(post["sender"], Dummy)
-        self.assertIs(post["instance"], inst)
+        self.assertIsNone(post["instance"])
+        self.assertIs(post["previous_instance"], inst)
+        self.assertIsNone(post["identification"])
         self.assertEqual(post["action"], "delete")

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -42,6 +42,10 @@ class Dummy:
         self.value = new_value
         return self
 
+    @data_change
+    def delete(self):
+        return None
+
 
 class DataChangeSignalTests(TestCase):
     def setUp(self):
@@ -113,3 +117,16 @@ class DataChangeSignalTests(TestCase):
         result = inst.update("baz")
         self.assertIsInstance(result, Dummy)
         self.assertEqual(result.value, "baz")
+
+    def test_delete_returning_none_sends_pre_change_instance_to_post_signal(self):
+        inst = Dummy()
+
+        with capture_signal(post_data_change) as post_calls:
+            result = inst.delete()
+
+        self.assertIsNone(result)
+        self.assertEqual(len(post_calls), 1)
+        post = post_calls[0]
+        self.assertIs(post["sender"], Dummy)
+        self.assertIs(post["instance"], inst)
+        self.assertEqual(post["action"], "delete")


### PR DESCRIPTION
Introduce class-wide subscriptions for GraphQL, allowing for event streaming across all instances of a manager. This feature includes enhancements to signal handling and ensures proper permissions are checked before emitting events. Additionally, it provides a deterministic channel-group naming convention for class-wide subscriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Class-level GraphQL subscriptions that stream future changes across entire object classes (no initial snapshot).
  * Remote invalidation now supports explicit identification metadata.

* **Bug Fixes**
  * Suppress events for unreadable or hard-deleted objects; avoid emitting empty/null payloads.
  * Post-change signals include prior-instance and explicit identification for delete/None-returning operations.

* **Documentation**
  * Subscription docs updated with class-wide patterns and new error-handling notes.

* **Tests / Chores**
  * Expanded unit and integration tests; test path config adjusted to include src.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimKleindick/general_manager/pull/208)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->