### PR TITLE
fix: resolve lazy users in GraphQL permissions

### DIFF
--- a/src/general_manager/permission/base_permission.py
+++ b/src/general_manager/permission/base_permission.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+from django.utils.functional import SimpleLazyObject
 
 from general_manager.logging import get_logger
 from general_manager.permission.audit import (
@@ -74,7 +75,7 @@ class BasePermission(ABC):
     ) -> None:
         """Initialise the permission context for a specific manager and user."""
         self._instance = instance
-        self._request_user = request_user
+        self._request_user = self.get_user_with_id(request_user)
 
     @property
     def instance(self) -> PermissionDataManager | GeneralManager | GeneralManagerMeta:
@@ -445,6 +446,11 @@ class BasePermission(ABC):
             UserLike: The resolved User instance, or an AnonymousUser when no matching User is found.
         """
         from django.contrib.auth import get_user_model
+
+        if isinstance(user, SimpleLazyObject):
+            lazy_user = cast(Any, user)
+            lazy_user._setup()
+            user = lazy_user._wrapped
 
         User = get_user_model()
         if isinstance(user, (AbstractBaseUser, AnonymousUser)):

--- a/src/general_manager/permission/base_permission.py
+++ b/src/general_manager/permission/base_permission.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
-from django.utils.functional import SimpleLazyObject
+from django.utils.functional import SimpleLazyObject, empty
 
 from general_manager.logging import get_logger
 from general_manager.permission.audit import (
@@ -449,7 +449,8 @@ class BasePermission(ABC):
 
         if isinstance(user, SimpleLazyObject):
             lazy_user = cast(Any, user)
-            lazy_user._setup()
+            if lazy_user._wrapped is empty:
+                lazy_user._setup()
             user = lazy_user._wrapped
 
         User = get_user_model()

--- a/src/general_manager/permission/graphql_capabilities.py
+++ b/src/general_manager/permission/graphql_capabilities.py
@@ -100,7 +100,15 @@ class CapabilityEvaluationContext:
     """Operation-scoped cache for GraphQL permission capability evaluation."""
 
     def __init__(self, *, user: Any | None = None) -> None:
-        self.user = user if user is not None else _AnonymousUser()
+        from django.contrib.auth.models import AnonymousUser
+
+        from general_manager.permission.base_permission import BasePermission
+
+        self.user = (
+            BasePermission.get_user_with_id(user)
+            if user is not None
+            else AnonymousUser()
+        )
         self._cache: dict[tuple[str, str, str, str], bool] = {}
 
     def evaluate(self, declaration: GraphQLPermissionCapability, instance: Any) -> bool:
@@ -210,7 +218,7 @@ def get_graphql_capabilities(
 def get_capability_context(info: Any) -> CapabilityEvaluationContext:
     """Return the operation-scoped capability context for a GraphQL resolver."""
     request_context = getattr(info, "context", None)
-    user = getattr(request_context, "user", _AnonymousUser())
+    user = getattr(request_context, "user", None)
     operation_key = id(getattr(info, "operation", None))
     storage_name = "_general_manager_graphql_capability_contexts"
     contexts = getattr(request_context, storage_name, None)
@@ -272,10 +280,3 @@ def _instance_identity(instance: Any) -> str:
 
 def _user_identity(user: Any) -> str:
     return repr(getattr(user, "pk", getattr(user, "id", None)))
-
-
-class _AnonymousUser:
-    is_authenticated = False
-    is_superuser = False
-    pk = None
-    id = None

--- a/tests/integration/test_graphql_permission_capabilities.py
+++ b/tests/integration/test_graphql_permission_capabilities.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from typing import Any, ClassVar
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AbstractBaseUser
 from django.db.models import CharField
 from django.test import override_settings
 from django.utils.crypto import get_random_string
+from django.utils.functional import SimpleLazyObject
 
 from general_manager.api.mutation import graph_ql_mutation
 from general_manager.manager.general_manager import GeneralManager
@@ -74,6 +76,13 @@ class TestGraphQLPermissionCapabilities(GeneralManagerTransactionTestCase):
                         "canRename",
                         can_rename,
                         batch_evaluator=can_rename_batch,
+                    ),
+                    object_capability(
+                        "hasConcreteUser",
+                        lambda _project, user: (
+                            isinstance(user, AbstractBaseUser)
+                            and not isinstance(user, SimpleLazyObject)
+                        ),
                     ),
                 )
 
@@ -191,6 +200,25 @@ class TestGraphQLPermissionCapabilities(GeneralManagerTransactionTestCase):
                 },
             ],
         )
+
+    def test_object_capability_receives_concrete_authenticated_user(self) -> None:
+        query = """
+        query {
+            projectList(pageSize: 1) {
+                items {
+                    capabilities {
+                        hasConcreteUser
+                    }
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        item = response.json()["data"]["projectList"]["items"][0]
+        self.assertTrue(item["capabilities"]["hasConcreteUser"])
 
     def test_list_query_does_not_warm_capabilities_when_unselected(self) -> None:
         query = """

--- a/tests/unit/test_base_permission.py
+++ b/tests/unit/test_base_permission.py
@@ -623,6 +623,28 @@ class BasePermissionTests(TestCase):
         self.assertIs(permission.request_user, user)
         self.assertTrue(permission.request_user.is_authenticated)
 
+    def test_resolved_lazy_request_user_is_not_evaluated_again(self) -> None:
+        """Permission construction should reuse an already resolved lazy user."""
+        UserModel = get_user_model()
+        user = UserModel.objects.create_user(
+            username="resolved-lazy-user",
+            password=get_random_string(12),
+        )
+        setup_calls = 0
+
+        def resolve_user():
+            nonlocal setup_calls
+            setup_calls += 1
+            return user
+
+        lazy_user = SimpleLazyObject(resolve_user)
+        self.assertTrue(lazy_user.is_authenticated)
+
+        permission = DummyPermission(self.dummy_instance, lazy_user)
+
+        self.assertIs(permission.request_user, user)
+        self.assertEqual(setup_calls, 1)
+
     def test_lazy_anonymous_request_user_is_resolved(self) -> None:
         """Permission checks should receive a concrete AnonymousUser."""
         anonymous_user = AnonymousUser()

--- a/tests/unit/test_base_permission.py
+++ b/tests/unit/test_base_permission.py
@@ -13,6 +13,7 @@ from general_manager.permission.permission_data_manager import (
     PermissionDataManager,
 )
 from django.contrib.auth import get_user_model
+from django.utils.functional import SimpleLazyObject
 from django.utils.crypto import get_random_string
 
 if TYPE_CHECKING:
@@ -606,6 +607,30 @@ class BasePermissionTests(TestCase):
     def test_request_user_property(self) -> None:
         """Test request_user property returns the user."""
         self.assertEqual(self.permission_obj.request_user, self.dummy_user)
+
+    def test_lazy_authenticated_request_user_is_resolved(self) -> None:
+        """Permission checks should receive the concrete authenticated user."""
+        UserModel = get_user_model()
+        user = UserModel.objects.create_user(
+            username="lazy-authenticated-user",
+            password=get_random_string(12),
+        )
+        lazy_user = SimpleLazyObject(lambda: user)
+        DummyPermission.read_permissions = {"field": "isAuthenticated"}
+
+        permission = DummyPermission(self.dummy_instance, lazy_user)
+
+        self.assertIs(permission.request_user, user)
+        self.assertTrue(permission.request_user.is_authenticated)
+
+    def test_lazy_anonymous_request_user_is_resolved(self) -> None:
+        """Permission checks should receive a concrete AnonymousUser."""
+        anonymous_user = AnonymousUser()
+        lazy_user = SimpleLazyObject(lambda: anonymous_user)
+
+        permission = DummyPermission(self.dummy_instance, lazy_user)
+
+        self.assertIs(permission.request_user, anonymous_user)
 
     def test_check_permission_all_actions_allowed(self) -> None:
         """Test check_permission when all actions are allowed."""


### PR DESCRIPTION
## Summary
- unwrap Django `SimpleLazyObject` users at the base permission boundary
- normalize GraphQL capability users to concrete authenticated or anonymous user instances
- add unit and HTTP GraphQL regression coverage for lazy authenticated and anonymous users

## Test Plan
- [x] `python -m pytest -q` (`2368 passed, 1 skipped`)
- [x] `ruff check` on changed files
- [x] `ruff format --check` on changed files
- [x] `mypy` on changed source files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user resolution in permission and capability evaluation to correctly handle lazy-loaded user objects and ensure anonymous-user fallbacks are consistent.

* **Tests**
  * Added unit tests validating lazy user resolution behavior during permission evaluation.
  * Added integration tests confirming capability evaluation sees concrete authenticated users and exposes capabilities correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->