### PR TITLE
[codex] Fix compound currency measurement conversion

### DIFF
--- a/docs/concepts/measurement/units_currency.md
+++ b/docs/concepts/measurement/units_currency.md
@@ -16,6 +16,7 @@ Measurements keep both the magnitude and the original unit. Convert units with `
 ```python
 length_cm = length.to("centimeter")
 price_usd = price.to("USD", exchange_rate=1.08)
+freight_eur = Measurement(100, "USD/t").to("EUR/t", exchange_rate=0.92)
 ```
 
 ## Arithmetic and comparisons

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -2,7 +2,7 @@
 
 # units.py
 from __future__ import annotations
-from typing import Any, Callable
+from typing import Any, Callable, cast
 import math
 import pint
 from decimal import Decimal, getcontext, InvalidOperation
@@ -102,6 +102,27 @@ def _convert_quantity(quantity: PlainQuantity, target_unit: str) -> PlainQuantit
     if _unit_uses_offset(quantity) or _unit_uses_offset(target_unit):
         source_quantity = _quantity_as_float(quantity)
     return source_quantity.to(target_unit)
+
+
+def _currency_component(unit: str) -> tuple[str, int] | None:
+    """Return the single configured currency component in a unit expression."""
+
+    parsed_unit = ureg.parse_units(str(unit))
+    currency_components = [
+        (unit_name, int(cast(Any, power)))
+        for unit_name, power in parsed_unit._units.items()
+        if unit_name in currency_units
+    ]
+    if len(currency_components) != 1:
+        return None
+    return currency_components[0]
+
+
+def _unit_without_currency(unit: str, currency: str, power: int) -> str:
+    """Return a unit expression with one currency component removed."""
+
+    stripped_unit = ureg.parse_units(str(unit)) / (ureg.parse_units(currency) ** power)
+    return str(stripped_unit)
 
 
 def convert_magnitude(value: Decimal, source_unit: str, target_unit: str) -> Decimal:
@@ -457,6 +478,30 @@ class Measurement:
         Raises:
             MissingExchangeRateError: If converting between two different currencies without providing an exchange rate.
         """
+        source_currency = _currency_component(self.unit)
+        target_currency = _currency_component(target_unit)
+        if (
+            source_currency is not None
+            and target_currency is not None
+            and source_currency[0] != target_currency[0]
+        ):
+            if exchange_rate is None:
+                raise MissingExchangeRateError()
+            source_currency_name, source_currency_power = source_currency
+            target_currency_name, target_currency_power = target_currency
+            if source_currency_power == target_currency_power:
+                value = convert_magnitude(
+                    self.magnitude,
+                    _unit_without_currency(
+                        self.unit, source_currency_name, source_currency_power
+                    ),
+                    _unit_without_currency(
+                        target_unit, target_currency_name, target_currency_power
+                    ),
+                )
+                value *= Decimal(str(exchange_rate)) ** source_currency_power
+                return Measurement(value, target_unit)
+
         if self.is_currency():
             if str(self.unit) == str(target_unit):
                 return self  # Same currency, no conversion needed

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -39,6 +39,35 @@ class MeasurementTestCase(TestCase):
         converted = m.to("USD", exchange_rate=1.2)
         self.assertEqual(str(converted), "120 USD")
 
+    def test_compound_currency_conversion(self):
+        m = Measurement(100, "USD/t")
+
+        converted = m.to("EUR/t", exchange_rate=1.25)
+
+        self.assertEqual(str(converted), "125 EUR / metric_ton")
+
+    def test_compound_currency_conversion_converts_physical_unit(self):
+        m = Measurement(100, "USD/kg")
+
+        converted = m.to("EUR/t", exchange_rate=1.25)
+
+        self.assertEqual(str(converted), "125000 EUR / metric_ton")
+
+    def test_compound_currency_conversion_requires_exchange_rate(self):
+        from general_manager.measurement.measurement import MissingExchangeRateError
+
+        m = Measurement(100, "USD/t")
+
+        with self.assertRaises(MissingExchangeRateError):
+            m.to("EUR/t")
+
+    def test_same_currency_compound_conversion_does_not_require_exchange_rate(self):
+        m = Measurement(100, "EUR/kg")
+
+        converted = m.to("EUR/t")
+
+        self.assertEqual(str(converted), "100000 EUR / metric_ton")
+
     def test_invalid_currency_conversion(self):
         m = Measurement(100, "EUR")
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- Fix `Measurement.to()` so compound units with one currency component can convert across currencies with an exchange rate.
- Preserve Pint conversion for the non-currency unit portion, including denominator scaling like `USD/kg` to `EUR/t`.
- Add regression tests for the issue #229 repro, missing exchange rates, same-currency compound conversion, and physical-unit scaling.
- Document compound currency conversion in the measurement docs.

## Root Cause
`Measurement.to()` only treated exact unit strings like `USD` or `EUR` as currency measurements. Compound units such as `USD / metric_ton` bypassed the exchange-rate branch and fell through to Pint, which correctly rejects conversion between separate currency dimensions.

## Validation
- `python -m pytest tests/unit/test_measurement.py`
- `ruff check src/general_manager/measurement/measurement.py tests/unit/test_measurement.py`
- `ruff format --check src/general_manager/measurement/measurement.py tests/unit/test_measurement.py`
- `mypy src/general_manager/measurement/measurement.py`
- pre-commit hooks during commit: ruff, ruff format, EOF, trailing whitespace, mixed line endings, merge conflicts, debug statements, mypy

Fixes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for compound currency conversions (e.g., USD/t to EUR/t) using exchange rates.
  * Validates that exchange rates are provided for currency conversions; same-currency conversions no longer require them.

* **Documentation**
  * Added currency conversion example demonstrating conversion between compound currency units.

* **Tests**
  * Added unit tests for compound currency conversion scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimKleindick/general_manager/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->