### PR TITLE
feat: expose nested GraphQL relation filters

### DIFF
--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -47,6 +47,47 @@ Schema generation should remain resilient when interface metadata includes edge-
 
 The intended behavior is that startup and schema registration remain reviewable and predictable even when a manager exposes less common field metadata.
 
+## Relation Filters
+
+Generated list queries expose scalar filters and relation filters. Direct
+relations such as foreign keys and one-to-one fields use nested filter input:
+
+```graphql
+query {
+  changerequestfeasibilityList(filter: {
+    changeRequest: { title: "Primary" }
+  }) {
+    items { id score }
+  }
+}
+```
+
+Collection relations such as reverse foreign keys and many-to-many fields expose
+`any` and `none`:
+
+```graphql
+query {
+  changerequestList(filter: {
+    changeRequestFeasibilityList: {
+      any: { score_Gte: 7 }
+    }
+  }) {
+    items { id title }
+  }
+}
+```
+
+`any` keeps rows with at least one related object matching the nested filter.
+`none` removes rows that have a related object matching the nested filter.
+
+The maximum relation nesting depth defaults to `1`. Configure it with:
+
+```python
+GENERAL_MANAGER = {
+    "GRAPHQL_FILTER_RELATION_DEPTH": 2,
+}
+```
+
 ## Buckets and pagination
 
 For bucket-returning fields, the schema registers list fields and page types. `PageInfo` exposes `total_count`, `current_page`, `total_pages`, and optional `page_size` so clients can implement cursor-less pagination quickly.

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -704,10 +704,12 @@ class GraphQL:
         field_type: Type[GeneralManager],
     ) -> type[graphene.InputObjectType] | None:
         """Build filter InputObjectType for *field_type*. See ``graphql_search.create_filter_options``."""
+        relation_depth = int(get_setting("GRAPHQL_FILTER_RELATION_DEPTH", 1) or 0)
         return _create_filter_options_fn(
             field_type,
             GraphQL.graphql_filter_type_registry,
             GraphQL._map_field_to_graphene_read,
+            relation_depth=relation_depth,
         )
 
     @staticmethod

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -102,6 +102,7 @@ from general_manager.api.graphql_search import (
     passes_permission_filters as _passes_permission_filters_fn,
     get_filter_options as _get_filter_options_fn,
     create_filter_options as _create_filter_options_fn,
+    normalize_filter_input as _normalize_filter_input_fn,
 )
 from general_manager.api.graphql_subscriptions import (
     get_channel_layer_safe as _get_channel_layer_fn,
@@ -782,16 +783,31 @@ class GraphQL:
         return _parse_input_fn(input_val)
 
     @staticmethod
+    def _normalize_filter_input(
+        field_type: Type[GeneralManager],
+        filter_input: dict[str, Any],
+    ) -> dict[str, dict[str, Any]]:
+        """Flatten nested relation filters. See ``graphql_search.normalize_filter_input``."""
+        return _normalize_filter_input_fn(field_type, filter_input)
+
+    @staticmethod
     def _apply_query_parameters(
         queryset: Bucket[GeneralManager],
         filter_input: dict[str, Any] | str | None,
         exclude_input: dict[str, Any] | str | None,
         sort_by: graphene.Enum | None,
         reverse: bool,
+        filter_normalizer: Callable[[dict[str, Any]], dict[str, dict[str, Any]]]
+        | None = None,
     ) -> Bucket[GeneralManager]:
         """Apply filter/exclude/sort to *queryset*. See ``graphql_resolvers.apply_query_parameters``."""
         return _apply_query_parameters_fn(
-            queryset, filter_input, exclude_input, sort_by, reverse
+            queryset,
+            filter_input,
+            exclude_input,
+            sort_by,
+            reverse,
+            filter_normalizer=filter_normalizer,
         )
 
     @staticmethod
@@ -816,7 +832,11 @@ class GraphQL:
         fallback_manager_class: type[GeneralManager],
     ) -> Callable[..., Any]:
         """Build a list-field resolver. See ``graphql_resolvers.create_list_resolver``."""
