### PR TITLE
[codex] Fix DatabaseBucket serialization snapshots

### DIFF
--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -140,6 +140,20 @@ class NonSortablePropertyError(ValueError):
         )
 
 
+class DuplicateDatabaseBucketSnapshotError(ValueError):
+    """Raised when a database bucket snapshot contains duplicate primary keys."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "DatabaseBucket snapshots cannot contain duplicate primary keys."
+        )
+
+
+def _ensure_unique_primary_keys(primary_keys: tuple[Any, ...]) -> None:
+    if len(primary_keys) != len(set(primary_keys)):
+        raise DuplicateDatabaseBucketSnapshotError()
+
+
 def _restore_database_bucket_from_primary_keys(
     model: type[models.Model],
     manager_class: Type[GeneralManagerType],
@@ -151,6 +165,7 @@ def _restore_database_bucket_from_primary_keys(
     sort_keys: tuple[str, ...] | None,
     sort_reverse: bool,
 ) -> DatabaseBucket[GeneralManagerType]:
+    _ensure_unique_primary_keys(primary_keys)
     manager = model._default_manager
     if database_alias is not None:
         manager = manager.db_manager(database_alias)
@@ -216,12 +231,14 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         Preserve a result snapshot without serializing the queryset object.
         """
         self._track_effective_dependencies()
