### PR TITLE
[codex] fix direct many-to-many bucket scoping

### DIFF
--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -270,10 +270,27 @@ class _FieldDescriptorBuilder:
         Iterates the model's many-to-many and reverse (one-to-many) relations and registers a collection descriptor for each, deriving descriptor names from each relation's base name and accessor name.
         """
         for m2m_field in _iter_many_to_many_fields(self.model):
+            if getattr(m2m_field, "auto_created", False) and not getattr(
+                m2m_field, "concrete", False
+            ):
+                relation_field_name = getattr(
+                    getattr(m2m_field, "field", None),
+                    "name",
+                    None,
+                )
+                relation_filter_name = None
+            else:
+                relation_field_name = None
+                relation_filter_name = _many_to_many_relation_filter_name(
+                    m2m_field,
+                    self.model,
+                )
             self._register_collection_field(
                 field=m2m_field,
                 base_name=m2m_field.name,
                 accessor_name=m2m_field.name,
+                relation_field_name=relation_field_name,
+                relation_filter_name=relation_filter_name,
             )
         for reverse_relation in _iter_reverse_relations(self.model):
             accessor_name = (
@@ -305,6 +322,7 @@ class _FieldDescriptorBuilder:
         base_name: str,
         accessor_name: str,
         relation_field_name: str | None = None,
+        relation_filter_name: str | None = None,
     ) -> None:
         """
         Register a collection relation as a FieldDescriptor under the generated "<base>_list" attribute.
@@ -341,6 +359,7 @@ class _FieldDescriptorBuilder:
                 general_manager_class=general_manager_class,
                 source_model=self.model,
                 relation_field_name=relation_field_name,
+                relation_filter_name=relation_filter_name,
             )
             relation_type = cast(type, general_manager_class)
         else:
@@ -675,6 +694,7 @@ def _general_manager_many_accessor(
     general_manager_class: type,
     source_model: type[models.Model],
     relation_field_name: str | None = None,
+    relation_filter_name: str | None = None,
 ) -> DescriptorAccessor:
     """
     Create an accessor that returns a manager filtered to objects related to the given source model instance.
@@ -688,7 +708,9 @@ def _general_manager_many_accessor(
     Returns:
         DescriptorAccessor: A callable that accepts an OrmInterfaceBase instance and returns the manager/QuerySet of related_model instances whose foreign-key fields pointing to `source_model` match the instance's primary key.
     """
-    if relation_field_name is not None:
+    if relation_filter_name is not None:
+        related_fields: list[models.Field] = []
+    elif relation_field_name is not None:
         related_fields = [
             cast(models.Field, related_model._meta.get_field(relation_field_name))
         ]
