### PR TITLE
[codex] Support grouping buckets by related managers

### DIFF
--- a/src/general_manager/bucket/group_bucket.py
+++ b/src/general_manager/bucket/group_bucket.py
@@ -1,9 +1,69 @@
 """Grouping bucket implementation for aggregating GeneralManager instances."""
 
 from __future__ import annotations
-from typing import Any, Generator, Generic, Type
+from typing import Any, Generator, Generic, Type, cast
 from general_manager.manager.group_manager import GroupManager
+from general_manager.manager.general_manager import GeneralManager
 from general_manager.bucket.base_bucket import Bucket, GeneralManagerType
+
+
+def _freeze_group_value(value: Any) -> Any:
+    """Return a hashable identity for values used to distinguish groups."""
+    if isinstance(value, GeneralManager):
+        return (
+            value.__class__,
+            tuple(
+                sorted(
+                    (
+                        key,
+                        _freeze_group_value(identifier),
+                    )
+                    for key, identifier in value.identification.items()
+                )
+            ),
+        )
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (
+                    _freeze_group_value(key),
+                    _freeze_group_value(item),
+                )
+                for key, item in value.items()
+            )
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_group_value(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze_group_value(item) for item in value)
+    return value
+
+
+def _group_filter_kwargs(
+    manager_class: Type[GeneralManagerType],
+    group_by_value: tuple[tuple[str, Any], ...],
+) -> dict[str, Any]:
+    """Translate grouped manager values into backend-neutral relation lookups."""
+    filters: dict[str, Any] = {}
+    get_attribute_types = getattr(
+        manager_class.Interface,
+        "get_attribute_types",
+        None,
+    )
+    attributes = get_attribute_types() if callable(get_attribute_types) else {}
+    for key, value in group_by_value:
+        attribute_info = cast(dict[str, Any], attributes.get(key, {}))
+        filter_key = attribute_info.get("filter_lookup", key)
+        if isinstance(value, GeneralManager):
+            filters.update(
+                {
+                    f"{filter_key}__{identifier_key}": identifier_value
+                    for identifier_key, identifier_value in value.identification.items()
+                }
+            )
+            continue
+        filters[filter_key] = value
+    return filters
 
 
 class InvalidGroupByKeyTypeError(TypeError):
