### PR TITLE
Automatic GraphQl schema generation issue

### DIFF
--- a/src/general_manager/bootstrap.py
+++ b/src/general_manager/bootstrap.py
@@ -298,6 +298,31 @@ def initialize_general_manager_classes(
             if isinstance(field_type, type) and issubclass(field_type, _GM):
                 yield attribute_name, field_type
 
+    def _has_reverse_relation_attribute(
+        manager_class: Type[_GM],
+        related_manager_class: Type[_GM],
+    ) -> bool:
+        get_attribute_types = getattr(
+            manager_class.Interface, "get_attribute_types", None
+        )
+        if not callable(get_attribute_types):
+            return False
+        try:
+            attribute_types = get_attribute_types()
+        except NotImplementedError:
+            return False
+        return any(
+            metadata.get("is_derived", False)
+            and metadata.get("relation_kind") in {"collection", "direct"}
+            and metadata.get("type") is related_manager_class
+            for metadata in attribute_types.values()
+        )
+
+    def _to_snake_case(name: str) -> str:
+        snake = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+        snake = re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake)
+        return snake.lower()
+
     logger.debug(
         "creating manager attributes",
         context={"pending_attributes": len(pending_attribute_initialization)},
@@ -323,13 +348,18 @@ def initialize_general_manager_classes(
         for attribute_name, connected_manager in _iter_manager_relation_fields(
             general_manager_class
         ):
+            if _has_reverse_relation_attribute(
+                connected_manager,
+                general_manager_class,
+            ):
+                continue
             resolver = _build_connection_resolver(attribute_name, general_manager_class)
             relation_property = GraphQLProperty(resolver)
             marked_relation_property: Any = relation_property
             marked_relation_property._general_manager_generated_relation = True
             setattr(
                 connected_manager,
-                f"{general_manager_class.__name__.lower()}_list",
+                f"{_to_snake_case(general_manager_class.__name__)}_list",
                 relation_property,
             )
     for general_manager_class in all_classes:

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -567,6 +567,10 @@ def _iter_foreign_key_fields(
         An iterable of Django `Field` objects for each many-to-one or one-to-one relation on the model, excluding `GenericForeignKey` fields.
     """
     for field in model._meta.get_fields():
+        if getattr(field, "auto_created", False) and not getattr(
+            field, "concrete", False
+        ):
+            continue
         if not field.is_relation:
             continue
         if isinstance(field, GenericForeignKey):

--- a/tests/integration/test_graphql_relation_filters.py
+++ b/tests/integration/test_graphql_relation_filters.py
@@ -25,10 +25,22 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
 
         class ChangeRequest(GeneralManager):
             title: str
+            change_request_approval: ChangeRequestApproval
             change_request_feasibility_list: Bucket[ChangeRequestFeasibility]
 
             class Interface(DatabaseInterface):
                 title = models.CharField(max_length=100)
+
+        class ChangeRequestApproval(GeneralManager):
+            approved_by: str
+            change_request: ChangeRequest
+
+            class Interface(DatabaseInterface):
+                approved_by = models.CharField(max_length=100)
+                change_request = models.OneToOneField(
+                    "general_manager.ChangeRequest",
+                    on_delete=models.CASCADE,
+                )
 
         class ChangeRequestFeasibility(GeneralManager):
             score: int
@@ -56,10 +68,12 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
                 )
 
         cls.ChangeRequest = ChangeRequest
+        cls.ChangeRequestApproval = ChangeRequestApproval
         cls.ChangeRequestFeasibility = ChangeRequestFeasibility
         cls.ChangeRequestTeam = ChangeRequestTeam
         cls.general_manager_classes = [
             ChangeRequest,
+            ChangeRequestApproval,
             ChangeRequestFeasibility,
             ChangeRequestTeam,
         ]
@@ -137,6 +151,48 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]["score"], 9)
         self.assertEqual(items[0]["changeRequest"]["title"], "Primary")
+
+    def test_multiword_reverse_relation_has_one_canonical_graphql_field(self):
+        query = """
+        query {
+            __type(name: "ChangeRequestType") {
+                fields {
+                    name
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        fields = [
+            field["name"] for field in response.json()["data"]["__type"]["fields"]
+        ]
+        self.assertEqual(fields.count("changeRequestFeasibilityList"), 1)
+        self.assertNotIn("changerequestfeasibilityList", fields)
+
+    def test_reverse_one_to_one_has_only_canonical_singular_graphql_field(self):
+        query = """
+        query {
+            __type(name: "ChangeRequestType") {
+                fields {
+                    name
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        fields = [
+            field["name"] for field in response.json()["data"]["__type"]["fields"]
+        ]
+        self.assertEqual(fields.count("changeRequestApproval"), 1)
+        self.assertNotIn("changerequestapproval", fields)
+        self.assertNotIn("changeRequestApprovalList", fields)
+        self.assertNotIn("changerequestapprovalList", fields)
 
     def test_filters_by_reverse_relation_any(self):
         query = """


### PR DESCRIPTION
fix for #242 & #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized GraphQL field naming for reverse relationships to ensure consistent formatting across the schema
  * Improved filtering of auto-generated relationship fields to prevent unwanted schema exposure

* **Tests**
  * Added validation tests to verify correct field naming for reverse relationship queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->