-        return _create_list_resolver_fn(base_getter, fallback_manager_class)
+        return _create_list_resolver_fn(
+            base_getter,
+            fallback_manager_class,
+            _normalize_filter_input_fn,
+        )
 
     @staticmethod
     def _apply_pagination(
@@ -847,7 +867,7 @@ class GraphQL:
     @classmethod
     def _create_resolver(cls, field_name: str, field_type: type) -> Callable[..., Any]:
         """Dispatch to the appropriate resolver factory. See ``graphql_resolvers.create_resolver``."""
-        return _create_resolver_fn(field_name, field_type)
+        return _create_resolver_fn(field_name, field_type, _normalize_filter_input_fn)
 
     @classmethod
     def _get_or_create_page_type(

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -39,6 +39,15 @@ GeneralManagerT = TypeVar("GeneralManagerT", bound=GeneralManager)
 logger = get_logger("api.graphql")
 
 
+class UnsupportedExcludeNoneRelationFilterError(ValueError):
+    """Raised when `none` relation filters are used in GraphQL exclude input."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "`none` relation filters are not supported inside `exclude` inputs."
+        )
+
+
 @dataclass(slots=True)
 class ReadAuthorizationResult(Generic[GeneralManagerT]):
     queryset: Bucket[GeneralManagerT]
@@ -70,6 +79,17 @@ def parse_input(input_val: dict[str, Any] | str | None) -> dict[str, Any]:
         except (json.JSONDecodeError, ValueError):
             return {}
     return input_val
+
+
+def contains_none_relation_filter(input_val: Any) -> bool:
+    """Return True when a nested relation filter contains a ``none`` operator."""
+    if isinstance(input_val, dict):
+        if "none" in input_val:
+            return True
+        return any(contains_none_relation_filter(value) for value in input_val.values())
+    if isinstance(input_val, list):
+        return any(contains_none_relation_filter(value) for value in input_val)
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -111,6 +131,8 @@ def apply_query_parameters(
 
     excludes = parse_input(exclude_input)
     if excludes and filter_normalizer is not None:
+        if contains_none_relation_filter(excludes):
+            raise UnsupportedExcludeNoneRelationFilterError
         normalized = filter_normalizer(excludes)
         excludes = normalized["filter"]
         normalized_excludes = {**normalized_excludes, **normalized["exclude"]}

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -83,6 +83,9 @@ def apply_query_parameters(
     exclude_input: dict[str, Any] | str | None,
     sort_by: graphene.Enum | None,
     reverse: bool,
+    *,
+    filter_normalizer: Callable[[dict[str, Any]], dict[str, dict[str, Any]]]
+    | None = None,
 ) -> Bucket[GeneralManager]:
     """
     Apply filtering, exclusion, and sorting to *queryset*.
@@ -96,13 +99,25 @@ def apply_query_parameters(
     Returns:
         The queryset after filters, exclusions, and sorting are applied.
     """
+    normalized_excludes: dict[str, Any] = {}
+
     filters = parse_input(filter_input)
+    if filters and filter_normalizer is not None:
+        normalized = filter_normalizer(filters)
+        filters = normalized["filter"]
+        normalized_excludes = normalized["exclude"]
     if filters:
         queryset = queryset.filter(**filters)
 
     excludes = parse_input(exclude_input)
+    if excludes and filter_normalizer is not None:
+        normalized = filter_normalizer(excludes)
+        excludes = normalized["filter"]
+        normalized_excludes = {**normalized_excludes, **normalized["exclude"]}
     if excludes:
         queryset = queryset.exclude(**excludes)
+    if normalized_excludes:
+        queryset = queryset.exclude(**normalized_excludes)
 
     if sort_by:
         sort_by_str = cast(str, getattr(sort_by, "value", sort_by))
@@ -440,6 +455,10 @@ def create_normal_resolver(field_name: str) -> Callable[..., Any]:
 def create_list_resolver(
     base_getter: Callable[[Any, bool], Any],
     fallback_manager_class: type[GeneralManager],
+    filter_normalizer: Callable[
+        [type[GeneralManager], dict[str, Any]], dict[str, dict[str, Any]]
+    ]
+    | None = None,
 ) -> Callable[..., Any]:
     """
     Build a resolver for list fields that applies filters, permissions, and pagination.
@@ -479,7 +498,22 @@ def create_list_resolver(
         ):
             manager_class = fallback_manager_class
         qs = apply_permission_filters(base_queryset, manager_class, info)
-        qs = apply_query_parameters(qs, filter, exclude, sort_by, reverse)
+        bound_filter_normalizer = None
+        if filter_normalizer is not None:
+
+            def bound_filter_normalizer(
+                filters: dict[str, Any],
+            ) -> dict[str, dict[str, Any]]:
+                return filter_normalizer(manager_class, filters)
+
+        qs = apply_query_parameters(
+            qs,
+            filter,
+            exclude,
+            sort_by,
+            reverse,
+            filter_normalizer=bound_filter_normalizer,
+        )
         qs_grouped = apply_grouping(qs, group_by)
 
         total_count = len(qs_grouped)
@@ -575,7 +609,14 @@ def _selection_set_includes_path(
     return False
 
 
-def create_resolver(field_name: str, field_type: type) -> Callable[..., Any]:
+def create_resolver(
+    field_name: str,
+    field_type: type,
+    filter_normalizer: Callable[
+        [type[GeneralManager], dict[str, Any]], dict[str, dict[str, Any]]
+    ]
+    | None = None,
+) -> Callable[..., Any]:
     """
     Return the appropriate resolver for *field_name* based on *field_type*.
 
@@ -586,7 +627,9 @@ def create_resolver(field_name: str, field_type: type) -> Callable[..., Any]:
     """
     if field_name.endswith("_list") and safe_issubclass(field_type, GeneralManager):
         return create_list_resolver(
-            lambda self, _include_inactive: getattr(self, field_name), field_type
+            lambda self, _include_inactive: getattr(self, field_name),
+            field_type,
+            filter_normalizer,
         )
     if safe_issubclass(field_type, Measurement):
         return create_measurement_resolver(field_name)

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -761,7 +761,7 @@ def register_search_query(
 
             hits.sort(key=_sort_key, reverse=sort_desc)
         else:
-            hits.sort(key=lambda item: (item[0] or 0), reverse=True)
+            hits.sort(key=lambda item: item[0] or 0, reverse=True)
 
         items: list[GeneralManager] = []
         for _, _hit, instance in hits[offset : offset + limit]:

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -493,6 +493,63 @@ def create_filter_options(
     return filter_class
 
 
+def normalize_filter_input(
+    field_type: Type[GeneralManager],
+    filter_input: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Flatten nested GraphQL relation filters into filter and exclude kwargs."""
+    interface = getattr(field_type, "Interface", None)
+    get_attribute_types = getattr(interface, "get_attribute_types", None)
+    if not callable(get_attribute_types):
+        return {"filter": dict(filter_input), "exclude": {}}
+
+    filters: dict[str, Any] = {}
+    excludes: dict[str, Any] = {}
+    attr_types = get_attribute_types()
+
+    for key, value in filter_input.items():
+        attr_info = attr_types.get(key)
+        if not attr_info or not isinstance(value, dict):
+            filters[key] = value
+            continue
+
+        attr_type = attr_info.get("type")
+        relation_kind = attr_info.get("relation_kind")
+        lookup = attr_info.get("filter_lookup", key)
+        if not safe_issubclass(attr_type, GeneralManager) or relation_kind is None:
+            filters[key] = value
+            continue
+
+        if relation_kind == "direct":
+            nested = normalize_filter_input(attr_type, value)
+            for nested_key, nested_value in nested["filter"].items():
+                filters[f"{lookup}__{nested_key}"] = nested_value
+            for nested_key, nested_value in nested["exclude"].items():
+                excludes[f"{lookup}__{nested_key}"] = nested_value
+            continue
+
+        if relation_kind == "collection":
+            any_value = value.get("any")
+            none_value = value.get("none")
+            if isinstance(any_value, dict):
+                nested = normalize_filter_input(attr_type, any_value)
+                for nested_key, nested_value in nested["filter"].items():
+                    filters[f"{lookup}__{nested_key}"] = nested_value
+                for nested_key, nested_value in nested["exclude"].items():
+                    excludes[f"{lookup}__{nested_key}"] = nested_value
+            if isinstance(none_value, dict):
+                nested = normalize_filter_input(attr_type, none_value)
+                for nested_key, nested_value in nested["filter"].items():
+                    excludes[f"{lookup}__{nested_key}"] = nested_value
+                for nested_key, nested_value in nested["exclude"].items():
+                    filters[f"{lookup}__{nested_key}"] = nested_value
+            continue
+
+        filters[key] = value
+
+    return {"filter": filters, "exclude": excludes}
+
+
 # ---------------------------------------------------------------------------
 # Top-level search query registration
 # ---------------------------------------------------------------------------

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -357,10 +357,66 @@ def get_filter_options(
                     )
 
 
+def get_relation_filter_option(
+    attribute_type: type,
+    attribute_name: str,
+    attr_info: Mapping[str, Any],
+    graphql_filter_type_registry: dict[str, type[graphene.InputObjectType]],
+    map_field_to_graphene_read: Callable[[type, str, Mapping[str, Any] | None], Any],
+    remaining_depth: int,
+) -> tuple[str, Any] | None:
+    """Build a nested relation filter field for direct and collection relations."""
+    if remaining_depth <= 0:
+        return None
+    if not safe_issubclass(attribute_type, GeneralManager):
+        return None
+
+    relation_kind = attr_info.get("relation_kind")
+    if relation_kind not in {"collection", "direct"}:
+        return None
+
+    nested_type = create_filter_options(
+        attribute_type,
+        graphql_filter_type_registry,
+        map_field_to_graphene_read,
+        relation_depth=remaining_depth - 1,
+        _remaining_depth=remaining_depth - 1,
+    )
+    if nested_type is None:
+        return None
+
+    if relation_kind == "collection":
+        relation_type_name = (
+            f"{attribute_type.__name__}{attribute_name.title().replace('_', '')}"
+            f"RelationFilterTypeDepth{remaining_depth - 1}"
+        )
+        if relation_type_name not in graphql_filter_type_registry:
+            graphql_filter_type_registry[relation_type_name] = type(
+                relation_type_name,
+                (graphene.InputObjectType,),
+                {
+                    "any": graphene.InputField(nested_type),
+                    "none": graphene.InputField(nested_type),
+                },
+            )
+        return (
+            attribute_name,
+            graphene.InputField(graphql_filter_type_registry[relation_type_name]),
+        )
+
+    if relation_kind == "direct":
+        return attribute_name, graphene.InputField(nested_type)
+
+    return None
+
+
 def create_filter_options(
     field_type: Type[GeneralManager],
     graphql_filter_type_registry: dict[str, type[graphene.InputObjectType]],
     map_field_to_graphene_read: Callable[[type, str, Mapping[str, Any] | None], Any],
+    *,
+    relation_depth: int = 1,
+    _remaining_depth: int | None = None,
 ) -> type[graphene.InputObjectType] | None:
     """
     Create (or retrieve from cache) a Graphene InputObjectType exposing all
@@ -378,13 +434,27 @@ def create_filter_options(
         A Graphene ``InputObjectType`` for *field_type*, or ``None`` if no
         filterable fields exist.
     """
-    graphene_filter_type_name = f"{field_type.__name__}FilterType"
+    remaining_depth = relation_depth if _remaining_depth is None else _remaining_depth
+    graphene_filter_type_name = f"{field_type.__name__}FilterTypeDepth{remaining_depth}"
     if graphene_filter_type_name in graphql_filter_type_registry:
         return graphql_filter_type_registry[graphene_filter_type_name]
 
     filter_fields: dict[str, Any] = {}
     for attr_name, attr_info in field_type.Interface.get_attribute_types().items():
         attr_type = attr_info["type"]
+        if safe_issubclass(attr_type, GeneralManager):
+            relation_option = get_relation_filter_option(
+                attr_type,
+                attr_name,
+                attr_info,
+                graphql_filter_type_registry,
+                map_field_to_graphene_read,
+                remaining_depth,
+            )
+            if relation_option is not None:
+                key, value = relation_option
+                filter_fields[key] = value
+            continue
         filter_fields = {
             **filter_fields,
             **{

--- a/src/general_manager/interface/base_interface.py
+++ b/src/general_manager/interface/base_interface.py
@@ -72,6 +72,8 @@ class AttributeTypedDict(TypedDict):
 
     type: type
     graphql_scalar: NotRequired[str]
+    relation_kind: NotRequired[str]
+    filter_lookup: NotRequired[str]
     default: Any
     is_required: bool
     is_editable: bool

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -205,6 +205,8 @@ class _FieldDescriptorBuilder:
                 default=default,
                 is_derived=False,
                 accessor=accessor,
+                relation_kind="direct",
+                filter_lookup=field.name,
             )
 
     def _add_collection_relations(self) -> None:
@@ -303,6 +305,8 @@ class _FieldDescriptorBuilder:
             default=None,
             is_derived=is_derived,
             accessor=accessor,
+            relation_kind="collection",
+            filter_lookup=field_base,
         )
 
     def _resolve_collection_base_name(
@@ -347,6 +351,8 @@ class _FieldDescriptorBuilder:
         default: Any,
         is_derived: bool,
         accessor: DescriptorAccessor,
+        relation_kind: str | None = None,
+        filter_lookup: str | None = None,
     ) -> None:
         """
         Register a FieldDescriptor for a named interface attribute.
@@ -375,6 +381,10 @@ class _FieldDescriptorBuilder:
         graphql_scalar = _graphql_scalar_hint(raw_type)
         if graphql_scalar is not None:
             metadata["graphql_scalar"] = graphql_scalar
+        if relation_kind is not None:
+            metadata["relation_kind"] = relation_kind
+        if filter_lookup is not None:
+            metadata["filter_lookup"] = filter_lookup
         self._descriptors[attribute_name] = FieldDescriptor(
             name=attribute_name,
             metadata=metadata,

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -306,7 +306,7 @@ class _FieldDescriptorBuilder:
             is_derived=is_derived,
             accessor=accessor,
             relation_kind="collection",
-            filter_lookup=field_base,
+            filter_lookup=getattr(field, "name", accessor_name),
         )
 
     def _resolve_collection_base_name(

--- a/tests/integration/test_graphql_relation_filters.py
+++ b/tests/integration/test_graphql_relation_filters.py
@@ -189,6 +189,26 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
 
         self.assertEqual(self._titles_from_response(response), ["Secondary"])
 
+    def test_exclude_rejects_reverse_relation_none(self):
+        query = """
+        query {
+            changerequestList(exclude: {
+                changeRequestFeasibilityList: { none: { score_Gte: 7 } }
+            }) {
+                items { id title }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        payload = response.json()
+        self.assertIn("errors", payload)
+        self.assertIn(
+            "`none` relation filters are not supported inside `exclude` inputs.",
+            payload["errors"][0]["message"],
+        )
+
     def test_relation_filter_depth_two_exposes_second_level_relation(self):
         parent_filter = GraphQL.graphql_filter_type_registry[
             "ChangeRequestFilterTypeDepth2"

--- a/tests/integration/test_graphql_relation_filters.py
+++ b/tests/integration/test_graphql_relation_filters.py
@@ -1,0 +1,256 @@
+# type: ignore
+from __future__ import annotations
+
+
+from django.contrib.auth import get_user_model
+from django.db import models
+from django.test import override_settings
+from django.utils.crypto import get_random_string
+
+from general_manager.bucket.base_bucket import Bucket
+from general_manager.api.graphql import GraphQL
+from general_manager.interface import DatabaseInterface
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.utils.testing import GeneralManagerTransactionTestCase
+
+
+class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        settings_override = override_settings(
+            GENERAL_MANAGER={"GRAPHQL_FILTER_RELATION_DEPTH": 2}
+        )
+        settings_override.enable()
+        cls.addClassCleanup(settings_override.disable)
+
+        class ChangeRequest(GeneralManager):
+            title: str
+            change_request_feasibility_list: Bucket[ChangeRequestFeasibility]
+
+            class Interface(DatabaseInterface):
+                title = models.CharField(max_length=100)
+
+        class ChangeRequestFeasibility(GeneralManager):
+            score: int
+            change_request: ChangeRequest
+            change_request_team_list: Bucket[ChangeRequestTeam]
+
+            class Interface(DatabaseInterface):
+                score = models.IntegerField(default=0)
+                change_request = models.ForeignKey(
+                    "general_manager.ChangeRequest",
+                    on_delete=models.CASCADE,
+                )
+
+        class ChangeRequestTeam(GeneralManager):
+            name: str
+            size: int
+            change_request_feasibility: ChangeRequestFeasibility
+
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=100)
+                size = models.IntegerField(default=0)
+                change_request_feasibility = models.ForeignKey(
+                    "general_manager.ChangeRequestFeasibility",
+                    on_delete=models.CASCADE,
+                )
+
+        cls.ChangeRequest = ChangeRequest
+        cls.ChangeRequestFeasibility = ChangeRequestFeasibility
+        cls.ChangeRequestTeam = ChangeRequestTeam
+        cls.general_manager_classes = [
+            ChangeRequest,
+            ChangeRequestFeasibility,
+            ChangeRequestTeam,
+        ]
+
+    def setUp(self):
+        super().setUp()
+        password = get_random_string(12)
+        self.user = get_user_model().objects.create_user(
+            username=f"relation-filter-{get_random_string(8)}",
+            password=password,
+        )
+        self.client.login(username=self.user.username, password=password)
+
+        self.primary = self.ChangeRequest.create(
+            creator_id=None,
+            title="Primary",
+            ignore_permission=True,
+        )
+        self.secondary = self.ChangeRequest.create(
+            creator_id=None,
+            title="Secondary",
+            ignore_permission=True,
+        )
+        self.high_feasibility = self.ChangeRequestFeasibility.create(
+            creator_id=None,
+            score=9,
+            change_request=self.primary,
+            ignore_permission=True,
+        )
+        self.low_feasibility = self.ChangeRequestFeasibility.create(
+            creator_id=None,
+            score=2,
+            change_request=self.secondary,
+            ignore_permission=True,
+        )
+        self.ChangeRequestTeam.create(
+            creator_id=None,
+            name="Large Team",
+            size=6,
+            change_request_feasibility=self.high_feasibility,
+            ignore_permission=True,
+        )
+        self.ChangeRequestTeam.create(
+            creator_id=None,
+            name="Small Team",
+            size=2,
+            change_request_feasibility=self.low_feasibility,
+            ignore_permission=True,
+        )
+
+    def _titles_from_response(self, response) -> list[str]:
+        self.assertResponseNoErrors(response)
+        payload = response.json()
+        return [item["title"] for item in payload["data"]["changerequestList"]["items"]]
+
+    def test_filters_by_direct_foreign_key_relation(self):
+        query = """
+        query {
+            changerequestfeasibilityList(filter: {
+                changeRequest: { title: "Primary" }
+            }) {
+                items {
+                    id
+                    score
+                    changeRequest { title }
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        items = response.json()["data"]["changerequestfeasibilityList"]["items"]
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["score"], 9)
+        self.assertEqual(items[0]["changeRequest"]["title"], "Primary")
+
+    def test_filters_by_reverse_relation_any(self):
+        query = """
+        query {
+            changerequestList(filter: {
+                changeRequestFeasibilityList: { any: { score_Gte: 7 } }
+            }) {
+                items { id title }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertEqual(self._titles_from_response(response), ["Primary"])
+
+    def test_filters_by_nested_reverse_relation_any(self):
+        query = """
+        query {
+            changerequestList(filter: {
+                changeRequestFeasibilityList: {
+                    any: {
+                        changeRequestTeamList: {
+                            any: { size_Gte: 5 }
+                        }
+                    }
+                }
+            }) {
+                items { id title }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertEqual(self._titles_from_response(response), ["Primary"])
+
+    def test_filters_by_reverse_relation_none(self):
+        query = """
+        query {
+            changerequestList(filter: {
+                changeRequestFeasibilityList: { none: { score_Gte: 7 } }
+            }) {
+                items { id title }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertEqual(self._titles_from_response(response), ["Secondary"])
+
+    def test_relation_filter_depth_two_exposes_second_level_relation(self):
+        parent_filter = GraphQL.graphql_filter_type_registry[
+            "ChangeRequestFilterTypeDepth2"
+        ]
+        relation_type = parent_filter._meta.fields[
+            "change_request_feasibility_list"
+        ].type
+        child_filter = relation_type._meta.fields["any"].type
+
+        self.assertIn("change_request_team_list", child_filter._meta.fields)
+
+
+class GraphQLRelationFilterDepthOneTests(GeneralManagerTransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        settings_override = override_settings(
+            GENERAL_MANAGER={"GRAPHQL_FILTER_RELATION_DEPTH": 1}
+        )
+        settings_override.enable()
+        cls.addClassCleanup(settings_override.disable)
+
+        class DepthOneChangeRequest(GeneralManager):
+            title: str
+            depth_one_feasibility_list: Bucket[DepthOneFeasibility]
+
+            class Interface(DatabaseInterface):
+                title = models.CharField(max_length=100)
+
+        class DepthOneFeasibility(GeneralManager):
+            score: int
+            change_request: DepthOneChangeRequest
+            depth_one_team_list: Bucket[DepthOneTeam]
+
+            class Interface(DatabaseInterface):
+                score = models.IntegerField(default=0)
+                change_request = models.ForeignKey(
+                    "general_manager.DepthOneChangeRequest",
+                    on_delete=models.CASCADE,
+                )
+
+        class DepthOneTeam(GeneralManager):
+            size: int
+            feasibility: DepthOneFeasibility
+
+            class Interface(DatabaseInterface):
+                size = models.IntegerField(default=0)
+                feasibility = models.ForeignKey(
+                    "general_manager.DepthOneFeasibility",
+                    on_delete=models.CASCADE,
+                )
+
+        cls.general_manager_classes = [
+            DepthOneChangeRequest,
+            DepthOneFeasibility,
+            DepthOneTeam,
+        ]
+
+    def test_relation_filter_depth_one_hides_second_level_relation(self):
+        parent_filter = GraphQL.graphql_filter_type_registry[
+            "DepthOneChangeRequestFilterTypeDepth1"
+        ]
+        relation_type = parent_filter._meta.fields["depth_one_feasibility_list"].type
+        child_filter = relation_type._meta.fields["any"].type
+
+        self.assertNotIn("depth_one_team_list", child_filter._meta.fields)

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -248,10 +248,13 @@ class GraphQLTests(TestCase):
             result = resolver(mock_instance, self.info, filter="bad", exclude="bad")
             self.assertEqual(result["items"], mock_qs)
 
-    def test_create_filter_options_measurement_fields(self):
+    def test_create_filter_options_includes_scalar_filter_variants(self):
         """
-        Tests that filter options are generated for numeric, string, and measurement fields, and that fields of type GeneralManager are excluded from the filter options.
+        Tests that filter options are generated for numeric, string, and measurement fields.
         """
+
+        class RelatedManager(GeneralManager):
+            pass
 
         class DummyManager:
             __name__ = "DummyManager"
@@ -265,13 +268,12 @@ class GraphQLTests(TestCase):
                         "num_field": {"type": int},
                         "str_field": {"type": str},
                         "measurement_field": {"type": Measurement},
-                        "gm_field": {"type": GeneralManager},
+                        "gm_field": {"type": RelatedManager},
                     }
 
         GraphQL.graphql_filter_type_registry.clear()
         filter_cls = GraphQL._create_filter_options(DummyManager)
         fields = filter_cls._meta.fields
-        self.assertNotIn("gm_field", fields)
         for key in [
             "num_field",
             *[f"num_field__{opt}" for opt in ["exact", "gt", "gte", "lt", "lte"]],

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -317,6 +317,100 @@ class GraphQLTests(TestCase):
         second = GraphQL._create_filter_options(DummyManager2)
         self.assertIs(first, second)
 
+    def test_create_filter_options_exposes_direct_relation_filter(self):
+        class RelatedManager:
+            __name__ = "RelatedManager"
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {"id": {"type": int}, "name": {"type": str}}
+
+        class DummyManager:
+            __name__ = "DummyManagerWithRelation"
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {
+                        "id": {"type": int},
+                        "related": {
+                            "type": RelatedManager,
+                            "relation_kind": "direct",
+                        },
+                    }
+
+        GraphQL.graphql_filter_type_registry.clear()
+
+        def relation_safe_issubclass(candidate, parent):
+            if parent is GeneralManager and candidate is RelatedManager:
+                return True
+            return isinstance(candidate, type) and issubclass(candidate, parent)
+
+        with patch(
+            "general_manager.api.graphql_search.safe_issubclass",
+            side_effect=relation_safe_issubclass,
+        ):
+            filter_type = GraphQL._create_filter_options(DummyManager)
+
+        self.assertIsNotNone(filter_type)
+        self.assertIn("related", filter_type._meta.fields)
+        related_type = filter_type._meta.fields["related"].type
+        self.assertIn("id", related_type._meta.fields)
+        self.assertIn("name__icontains", related_type._meta.fields)
+
+    def test_create_filter_options_exposes_collection_any_none_filter(self):
+        class ChildManager:
+            __name__ = "ChildManager"
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {"id": {"type": int}, "title": {"type": str}}
+
+        class ParentManager:
+            __name__ = "ParentManagerWithCollection"
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {
+                        "id": {"type": int},
+                        "child_list": {
+                            "type": ChildManager,
+                            "relation_kind": "collection",
+                            "filter_lookup": "child",
+                        },
+                    }
+
+        GraphQL.graphql_filter_type_registry.clear()
+
+        def relation_safe_issubclass(candidate, parent):
+            if parent is GeneralManager and candidate is ChildManager:
+                return True
+            return isinstance(candidate, type) and issubclass(candidate, parent)
+
+        with patch(
+            "general_manager.api.graphql_search.safe_issubclass",
+            side_effect=relation_safe_issubclass,
+        ):
+            filter_type = GraphQL._create_filter_options(ParentManager)
+
+        self.assertIsNotNone(filter_type)
+        relation_type = filter_type._meta.fields["child_list"].type
+        self.assertIn("any", relation_type._meta.fields)
+        self.assertIn("none", relation_type._meta.fields)
+        child_filter_type = relation_type._meta.fields["any"].type
+        self.assertIn("title__icontains", child_filter_type._meta.fields)
+
     def test_build_identification_arguments_respects_optional_inputs(self):
         class DependencyManager(GeneralManager):
             pass

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -411,6 +411,110 @@ class GraphQLTests(TestCase):
         child_filter_type = relation_type._meta.fields["any"].type
         self.assertIn("title__icontains", child_filter_type._meta.fields)
 
+    def test_normalize_relation_filter_input_flattens_direct_and_any_filters(self):
+        class ChildManager:
+            __name__ = "NormalizeChildManager"
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {"name": {"type": str}}
+
+        class ParentManager:
+            __name__ = "NormalizeParentManager"
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {
+                        "child": {
+                            "type": ChildManager,
+                            "relation_kind": "direct",
+                            "filter_lookup": "child",
+                        },
+                        "child_list": {
+                            "type": ChildManager,
+                            "relation_kind": "collection",
+                            "filter_lookup": "child",
+                        },
+                    }
+
+        def relation_safe_issubclass(candidate, parent):
+            if parent is GeneralManager and candidate is ChildManager:
+                return True
+            return isinstance(candidate, type) and issubclass(candidate, parent)
+
+        with patch(
+            "general_manager.api.graphql_search.safe_issubclass",
+            side_effect=relation_safe_issubclass,
+        ):
+            normalized = GraphQL._normalize_filter_input(
+                ParentManager,
+                {
+                    "child": {"name__icontains": "alpha"},
+                    "child_list": {"any": {"name": "beta"}},
+                },
+            )
+
+        self.assertEqual(
+            normalized,
+            {
+                "filter": {
+                    "child__name__icontains": "alpha",
+                    "child__name": "beta",
+                },
+                "exclude": {},
+            },
+        )
+
+    def test_normalize_relation_filter_input_flattens_none_to_exclude(self):
+        class ChildManager:
+            __name__ = "NormalizeNoneChildManager"
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {"name": {"type": str}}
+
+        class ParentManager:
+            __name__ = "NormalizeNoneParentManager"
+
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {
+                        "child_list": {
+                            "type": ChildManager,
+                            "relation_kind": "collection",
+                            "filter_lookup": "child",
+                        },
+                    }
+
+        def relation_safe_issubclass(candidate, parent):
+            if parent is GeneralManager and candidate is ChildManager:
+                return True
+            return isinstance(candidate, type) and issubclass(candidate, parent)
+
+        with patch(
+            "general_manager.api.graphql_search.safe_issubclass",
+            side_effect=relation_safe_issubclass,
+        ):
+            normalized = GraphQL._normalize_filter_input(
+                ParentManager,
+                {"child_list": {"none": {"name__icontains": "blocked"}}},
+            )
+
+        self.assertEqual(normalized["filter"], {})
+        self.assertEqual(normalized["exclude"], {"child__name__icontains": "blocked"})
+
     def test_build_identification_arguments_respects_optional_inputs(self):
         class DependencyManager(GeneralManager):
             pass


### PR DESCRIPTION
## Summary
- Generate relation-aware GraphQL filter input types for direct and collection relations with configurable nesting depth.
- Normalize nested relation filters into existing ORM filter/exclude kwargs, including `any` and `none` collection semantics.
- Add integration coverage for FK, reverse FK, nested relation filters, depth limits, and document the public API.

## Test Plan
- `ruff check src/general_manager/api/graphql.py src/general_manager/api/graphql_search.py src/general_manager/api/graphql_resolvers.py src/general_manager/interface/capabilities/orm_utils/field_descriptors.py tests/unit/test_graph_ql.py tests/integration/test_graphql_relation_filters.py`
- `mypy src/general_manager/api/graphql.py src/general_manager/api/graphql_search.py src/general_manager/api/graphql_resolvers.py src/general_manager/interface/capabilities/orm_utils/field_descriptors.py`
- `python -m pytest tests/unit/test_graph_ql.py tests/integration/test_graphql_relation_filters.py tests/integration/test_database_manager.py -q`
- `python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GraphQL list queries support nested relation filters for direct and collection relations, including configurable nesting depth and `any`/`none` operators.
* **Documentation**
  * Added "Relation Filters" section with examples and depth configuration guidance.
* **Bug Fixes**
  * Validation improved to reject unsupported uses of `none` in exclusion filters.
* **Tests**
  * New integration and unit tests covering relation-filter behavior across depths and normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimKleindick/general_manager/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->