@@ -706,7 +728,10 @@ def _general_manager_many_accessor(
         Returns:
             A manager or queryset containing related model instances whose foreign-key fields equal this interface instance's primary key.
         """
-        filter_kwargs = {field.name: self.pk for field in related_fields}
+        if relation_filter_name is not None:
+            filter_kwargs = {relation_filter_name: self.pk}
+        else:
+            filter_kwargs = {field.name: self.pk for field in related_fields}
         manager_cls = cast(Any, general_manager_class)
         if not filter_kwargs:
             raise MissingRelatedFieldsError(
@@ -717,6 +742,29 @@ def _general_manager_many_accessor(
         return manager_cls.filter(**filter_kwargs)
 
     return getter
+
+
+def _many_to_many_relation_filter_name(
+    field: models.Field,
+    source_model: type[models.Model],
+) -> str | None:
+    """Return the target-side query lookup for a direct many-to-many field."""
+    remote_field = getattr(field, "remote_field", None)
+    related_query_name = getattr(remote_field, "related_query_name", None)
+    if callable(related_query_name):
+        related_query_name = related_query_name()
+    if isinstance(related_query_name, str) and related_query_name:
+        return related_query_name
+    related_name = getattr(remote_field, "related_name", None)
+    if related_name == "+":
+        return None
+    if isinstance(related_name, str) and related_name:
+        return related_name
+    source_meta = getattr(source_model, "_meta", None)
+    source_model_name = getattr(source_meta, "model_name", None)
+    if isinstance(source_model_name, str) and source_model_name:
+        return source_model_name
+    return None
 
 
 def _direct_many_accessor(

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -18,7 +18,6 @@ from general_manager.utils.testing import (
     run_registered_startup_hooks,
 )
 from general_manager.manager.meta import (
-    AttributeEvaluationError,
     GeneralManagerMeta,
     InvalidManagerStateError,
 )
@@ -75,6 +74,36 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
                 class Meta:
                     use_soft_delete = True
 
+        class TestSupplier(GeneralManager):
+            name: str
+
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=50)
+
+        class TestProjectQualityStatus(GeneralManager):
+            name: str
+            processing_supplier_list: Bucket[TestSupplier]
+            standard_part_supplier_list: Bucket[TestSupplier]
+            direct_delivery_supplier_list: Bucket[TestSupplier]
+
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=50)
+                processing_supplier = models.ManyToManyField(
+                    "general_manager.TestSupplier",
+                    blank=True,
+                    related_name="processing_supplier",
+                )
+                standard_part_supplier = models.ManyToManyField(
+                    "general_manager.TestSupplier",
+                    blank=True,
+                    related_name="standard_part_supplier",
+                )
+                direct_delivery_supplier = models.ManyToManyField(
+                    "general_manager.TestSupplier",
+                    blank=True,
+                    related_name="direct_delivery_supplier",
+                )
+
         class ChangeRequest(GeneralManager):
             title: str
             change_request_approval: ChangeRequestApproval
@@ -121,6 +150,8 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         cls.TestCountry = TestCountry
         cls.TestHuman = TestHuman
         cls.TestFamily = TestFamily
+        cls.TestSupplier = TestSupplier
+        cls.TestProjectQualityStatus = TestProjectQualityStatus
         cls.ChangeRequest = ChangeRequest
         cls.ChangeRequestApproval = ChangeRequestApproval
         cls.ChangeRequestFeasibility = ChangeRequestFeasibility
@@ -129,6 +160,8 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             TestCountry,
             TestHuman,
             TestFamily,
+            TestSupplier,
+            TestProjectQualityStatus,
             ChangeRequest,
             ChangeRequestApproval,
             ChangeRequestFeasibility,
@@ -202,6 +235,8 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.TestCountry.Interface._model._meta.model.objects.all().delete()
         self.TestHuman.Interface._model._meta.model.objects.all().delete()
         self.TestFamily.Interface._model._meta.model.objects.all().delete()
+        self.TestProjectQualityStatus.Interface._model._meta.model.objects.all().delete()
+        self.TestSupplier.Interface._model._meta.model.objects.all().delete()
         self.ChangeRequest.Interface._model._meta.model.objects.all().delete()
         self.ChangeRequestApproval.Interface._model._meta.model.objects.all().delete()
         self.ChangeRequestFeasibility.Interface._model._meta.model.objects.all().delete()
@@ -759,10 +794,58 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertIn("Alice", human_names)
         self.assertIn("Bob", human_names)
 
-    def test_many_to_many_bucket_raises_without_reverse_metadata(self):
+    def test_multiple_many_to_many_fields_to_same_manager_stay_independent(self):
         """
-        Verify direct many-to-many buckets fail explicitly
-        when Django does not expose the reverse relation on the related model.
+        Verify direct M2M buckets scope reads to their own relation field.
+        """
+        supplier_1 = self.TestSupplier.create(
+            creator_id=None,
+            name="Supplier 1",
+            ignore_permission=True,
+        )
+        supplier_2 = self.TestSupplier.create(
+            creator_id=None,
+            name="Supplier 2",
+            ignore_permission=True,
+        )
+        supplier_3 = self.TestSupplier.create(
+            creator_id=None,
+            name="Supplier 3",
+            ignore_permission=True,
+        )
+        status = self.TestProjectQualityStatus.create(
+            creator_id=None,
+            name="Quality",
+            ignore_permission=True,
+        )
+
+        status.update(
+            processing_supplier_list=[supplier_1, supplier_2],
+            standard_part_supplier_list=[supplier_2],
+            direct_delivery_supplier_list=[supplier_3],
+            ignore_permission=True,
+        )
+
+        self.assertEqual(
+            list(status.processing_supplier_list), [supplier_1, supplier_2]
+        )
+        self.assertEqual(list(status.standard_part_supplier_list), [supplier_2])
+        self.assertEqual(list(status.direct_delivery_supplier_list), [supplier_3])
+
+        status.update(
+            direct_delivery_supplier_list=[supplier_1],
+            ignore_permission=True,
+        )
+
+        self.assertEqual(
+            list(status.processing_supplier_list), [supplier_1, supplier_2]
+        )
+        self.assertEqual(list(status.standard_part_supplier_list), [supplier_2])
+        self.assertEqual(list(status.direct_delivery_supplier_list), [supplier_1])
+
+    def test_many_to_many_bucket_uses_direct_relation_without_reverse_metadata(self):
+        """
+        Verify direct many-to-many buckets do not depend on reverse metadata scans.
         """
         self.TestHuman.create(
             creator_id=None,
@@ -788,11 +871,11 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             if "_attributes" in vars(self.TestFamily):
                 delattr(self.TestFamily, "_attributes")
 
-            with self.assertRaisesRegex(
-                AttributeEvaluationError,
-                "Unable to resolve related fields",
-            ):
-                _ = self.test_family.humans_list
+            humans = self.test_family.humans_list
+
+        self.assertEqual(len(humans), 2)
+        self.assertIn(self.test_human1, humans)
+        self.assertIn(self.test_human2, humans)
         self.TestFamily.Interface._field_descriptors = None
         if "_attributes" in vars(self.TestFamily):
             delattr(self.TestFamily, "_attributes")


### PR DESCRIPTION
## Summary

Fixes #239.

Direct `ManyToManyField` bucket reads now scope through the specific relation query name for that field instead of scanning every relation from the target model back to the source model. This prevents multiple M2M fields pointing at the same manager/model from merging filters or returning empty results when their values differ.

## Root Cause

Direct M2M descriptors used the generic collection accessor path without an explicit relation scope. When several source fields pointed to the same target model, the accessor collected all reverse relations from the target model back to the source model and applied them together.

## Changes

- Split direct M2M descriptor registration from reverse M2M relation registration.
- Added a direct relation filter-name helper for target-side M2M lookups.
- Added an integration regression test with three M2M fields pointing to the same supplier manager.
- Updated the reverse-metadata test to assert direct M2M reads no longer depend on reverse metadata scans.

## Validation

- `python -m pytest` -> `2365 passed, 1 skipped, 1 warning`
- `pre-commit` during commit -> Ruff lint, Ruff format, EOF, whitespace, line endings, merge conflict check, debug statement check, and mypy all passed
- Earlier targeted check: `python -m pytest tests/unit/test_field_descriptors.py tests/integration/test_database_manager.py -q` -> `46 passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of multiple many-to-many relations to the same model so each relation remains independent and correctly scoped; when reverse metadata is absent, relations now use direct relation lookups instead of erroring.

* **Tests**
  * Added integration test verifying multiple many-to-many fields on one instance remain independent and that updates only affect the targeted relation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->