### PR TITLE
[codex] Fix reverse one-to-one relation access

### DIFF
--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -135,6 +135,7 @@ class _FieldDescriptorBuilder:
         self._add_custom_fields()
         self._add_model_fields()
         self._add_foreign_key_fields()
+        self._add_reverse_one_to_one_relations()
         self._add_collection_relations()
         return self._descriptors
 
@@ -207,6 +208,41 @@ class _FieldDescriptorBuilder:
                 accessor=accessor,
                 relation_kind="direct",
                 filter_lookup=field.name,
+            )
+
+    def _add_reverse_one_to_one_relations(self) -> None:
+        """Register snake_case aliases for reverse one-to-one relation accessors."""
+        for relation in _iter_reverse_one_to_one_relations(self.model):
+            related_model = self._resolve_related_model(
+                getattr(relation, "related_model", None)
+            )
+            if related_model is None:
+                continue
+            accessor_name = relation.get_accessor_name() or relation.name
+            attribute_name = _to_snake_case(related_model.__name__)
+            if attribute_name in self._descriptors:
+                continue
+            general_manager_class = getattr(
+                related_model, "_general_manager_class", None
+            )
+            if general_manager_class:
+                accessor = _general_manager_accessor(
+                    accessor_name, general_manager_class
+                )
+                relation_type = cast(type, general_manager_class)
+            else:
+                accessor = _instance_attribute_accessor(accessor_name)
+                relation_type = cast(type, related_model)
+            self._register(
+                attribute_name=attribute_name,
+                raw_type=relation_type,
+                is_required=False,
+                is_editable=False,
+                default=None,
+                is_derived=True,
+                accessor=accessor,
+                relation_kind="direct",
+                filter_lookup=relation.name,
             )
 
     def _add_collection_relations(self) -> None:
@@ -519,6 +555,22 @@ def _iter_many_to_many_fields(
             field, "many_to_many", False
         ):
             yield cast(models.Field, field)
