### PR TITLE
fix: use GraphQL ID for identifier filters

### DIFF
--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -2,6 +2,12 @@
 
 Managers with an `Interface` are registered during GeneralManager startup and receive generated query, mutation, and subscription fields based on their interface capabilities.
 
+## Filter by identifier
+
+Identifier equality filters (`id`, `id_Exact`, and `id_In`) use the GraphQL
+`ID` scalar, matching detail-query arguments. Ordered comparisons such as
+`id_Gt` retain the identifier's underlying numeric scalar when available.
+
 ## Expose authorization hints
 
 Use GraphQL permission capabilities when frontend code needs business-oriented authorization hints, such as whether the current user can rename a project. These fields are advisory only; backend permissions still enforce all reads and writes.

--- a/docs/superpowers/plans/2026-06-08-graphql-id-filter-consistency.md
+++ b/docs/superpowers/plans/2026-06-08-graphql-id-filter-consistency.md
@@ -1,0 +1,350 @@
+# GraphQL ID Filter Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make equality-style GraphQL filters for manager `id` fields use the `ID` scalar while preserving numeric ordered comparisons and backend identifier types.
+
+**Architecture:** Special-case the conventional manager field name `id` in the existing filter-option generator, because that is the single point used by top-level and nested relation filter types. Extend the existing recursive filter normalizer to cast equality-style ID values through `Interface.input_fields["id"]` before passing them to manager backends.
+
+**Tech Stack:** Python 3.12, Django, Graphene, pytest, Ruff, mypy
+
+---
+
+## File Structure
+
+- Modify `tests/integration/test_graphql_relation_filters.py`: add the public regression query and generated schema scalar assertions.
+- Modify `tests/unit/test_graph_ql.py`: add focused tests for scalar and list ID normalization.
+- Modify `src/general_manager/api/graphql_search.py`: generate `ID` equality filters and normalize their runtime values.
+
+### Task 1: Reproduce the Schema Mismatch
+
+**Files:**
+- Test: `tests/integration/test_graphql_relation_filters.py`
+
+- [ ] **Step 1: Add the failing integration regression test**
+
+Add this method to `GraphQLRelationFilterIntegrationTests`:
+
+```python
+def test_reuses_id_variable_for_detail_and_relation_filter(self):
+    query = """
+    query Issue247($id: ID!) {
+        changerequest(id: $id) {
+            id
+        }
+        changerequestfeasibilityList(
+            filter: {changeRequest: {id: $id}}
+        ) {
+            items {
+                id
+                changeRequest { id }
+            }
+        }
+    }
+    """
+
+    response = self.query(query, variables={"id": self.primary.id})
+
+    self.assertResponseNoErrors(response)
+    payload = response.json()["data"]
+    self.assertEqual(payload["changerequest"]["id"], str(self.primary.id))
+    self.assertEqual(
+        [item["id"] for item in payload["changerequestfeasibilityList"]["items"]],
+        [str(self.high_feasibility.id)],
+    )
+```
+
+- [ ] **Step 2: Run the regression test and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/integration/test_graphql_relation_filters.py::GraphQLRelationFilterIntegrationTests::test_reuses_id_variable_for_detail_and_relation_filter -q
+```
+
+Expected: FAIL with HTTP 400 and `Variable '$id' of type 'ID!' used in position expecting type 'Int'.`
+
+- [ ] **Step 3: Add failing generated-schema type assertions**
+
+Add this method to the same class:
+
+```python
+def test_id_filter_variants_use_identifier_and_numeric_scalars(self):
+    filter_type = GraphQL.graphql_filter_type_registry[
+        "ChangeRequestFilterTypeDepth2"
+    ]
+
+    self.assertIsInstance(filter_type._meta.fields["id"].type, graphene.ID)
+    self.assertIsInstance(filter_type._meta.fields["id__exact"].type, graphene.ID)
+    self.assertIsInstance(filter_type._meta.fields["id__in"].type, graphene.List)
+    self.assertIs(filter_type._meta.fields["id__in"].type.of_type, graphene.ID)
+    self.assertIsInstance(filter_type._meta.fields["id__gt"].type, graphene.Int)
+```
+
+Add `import graphene` near the other imports in
+`tests/integration/test_graphql_relation_filters.py`.
+
+- [ ] **Step 4: Run the schema assertion and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/integration/test_graphql_relation_filters.py::GraphQLRelationFilterIntegrationTests::test_id_filter_variants_use_identifier_and_numeric_scalars -q
+```
+
+Expected: FAIL because `id` and `id__exact` are `Int`, and `id__in` is absent.
+
+- [ ] **Step 5: Commit the failing tests**
+
+```bash
+git add tests/integration/test_graphql_relation_filters.py
+git commit -m "test: reproduce inconsistent GraphQL ID filters"
+```
+
+### Task 2: Generate ID Equality Filter Scalars
+
+**Files:**
+- Modify: `src/general_manager/api/graphql_search.py:281-356`
+- Test: `tests/integration/test_graphql_relation_filters.py`
+
+- [ ] **Step 1: Implement the minimal ID filter type special case**
+
+In `get_filter_options`, add a branch before the `Measurement` branch:
+
+```python
+if safe_issubclass(normalized_type, GeneralManager):
+    yield attribute_name, None
+elif attribute_name == "id":
+    yield attribute_name, graphene.ID()
+    yield f"{attribute_name}__exact", graphene.ID()
+    yield f"{attribute_name}__in", graphene.List(graphene.ID)
+    for option in ("gt", "gte", "lt", "lte"):
+        yield (
+            f"{attribute_name}__{option}",
+            map_field_to_graphene_read(
+                normalized_type,
+                attribute_name,
+                attr_info,
+            ),
+        )
+elif safe_issubclass(normalized_type, Measurement):
+    ...
+```
+
+Do not alter handling for any field whose name is not exactly `id`.
+
+- [ ] **Step 2: Run the schema assertion and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/integration/test_graphql_relation_filters.py::GraphQLRelationFilterIntegrationTests::test_id_filter_variants_use_identifier_and_numeric_scalars -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the public regression test**
+
+Run:
+
+```bash
+python -m pytest tests/integration/test_graphql_relation_filters.py::GraphQLRelationFilterIntegrationTests::test_reuses_id_variable_for_detail_and_relation_filter -q
+```
+
+Expected: PASS if Graphene and the backend accept the normalized value; otherwise fail at runtime rather than schema validation, proving the remaining normalization requirement.
+
+### Task 3: Preserve Backend Identifier Types
+
+**Files:**
+- Modify: `tests/unit/test_graph_ql.py`
+- Modify: `src/general_manager/api/graphql_search.py:496-550`
+
+- [ ] **Step 1: Add failing scalar normalization coverage**
+
+Add this test beside the existing relation-filter normalization tests:
+
+```python
+def test_normalize_filter_input_casts_id_equality_values(self):
+    class IdentifierManager:
+        class Interface(InterfaceBase):
+            input_fields: ClassVar[dict] = {"id": Input(int)}
+
+            @staticmethod
+            def get_attribute_types():
+                return {"id": {"type": int}}
+
+    normalized = GraphQL._normalize_filter_input(
+        IdentifierManager,
+        {"id": "7", "id__exact": "8"},
+    )
+
+    self.assertEqual(
+        normalized,
+        {"filter": {"id": 7, "id__exact": 8}, "exclude": {}},
+    )
+```
+
+- [ ] **Step 2: Add failing membership normalization coverage**
+
+Add:
+
+```python
+def test_normalize_filter_input_casts_each_id_in_value(self):
+    class IdentifierManager:
+        class Interface(InterfaceBase):
+            input_fields: ClassVar[dict] = {"id": Input(int)}
+
+            @staticmethod
+            def get_attribute_types():
+                return {"id": {"type": int}}
+
+    normalized = GraphQL._normalize_filter_input(
+        IdentifierManager,
+        {"id__in": ["7", "8"]},
+    )
+
+    self.assertEqual(
+        normalized,
+        {"filter": {"id__in": [7, 8]}, "exclude": {}},
+    )
+```
+
+- [ ] **Step 3: Run both normalization tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/unit/test_graph_ql.py -k "casts_id_equality_values or casts_each_id_in_value" -q
+```
+
+Expected: two assertion failures showing string values were returned unchanged.
+
+- [ ] **Step 4: Add a focused ID filter value normalizer**
+
+Add above `normalize_filter_input`:
+
+```python
+def normalize_id_filter_value(
+    field_type: Type[GeneralManager],
+    lookup: str,
+    value: Any,
+) -> Any:
+    """Cast equality-style ID filter values to the manager's identifier type."""
+    if lookup not in {"id", "id__exact", "id__in"}:
+        return value
+
+    interface = getattr(field_type, "Interface", None)
+    input_fields = getattr(interface, "input_fields", {})
+    id_input = input_fields.get("id") if isinstance(input_fields, dict) else None
+    if id_input is None:
+        return value
+
+    if lookup == "id__in":
+        if not isinstance(value, (list, tuple)):
+            return value
+        return [id_input.cast(item) for item in value]
+    return id_input.cast(value)
+```
+
+In the non-relation path at the beginning of `normalize_filter_input`, change:
+
+```python
+if not attr_info or not isinstance(value, dict):
+    filters[key] = normalize_id_filter_value(field_type, key, value)
+    continue
+```
+
+This path also runs recursively for nested relation filters.
+
+- [ ] **Step 5: Run both normalization tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/unit/test_graph_ql.py -k "casts_id_equality_values or casts_each_id_in_value" -q
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 6: Run the complete relation-filter integration file**
+
+Run:
+
+```bash
+python -m pytest tests/integration/test_graphql_relation_filters.py -q
+```
+
+Expected: all tests pass, including the issue #247 regression.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add src/general_manager/api/graphql_search.py tests/unit/test_graph_ql.py tests/integration/test_graphql_relation_filters.py
+git commit -m "fix: use GraphQL ID for identifier filters"
+```
+
+### Task 4: Documentation and Verification
+
+**Files:**
+- Modify: `docs/howto/expose_via_graphql.md`
+
+- [ ] **Step 1: Document identifier filter semantics**
+
+Add this section before the existing `Expose authorization hints` section:
+
+```markdown
+## Filter by identifier
+
+Identifier equality filters (`id`, `id_Exact`, and `id_In`) use the GraphQL
+`ID` scalar, matching detail-query arguments. Ordered comparisons such as
+`id_Gt` retain the identifier's underlying numeric scalar when available.
+```
+
+- [ ] **Step 2: Run focused tests**
+
+```bash
+python -m pytest tests/integration/test_graphql_relation_filters.py tests/unit/test_graph_ql.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run formatting and lint checks**
+
+```bash
+ruff format src/general_manager/api/graphql_search.py tests/unit/test_graph_ql.py tests/integration/test_graphql_relation_filters.py
+ruff check src/general_manager/api/graphql_search.py tests/unit/test_graph_ql.py tests/integration/test_graphql_relation_filters.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Run type checking**
+
+```bash
+mypy src/general_manager/api/graphql_search.py
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+python -m pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Check the final diff**
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only the intended implementation, tests, and documentation are changed.
+
+- [ ] **Step 7: Commit documentation and any formatting changes**
+
+```bash
+git add docs/howto/expose_via_graphql.md src/general_manager/api/graphql_search.py tests/unit/test_graph_ql.py tests/integration/test_graphql_relation_filters.py
+git commit -m "docs: clarify GraphQL identifier filters"
+```

--- a/docs/superpowers/specs/2026-06-08-graphql-id-filter-consistency-design.md
+++ b/docs/superpowers/specs/2026-06-08-graphql-id-filter-consistency-design.md
@@ -1,0 +1,83 @@
+# GraphQL ID Filter Consistency
+
+## Problem
+
+GeneralManager exposes root object lookup arguments named `id` as GraphQL
+`ID`, but generated filter inputs derive the same field from its Python type.
+For ORM-backed managers, that maps `id` to GraphQL `Int`.
+
+This prevents a client from reusing one `$id: ID!` variable for both a detail
+lookup and an equality filter, including equality filters nested below a
+relation.
+
+## Scope
+
+The change applies to generated GraphQL filter input fields named `id`:
+
+- `id` uses GraphQL `ID`.
+- `id_Exact` uses GraphQL `ID`.
+- `id_In` uses a list of GraphQL `ID` values.
+- Ordered comparisons such as `id_Gt`, `id_Gte`, `id_Lt`, and `id_Lte`
+  continue to use the scalar derived from the manager attribute type.
+
+The behavior applies wherever a manager filter type is reused, including
+top-level list filters and nested direct or collection relation filters.
+Other integer fields retain their current GraphQL types.
+
+## Design
+
+Filter generation will identify the base field name `id` before selecting the
+Graphene type for equality-style filter variants. It will use `graphene.ID`
+for the base, exact, and membership variants without changing the manager's
+runtime identifier type.
+
+Filter normalization will cast values supplied for `id` and `id__exact`
+through the manager interface's declared `id` input field. It will cast each
+member of `id__in` the same way. This mirrors root lookup construction, where
+GraphQL `ID` input is normalized to the manager's declared runtime identifier
+type before use.
+
+Ordered comparison variants will continue through the existing field mapping.
+This preserves numeric filtering for integer-backed identifiers while keeping
+GraphQL `ID` semantics for operations that treat an identifier as an opaque
+key.
+
+No new configuration or dependency is introduced.
+
+## Compatibility
+
+Root detail lookup arguments remain GraphQL `ID`, so existing detail-query
+clients are unaffected. The generated schema changes `id`, `id_Exact`, and
+`id_In` filter inputs from `Int` to `ID`, which resolves the inconsistency
+reported in issue #247.
+
+GraphQL accepts integer JSON values for `ID` variables and provides ID input
+values to resolvers as strings. Explicit normalization preserves the existing
+backend-facing value type for integer-backed and other custom identifiers.
+
+Ordered ID comparisons remain numeric and therefore continue accepting `Int`
+variables.
+
+## Testing
+
+Development follows a red-green-refactor cycle:
+
+1. Add an integration regression test that reuses one `$id: ID!` variable in a
+   root detail lookup and a nested relation equality filter.
+2. Run that test and confirm it fails with the current `ID!` versus `Int`
+   validation error.
+3. Add focused schema assertions for `id`, `id_Exact`, `id_In`, and an ordered
+   comparison such as `id_Gt`.
+4. Add focused normalization tests showing scalar and list ID values are cast
+   through the manager's declared input field.
+5. Implement the smallest filter-generation and normalization changes that
+   make the tests pass.
+6. Run the relation-filter tests, relevant GraphQL unit tests, formatting,
+   linting, type checking, and the full test suite.
+
+## Non-Goals
+
+- Changing root lookup arguments from `ID` to `Int`.
+- Removing ordered comparisons for integer-backed identifiers.
+- Changing non-ID integer fields.
+- Generalizing identifier metadata beyond the existing field name convention.

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -690,7 +690,12 @@ class GraphQL:
         attribute_type: type, attribute_name: str
     ) -> Generator[
         tuple[
-            str, type[graphene.ObjectType] | MeasurementScalar | graphene.List | None
+            str,
+            type[graphene.ObjectType]
+            | graphene.Scalar
+            | MeasurementScalar
+            | graphene.List
+            | None,
         ],
         None,
         None,

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -284,7 +284,14 @@ def get_filter_options(
     map_field_to_graphene_read: Callable[[type, str, Mapping[str, Any] | None], Any],
     attr_info: Mapping[str, Any] | None = None,
 ) -> Generator[
-    tuple[str, type[graphene.ObjectType] | MeasurementScalar | graphene.List | None],
+    tuple[
+        str,
+        type[graphene.ObjectType]
+        | graphene.Scalar
+        | MeasurementScalar
+        | graphene.List
+        | None,
+    ],
     None,
     None,
 ]:
@@ -323,6 +330,19 @@ def get_filter_options(
 
     if safe_issubclass(normalized_type, GeneralManager):
         yield attribute_name, None
+    elif attribute_name == "id":
+        yield attribute_name, graphene.ID()
+        yield f"{attribute_name}__exact", graphene.ID()
+        yield f"{attribute_name}__in", graphene.List(graphene.ID)
+        for option in ("gt", "gte", "lt", "lte"):
+            yield (
+                f"{attribute_name}__{option}",
+                map_field_to_graphene_read(
+                    normalized_type,
+                    attribute_name,
+                    attr_info,
+                ),
+            )
     elif safe_issubclass(normalized_type, Measurement):
         yield attribute_name, MeasurementScalar()
         for option in number_options:
@@ -493,6 +513,28 @@ def create_filter_options(
     return filter_class
 
 
+def normalize_id_filter_value(
+    field_type: Type[GeneralManager],
+    lookup: str,
+    value: Any,
+) -> Any:
+    """Cast equality-style ID filter values to the manager's identifier type."""
+    if lookup not in {"id", "id__exact", "id__in"}:
+        return value
+
+    interface = getattr(field_type, "Interface", None)
+    input_fields = getattr(interface, "input_fields", {})
+    id_input = input_fields.get("id") if isinstance(input_fields, dict) else None
+    if id_input is None:
+        return value
+
+    if lookup == "id__in":
+        if not isinstance(value, (list, tuple)):
+            return value
+        return [id_input.cast(item) for item in value]
+    return id_input.cast(value)
+
+
 def normalize_filter_input(
     field_type: Type[GeneralManager],
     filter_input: dict[str, Any],
@@ -510,7 +552,7 @@ def normalize_filter_input(
     for key, value in filter_input.items():
         attr_info = attr_types.get(key)
         if not attr_info or not isinstance(value, dict):
-            filters[key] = value
+            filters[key] = normalize_id_filter_value(field_type, key, value)
             continue
 
         attr_type = attr_info.get("type")

--- a/tests/integration/test_graphql_relation_filters.py
+++ b/tests/integration/test_graphql_relation_filters.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 
+import graphene
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.test import override_settings
@@ -193,6 +194,56 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
         self.assertNotIn("changerequestapproval", fields)
         self.assertNotIn("changeRequestApprovalList", fields)
         self.assertNotIn("changerequestapprovalList", fields)
+
+    def test_reuses_id_variable_for_detail_and_relation_filter(self):
+        query = """
+        query Issue247($id: ID!) {
+            changerequest(id: $id) {
+                id
+            }
+            changerequestfeasibilityList(
+                filter: {changeRequest: {id: $id}}
+            ) {
+                items {
+                    id
+                    changeRequest { id }
+                }
+            }
+        }
+        """
+
+        response = self.query(query, variables={"id": self.primary.id})
+
+        self.assertResponseNoErrors(response)
+        payload = response.json()["data"]
+        self.assertEqual(payload["changerequest"]["id"], str(self.primary.id))
+        self.assertEqual(
+            [item["id"] for item in payload["changerequestfeasibilityList"]["items"]],
+            [str(self.high_feasibility.id)],
+        )
+
+    def test_id_filter_variants_use_identifier_and_numeric_scalars(self):
+        filter_type = GraphQL.graphql_filter_type_registry[
+            "ChangeRequestFilterTypeDepth2"
+        ]
+
+        self.assertIsInstance(filter_type._meta.fields["id"].type, graphene.ID)
+        self.assertIsInstance(
+            filter_type._meta.fields["id__exact"].type,
+            graphene.ID,
+        )
+        self.assertIsInstance(
+            filter_type._meta.fields["id__in"].type,
+            graphene.List,
+        )
+        self.assertIs(
+            filter_type._meta.fields["id__in"].type.of_type,
+            graphene.ID,
+        )
+        self.assertIsInstance(
+            filter_type._meta.fields["id__gt"].type,
+            graphene.Int,
+        )
 
     def test_filters_by_reverse_relation_any(self):
         query = """

--- a/tests/integration/test_graphql_relation_filters.py
+++ b/tests/integration/test_graphql_relation_filters.py
@@ -216,10 +216,10 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
 
         self.assertResponseNoErrors(response)
         payload = response.json()["data"]
-        self.assertEqual(payload["changerequest"]["id"], str(self.primary.id))
+        self.assertEqual(payload["changerequest"]["id"], self.primary.id)
         self.assertEqual(
             [item["id"] for item in payload["changerequestfeasibilityList"]["items"]],
-            [str(self.high_feasibility.id)],
+            [self.high_feasibility.id],
         )
 
     def test_id_filter_variants_use_identifier_and_numeric_scalars(self):
@@ -227,8 +227,8 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
             "ChangeRequestFilterTypeDepth2"
         ]
 
-        self.assertIsInstance(filter_type._meta.fields["id"].type, graphene.ID)
-        self.assertIsInstance(
+        self.assertIs(filter_type._meta.fields["id"].type, graphene.ID)
+        self.assertIs(
             filter_type._meta.fields["id__exact"].type,
             graphene.ID,
         )
@@ -240,7 +240,7 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
             filter_type._meta.fields["id__in"].type.of_type,
             graphene.ID,
         )
-        self.assertIsInstance(
+        self.assertIs(
             filter_type._meta.fields["id__gt"].type,
             graphene.Int,
         )

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -515,6 +515,44 @@ class GraphQLTests(TestCase):
         self.assertEqual(normalized["filter"], {})
         self.assertEqual(normalized["exclude"], {"child__name__icontains": "blocked"})
 
+    def test_normalize_filter_input_casts_id_equality_values(self):
+        class IdentifierManager:
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {"id": Input(int)}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {"id": {"type": int}}
+
+        normalized = GraphQL._normalize_filter_input(
+            IdentifierManager,
+            {"id": "7", "id__exact": "8"},
+        )
+
+        self.assertEqual(
+            normalized,
+            {"filter": {"id": 7, "id__exact": 8}, "exclude": {}},
+        )
+
+    def test_normalize_filter_input_casts_each_id_in_value(self):
+        class IdentifierManager:
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {"id": Input(int)}
+
+                @staticmethod
+                def get_attribute_types():
+                    return {"id": {"type": int}}
+
+        normalized = GraphQL._normalize_filter_input(
+            IdentifierManager,
+            {"id__in": ["7", "8"]},
+        )
+
+        self.assertEqual(
+            normalized,
+            {"filter": {"id__in": [7, 8]}, "exclude": {}},
+        )
+
     def test_build_identification_arguments_respects_optional_inputs(self):
         class DependencyManager(GeneralManager):
             pass


### PR DESCRIPTION
## Summary
- expose `id`, `id_Exact`, and `id_In` filters with the GraphQL `ID` scalar
- preserve numeric scalar types for ordered identifier comparisons such as `id_Gt`
- cast GraphQL ID equality-filter values through the manager's declared identifier input type
- document identifier filter semantics

## Root cause
Root detail queries explicitly generated `id` arguments as GraphQL `ID`, while filter input generation derived `id` from the ORM/Python integer type and exposed it as `Int`. A single `$id: ID!` variable therefore could not be reused in a detail lookup and nested relation filter.

## Impact
Clients can now reuse one ID variable across detail queries and equality-style top-level or nested relation filters. Existing numeric ordered comparisons remain available.

## Validation
- TDD regression reproduced the original `ID!` versus `Int` schema validation failure before implementation
- focused GraphQL tests: 57 passed
- Ruff format and lint checks passed
- mypy passed
- full suite: 2373 passed, 1 skipped

Closes #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GraphQL `id` filters now use `ID` scalar type for equality checks (`id`, `id__exact`, `id__in`); ordered comparisons use numeric scalars.

* **Documentation**
  * Added "Filter by identifier" subsection explaining GraphQL ID filter semantics.
  * Added implementation plan and design specification documents for ID filter changes.

* **Tests**
  * Added integration tests for ID variable reuse across detail and relation filters.
  * Added unit tests for ID filter value normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->