### PR TITLE
[codex] fix nullable factory relations with string related models

### DIFF
--- a/src/general_manager/factory/factories.py
+++ b/src/general_manager/factory/factories.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from factory.declarations import LazyFunction
 from factory.faker import Faker
 import exrex  # type: ignore[import-untyped]
+from django.apps import apps
 from django.core.validators import RegexValidator
 from django.db import models
 from datetime import date, datetime, timezone, timedelta
@@ -18,6 +19,7 @@ from general_manager.manager.general_manager import GeneralManager
 
 
 _RNG = SystemRandom()
+_NO_DEFAULT = object()
 
 
 class MissingFactoryOrInstancesError(ValueError):
@@ -96,6 +98,13 @@ def get_field_value(
         MissingRelatedModelError: When a relational field does not declare a related model.
         InvalidRelatedModelTypeError: When a relational field's related value is not a Django model class.
     """
+    if (
+        getattr(field, "null", False)
+        and getattr(field, "default", _NO_DEFAULT) is None
+        and getattr(field, "is_relation", False)
+    ):
+        return None
+
     if field.null:
         if _RNG.choice([True] + 9 * [False]):
             return None
@@ -246,16 +255,39 @@ def get_related_model(
         MissingRelatedModelError: If the field does not declare a related model.
         InvalidRelatedModelTypeError: If the resolved related model is not a Django model class.
     """
-    related_model = field.related_model
+    related_model: object = field.related_model
     if related_model is None:
         raise MissingRelatedModelError(field.name)
-    if related_model == "self":
-        related_model = field.model
+    if isinstance(related_model, str):
+        related_model = _resolve_related_model_string(field, related_model)
     if not isinstance(related_model, type) or not issubclass(
         related_model, models.Model
     ):
         raise InvalidRelatedModelTypeError(field.name, related_model)
     return cast(type[models.Model], related_model)
+
+
+def _resolve_related_model_string(
+    field: models.ForeignObjectRel | models.Field[Any, Any],
+    related_model: str,
+) -> object:
+    if related_model == "self":
+        return field.model
+    app_label: str | None
+    if "." in related_model:
+        app_label, model_name = related_model.split(".", 1)
+    else:
+        model = getattr(field, "model", None)
+        opts = getattr(model, "_meta", None)
+        app_label_value = getattr(opts, "app_label", None)
+        app_label = app_label_value if isinstance(app_label_value, str) else None
+        model_name = related_model
+    if not app_label:
+        return related_model
+    try:
+        return apps.get_model(app_label, model_name)
+    except LookupError:
+        return related_model
 
 
 def get_many_to_many_field_value(

--- a/tests/unit/test_factories.py
+++ b/tests/unit/test_factories.py
@@ -431,6 +431,48 @@ class TestGetManyToManyFieldValue(TestCase):
         self.assertIn("test_field", str(ctx.exception))
         self.assertIn("must be a Django model class", str(ctx.exception))
 
+    def test_get_related_model_resolves_dotted_string_reference(self):
+        """String relation references should resolve through Django's app registry."""
+        from general_manager.factory.factories import get_related_model
+
+        field = Mock()
+        field.related_model = "financials.AccountNumber"
+        field.name = "project_number"
+
+        with patch(
+            "django.apps.apps.get_model", return_value=DummyForeignKey
+        ) as get_model:
+            self.assertIs(get_related_model(field), DummyForeignKey)
+
+        get_model.assert_called_once_with("financials", "AccountNumber")
+
+    def test_nullable_relation_with_default_none_returns_none_before_resolution(self):
+        """Nullable relation fields with default=None should not require resolving a related model."""
+        from general_manager.factory.factories import get_field_value
+
+        field = Mock()
+        field.related_model = "financials.AccountNumber"
+        field.name = "project_number"
+        field.null = True
+        field.default = None
+
+        def custom_isinstance(obj, cls):
+            if cls == models.OneToOneField:
+                return True
+            return isinstance(obj, cls)
+
+        with (
+            patch("general_manager.factory.factories._RNG.choice", return_value=False),
+            patch(
+                "general_manager.factory.factories.isinstance",
+                side_effect=custom_isinstance,
+            ),
+            patch("django.apps.apps.get_model") as get_model,
+        ):
+            self.assertIsNone(get_field_value(field))
+
+        get_model.assert_not_called()
+
     def test_nullable_foreign_key_without_factory_returns_none(self):
         """Nullable foreign keys without factories or instances should fall back to None."""
         from general_manager.factory.factories import get_field_value


### PR DESCRIPTION
## Summary
- Return `None` for nullable relation fields that explicitly default to `None` before attempting related-instance generation.
- Resolve string related model references through Django's app registry before validating relation targets.
- Add regression coverage for dotted string relation resolution and nullable `default=None` relation handling.

## Root Cause
`AutoFactory` calls `get_field_value()` for missing model fields. For relation fields, that path called `get_related_model()` before honoring an explicit nullable `default=None`. When Django still exposed `field.related_model` as a string such as `"financials.AccountNumber"`, `get_related_model()` rejected it as an invalid related model instead of resolving it.

Fixes #223.

## Validation
- `python -m pytest tests/unit/test_factories.py tests/unit/test_auto_factory.py tests/integration/test_auto_factory.py`
- `ruff check src/general_manager/factory/factories.py tests/unit/test_factories.py`
- `ruff format --check src/general_manager/factory/factories.py tests/unit/test_factories.py`
- pre-commit during commit: ruff, format, whitespace/eof checks, mypy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced model relation resolution to more robustly handle string-based model references.
  * Improved handling of null defaults for nullable relation fields.
  * Strengthened validation and error handling for related model lookups.

* **Tests**
  * Added unit tests for model relation string resolution and nullable field default behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimKleindick/general_manager/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->