### PR TITLE
[codex] fix null filter cache invalidation

### DIFF
--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -661,7 +661,8 @@ def generic_cache_invalidation(
         - "regex": treats `val_key` as a regular expression pattern and tests it against the string form of `value`.
 
         Behavior notes:
-        - If `value` is None the function returns `False`.
+        - If `value` is None the function only matches explicit null equality
+          or membership checks.
         - ``val_key`` is a JSON-serialised string produced by
           :func:`json.dumps`.  Parsing is done with :func:`json.loads`; if
           JSON parsing or type coercion fails, the function falls back to
@@ -676,12 +677,11 @@ def generic_cache_invalidation(
         Returns:
             bool: `True` if the comparison defined by `op` and `val_key` matches `value`, `False` otherwise.
         """
-        if value is None:
-            return False
-
         # eq
         if op == "eq":
             literal_val = _json_loads_val_key(val_key)
+            if literal_val is None:
+                return value is None
             repr_marker = _repr_marker(literal_val)
             if repr_marker is not None:
                 return repr(value) == repr_marker
@@ -697,6 +697,10 @@ def generic_cache_invalidation(
             except (json.JSONDecodeError, ValueError):
                 return False
             for item in seq:
+                if item is None:
+                    if value is None:
+                        return True
+                    continue
                 repr_marker = _repr_marker(item)
                 if repr_marker is not None:
                     if repr(value) == repr_marker:
@@ -712,6 +716,8 @@ def generic_cache_invalidation(
 
         # range comparisons
         if op in ("gt", "gte", "lt", "lte"):
+            if value is None:
+                return False
             literal_val = _json_loads_val_key(val_key)
             thr = _coerce_to_type(value, literal_val)
             if thr is None:
@@ -727,6 +733,8 @@ def generic_cache_invalidation(
 
         # wildcard / regex comparisons
         if op in ("contains", "startswith", "endswith", "regex"):
+            if value is None:
+                return False
             try:
                 literal = json.loads(val_key)
             except (json.JSONDecodeError, ValueError):

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -33,6 +33,10 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
                 name = CharField(max_length=100)
                 salary = MeasurementField(base_unit="EUR")
 
+            @graph_ql_property()
+            def salary_rate(self) -> float:
+                return float(self.salary.quantity.magnitude / 100)
+
         class TaxCalculation(GeneralManager):
             employee: Employee
 
@@ -92,6 +96,53 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         data = response.json()["data"]["taxcalculation"]
         self.assertEqual(data["calculatedTax"]["value"], 600)
         self.assertEqual(data["calculatedTax"]["unit"], "EUR")
+
+    def test_entry_based_graphql_property_refreshes_after_update(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+        query = """
+        query($id: ID!) {
+            employee(id: $id) {
+                salaryRate
+            }
+        }
+        """
+
+        response = self.query(query, variables={"id": employee.id})
+        self.assertResponseNoErrors(response)
+        self.assertEqual(response.json()["data"]["employee"]["salaryRate"], 30)
+
+        employee.update(
+            salary=Measurement(4000, "EUR"),
+            creator_id=self.user.id,
+            ignore_permission=True,
+        )
+
+        response = self.query(query, variables={"id": employee.id})
+        self.assertResponseNoErrors(response)
+        self.assertEqual(response.json()["data"]["employee"]["salaryRate"], 40)
+
+    def test_calculation_graphql_property_refreshes_after_entry_update(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+
+        response = self.query(self.mutation, variables={"employeeId": employee.id})
+        self.assertResponseNoErrors(response)
+        data = response.json()["data"]["taxcalculation"]
+        self.assertEqual(data["calculatedTax"]["value"], 600)
+
+        employee.update(
+            salary=Measurement(4000, "EUR"),
+            creator_id=self.user.id,
+            ignore_permission=True,
+        )
+
+        response = self.query(self.mutation, variables={"employeeId": employee.id})
+        self.assertResponseNoErrors(response)
+        data = response.json()["data"]["taxcalculation"]
+        self.assertEqual(data["calculatedTax"]["value"], 800)
 
     def test_sort_by_calculation_property(self):
         """

--- a/tests/integration/test_default_mutations.py
+++ b/tests/integration/test_default_mutations.py
@@ -12,6 +12,7 @@ from general_manager.permission.manager_based_permission import ManagerBasedPerm
 from typing import ClassVar
 from django.core.exceptions import ObjectDoesNotExist
 from unittest.mock import patch
+from general_manager.api.property import graph_ql_property
 
 
 class DefaultCreateMutationTest(GeneralManagerTransactionTestCase):
@@ -314,6 +315,12 @@ class DefaultUpdateMutationTest(GeneralManagerTransactionTestCase):
                 class Meta:
                     app_label = "general_manager"
 
+            @graph_ql_property()
+            def number_rate(self) -> float | None:
+                if self.number is None:
+                    return None
+                return self.number / 100
+
         cls.TestProject = TestProject
         cls.general_manager_classes = [TestProject]
 
@@ -365,6 +372,13 @@ class DefaultUpdateMutationTest(GeneralManagerTransactionTestCase):
                 }
             }
             """
+        self.query_number_rate = """
+            query Project($id: ID!) {
+                testproject(id: $id) {
+                    numberRate
+                }
+            }
+            """
         self.update_mutation_without_name = """
             mutation UpdateProject($id: Int!, $budget: MeasurementScalar) {
                 updateTestProject(id: $id, budget: $budget) {
@@ -413,6 +427,23 @@ class DefaultUpdateMutationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(updated_project.number, 1)
         self.assertEqual(updated_project.budget, "2000 EUR")
         self.assertEqual(self._latest_history_user(updated_project), self.user)
+
+    def test_entry_based_graphql_property_refreshes_after_update(self):
+        response = self.query(
+            self.query_number_rate,
+            variables={"id": self.project.id},
+        )
+        self.assertResponseNoErrors(response)
+        self.assertEqual(response.json()["data"]["testproject"]["numberRate"], 0.01)
+
+        self.project = self.project.update(number=200, ignore_permission=True)
+
+        response = self.query(
+            self.query_number_rate,
+            variables={"id": self.project.id},
+        )
+        self.assertResponseNoErrors(response)
+        self.assertEqual(response.json()["data"]["testproject"]["numberRate"], 2)
 
     def test_update_project_without_budget(self):
         """

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -961,6 +961,31 @@ class GenericCacheInvalidationTests(TestCase):
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
     @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
+    def test_filter_invalidation_when_old_value_was_none(
+        self,
+        mock_remove,
+        mock_invalidate,
+        mock_get_index,
+    ):
+        mock_get_index.return_value = {
+            "filter": {"DummyManager2": {"count": {"null": ["MISSING"]}}},
+            "exclude": {},
+        }
+        old_vals = {"count": None}
+        inst = DummyManager2(status="any", count=1000)
+
+        generic_cache_invalidation(
+            sender=DummyManager2,
+            instance=inst,
+            old_relevant_values=old_vals,
+        )
+
+        mock_invalidate.assert_called_once_with("MISSING")
+        mock_remove.assert_called_once_with("MISSING")
+
+    @patch("general_manager.cache.dependency_index.get_full_index")
+    @patch("general_manager.cache.dependency_index.invalidate_cache_key")
+    @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
     def test_exclude_invalidation_only_on_change(
         self,
         mock_remove,

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -986,6 +986,31 @@ class GenericCacheInvalidationTests(TestCase):
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
     @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
+    def test_filter_invalidation_when_old_value_was_none_for_in(
+        self,
+        mock_remove,
+        mock_invalidate,
+        mock_get_index,
+    ):
+        mock_get_index.return_value = {
+            "filter": {"DummyManager2": {"count__in": {"[null]": ["MISSING"]}}},
+            "exclude": {},
+        }
+        old_vals = {"count": None}
+        inst = DummyManager2(status="any", count=1000)
+
+        generic_cache_invalidation(
+            sender=DummyManager2,
+            instance=inst,
+            old_relevant_values=old_vals,
+        )
+
+        mock_invalidate.assert_called_once_with("MISSING")
+        mock_remove.assert_called_once_with("MISSING")
+
+    @patch("general_manager.cache.dependency_index.get_full_index")
+    @patch("general_manager.cache.dependency_index.invalidate_cache_key")
+    @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
     def test_exclude_invalidation_only_on_change(
         self,
         mock_remove,


### PR DESCRIPTION
## Summary

Fixes the stale calculation/cache behavior reported in #222 by making dependency invalidation treat explicit null equality and null membership lookups as real matches.

Also adds focused regression coverage for #221-style entry-derived `@graph_ql_property` refreshes after updates. I could not reproduce #221 as a failing path on this branch: direct entry properties, calculation properties derived from an updated entry, and mutation/update readback all refreshed correctly. The added tests lock that behavior down.

## Root Cause

For #222, the dependency matcher returned `False` immediately for `None` values. That meant cache entries registered for filters like `count=None` were not invalidated when a row changed from `None` back to a concrete value, leaving stale "missing" results visible.

For #221, the existing identification-based property invalidation path is already refreshing in the tested paths, so no production change was needed beyond the cache fix in this PR.

## Changes

- Allow explicit JSON `null` equality and `__in` membership checks to match Python `None`.
- Keep range and string operators non-matching for `None` values.
- Add a regression test for invalidating a cached null filter when the old value was `None` and the new value is concrete.
- Add regression coverage for entry-derived and calculation-derived GraphQL properties refreshing after their backing entry changes.

## Validation

- `python -m pytest tests/unit/test_dependency_index.py`
- `python -m pytest tests/integration/test_calculation_manager.py tests/integration/test_default_mutations.py tests/unit/test_dependency_index.py`
- `ruff check src/general_manager/cache/dependency_index.py tests/unit/test_dependency_index.py`
- `ruff check tests/integration/test_calculation_manager.py tests/integration/test_default_mutations.py`
- Commit hooks: ruff lint/fix, ruff format, EOF, trailing whitespace, mixed line ending, merge conflict, debug statements, mypy where applicable

Closes #222.
Refs #221.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache invalidation now correctly treats nulls for equality and membership checks, preventing missed or incorrect invalidations.

* **Tests**
  * Added integration tests ensuring computed GraphQL properties refresh after underlying data updates.
  * Added unit tests covering cache invalidation behavior when previous values are null.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimKleindick/general_manager/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->