+
+
+def _iter_reverse_one_to_one_relations(
+    model: type[models.Model],
+) -> Iterable[models.OneToOneRel]:
+    """Yield reverse one-to-one relations declared on a Django model."""
+    meta = getattr(model, "_meta", None)
+    get_fields = getattr(meta, "get_fields", None)
+    if not callable(get_fields):
+        return
+    for field in get_fields():
+        if getattr(field, "is_relation", False) and getattr(field, "one_to_one", False):
+            if getattr(field, "auto_created", False) and not getattr(
+                field, "concrete", False
+            ):
+                yield cast(models.OneToOneRel, field)
 
 
 def _iter_reverse_relations(

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from general_manager.interface.base_interface import AttributeTypedDict
@@ -610,7 +611,10 @@ def _instance_attribute_accessor(field_name: str) -> DescriptorAccessor:
         Returns:
             The attribute value retrieved from the underlying model instance.
         """
-        return getattr(self._instance, field_name)
+        try:
+            return getattr(self._instance, field_name)
+        except ObjectDoesNotExist:
+            return None
 
     return getter
 
@@ -636,7 +640,10 @@ def _general_manager_accessor(
         Returns:
             The value produced by calling `manager_class` with the related object's primary key, or `None` if the related object is `None`.
         """
-        related = getattr(self._instance, field_name)
+        try:
+            related = getattr(self._instance, field_name)
+        except ObjectDoesNotExist:
+            return None
         if related is None:
             return None
         return manager_class(related.pk)

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -355,6 +355,9 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(approval.id, self.change_request_approval.id)
         self.assertEqual(approval.approved_by, "Reviewer")
 
+    def test_missing_reverse_one_to_one_relation_returns_none(self):
+        self.assertIsNone(self.other_change_request.change_request_approval)
+
     def test_exclude_supports_snake_case_reverse_relation_aliases(self):
         remaining = self.ChangeRequest.exclude(
             change_request_feasibility__id=self.change_request_feasibility.id

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -73,11 +73,23 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
         class ChangeRequest(GeneralManager):
             title: str
+            change_request_approval: ChangeRequestApproval
             changerequestfeasibility_list: Bucket[ChangeRequestFeasibility]
             change_request_reviews_list: Bucket[ChangeRequestReview]
 
             class Interface(DatabaseInterface):
                 title = models.CharField(max_length=100)
+
+        class ChangeRequestApproval(GeneralManager):
+            approved_by: str
+            change_request: ChangeRequest
+
+            class Interface(DatabaseInterface):
+                approved_by = models.CharField(max_length=100)
+                change_request = models.OneToOneField(
+                    "general_manager.ChangeRequest",
+                    on_delete=models.CASCADE,
+                )
 
         class ChangeRequestFeasibility(GeneralManager):
             score: int
@@ -106,6 +118,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         cls.TestHuman = TestHuman
         cls.TestFamily = TestFamily
         cls.ChangeRequest = ChangeRequest
+        cls.ChangeRequestApproval = ChangeRequestApproval
         cls.ChangeRequestFeasibility = ChangeRequestFeasibility
         cls.ChangeRequestReview = ChangeRequestReview
         cls.general_manager_classes = [
@@ -113,6 +126,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             TestHuman,
             TestFamily,
             ChangeRequest,
+            ChangeRequestApproval,
             ChangeRequestFeasibility,
             ChangeRequestReview,
         ]
@@ -157,6 +171,12 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             change_request=self.change_request,
             ignore_permission=True,
         )
+        self.change_request_approval = self.ChangeRequestApproval.create(
+            creator_id=None,
+            approved_by="Reviewer",
+            change_request=self.change_request,
+            ignore_permission=True,
+        )
         self.change_request_review = self.ChangeRequestReview.create(
             creator_id=None,
             summary="Initial review",
@@ -179,6 +199,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.TestHuman.Interface._model._meta.model.objects.all().delete()
         self.TestFamily.Interface._model._meta.model.objects.all().delete()
         self.ChangeRequest.Interface._model._meta.model.objects.all().delete()
+        self.ChangeRequestApproval.Interface._model._meta.model.objects.all().delete()
         self.ChangeRequestFeasibility.Interface._model._meta.model.objects.all().delete()
         self.ChangeRequestReview.Interface._model._meta.model.objects.all().delete()
         super().tearDown()
@@ -327,6 +348,12 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(legacy_matches[0].id, self.change_request.id)
         self.assertEqual(len(explicit_related_name_matches), 1)
         self.assertEqual(explicit_related_name_matches[0].id, self.change_request.id)
+
+    def test_reverse_one_to_one_relation_uses_snake_case_accessor(self):
+        approval = self.change_request.change_request_approval
+
+        self.assertEqual(approval.id, self.change_request_approval.id)
+        self.assertEqual(approval.approved_by, "Reviewer")
 
     def test_exclude_supports_snake_case_reverse_relation_aliases(self):
         remaining = self.ChangeRequest.exclude(


### PR DESCRIPTION
## Summary

- Fixes #231 by exposing snake_case aliases for reverse one-to-one accessors while preserving Django's normalized accessor behavior.
- Fixes #232 by returning `None` when a reverse one-to-one relation has no related row instead of surfacing `RelatedObjectDoesNotExist` through descriptor evaluation.
- Adds integration coverage for present and missing reverse one-to-one relations.

## Validation

- `python -m pytest tests/integration/test_database_manager.py::DatabaseIntegrationTest tests/integration/test_database_manager.py::ReverseRelationFilterAliasIntegrationTest -q`
- `python -m pytest tests/unit/test_field_descriptors.py -q`
- `ruff check src/general_manager/interface/capabilities/orm_utils/field_descriptors.py tests/integration/test_database_manager.py`
- `mypy src/general_manager/interface/capabilities/orm_utils/field_descriptors.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for reverse one-to-one relationships using snake_case attribute accessors.

* **Bug Fixes**
  * Improved error handling for missing related objects; now returns `None` instead of raising exceptions when accessing undefined relationships.

* **Tests**
  * Added test coverage for reverse one-to-one relationship functionality and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->