### PR TITLE
[codex] Normalize custom mutation manager arguments

### DIFF
--- a/docs/concepts/graphql/custom_mutations.md
+++ b/docs/concepts/graphql/custom_mutations.md
@@ -41,21 +41,39 @@ The decorator builds the GraphQL arguments and payload from type annotations:
 
 Basic Python types such as `str`, `int`, `float`, and `bool` map to their
 corresponding GraphQL scalars. A parameter annotated with a `GeneralManager`
-subclass is exposed as a GraphQL `ID`.
+subclass is exposed as a GraphQL `ID` when the manager uses the conventional
+single `id` input.
 
-!!! important
-    A manager-typed argument is still passed to the resolver as its identifier;
-    the decorator does not instantiate the manager. Convert the value and load
-    the manager explicitly inside the resolver.
+The resolver receives manager-typed arguments as manager instances. The
+decorator casts GraphQL input through the manager's `Interface.input_fields`
+before calling mutation permissions or the resolver.
 
 ```python
 @graph_ql_mutation
 def archive_project(info, project: Project) -> Project:
-    manager = Project(id=int(project))
-    return manager.update(
+    return project.update(
         status="archived",
         creator_id=getattr(info.context.user, "id", None),
     )
+```
+
+Managers with multiple identification inputs are exposed as input objects:
+
+```python
+@graph_ql_mutation
+def preview_price(info, quote: PriceQuote) -> PriceQuote:
+    return quote
+```
+
+```graphql
+mutation {
+  previewPrice(quote: { market: "de", sku: "A-100" }) {
+    success
+    priceQuote {
+      sku
+    }
+  }
+}
 ```
 
 ## Return payloads
@@ -121,8 +139,9 @@ def publish_project(info, project_id: int) -> Project:
     ...
 ```
 
-The permission class receives the raw mutation arguments and
-`info.context.user` before the resolver runs. The positional form is equivalent:
+The permission class receives the normalized mutation arguments and
+`info.context.user` before the resolver runs. Manager-typed arguments are
+manager instances there too. The positional form is equivalent:
 
 ```python
 @graph_ql_mutation(PublishProjectPermission)

--- a/docs/examples/permission_cookbook.md
+++ b/docs/examples/permission_cookbook.md
@@ -82,7 +82,10 @@ class Invoice(GeneralManager):
         ...
 ```
 
-Because the GraphQL decorator emits `ID` inputs for manager arguments, the resolver and the accompanying mutation permission receive the identifier and must instantiate the manager explicitly:
+Because the GraphQL decorator emits `ID` inputs for conventional manager
+arguments, clients pass the invoice identifier. The decorator casts that input
+through the manager interface before calling the mutation permission or
+resolver, so both receive an `Invoice` instance:
 
 ```python
 from typing import Any
@@ -94,8 +97,7 @@ from general_manager.permission.mutation_permission import MutationPermission
 class RejectInvoicePermission(MutationPermission):
     @classmethod
     def check(cls, data: dict[str, Any], request_user: Any) -> None:
-        invoice_id = int(data["invoice"])
-        invoice = Invoice(id=invoice_id)
+        invoice = data["invoice"]
         if invoice.status != "submitted":
             cls.raise_error("Only submitted invoices can be rejected.")
         if not request_user.groups.filter(name="finance_lead").exists():
@@ -104,18 +106,16 @@ class RejectInvoicePermission(MutationPermission):
 
 @graph_ql_mutation(permission=RejectInvoicePermission)
 def reject_invoice(info, invoice: Invoice, reason: str) -> Invoice:
