### PR TITLE
[codex] fix partial GraphQL update mutations

### DIFF
--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -1307,9 +1307,14 @@ class GraphQL:
             cls._subscription_fields[f"resolve_{class_field_name}"] = resolve
 
     @classmethod
-    def create_write_fields(cls, interface_cls: InterfaceBase) -> dict[str, Any]:
+    def create_write_fields(
+        cls,
+        interface_cls: InterfaceBase,
+        *,
+        require_fields: bool = True,
+    ) -> dict[str, Any]:
         """Thin wrapper - see :func:`general_manager.api.graphql_mutations.create_write_fields`."""
-        return _create_write_fields_fn(interface_cls)
+        return _create_write_fields_fn(interface_cls, require_fields=require_fields)
 
     @classmethod
     def generate_create_mutation_class(

--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -66,7 +66,11 @@ def _normalize_mutation_kwargs_for_manager(
 # ---------------------------------------------------------------------------
 
 
-def create_write_fields(interface_cls: InterfaceBase) -> dict[str, Any]:
+def create_write_fields(
+    interface_cls: InterfaceBase,
+    *,
+    require_fields: bool = True,
+) -> dict[str, Any]:
     """
     Create Graphene input fields for writable attributes defined by an Interface.
 
@@ -79,6 +83,9 @@ def create_write_fields(interface_cls: InterfaceBase) -> dict[str, Any]:
     Parameters:
         interface_cls: Interface providing attribute metadata used to build
             the input fields.
+        require_fields: Whether generated fields should mirror interface
+            requiredness. Update mutations set this to ``False`` to support
+            partial updates.
 
     Returns:
         Mapping from attribute name to a Graphene input field instance.
@@ -91,7 +98,7 @@ def create_write_fields(interface_cls: InterfaceBase) -> dict[str, Any]:
             continue
 
         typ = info["type"]
-        req = info["is_required"]
+        req = info["is_required"] if require_fields else False
         default = info["default"]
 
         fld: Any
@@ -243,7 +250,8 @@ def generate_update_mutation_class(
                     **{
                         field_name: field
                         for field_name, field in create_write_fields(
-                            interface_cls
+                            interface_cls,
+                            require_fields=False,
                         ).items()
                         if field.editable
                     },

--- a/tests/integration/test_default_mutations.py
+++ b/tests/integration/test_default_mutations.py
@@ -365,6 +365,21 @@ class DefaultUpdateMutationTest(GeneralManagerTransactionTestCase):
                 }
             }
             """
+        self.update_mutation_without_name = """
+            mutation UpdateProject($id: Int!, $budget: MeasurementScalar) {
+                updateTestProject(id: $id, budget: $budget) {
+                    TestProject {
+                        name
+                        number
+                        budget {
+                            value
+                            unit
+                        }
+                    }
+                    success
+                }
+            }
+            """
 
     def _latest_history_user(self, manager):
         history = manager.history.order_by("-history_date").first()
@@ -426,6 +441,34 @@ class DefaultUpdateMutationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(updated_project.name, "Updated Project Without Budget")
         self.assertEqual(updated_project.number, 1)
         self.assertEqual(updated_project.budget, "1000 EUR")
+        self.assertEqual(self._latest_history_user(updated_project), self.user)
+
+    def test_update_project_without_name(self):
+        """
+        Tests that update mutations allow partial updates without resubmitting
+        unchanged non-nullable fields.
+        """
+        variables = {
+            "id": self.project.id,
+            "budget": "2000 EUR",
+        }
+
+        response = self.query(self.update_mutation_without_name, variables=variables)
+        self.assertResponseNoErrors(response)
+        response = response.json()
+        data = response.get("data", {})
+        self.assertTrue(data["updateTestProject"]["success"])
+
+        data = data["updateTestProject"]["TestProject"]
+        self.assertEqual(data["name"], "Initial Project")
+        self.assertEqual(data["number"], 1)
+        self.assertEqual(data["budget"]["value"], 2000)
+        self.assertEqual(data["budget"]["unit"], "EUR")
+
+        updated_project = self.TestProject(self.project.id)
+        self.assertEqual(updated_project.name, "Initial Project")
+        self.assertEqual(updated_project.number, 1)
+        self.assertEqual(updated_project.budget, "2000 EUR")
         self.assertEqual(self._latest_history_user(updated_project), self.user)
 
 

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -897,6 +897,7 @@ class TestGrapQlMutation(TestCase):
         self.assertTrue(issubclass(mutation_class, graphene.Mutation))
         self.assertIn("field1", mutation_class._meta.arguments)
         self.assertIsInstance(mutation_class._meta.arguments["field1"], graphene.String)
+        self.assertTrue(mutation_class._meta.arguments["field1"].kwargs["required"])
         self.assertEqual(
             mutation_class._meta.arguments["field1"].kwargs["default_value"],
             "test123",
@@ -963,6 +964,9 @@ class TestGrapQlMutation(TestCase):
         self.assertTrue(issubclass(mutation_class, graphene.Mutation))
         self.assertIn("field1", mutation_class._meta.arguments)
         self.assertIsInstance(mutation_class._meta.arguments["field1"], graphene.String)
+        self.assertFalse(
+            mutation_class._meta.arguments["field1"].kwargs.get("required", False)
+        )
         self.assertEqual(
             mutation_class._meta.arguments["field1"].kwargs["default_value"],
             "test123",


### PR DESCRIPTION
## Summary

Fixes #210 by making generated GraphQL update mutation payload fields optional, while preserving required fields for create mutations. The manager identifier `id` remains required for updates.

## Root Cause

Update mutation generation reused the same write-field metadata as create mutation generation, so non-nullable database fields kept `required=True` in the update schema. That made partial updates appear invalid unless callers resubmitted unchanged non-nullable fields.

## Changes

- Added a `require_fields` option to GraphQL write-field generation.
- Kept create mutations using required field metadata.
- Switched update mutations to generate optional editable payload arguments.
- Added unit coverage for create/update argument requiredness.
- Added integration coverage for updating only `budget` while omitting required `name`.

## Validation

- `PYTHONPATH=src python -m pytest` -> `2309 passed, 1 skipped, 1 warning in 59.61s`
- `pre-commit run --all-files` -> all hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update mutations now support partial updates with optional fields, allowing users to modify specific attributes without requiring all fields to be provided.

* **Tests**
  * Added integration test verifying partial update behavior for mutations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimKleindick/general_manager/pull/216)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->