### PR TITLE
[codex] Guard M2M related field resolution

### DIFF
--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -36,6 +36,23 @@ class FieldDescriptor:
     accessor: DescriptorAccessor
 
 
+class MissingRelatedFieldsError(RuntimeError):
+    """Raised when a GeneralManager collection relation cannot be scoped."""
+
+    def __init__(
+        self,
+        *,
+        accessor_name: str,
+        related_model: type[models.Model],
+        source_model: type[models.Model],
+    ) -> None:
+        super().__init__(
+            "Unable to resolve related fields for collection relation "
+            f"'{accessor_name}' from {source_model.__name__} to "
+            f"{related_model.__name__}."
+        )
+
+
 TRANSLATION: dict[type[models.Field], type] = {
     models.fields.BigAutoField: int,
     models.AutoField: int,
@@ -691,6 +708,12 @@ def _general_manager_many_accessor(
         """
         filter_kwargs = {field.name: self.pk for field in related_fields}
         manager_cls = cast(Any, general_manager_class)
+        if not filter_kwargs:
+            raise MissingRelatedFieldsError(
+                accessor_name=accessor_name,
+                related_model=related_model,
+                source_model=source_model,
+            )
         return manager_cls.filter(**filter_kwargs)
 
     return getter

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -17,7 +17,11 @@ from general_manager.utils.testing import (
     GeneralManagerTransactionTestCase,
     run_registered_startup_hooks,
 )
-from general_manager.manager.meta import InvalidManagerStateError
+from general_manager.manager.meta import (
+    AttributeEvaluationError,
+    GeneralManagerMeta,
+    InvalidManagerStateError,
+)
 
 
 class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
@@ -754,6 +758,45 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         human_names = [h.name for h in smith_family_humans]
         self.assertIn("Alice", human_names)
         self.assertIn("Bob", human_names)
+
+    def test_many_to_many_bucket_raises_without_reverse_metadata(self):
+        """
+        Verify direct many-to-many buckets fail explicitly
+        when Django does not expose the reverse relation on the related model.
+        """
+        self.TestHuman.create(
+            creator_id=None,
+            name="Unrelated",
+            ignore_permission=True,
+        )
+        original_get_fields = self.TestHuman.Interface._model._meta.get_fields
+
+        def get_fields_without_family_reverse(*args, **kwargs):
+            return [
+                field
+                for field in original_get_fields(*args, **kwargs)
+                if getattr(field, "related_model", None)
+                != self.TestFamily.Interface._model
+            ]
+
+        with patch.object(
+            self.TestHuman.Interface._model._meta,
+            "get_fields",
+            side_effect=get_fields_without_family_reverse,
+        ):
+            self.TestFamily.Interface._field_descriptors = None
+            if "_attributes" in vars(self.TestFamily):
+                delattr(self.TestFamily, "_attributes")
+
+            with self.assertRaisesRegex(
+                AttributeEvaluationError,
+                "Unable to resolve related fields",
+            ):
+                _ = self.test_family.humans_list
+        self.TestFamily.Interface._field_descriptors = None
+        if "_attributes" in vars(self.TestFamily):
+            delattr(self.TestFamily, "_attributes")
+        GeneralManagerMeta.ensure_attributes_initialized(self.TestFamily)
 
     def test_edge_cases_and_error_handling(self):
         """


### PR DESCRIPTION
## Summary

- Add an explicit `MissingRelatedFieldsError` when a GeneralManager-backed collection relation cannot resolve any related fields.
- Prevent `_general_manager_many_accessor` from calling `filter()` with empty kwargs, which could widen a many-to-many bucket to all related objects.
- Add an integration regression that simulates missing reverse metadata and verifies the manager attribute fails explicitly.

## Root Cause

For many-to-many relations whose related model has a GeneralManager wrapper, `_general_manager_many_accessor` builds filter kwargs from reverse relation metadata on the related model. In the devcontainer reproduction, Django exposed no reverse relation from the custom auth user model back to `Customer`, so the accessor built `{}` and returned `User.filter()` with no filters.

## Validation

- `python -m pytest` -> 2360 passed, 1 skipped
- `ruff check .` -> passed
- `mypy` -> passed
- `pre-commit` during commit -> passed

Note: `ruff format --check .` still reports existing formatting drift in unrelated files: `src/general_manager/factory/factory_methods.py`, `src/general_manager/interface/capabilities/request/__init__.py`, and `tests/unit/test_capabilities_observability.py`. The touched files passed `ruff format --check` earlier and commit hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection relation filtering operations now fail with clear error messages when required field constraints are missing, instead of silently proceeding without constraints.

* **Tests**
  * Added integration tests validating error handling for many-to-many relationship operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->