### PR TITLE
[codex] fix database manager reverse relation links

### DIFF
--- a/src/general_manager/bootstrap.py
+++ b/src/general_manager/bootstrap.py
@@ -28,7 +28,7 @@ from general_manager.api.graphql import GraphQL
 from general_manager.api.remote_api import add_remote_api_urls
 from general_manager.api.remote_invalidation import ensure_remote_invalidation_route
 from general_manager.conf import get_setting
-from general_manager.api.property import graph_ql_property
+from general_manager.api.property import GraphQLProperty
 from general_manager.logging import get_logger
 from general_manager.interface.infrastructure.startup_hooks import (
     registered_startup_hook_entries,
@@ -272,6 +272,32 @@ def initialize_general_manager_classes(
         resolver.__annotations__ = {"return": manager_cls}
         return resolver
 
+    def _iter_manager_relation_fields(
+        general_manager_class: Type[_GM],
+    ) -> Iterable[tuple[str, Type[_GM]]]:
+        seen: set[str] = set()
+        input_fields = getattr(general_manager_class.Interface, "input_fields", {})
+        for attribute_name, attribute in input_fields.items():
+            if isinstance(attribute, Input) and issubclass(attribute.type, _GM):
+                seen.add(attribute_name)
+                yield attribute_name, attribute.type
+
+        get_attribute_types = getattr(
+            general_manager_class.Interface, "get_attribute_types", None
+        )
+        if not callable(get_attribute_types):
+            return
+        try:
+            attribute_types = get_attribute_types()
+        except NotImplementedError:
+            return
+        for attribute_name, metadata in attribute_types.items():
+            if attribute_name in seen or metadata.get("relation_kind") != "direct":
+                continue
+            field_type = metadata.get("type")
+            if isinstance(field_type, type) and issubclass(field_type, _GM):
+                yield attribute_name, field_type
+
     logger.debug(
         "creating manager attributes",
         context={"pending_attributes": len(pending_attribute_initialization)},
@@ -294,18 +320,18 @@ def initialize_general_manager_classes(
         context={"total_classes": len(all_classes)},
     )
     for general_manager_class in all_classes:
-        attributes = getattr(general_manager_class.Interface, "input_fields", {})
-        for attribute_name, attribute in attributes.items():
-            if isinstance(attribute, Input) and issubclass(attribute.type, _GM):
-                connected_manager = attribute.type
-                resolver = _build_connection_resolver(
-                    attribute_name, general_manager_class
-                )
-                setattr(
-                    connected_manager,
-                    f"{general_manager_class.__name__.lower()}_list",
-                    graph_ql_property(resolver),
-                )
+        for attribute_name, connected_manager in _iter_manager_relation_fields(
+            general_manager_class
+        ):
+            resolver = _build_connection_resolver(attribute_name, general_manager_class)
+            relation_property = GraphQLProperty(resolver)
+            marked_relation_property: Any = relation_property
+            marked_relation_property._general_manager_generated_relation = True
+            setattr(
+                connected_manager,
+                f"{general_manager_class.__name__.lower()}_list",
+                relation_property,
+            )
     for general_manager_class in all_classes:
         check_permission_class(general_manager_class)
 

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -196,6 +196,8 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         for name, value in self.__class__.__dict__.items():
             if name == "history":
                 continue
+            if getattr(value, "_general_manager_generated_relation", False):
+                continue
             if isinstance(value, (GraphQLProperty, property)):
                 yield name, getattr(self, name)
 

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -1,7 +1,7 @@
 # type: ignore
 
 from django.contrib.auth import get_user_model
-from django.db.models import CharField
+from django.db.models import CASCADE, CharField, ForeignKey, IntegerField
 from django.utils.crypto import get_random_string
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface import CalculationInterface, DatabaseInterface
@@ -53,10 +53,38 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
                 """
                 return self.employee.salary * 0.2
 
+        class Bonus(GeneralManager):
+            employee: Employee
+            amount: int
+
+            class Interface(DatabaseInterface):
+                employee = ForeignKey(
+                    "general_manager.Employee",
+                    on_delete=CASCADE,
+                )
+                amount = IntegerField()
+
+        class BonusCalculation(GeneralManager):
+            employee: Employee
+
+            class Interface(CalculationInterface):
+                employee = Input(Employee, possible_values=lambda: Employee.all())
+
+            @graph_ql_property
+            def total_bonus(self) -> int:
+                return sum(bonus.amount for bonus in self.employee.bonus_list)
+
         cls.Employee = Employee
         cls.TaxCalculation = TaxCalculation
+        cls.Bonus = Bonus
+        cls.BonusCalculation = BonusCalculation
 
-        cls.general_manager_classes = [Employee, TaxCalculation]
+        cls.general_manager_classes = [
+            Employee,
+            TaxCalculation,
+            Bonus,
+            BonusCalculation,
+        ]
 
     def setUp(self):
         """
@@ -143,6 +171,27 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         self.assertResponseNoErrors(response)
         data = response.json()["data"]["taxcalculation"]
         self.assertEqual(data["calculatedTax"]["value"], 800)
+
+    def test_calculation_property_can_traverse_database_reverse_relation(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+        self.Bonus.create(
+            employee=employee,
+            amount=100,
+            creator_id=self.user.id,
+            ignore_permission=True,
+        )
+        self.Bonus.create(
+            employee=employee,
+            amount=250,
+            creator_id=self.user.id,
+            ignore_permission=True,
+        )
+
+        calculation = self.BonusCalculation(employee=employee)
+
+        self.assertEqual(calculation.total_bonus, 350)
 
     def test_sort_by_calculation_property(self):
         """


### PR DESCRIPTION
## Summary

Fixes reverse manager list wiring for database-backed `GeneralManager` relations.

`initialize_general_manager_classes()` only built reverse list properties from `Interface.input_fields`. That works for calculation/request inputs, but `DatabaseInterface.input_fields` only contains the manager identifier. Direct database relations, such as a `ForeignKey` from `DerivativeConstellium` to `Project`, are exposed through `Interface.get_attribute_types()` instead.

When a calculation property traversed one of those reverse relations, for example `project.derivative_constellium_list`, the property getter raised `AttributeError`. Python then fell through to `GeneralManager.__getattr__`, which made the user-facing error appear as a missing computed property such as `earliest_sop`.

## Changes

- Link reverse manager list properties from direct relation metadata returned by `get_attribute_types()`.
- Preserve existing input-field based linking for calculation/request interfaces.
- Keep generated reverse relation properties out of `dict(manager)` iteration.
- Avoid caching generated reverse relation resolvers so local test managers do not hit locmem pickling errors.
- Add a regression test covering a calculation property traversing a database-backed reverse relation.

## Validation

- `PYTHONPATH=src python -m pytest -q`
- `PYTHONPATH=src python -m pytest tests/integration/test_database_manager.py::DatabaseIntegrationTest::test_dict_conversion tests/integration/test_graphql_query.py::TestGraphQLQueryPagination::test_query_commercials_with_project_list tests/unit/test_field_descriptors.py::test_initialize_general_manager_classes_clears_stale_field_descriptors -q`
- `mypy src/general_manager/bootstrap.py src/general_manager/manager/general_manager.py`
- `ruff check src/general_manager/bootstrap.py src/general_manager/manager/general_manager.py tests/integration/test_calculation_manager.py`
- pre-commit hooks during commit, including ruff, formatting checks, and mypy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Calculated GraphQL properties can now access related data through reverse relationships, enabling proper aggregation and computation of values based on connected records.

* **Tests**
  * Added integration tests verifying calculated properties correctly traverse and aggregate data from reverse database relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->