### PR TITLE
[codex] fix based_on create permissions with relation ids

### DIFF
--- a/src/general_manager/permission/manager_based_permission.py
+++ b/src/general_manager/permission/manager_based_permission.py
@@ -182,12 +182,28 @@ class _ConfiguredManagerPermission(BasePermission):
 
     def __get_based_on_permission(self) -> Optional[BasePermission]:
         from general_manager.manager.general_manager import GeneralManager
+        from general_manager.permission.permission_data_manager import (
+            PermissionDataManager,
+        )
 
         __based_on__ = self.__based_on__
         if __based_on__ is None:
             return None
 
         basis_object = getattr(self.instance, __based_on__, notExistent)
+        if (
+            basis_object is not None
+            and basis_object is not notExistent
+            and not isinstance(basis_object, GeneralManager)
+            and isinstance(self.instance, PermissionDataManager)
+            and self.instance.manager is not None
+        ):
+            field_type = self.instance.manager.Interface.get_field_type(__based_on__)
+            if isinstance(field_type, type) and issubclass(field_type, GeneralManager):
+                if isinstance(basis_object, dict):
+                    basis_object = field_type(**basis_object)
+                else:
+                    basis_object = field_type(id=basis_object)
         if basis_object is notExistent:
             if self._is_class_context:
                 return None
@@ -218,7 +234,7 @@ class _ConfiguredManagerPermission(BasePermission):
             return None
 
         return Permission(
-            instance=getattr(self.instance, __based_on__),
+            instance=basis_object,
             request_user=self.request_user,
         )
 

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -226,6 +226,14 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(human_with_country.name, "David")
         self.assertEqual(human_with_country.country.code, "US")  # type: ignore
 
+        human_with_country_id = self.TestHuman.create(
+            creator_id=None,
+            name="Dora",
+            country=str(self.de.identification["id"]),
+        )
+        self.assertEqual(human_with_country_id.name, "Dora")
+        self.assertEqual(human_with_country_id.country.code, "DE")  # type: ignore
+
         # Test creating human without country -> should fall back to default permissions
         with self.assertRaises(PermissionError):
             self.TestHuman.create(


### PR DESCRIPTION
## Summary

Fixes #211 by resolving raw relation identifiers in `__based_on__` create permission checks before delegating to the related manager permission.

## Root cause

Create permission checks run before ORM payload normalization. When a create payload contains a relation id such as `country="5"`, `PermissionDataManager` exposes that raw value, but `__get_based_on_permission()` expected the `__based_on__` attribute to already be a `GeneralManager` instance. That raised `InvalidBasedOnTypeError` before the create operation could proceed.

## Changes

- Resolve raw `__based_on__` payload values through the declaring manager interface field type when permission data comes from a create/update payload.
- Preserve existing behavior for already-materialized `GeneralManager` values, `None`, and class-context read planning.
- Add an integration regression test covering create with a string relation id.

## Validation

- `PYTHONPATH=src python -m pytest tests/integration/test_manager_based_permission.py -q`
- `PYTHONPATH=src python -m pytest tests/unit/test_manager_based_permission.py -q`
- `ruff check src/general_manager/permission/manager_based_permission.py tests/integration/test_manager_based_permission.py`
- pre-commit on commit: `ruff`, `ruff format`, whitespace/merge-conflict/debug hooks, and `mypy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission validation now properly handles identifier references, allowing more flexible permission-based operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimKleindick/general_manager/pull/213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->