### PR TITLE
[codex] Clarify GraphQL capability descriptions

### DIFF
--- a/docs/concepts/graphql/permission_capabilities.md
+++ b/docs/concepts/graphql/permission_capabilities.md
@@ -79,6 +79,10 @@ Name capability fields in stable business language. Prefer `canRename`,
 `canArchiveProject`, or `canCreateDerivative` over UI-specific names such as
 `showRenameButton`.
 
+Capability declarations also carry GraphQL field descriptions. The helper
+functions provide default descriptions, and you can pass `description=` when a
+client needs more precise business language in schema introspection.
+
 ## Object capabilities
 
 Use `object_capability(...)` when the rule is domain-specific and cannot be
@@ -99,13 +103,18 @@ def can_lock_project(project, user):
 class Permission(AdditiveManagerPermission):
     __read__ = ["public"]
     graphql_capabilities = (
-        object_capability("canLock", can_lock_project),
+        object_capability(
+            "canLock",
+            can_lock_project,
+            description="Whether the current user can lock this draft project.",
+        ),
     )
 ```
 
 The evaluator receives `(instance, user)` and should return `True` or `False`.
 If it raises an exception, the GraphQL resolver logs the failure and returns
-`false` for the capability.
+`false` for the capability. The optional `description` text is exposed on the
+generated GraphQL field.
 
 ## Permission-backed capabilities
 
@@ -131,6 +140,9 @@ Project.Permission.graphql_capabilities = (
         "update",
         name="canUpdateProject",
         payload=lambda project, _user: {"name": project.name},
+        description=(
+            "Whether the current user can submit an update for this project."
+        ),
     ),
     permission_capability(
         Project,
@@ -146,9 +158,62 @@ Project.Permission.graphql_capabilities = (
 - `action="update"` calls `check_update_permission(payload, instance, user)`
 - `action="delete"` calls `check_delete_permission(instance, user)`
 
-Use `payload=` when create or update permission checks need the fields that
-would be submitted by the real mutation. The payload can be a mapping or a
-callable receiving `(instance, user)`.
+### Payloads
+
+`payload` means "the input data that should be handed to the permission check
+while answering this capability field." Capability evaluation does not execute a
+mutation, so GeneralManager cannot infer the future mutation input by itself.
+Use `payload=` when a permission rule depends on field values that would
+normally come from the GraphQL mutation arguments.
+
+For `permission_capability(...)`, the resolved payload is used like this:
+
+- `action="create"` passes the payload to
+  `check_create_permission(payload, target, user)`.
+- `action="update"` passes the payload to
+  `check_update_permission(payload, instance, user)`.
+- `action="delete"` ignores the payload because
+  `check_delete_permission(instance, user)` does not accept one.
+
+The payload can be a static mapping:
+
+```python
+permission_capability(
+    Project,
+    "create",
+    name="canCreateDraftProject",
+    payload={"status": "draft"},
+)
+```
+
+Or it can be a callable:
+
+```python
+permission_capability(
+    Project,
+    "update",
+    name="canRenameProject",
+    payload=lambda project, user: {
+        "name": project.name,
+        "requested_by": user.id,
+    },
+)
+```
+
+The callable receives `(instance, user)`:
+
+- `instance` is the object whose GraphQL `capabilities` field is being resolved.
+  In a `projectList { items { capabilities { canRenameProject } } }` query, it
+  is the current `Project` item. In a detail query, it is that single resolved
+  object. For create previews, it is still the object currently being rendered,
+  not a new unsaved object.
+- `user` is the request user after GeneralManager's standard permission user
+  resolution. It is the same user object that is passed to the permission check.
+
+Return a mapping whose keys match the field or argument names your permission
+class expects. The mapping is copied to a plain `dict` before evaluation, so the
+lambda should not rely on mutating shared state. If the payload callable raises
+an exception, the capability fails closed and GraphQL returns `false`.
 
 ## Mutation-backed capabilities
 
@@ -186,6 +251,14 @@ Project.Permission.graphql_capabilities = (
 
 The capability calls the mutation permission's `check(payload, user)` method.
 Permission errors return `false`; successful checks return `true`.
+
+`mutation_capability(...)` uses the same payload rules as
+`permission_capability(...)`: a mapping is used directly, and a callable
+receives `(instance, user)`. The returned mapping should contain the arguments
+that the mutation permission validates. For example, if
+`ArchiveProjectPermission` checks a `status` argument, the payload should include
+`{"status": project.status}` or another value that represents the action being
+previewed.
 
 ## Current-user capabilities
 

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -452,7 +452,10 @@ class GraphQL:
 
         fields: dict[str, Any] = {}
         for declaration in declarations:
-            fields[declaration.name] = graphene.Boolean(required=True)
+            fields[declaration.name] = graphene.Boolean(
+                required=True,
+                description=declaration.description,
+            )
 
             def resolver(
                 parent: dict[str, GeneralManager],
@@ -544,7 +547,10 @@ class GraphQL:
 
         fields: dict[str, Any] = {}
         for declaration in declarations:
-            fields[declaration.name] = graphene.Boolean(required=True)
+            fields[declaration.name] = graphene.Boolean(
+                required=True,
+                description=declaration.description,
+            )
 
             def resolver(
                 parent: dict[str, Any],

--- a/src/general_manager/permission/graphql_capabilities.py
+++ b/src/general_manager/permission/graphql_capabilities.py
@@ -20,11 +20,20 @@ BatchCapabilityEvaluator = Callable[
 
 @dataclass(frozen=True, slots=True)
 class GraphQLPermissionCapability:
-    """Declarative permission capability exposed as a GraphQL boolean field."""
+    """
+    Boolean authorization hint exposed under a GraphQL ``capabilities`` object.
+
+    Capability fields are advisory frontend hints, not authorization gates. The
+    evaluator receives the resolved object and request user, and GraphQL returns
+    ``false`` if evaluation fails. Use ``description`` to explain the business
+    action the field previews so schema introspection remains useful to client
+    developers.
+    """
 
     name: str
     evaluator: ObjectCapabilityEvaluator
     batch_evaluator: BatchCapabilityEvaluator | None = None
+    description: str | None = None
 
 
 def object_capability(
@@ -32,12 +41,22 @@ def object_capability(
     evaluator: ObjectCapabilityEvaluator,
     *,
     batch_evaluator: BatchCapabilityEvaluator | None = None,
+    description: str | None = None,
 ) -> GraphQLPermissionCapability:
-    """Declare a domain-specific object capability."""
+    """
+    Declare a domain-specific GraphQL capability for one resolved object.
+
+    Use this helper when the capability is a business rule that does not map
+    directly to a generated CRUD mutation or custom mutation permission. The
+    evaluator is called with ``(instance, user)`` and should return a boolean.
+    Provide ``batch_evaluator`` for list pages to avoid repeated per-row policy
+    work, and ``description`` to document the generated GraphQL field.
+    """
     return GraphQLPermissionCapability(
         name=name,
         evaluator=evaluator,
         batch_evaluator=batch_evaluator,
+        description=description or _object_capability_description(name),
     )
 
 
@@ -47,8 +66,22 @@ def permission_capability(
     *,
     name: str | None = None,
     payload: CapabilityPayload | None = None,
+    description: str | None = None,
 ) -> GraphQLPermissionCapability:
-    """Declare a capability backed by a manager Permission CRUD check."""
+    """
+    Declare a GraphQL capability backed by a manager ``Permission`` CRUD check.
+
+    The generated capability previews the same permission method used by the
+    corresponding generated mutation: create delegates to
+    ``check_create_permission``, update to ``check_update_permission``, and
+    delete to ``check_delete_permission``. Pass ``payload`` when create or
+    update checks need proposed field values from the current object context.
+    ``payload`` may be a mapping or a callable receiving ``(instance, user)``:
+    ``instance`` is the object whose GraphQL ``capabilities`` field is being
+    resolved, and ``user`` is the authenticated request user after the standard
+    permission user lookup. The resolved mapping is passed unchanged to create
+    and update permission checks; delete checks ignore it.
+    """
     capability_name = name or _default_capability_name(action, target)
 
     def evaluator(instance: Any, user: Any) -> bool:
@@ -68,16 +101,31 @@ def permission_capability(
             return False
         return True
 
-    return object_capability(capability_name, evaluator)
+    return object_capability(
+        capability_name,
+        evaluator,
+        description=description or _permission_capability_description(action, target),
+    )
 
 
 def mutation_capability(
-    mutation: type[Any],
+    mutation: Any,
     *,
     name: str | None = None,
     payload: CapabilityPayload | None = None,
+    description: str | None = None,
 ) -> GraphQLPermissionCapability:
-    """Declare a capability backed by a custom MutationPermission class."""
+    """
+    Declare a GraphQL capability backed by a custom mutation permission.
+
+    The capability calls the mutation's configured ``MutationPermission`` with a
+    resolved payload and returns whether the current user would pass that check.
+    Use it when a boolean field should preview a custom GraphQL action rather
+    than generated manager create, update, or delete behavior. ``payload`` may
+    be a mapping or a callable receiving ``(instance, user)``: ``instance`` is
+    the object whose GraphQL ``capabilities`` field is being resolved, and the
+    returned mapping is passed to the mutation permission's ``check`` method.
+    """
     capability_name = name or _lower_camel(getattr(mutation, "__name__", "mutation"))
 
     def evaluator(instance: Any, user: Any) -> bool:
@@ -93,7 +141,11 @@ def mutation_capability(
             return False
         return True
 
-    return object_capability(capability_name, evaluator)
+    return object_capability(
+        capability_name,
+        evaluator,
+        description=description or _mutation_capability_description(mutation),
+    )
 
 
 class CapabilityEvaluationContext:
@@ -257,6 +309,34 @@ def _resolve_payload(
 
 def _default_capability_name(action: str, target: type[Any]) -> str:
     return _lower_camel(f"{action}_{target.__name__}")
+
+
+def _object_capability_description(name: str) -> str:
+    return (
+        f"Whether the current user has the {name} capability for this object. "
+        "This is an advisory UI hint; backend permissions still enforce the action."
+    )
+
+
+def _permission_capability_description(
+    action: CapabilityAction,
+    target: type[Any],
+) -> str:
+    manager_name = getattr(target, "__name__", "manager")
+    return (
+        f"Whether the current user would pass the {manager_name} {action} "
+        "permission check for this object context. This is an advisory UI hint; "
+        "the mutation still enforces backend permissions."
+    )
+
+
+def _mutation_capability_description(mutation: Any) -> str:
+    mutation_name = getattr(mutation, "__name__", "mutation")
+    return (
+        f"Whether the current user would pass the {mutation_name} mutation "
+        "permission check for this object context. This is an advisory UI hint; "
+        "the mutation still enforces backend permissions."
+    )
 
 
 def _lower_camel(value: str) -> str:

--- a/tests/unit/test_graphql_permission_capabilities.py
+++ b/tests/unit/test_graphql_permission_capabilities.py
@@ -58,6 +58,51 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
 
         self.assertIs(public_helper, object_capability)
 
+    def test_object_capability_uses_custom_description(self) -> None:
+        """
+        Verify object capability declarations preserve explicit GraphQL descriptions.
+        """
+        declaration = object_capability(
+            "canRename",
+            lambda _instance, _user: True,
+            description="Whether the current user can rename this draft project.",
+        )
+
+        self.assertEqual(
+            declaration.description,
+            "Whether the current user can rename this draft project.",
+        )
+
+    def test_capability_helpers_provide_default_descriptions(self) -> None:
+        """
+        Verify GraphQL capability helpers produce descriptive schema text by default.
+        """
+
+        class Project:
+            """Manager stub used to derive permission capability descriptions."""
+
+            pass
+
+        def archive_project() -> None:
+            """Mutation stub used to derive mutation capability descriptions."""
+
+        object_declaration = object_capability(
+            "canRename",
+            lambda _instance, _user: True,
+        )
+        permission_declaration = permission_capability(Project, "update")
+        mutation_declaration = mutation_capability(archive_project)
+
+        self.assertIn("canRename capability", object_declaration.description or "")
+        self.assertIn(
+            "Project update permission check",
+            permission_declaration.description or "",
+        )
+        self.assertIn(
+            "archive_project mutation permission check",
+            mutation_declaration.description or "",
+        )
+
     def test_object_capability_evaluates_once_per_operation_cache_key(self) -> None:
         """
         Verify object capability results are cached per operation identity.
@@ -523,7 +568,11 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
 
             pass
 
-        declaration = object_capability("canView", lambda _instance, _user: True)
+        declaration = object_capability(
+            "canView",
+            lambda _instance, _user: True,
+            description="Whether the current user can view this project.",
+        )
         GraphQL.reset_registry()
         try:
             capability_type = GraphQL._get_or_create_capability_type(
@@ -540,6 +589,10 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
             )
 
             self.assertIs(capability_type, cached_type)
+            self.assertEqual(
+                capability_type._meta.fields["canView"].description,
+                "Whether the current user can view this project.",
+            )
             self.assertTrue(
                 resolver({"instance": DummyManager({"code": "ALPHA"})}, info)
             )
@@ -556,6 +609,7 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
         declaration = object_capability(
             "canViewProfile",
             lambda current_user, request_user: current_user is request_user,
+            description="Whether the current user can view this profile.",
         )
         GraphQL.reset_registry()
         try:
@@ -571,6 +625,10 @@ class GraphQLPermissionCapabilityTests(SimpleTestCase):
             )
 
             self.assertIs(capability_type, cached_type)
+            self.assertEqual(
+                capability_type._meta.fields["canViewProfile"].description,
+                "Whether the current user can view this profile.",
+            )
             self.assertTrue(resolver({"instance": user}, info))
         finally:
             GraphQL.reset_registry()


### PR DESCRIPTION
## Summary

- Add descriptive metadata to GraphQL permission capability declarations and expose it through generated Graphene fields.
- Document `description=` usage for capability fields.
- Expand `payload` guidance with concrete mapping/callable examples and explain the `(instance, user)` lambda inputs for permission- and mutation-backed capabilities.
- Add focused tests for default/custom capability descriptions and generated field metadata.

## Validation

- `python -m pytest tests/unit/test_graphql_permission_capabilities.py`
- `ruff check src/general_manager/permission/graphql_capabilities.py src/general_manager/api/graphql.py tests/unit/test_graphql_permission_capabilities.py`
- `ruff format --check src/general_manager/permission/graphql_capabilities.py src/general_manager/api/graphql.py tests/unit/test_graphql_permission_capabilities.py`
- `mypy src/general_manager/permission/graphql_capabilities.py src/general_manager/api/graphql.py tests/unit/test_graphql_permission_capabilities.py`
- commit hooks: ruff, ruff format, EOF/trailing whitespace checks, merge conflict check, debug statement check, mypy