@@ -191,15 +251,25 @@ class GroupBucket(Generic[GeneralManagerType]):
         Returns:
             list[GroupManager[GeneralManagerType]]: A list of GroupManager objects, one per unique tuple of group-by key values; groups are produced in order sorted by the string representation of their key tuples.
         """
-        group_by_values: set[tuple[tuple[str, Any], ...]] = set()
+        group_by_values: dict[
+            tuple[tuple[str, Any], ...],
+            tuple[tuple[str, Any], ...],
+        ] = {}
         for entry in data:
-            key = tuple((arg, getattr(entry, arg)) for arg in self._group_by_keys)
-            group_by_values.add(key)
+            group_by_value = tuple(
+                (arg, getattr(entry, arg)) for arg in self._group_by_keys
+            )
+            group_identity = tuple(
+                (arg, _freeze_group_value(value)) for arg, value in group_by_value
+            )
+            group_by_values.setdefault(group_identity, group_by_value)
 
         groups: list[GroupManager[GeneralManagerType]] = []
-        for group_by_value in sorted(group_by_values, key=str):
+        for group_by_value in sorted(group_by_values.values(), key=str):
             group_by_dict = {key: value for key, value in group_by_value}
-            grouped_manager_objects = data.filter(**group_by_dict)
+            grouped_manager_objects = data.filter(
+                **_group_filter_kwargs(self._manager_class, group_by_value)
+            )
             groups.append(
                 GroupManager(
                     self._manager_class, group_by_dict, grouped_manager_objects

--- a/src/general_manager/manager/group_manager.py
+++ b/src/general_manager/manager/group_manager.py
@@ -12,6 +12,35 @@ from general_manager.bucket.base_bucket import (
 )
 
 
+def _freeze_manager_value(value: Any) -> Any:
+    """Return a hashable representation for manager-backed group state."""
+    if isinstance(value, GeneralManager):
+        return tuple(
+            sorted(
+                (
+                    key,
+                    _freeze_manager_value(identifier),
+                )
+                for key, identifier in value.identification.items()
+            )
+        )
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (
+                    _freeze_manager_value(key),
+                    _freeze_manager_value(item),
+                )
+                for key, item in value.items()
+            )
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_manager_value(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze_manager_value(item) for item in value)
+    return value
+
+
 class MissingGroupAttributeError(AttributeError):
     """Raised when a GroupManager access attempts to use an undefined attribute."""
 
@@ -61,8 +90,8 @@ class GroupManager(Generic[GeneralManagerType]):
         return hash(
             (
                 self._manager_class,
-                tuple(self._group_by_value.items()),
-                frozenset(self._data),
+                _freeze_manager_value(self._group_by_value),
+                frozenset(_freeze_manager_value(entry) for entry in self._data),
             )
         )
 
@@ -80,7 +109,8 @@ class GroupManager(Generic[GeneralManagerType]):
             isinstance(other, self.__class__)
             and self._manager_class == other._manager_class
             and self._group_by_value == other._group_by_value
-            and frozenset(self._data) == frozenset(other._data)
+            and frozenset(_freeze_manager_value(entry) for entry in self._data)
+            == frozenset(_freeze_manager_value(entry) for entry in other._data)
         )
 
     def __repr__(self) -> str:

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -125,6 +125,34 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(data["calculatedTax"]["value"], 600)
         self.assertEqual(data["calculatedTax"]["unit"], "EUR")
 
+    def test_group_by_manager_input(self):
+        first_employee = self.Employee.create(
+            name="Alice",
+            salary=Measurement(3000, "EUR"),
+            creator_id=self.user.id,
+        )
+        second_employee = self.Employee.create(
+            name="Bob",
+            salary=Measurement(4000, "EUR"),
+            creator_id=self.user.id,
+        )
+
+        grouped = self.TaxCalculation.all().group_by("employee")
+
+        self.assertEqual(grouped.count(), 2)
+        self.assertEqual(
+            {group.employee.identification["id"] for group in grouped},
+            {
+                first_employee.identification["id"],
+                second_employee.identification["id"],
+            },
+        )
+        self.assertTrue(all(group._data.count() == 1 for group in grouped))
+        self.assertEqual(
+            grouped,
+            self.TaxCalculation.all().group_by("employee"),
+        )
+
     def test_entry_based_graphql_property_refreshes_after_update(self):
         employee = self.Employee.create(
             name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -983,6 +983,71 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(len(related_humans), 1)
         self.assertEqual(related_humans[0].name, "Alice")
 
+    def test_group_by_foreign_key(self):
+        grouped = self.TestHuman.all().group_by("country")
+
+        self.assertEqual(grouped.count(), 2)
+        groups_by_country = {
+            group.country.code if group.country is not None else None: group
+            for group in grouped
+        }
+        self.assertEqual(groups_by_country["US"]._data.count(), 1)
+        self.assertEqual(groups_by_country[None]._data.count(), 1)
+
+    def test_group_by_one_to_one_relation(self):
+        first_request = self.ChangeRequest.create(
+            title="First",
+            ignore_permission=True,
+        )
+        second_request = self.ChangeRequest.create(
+            title="Second",
+            ignore_permission=True,
+        )
+        first_approval = self.ChangeRequestApproval.create(
+            approved_by="Alice",
+            change_request=first_request,
+            ignore_permission=True,
+        )
+        second_approval = self.ChangeRequestApproval.create(
+            approved_by="Bob",
+            change_request=second_request,
+            ignore_permission=True,
+        )
+
+        grouped = self.ChangeRequestApproval.filter(
+            id__in=[first_approval.id, second_approval.id]
+        ).group_by("change_request")
+
+        self.assertEqual(grouped.count(), 2)
+        self.assertEqual(
+            {group.change_request.title for group in grouped},
+            {"First", "Second"},
+        )
+        self.assertTrue(all(group._data.count() == 1 for group in grouped))
+
+    def test_group_by_reverse_one_to_one_relation(self):
+        request_without_approval = self.ChangeRequest.create(
+            title="Without approval",
+            ignore_permission=True,
+        )
+
+        grouped = self.ChangeRequest.filter(
+            id__in=[self.change_request.id, request_without_approval.id]
+        ).group_by("change_request_approval")
+
+        self.assertEqual(grouped.count(), 2)
+        groups_by_approval = {
+            group.change_request_approval.approved_by
+            if group.change_request_approval is not None
+            else None: group
+            for group in grouped
+        }
+        self.assertEqual(
+            groups_by_approval[self.change_request_approval.approved_by]._data.count(),
+            1,
+        )
+        self.assertEqual(groups_by_approval[None]._data.count(), 1)
+
     def test_factory_creates_instances(self) -> None:
         """
         Test that the Factory class creates instances of the GeneralManager with correct default attributes.


### PR DESCRIPTION
## Summary
- support `group_by()` for manager-valued calculation inputs
- support forward foreign-key and one-to-one relations, including nullable values
- support reverse one-to-one relations through interface `filter_lookup` metadata
- preserve `GroupBucket` and `GroupManager` equality/hash behavior for related managers

## Root cause
Grouping stored raw relation values in sets and frozensets. `GeneralManager` instances define equality but are intentionally unhashable. Group construction also reused public attribute names directly as backend filters, which bypassed relation identity conversion and reverse-relation lookup aliases.

## Validation
- `python -m pytest -q`: 2369 passed, 1 skipped, 1733 subtests passed
- `ruff check` and `ruff format --check`
- `mypy` on the changed source modules
- pre-commit hooks passed during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced grouping functionality to support relationship-based attributes and complex nested data structures.

* **Tests**
  * Expanded integration test coverage for group-by operations across foreign key, one-to-one, and reverse relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->