-    invoice_id = int(invoice)
-    manager = Invoice(id=invoice_id)
-    manager.update(
+    invoice.update(
         creator_id=getattr(info.context.user, "id", None),
         status="rejected",
         rejection_reason=reason,
     )
-    return manager
+    return invoice
 ```
 
 - `graph_ql_mutation` inspects the resolver signature and return annotation to build the GraphQL payload; no separate `base_type` configuration is required.
-- `MutationPermission.check` is a classmethod that receives the mutation data and `request_user`, so convert IDs into managers before enforcing domain rules.
+- `MutationPermission.check` is a classmethod that receives normalized mutation data and `request_user`, so manager-typed arguments are available as manager instances before enforcing domain rules.
 - Use `raise_error()` to produce a structured GraphQL error with `success=False`.
 - Call `GeneralManager.update` instead of writing to model fields directly; it re-runs permission checks and records history comments when provided.
 

--- a/src/general_manager/api/mutation.py
+++ b/src/general_manager/api/mutation.py
@@ -28,6 +28,7 @@ from types import UnionType
 
 
 FuncT = TypeVar("FuncT", bound=Callable[..., object])
+_manager_input_type_registry: dict[str, type[graphene.InputObjectType]] = {}
 
 
 class MissingParameterTypeHintError(TypeError):
@@ -91,6 +92,125 @@ class DuplicateMutationOutputNameError(ValueError):
         )
 
 
+def _is_general_manager_type(annotation: object) -> bool:
+    """Return True for class annotations that subclass GeneralManager."""
+    return inspect.isclass(annotation) and issubclass(annotation, GeneralManager)
+
+
+def _manager_input_fields(
+    manager_class: type[GeneralManager],
+) -> dict[str, Any]:
+    """Extract Interface.input_fields from a manager class."""
+    interface = getattr(manager_class, "Interface", None)
+    input_fields = getattr(interface, "input_fields", {})
+    return dict(input_fields) if isinstance(input_fields, dict) else {}
+
+
+def _uses_single_id_input(manager_class: type[GeneralManager]) -> bool:
+    """Return True when the manager expects one ID instead of nested input."""
+    input_fields = _manager_input_fields(manager_class)
+    return not input_fields or tuple(input_fields) == ("id",)
+
+
+def _manager_input_type_identifier(manager_class: type[GeneralManager]) -> str:
+    """Build a stable cache key from the manager's module and qualname."""
+    return f"{manager_class.__module__}.{manager_class.__qualname__}"
+
+
+def _manager_input_type_name(manager_class: type[GeneralManager]) -> str:
+    """Build a GraphQL-safe input type name from a unique manager identifier."""
+    identifier = _manager_input_type_identifier(manager_class)
+    safe_identifier = "".join(
+        char if char.isalnum() else "_" for char in identifier
+    ).strip("_")
+    if safe_identifier[:1].isdigit():
+        safe_identifier = f"_{safe_identifier}"
+    return f"{safe_identifier}MutationInput"
+
+
+def _get_or_create_manager_input_type(
+    manager_class: type[GeneralManager],
+) -> type[graphene.InputObjectType]:
+    """Build and cache a graphene InputObjectType for nested manager inputs."""
+    cache_key = _manager_input_type_identifier(manager_class)
+    cached = _manager_input_type_registry.get(cache_key)
+    if cached is not None:
+        return cached
+
+    type_name = _manager_input_type_name(manager_class)
+    fields: dict[str, Any] = {}
+    for input_name, input_field in _manager_input_fields(manager_class).items():
+        field_type = input_field.type
+        required = input_field.required
+        if _is_general_manager_type(field_type):
+            if _uses_single_id_input(field_type):
+                fields[input_name] = graphene.ID(required=required)
+            else:
+                fields[input_name] = graphene.InputField(
+                    _get_or_create_manager_input_type(field_type),
+                    required=required,
+                )
+            continue
+
+        fields[input_name] = GraphQL._map_field_to_graphene_base_type(field_type)(
+            required=required,
+        )
+
+    input_type = type(type_name, (graphene.InputObjectType,), fields)
+    _manager_input_type_registry[cache_key] = input_type
+    return input_type
+
+
+def _build_manager_argument_field(
+    manager_class: type[GeneralManager],
+    **kwargs: Any,
+) -> Any:
+    """Return graphene.ID or a nested manager input argument."""
+    if _uses_single_id_input(manager_class):
+        return graphene.ID(**kwargs)
+    return graphene.Argument(_get_or_create_manager_input_type(manager_class), **kwargs)
+
+
+def _normalize_manager_argument(
+    manager_class: type[GeneralManager],
+    value: Any,
+) -> GeneralManager | None:
+    """Normalize None, instances, dict input, or ID input into a manager."""
+    if value is None or isinstance(value, manager_class):
+        return value
+    if isinstance(value, dict):
+        return manager_class(**value)
+    return manager_class(value)
+
+
+def _normalize_mutation_arguments(
+    annotations: dict[str, Any],
+    kwargs: dict[str, object],
+) -> dict[str, Any]:
+    """Normalize manager-typed arguments and lists using resolver annotations."""
+    normalized = dict(kwargs)
+    for name, annotation in annotations.items():
+        if name not in normalized:
+            continue
+
+        origin = get_origin(annotation)
+        if origin is list or origin is List:
+            inner = get_args(annotation)[0]
+            if _is_general_manager_type(inner) and normalized[name] is not None:
+                normalized[name] = [
+                    _normalize_manager_argument(inner, item)
+                    for item in cast(list[Any], normalized[name])
+                ]
+            continue
+
+        if _is_general_manager_type(annotation):
+            normalized[name] = _normalize_manager_argument(
+                annotation,
+                normalized[name],
+            )
+    return normalized
+
+
 def graph_ql_mutation(
     _func: FuncT | type[MutationPermission] | None = None,
     permission: Optional[Type[MutationPermission]] = None,
@@ -133,6 +253,7 @@ def graph_ql_mutation(
 
         # Build Arguments inner class dynamically
         arg_fields: dict[str, Any] = {}
+        argument_annotations: dict[str, Any] = {}
         for name, param in sig.parameters.items():
             if name == "info":
                 continue
@@ -158,17 +279,29 @@ def graph_ql_mutation(
                 ann = next(a for a in get_args(ann) if a is not type(None))
                 kwargs["required"] = False
 
+            argument_annotations[name] = ann
+
             # Resolve list types to List scalar
             field: Any
             if get_origin(ann) is list or get_origin(ann) is List:
                 inner = get_args(ann)[0]
+                if _is_general_manager_type(inner):
+                    if _uses_single_id_input(inner):
+                        field = graphene.List(graphene.ID, **kwargs)
+                    else:
+                        field = graphene.List(
+                            _get_or_create_manager_input_type(inner),
+                            **kwargs,
+                        )
+                    arg_fields[name] = field
+                    continue
                 field = graphene.List(
                     GraphQL._map_field_to_graphene_base_type(inner),
                     **kwargs,
                 )
             else:
-                if inspect.isclass(ann) and issubclass(ann, GeneralManager):
-                    field = graphene.ID(**kwargs)
+                if _is_general_manager_type(ann):
+                    field = _build_manager_argument_field(ann, **kwargs)
                 else:
                     field = GraphQL._map_field_to_graphene_base_type(ann)(**kwargs)
 
@@ -223,10 +356,14 @@ def graph_ql_mutation(
             Returns:
                 mutation_class: Instance of the mutation with output fields populated; `success` is `True` on successful execution and `False` if a handled manager error occurred (after being forwarded to GraphQL._handle_graph_ql_error).
             """
-            if permission:
-                permission.check(kwargs, info.context.user)
             try:
-                result = fn(info, **kwargs)
+                normalized_kwargs = _normalize_mutation_arguments(
+                    argument_annotations,
+                    kwargs,
+                )
+                if permission:
+                    permission.check(normalized_kwargs, info.context.user)
+                result = fn(info, **normalized_kwargs)
                 data: dict[str, Any] = {}
                 if isinstance(result, tuple):
                     # unpack according to outputs ordering after success

--- a/tests/unit/test_mutation.py
+++ b/tests/unit/test_mutation.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import AnonymousUser, User
 from general_manager.api.mutation import graph_ql_mutation
 from general_manager.api.graphql import GraphQL
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.input import Input
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.permission.mutation_permission import MutationPermission
 from graphql import GraphQLError
@@ -67,6 +68,50 @@ class DummyGM(GeneralManager):
         pass
 
 
+class SingleInputInterface(DummyInterface):
+    input_fields: ClassVar[dict] = {"id": Input(int)}
+
+    def __init__(self, *args, **kwargs):
+        InterfaceBase.__init__(self, *args, **kwargs)
+
+
+class SingleInputGM(GeneralManager):
+    class Interface(SingleInputInterface):
+        pass
+
+
+# Required because the dummy handle_interface hook does not attach Interface.
+SingleInputGM.Interface = SingleInputInterface
+
+
+class MultiInputInterface(DummyInterface):
+    input_fields: ClassVar[dict] = {
+        "tenant": Input(str),
+        "code": Input(int),
+    }
+
+    def __init__(self, *args, **kwargs):
+        InterfaceBase.__init__(self, *args, **kwargs)
+
+
+class MultiInputGM(GeneralManager):
+    class Interface(MultiInputInterface):
+        pass
+
+
+# Required because the dummy handle_interface hook does not attach Interface.
+MultiInputGM.Interface = MultiInputInterface
+
+
+class RegionInputInterface(DummyInterface):
+    input_fields: ClassVar[dict] = {
+        "region": Input(str),
+    }
+
+    def __init__(self, *args, **kwargs):
+        InterfaceBase.__init__(self, *args, **kwargs)
+
+
 class MutationDecoratorTests(TestCase):
     def tearDown(self) -> None:
         GraphQL._mutations.clear()
@@ -111,7 +156,7 @@ class MutationDecoratorTests(TestCase):
 
     def test_general_manager_argument_uses_id(self):
         @graph_ql_mutation()
-        def gm(info, item: DummyGM) -> str:
+        def gm(info, item: SingleInputGM) -> str:
             _ = info
             _ = item
             return "ok"
@@ -119,6 +164,110 @@ class MutationDecoratorTests(TestCase):
         mutation = GraphQL._mutations["gm"]
         arg = mutation._meta.arguments["item"]
         self.assertIsInstance(arg, graphene.ID)
+
+    def test_general_manager_argument_passes_manager_to_permission_and_resolver(self):
+        class CapturePermission(MutationPermission):
+            received_item = None
+
+            @classmethod
+            def check(cls, data: dict, user: object) -> None:
+                cls.received_item = data["item"]
+
+        @graph_ql_mutation(permission=CapturePermission)
+        def gm(info, item: SingleInputGM) -> str:
+            _ = info
+            return str(item.identification["id"])
+
+        mutation = GraphQL._mutations["gm"]
+        info = type("Info", (), {"context": type("Ctx", (), {"user": object()})()})
+
+        result = mutation.mutate(None, info, item="42")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.str, "42")
+        self.assertIsInstance(CapturePermission.received_item, SingleInputGM)
+        self.assertEqual(CapturePermission.received_item.identification, {"id": 42})
+
+    def test_multi_input_general_manager_argument_uses_input_object(self):
+        seen: dict[str, MultiInputGM] = {}
+
+        @graph_ql_mutation()
+        def gm(info, item: MultiInputGM) -> str:
+            _ = info
+            seen["item"] = item
+            return f"{item.identification['tenant']}:{item.identification['code']}"
+
+        mutation = GraphQL._mutations["gm"]
+        arg = mutation._meta.arguments["item"]
+        arg_type = arg.type.of_type if hasattr(arg.type, "of_type") else arg.type
+        self.assertTrue(issubclass(arg_type, graphene.InputObjectType))
+        self.assertIn("tenant", arg_type._meta.fields)
+        self.assertIn("code", arg_type._meta.fields)
+
+        info = type("Info", (), {"context": type("Ctx", (), {"user": object()})()})
+        result = mutation.mutate(
+            None,
+            info,
+            item={"tenant": "customer-a", "code": "7"},
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.str, "customer-a:7")
+        self.assertEqual(seen["item"].identification["code"], 7)
+        self.assertIsInstance(seen["item"].identification["code"], int)
+
+    def test_manager_input_type_cache_uses_unique_manager_identifier(self):
+        FirstSharedName = type(
+            "SharedName",
+            (GeneralManager,),
+            {
+                "__module__": "tests.unit.test_mutation.first",
+                "Interface": MultiInputInterface,
+            },
+        )
+        FirstSharedName.Interface = MultiInputInterface
+        SecondSharedName = type(
+            "SharedName",
+            (GeneralManager,),
+            {
+                "__module__": "tests.unit.test_mutation.second",
+                "Interface": RegionInputInterface,
+            },
+        )
+        SecondSharedName.Interface = RegionInputInterface
+
+        @graph_ql_mutation()
+        def first(info, item: FirstSharedName) -> str:
+            _ = info, item
+            return "first"
+
+        @graph_ql_mutation()
+        def second(info, item: SecondSharedName) -> str:
+            _ = info, item
+            return "second"
+
+        first_type = GraphQL._mutations["first"]._meta.arguments["item"].type.of_type
+        second_type = GraphQL._mutations["second"]._meta.arguments["item"].type.of_type
+
+        self.assertIsNot(first_type, second_type)
+        self.assertIn("tenant", first_type._meta.fields)
+        self.assertIn("code", first_type._meta.fields)
+        self.assertIn("region", second_type._meta.fields)
+        self.assertNotIn("tenant", second_type._meta.fields)
+
+    def test_manager_argument_normalization_errors_are_graphql_errors(self):
+        @graph_ql_mutation()
+        def gm(info, item: SingleInputGM) -> str:
+            _ = info
+            return str(item.identification["id"])
+
+        mutation = GraphQL._mutations["gm"]
+        info = type("Info", (), {"context": type("Ctx", (), {"user": object()})()})
+
+        with self.assertRaises(GraphQLError) as ctx:
+            mutation.mutate(None, info, item="not-an-int")
+
+        self.assertEqual(ctx.exception.extensions["code"], "BAD_USER_INPUT")
 
     def test_list_argument(self):
         @graph_ql_mutation()
@@ -167,7 +316,7 @@ class MutationDecoratorTests(TestCase):
         mutation = GraphQL._mutations["add"]
 
         InfoNoAuth = type("Info", (), {"context": type("Ctx", (), {"user": None})()})
-        with self.assertRaises(PermissionError):
+        with self.assertRaises(GraphQLError):
             mutation.mutate(None, InfoNoAuth, a=1, b=2)
 
     def test_mutation_with_manager_return(self):
@@ -238,7 +387,51 @@ class MutationDecoratorTests(TestCase):
         mutation = GraphQL._mutations["bulk"]
         arg = mutation._meta.arguments["items"]
         self.assertIsInstance(arg, graphene.List)
-        self.assertEqual(arg.of_type, graphene.String)  # IDs are strings in GraphQL
+        self.assertEqual(arg.of_type, graphene.ID)
+
+    def test_general_manager_list_argument_normalizes_manager_items(self):
+        seen: dict[str, list] = {}
+
+        @graph_ql_mutation()
+        def bulk_single(info, items: List[SingleInputGM]) -> int:
+            _ = info
+            seen["single"] = items
+            return len(items)
+
+        @graph_ql_mutation()
+        def bulk_multi(info, items: List[MultiInputGM]) -> int:
+            _ = info
+            seen["multi"] = items
+            return len(items)
+
+        info = type("Info", (), {"context": type("Ctx", (), {"user": object()})()})
+
+        single_result = GraphQL._mutations["bulkSingle"].mutate(
+            None,
+            info,
+            items=["1", "2", "3"],
+        )
+        multi_result = GraphQL._mutations["bulkMulti"].mutate(
+            None,
+            info,
+            items=[
+                {"tenant": "a", "code": "1"},
+                {"tenant": "b", "code": "2"},
+            ],
+        )
+
+        self.assertEqual(single_result.int, 3)
+        self.assertTrue(all(isinstance(item, SingleInputGM) for item in seen["single"]))
+        self.assertEqual(
+            [item.identification["id"] for item in seen["single"]],
+            [1, 2, 3],
+        )
+        self.assertTrue(all(isinstance(item, MultiInputGM) for item in seen["multi"]))
+        self.assertEqual(
+            [item.identification for item in seen["multi"]],
+            [{"tenant": "a", "code": 1}, {"tenant": "b", "code": 2}],
+        )
+        self.assertEqual(multi_result.int, 2)
 
     def test_permission_allows_authenticated(self):
         class addPermission(MutationPermission):
@@ -456,7 +649,7 @@ class MutationDecoratorTests(TestCase):
         Info = type("Info", (), {"context": type("Ctx", (), {"user": object()})()})
 
         # Should fail with negative value
-        with self.assertRaises(PermissionError):
+        with self.assertRaises(GraphQLError):
             mutation.mutate(None, Info, value=-5)
 
         # Should succeed with positive value


### PR DESCRIPTION
## Summary
- Normalize `GeneralManager`-typed custom mutation arguments before permission checks and resolver execution.
- Keep conventional single-`id` managers exposed as `ID`, and expose multi-input managers as generated input objects.
- Update custom mutation documentation and permission cookbook examples for the new contract.

## Impact
This is a breaking behavior change for custom mutation resolvers or mutation permissions that expected raw manager identifiers. Manager-typed arguments now match their Python annotations at runtime.

## Validation
- `python -m pytest tests/unit/test_mutation.py tests/integration/test_custom_mutation.py tests/integration/test_graphql_permission_capabilities.py -q`
- `ruff check src/general_manager/api/mutation.py tests/unit/test_mutation.py`
- `ruff format --check src/general_manager/api/mutation.py tests/unit/test_mutation.py`
- `mypy src/general_manager/api/mutation.py`
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GraphQL mutations now accept manager-typed inputs as either IDs or structured input objects and automatically convert them into manager instances before permission checks and resolver execution.

* **Documentation**
  * Updated mutation docs and examples to reflect automatic conversion and that permission checks receive normalized mutation arguments.

* **Tests**
  * Added tests for input-object handling, list normalization, normalization failures, schema caching distinctions, and permission/resolver argument behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->