+        primary_keys = tuple(self._data.values_list("pk", flat=True))
+        _ensure_unique_primary_keys(primary_keys)
         return (
             _restore_database_bucket_from_primary_keys,
             (
                 self._data.model,
                 self._manager_class,
-                tuple(self._data.values_list("pk", flat=True)),
+                primary_keys,
                 self.filters,
                 self.excludes,
                 self._data.db,

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -140,6 +140,42 @@ class NonSortablePropertyError(ValueError):
         )
 
 
+def _restore_database_bucket_from_primary_keys(
+    model: type[models.Model],
+    manager_class: Type[GeneralManagerType],
+    primary_keys: tuple[Any, ...],
+    filter_definitions: dict[str, list[Any]],
+    exclude_definitions: dict[str, list[Any]],
+    database_alias: str | None,
+    search_date: datetime | date | None,
+    sort_keys: tuple[str, ...] | None,
+    sort_reverse: bool,
+) -> DatabaseBucket[GeneralManagerType]:
+    manager = model._default_manager
+    if database_alias is not None:
+        manager = manager.db_manager(database_alias)
+    if not primary_keys:
+        queryset = manager.none()
+    else:
+        preserved_order = models.Case(
+            *(
+                models.When(pk=primary_key, then=position)
+                for position, primary_key in enumerate(primary_keys)
+            ),
+            output_field=models.IntegerField(),
+        )
+        queryset = manager.filter(pk__in=primary_keys).order_by(preserved_order)
+    return DatabaseBucket(
+        queryset,
+        manager_class,
+        filter_definitions,
+        exclude_definitions,
+        search_date=search_date,
+        sort_keys=sort_keys,
+        sort_reverse=sort_reverse,
+    )
+
+
 class DatabaseBucket(Bucket[GeneralManagerType]):
     """Bucket implementation backed by Django ORM querysets."""
 
@@ -174,6 +210,26 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         self._search_date = search_date
         self._sort_keys = sort_keys
         self._sort_reverse = sort_reverse
+
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        """
+        Preserve a result snapshot without serializing the queryset object.
+        """
+        self._track_effective_dependencies()
+        return (
+            _restore_database_bucket_from_primary_keys,
+            (
+                self._data.model,
+                self._manager_class,
+                tuple(self._data.values_list("pk", flat=True)),
+                self.filters,
+                self.excludes,
+                self._data.db,
+                self._search_date,
+                self._sort_keys,
+                self._sort_reverse,
+            ),
+        )
 
     def _build_manager(self, pk: Any) -> GeneralManagerType:
         if self._search_date is None:

--- a/tests/integration/test_graphql_calculation_input_options.py
+++ b/tests/integration/test_graphql_calculation_input_options.py
@@ -1,5 +1,6 @@
 # type: ignore
 
+from copy import deepcopy
 from datetime import date
 
 from django.contrib.auth import get_user_model
@@ -207,6 +208,17 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
         data = response.json()["data"]["optionalinputcalculation"]
         self.assertEqual(data["employee"]["name"], "Alice")
         self.assertEqual(data["asOf"], "2024-02-10")
+
+    def test_database_bucket_possible_values_survive_deepcopy(self) -> None:
+        input_field = self.OptionalInputCalculation.Interface.input_fields["employee"]
+
+        possible_values = input_field.resolve_possible_values({})
+        copied_values = deepcopy(possible_values)
+
+        self.assertEqual(
+            [employee.name for employee in copied_values],
+            ["Alice", "Bob"],
+        )
 
     def test_min_value_constraint_is_enforced_via_graphql(self) -> None:
         query = """

--- a/tests/integration/test_graphql_calculation_input_options.py
+++ b/tests/integration/test_graphql_calculation_input_options.py
@@ -216,7 +216,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
         copied_values = deepcopy(possible_values)
 
         self.assertEqual(
-            [employee.name for employee in copied_values],
+            sorted(employee.name for employee in copied_values),
             ["Alice", "Bob"],
         )
 

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -9,6 +9,7 @@ from django.db.models.query import QuerySet
 
 from general_manager.bucket.database_bucket import (
     DatabaseBucket,
+    DuplicateDatabaseBucketSnapshotError,
     _restore_database_bucket_from_primary_keys,
 )
 from general_manager.manager.general_manager import GeneralManager
@@ -329,19 +330,57 @@ class DatabaseBucketTestCase(TestCase):
         """
         Cache serialization should store a stable identity snapshot, not a live QuerySet.
         """
-        reduced = self.bucket.__reduce__()
+        search_date = datetime(2024, 1, 1)
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]),
+            SearchDateManager,
+            {"username__in": [["alice", "bob"]]},
+            {"is_staff": [True]},
+            search_date=search_date,
+            sort_keys=("username",),
+            sort_reverse=True,
+        )
+        reduced = bucket.__reduce__()
         restore_func, args = reduced
 
         self.assertEqual(restore_func, _restore_database_bucket_from_primary_keys)
         self.assertEqual(args[0], User)
-        self.assertEqual(args[2], (self.u1.pk, self.u2.pk, self.u3.pk))
+        self.assertEqual(args[2], (self.u1.pk, self.u2.pk))
+        self.assertEqual(args[3], bucket.filters)
+        self.assertEqual(args[4], bucket.excludes)
+        self.assertEqual(args[5], bucket._data.db)
+        self.assertEqual(args[6], bucket._search_date)
+        self.assertEqual(args[7], bucket._sort_keys)
+        self.assertEqual(args[8], bucket._sort_reverse)
         self.assertFalse(any(isinstance(arg, QuerySet) for arg in args))
 
         restored = restore_func(*args)
         self.assertEqual(
             [manager.identification["id"] for manager in restored],
-            [self.u1.pk, self.u2.pk, self.u3.pk],
+            [self.u1.pk, self.u2.pk],
         )
+        self.assertEqual(restored.filters, bucket.filters)
+        self.assertEqual(restored.excludes, bucket.excludes)
+        self.assertEqual(restored._search_date, bucket._search_date)
+        self.assertEqual(restored._sort_keys, bucket._sort_keys)
+        self.assertEqual(restored._sort_reverse, bucket._sort_reverse)
+
+    def test_restore_rejects_duplicate_primary_key_snapshots(self):
+        """
+        DatabaseBucket snapshots cannot silently collapse duplicate primary keys.
+        """
+        with self.assertRaises(DuplicateDatabaseBucketSnapshotError):
+            _restore_database_bucket_from_primary_keys(
+                User,
+                UserManager,
+                (self.u1.pk, self.u1.pk),
+                {},
+                {},
+                "default",
+                None,
+                None,
+                False,
+            )
 
     def test_or_union_with_bucket(self):
         # split buckets

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -5,8 +5,12 @@ from datetime import datetime
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.db.models import functions
+from django.db.models.query import QuerySet
 
-from general_manager.bucket.database_bucket import DatabaseBucket
+from general_manager.bucket.database_bucket import (
+    DatabaseBucket,
+    _restore_database_bucket_from_primary_keys,
+)
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.api.property import graph_ql_property
@@ -320,6 +324,24 @@ class DatabaseBucketTestCase(TestCase):
         sibling_excluded = excluded.all()
         excluded.excludes["username"].append("carol")
         self.assertListEqual(sibling_excluded.excludes["username"], ["bob"])
+
+    def test_reduce_stores_primary_keys_instead_of_queryset(self):
+        """
+        Cache serialization should store a stable identity snapshot, not a live QuerySet.
+        """
+        reduced = self.bucket.__reduce__()
+        restore_func, args = reduced
+
+        self.assertEqual(restore_func, _restore_database_bucket_from_primary_keys)
+        self.assertEqual(args[0], User)
+        self.assertEqual(args[2], (self.u1.pk, self.u2.pk, self.u3.pk))
+        self.assertFalse(any(isinstance(arg, QuerySet) for arg in args))
+
+        restored = restore_func(*args)
+        self.assertEqual(
+            [manager.identification["id"] for manager in restored],
+            [self.u1.pk, self.u2.pk, self.u3.pk],
+        )
 
     def test_or_union_with_bucket(self):
         # split buckets

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -332,7 +332,7 @@ class DatabaseBucketTestCase(TestCase):
         """
         search_date = datetime(2024, 1, 1)
         bucket = DatabaseBucket(
-            User.objects.filter(username__in=["alice", "bob"]),
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
             SearchDateManager,
             {"username__in": [["alice", "bob"]]},
             {"is_staff": [True]},


### PR DESCRIPTION
## Summary
- Add `DatabaseBucket` serialization that snapshots primary keys instead of serializing a live queryset.
- Restore serialized buckets by rebuilding a queryset constrained to the captured primary keys while preserving order and metadata.
- Add regression coverage for database-backed `Input.resolve_possible_values` surviving `deepcopy` and for reducer payloads avoiding `QuerySet` objects.

## Root Cause
`DatabaseBucket` inherited the base `Bucket.__reduce__`, which reconstructed buckets with `_data=None`. When a database-backed possible-values bucket crossed a copy or cache serialization boundary, later iteration failed on a `DatabaseBucket` whose queryset state had been dropped.

## Validation
- `python -m pytest tests/unit/test_database_bucket.py tests/integration/test_graphql_calculation_input_options.py tests/unit/test_input.py`
- `ruff check src/general_manager/bucket/database_bucket.py tests/unit/test_database_bucket.py tests/integration/test_graphql_calculation_input_options.py`
- `ruff format --check src/general_manager/bucket/database_bucket.py tests/unit/test_database_bucket.py tests/integration/test_graphql_calculation_input_options.py`
- `mypy src/general_manager/bucket/database_bucket.py`
- pre-commit hooks during commit: ruff, format, eof, trailing whitespace, mixed line endings, merge conflicts, debug statements, mypy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buckets (query results) can be snapshotted and restored reliably, preserving filters, sort order and database selection; snapshots avoid serializing live query objects and survive deep copies.
  * Snapshots now validate uniqueness and reject duplicate primary-key snapshots.

* **Tests**
  * Added tests covering snapshot serialization, restoration, deep-copy behavior, and duplicate-snapshot rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->