### PR TITLE
[codex] Expand documentation coverage for public APIs

### DIFF
--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -1,0 +1,13 @@
+# Cache API
+
+::: general_manager.cache.cache_decorator.cached
+
+::: general_manager.cache.cache_decorator.CacheBackend
+
+::: general_manager.cache.cache_tracker.DependencyTracker
+
+::: general_manager.cache.dependency_index.record_dependencies
+
+::: general_manager.cache.dependency_index.invalidate_cache_key
+
+::: general_manager.cache.dependency_index.remove_cache_key_from_index

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -2,12 +2,28 @@
 
 ::: general_manager.manager.general_manager.GeneralManager
 
-::: general_manager.bucket.base_bucket.Bucket
-
-::: general_manager.bucket.database_bucket.DatabaseBucket
+::: general_manager.manager.meta.GeneralManagerMeta
 
 ::: general_manager.manager.group_manager.GroupManager
 
 ::: general_manager.manager.input.Input
 
+::: general_manager.manager.input.InputDomain
+
+::: general_manager.manager.input.NumericRangeDomain
+
+::: general_manager.manager.input.DateRangeDomain
+
+::: general_manager.bucket.base_bucket.Bucket
+
+::: general_manager.bucket.database_bucket.DatabaseBucket
+
+::: general_manager.bucket.group_bucket.GroupBucket
+
+::: general_manager.bucket.calculation_bucket.CalculationBucket
+
+::: general_manager.bucket.request_bucket.RequestBucket
+
 ::: general_manager.rule.rule.Rule
+
+::: general_manager.rule.handler.BaseRuleHandler

--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -1,0 +1,37 @@
+# Factory API
+
+::: general_manager.factory.auto_factory.AutoFactory
+
+::: general_manager.factory.factory_methods.lazy_measurement
+
+::: general_manager.factory.factory_methods.lazy_delta_date
+
+::: general_manager.factory.factory_methods.lazy_project_name
+
+::: general_manager.factory.factory_methods.lazy_date_today
+
+::: general_manager.factory.factory_methods.lazy_date_between
+
+::: general_manager.factory.factory_methods.lazy_date_time_between
+
+::: general_manager.factory.factory_methods.lazy_integer
+
+::: general_manager.factory.factory_methods.lazy_decimal
+
+::: general_manager.factory.factory_methods.lazy_choice
+
+::: general_manager.factory.factory_methods.lazy_sequence
+
+::: general_manager.factory.factory_methods.lazy_boolean
+
+::: general_manager.factory.factory_methods.lazy_uuid
+
+::: general_manager.factory.factory_methods.lazy_faker_name
+
+::: general_manager.factory.factory_methods.lazy_faker_email
+
+::: general_manager.factory.factory_methods.lazy_faker_sentence
+
+::: general_manager.factory.factory_methods.lazy_faker_address
+
+::: general_manager.factory.factory_methods.lazy_faker_url

--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -1,0 +1,31 @@
+# GraphQL API
+
+::: general_manager.api.graphql.GraphQL
+
+::: general_manager.api.graphql.MeasurementType
+
+::: general_manager.api.graphql.MeasurementScalar
+
+::: general_manager.api.graphql.BigIntScalar
+
+::: general_manager.api.mutation.graph_ql_mutation
+
+::: general_manager.api.property.graph_ql_property
+
+::: general_manager.api.registry.GraphQLRegistry
+
+::: general_manager.api.graphql_view.GeneralManagerGraphQLView
+
+::: general_manager.api.graphql.SubscriptionEvent
+
+::: general_manager.api.graphql_subscription_consumer.GraphQLSubscriptionConsumer
+
+::: general_manager.api.remote_invalidation_client.RemoteInvalidationClient
+
+::: general_manager.api.remote_invalidation.emit_remote_invalidation
+
+::: general_manager.api.remote_api.RemoteAPIConfig
+
+::: general_manager.api.remote_api.add_remote_api_urls
+
+::: general_manager.api.remote_api.clear_remote_api_urls

--- a/docs/api/interface.md
+++ b/docs/api/interface.md
@@ -21,3 +21,89 @@
 ::: general_manager.interface.capabilities.calculation.lifecycle
 
 ::: general_manager.interface.capabilities.existing_model.resolution
+
+## Request Interfaces
+
+::: general_manager.interface.requests.RequestField
+
+::: general_manager.interface.requests.RequestFilter
+
+::: general_manager.interface.requests.RequestQueryOperation
+
+::: general_manager.interface.requests.RequestMutationOperation
+
+::: general_manager.interface.requests.RequestQueryPlan
+
+::: general_manager.interface.requests.RequestQueryResult
+
+::: general_manager.interface.requests.SharedRequestTransport
+
+::: general_manager.interface.requests.UrllibRequestTransport
+
+::: general_manager.interface.requests.RequestTransportConfig
+
+::: general_manager.interface.requests.RequestRetryPolicy
+
+::: general_manager.interface.requests.RequestTransportRequest
+
+::: general_manager.interface.requests.RequestTransportResponse
+
+::: general_manager.interface.requests.RequestAuthProvider
+
+::: general_manager.interface.requests.BearerTokenAuthProvider
+
+::: general_manager.interface.requests.HeaderApiKeyAuthProvider
+
+::: general_manager.interface.requests.QueryApiKeyAuthProvider
+
+::: general_manager.interface.requests.BasicAuthProvider
+
+::: general_manager.interface.requests.FieldMappingSerializer
+
+::: general_manager.interface.requests.RequestMetricsBackend
+
+::: general_manager.interface.requests.NoopRequestMetricsBackend
+
+::: general_manager.interface.requests.RequestTraceBackend
+
+::: general_manager.interface.requests.NoopRequestTraceBackend
+
+## Request Errors
+
+::: general_manager.interface.requests.RequestRemoteError
+
+::: general_manager.interface.requests.RequestTransportError
+
+::: general_manager.interface.requests.RequestTransportStatusError
+
+::: general_manager.interface.requests.RequestAuthenticationError
+
+::: general_manager.interface.requests.RequestAuthorizationError
+
+::: general_manager.interface.requests.RequestNotFoundError
+
+::: general_manager.interface.requests.RequestConflictError
+
+::: general_manager.interface.requests.RequestRateLimitedError
+
+::: general_manager.interface.requests.RequestSchemaError
+
+::: general_manager.interface.requests.RequestServerError
+
+## Interface Infrastructure
+
+::: general_manager.interface.infrastructure.startup_hooks.register_startup_hook
+
+::: general_manager.interface.infrastructure.startup_hooks.iter_interface_startup_hooks
+
+::: general_manager.interface.infrastructure.startup_hooks.registered_startup_hooks
+
+::: general_manager.interface.infrastructure.startup_hooks.registered_startup_hook_entries
+
+::: general_manager.interface.infrastructure.startup_hooks.order_interfaces_by_dependency
+
+::: general_manager.interface.infrastructure.system_checks.register_system_check
+
+::: general_manager.interface.infrastructure.system_checks.iter_interface_system_checks
+
+::: general_manager.interface.infrastructure.system_checks.registered_system_checks

--- a/docs/api/interface.md
+++ b/docs/api/interface.md
@@ -28,11 +28,15 @@
 
 ::: general_manager.interface.requests.RequestFilter
 
-::: general_manager.interface.requests.RequestQueryOperation
+::: general_manager.interface.requests.RequestOperation
+
+`RequestQueryOperation` is the public query-operation alias for `RequestOperation`.
 
 ::: general_manager.interface.requests.RequestMutationOperation
 
-::: general_manager.interface.requests.RequestQueryPlan
+::: general_manager.interface.requests.RequestPlan
+
+`RequestQueryPlan` is the public query-plan alias for `RequestPlan`.
 
 ::: general_manager.interface.requests.RequestQueryResult
 

--- a/docs/api/measurement.md
+++ b/docs/api/measurement.md
@@ -3,3 +3,7 @@
 ::: general_manager.measurement.measurement.Measurement
 
 ::: general_manager.measurement.measurement_field.MeasurementField
+
+::: general_manager.measurement.measurement.ureg
+
+::: general_manager.measurement.measurement.currency_units

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -13,3 +13,7 @@
 ::: general_manager.metrics.graphql.get_graphql_metrics_backend
 
 ::: general_manager.metrics.graphql.build_graphql_middleware
+
+::: general_manager.metrics.graphql.graphql_metrics_enabled
+
+::: general_manager.metrics.graphql.graphql_metrics_resolver_timing_enabled

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -1,0 +1,15 @@
+# Metrics API
+
+::: general_manager.metrics.graphql.GraphQLMetricsBackend
+
+::: general_manager.metrics.graphql.GraphQLMetricsSettings
+
+::: general_manager.metrics.graphql.NoopGraphQLMetricsBackend
+
+::: general_manager.metrics.graphql.PrometheusGraphQLMetricsBackend
+
+::: general_manager.metrics.graphql.GraphQLResolverTimingMiddleware
+
+::: general_manager.metrics.graphql.get_graphql_metrics_backend
+
+::: general_manager.metrics.graphql.build_graphql_middleware

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -1,0 +1,45 @@
+# Search API
+
+::: general_manager.search.config.FieldConfig
+
+::: general_manager.search.config.IndexConfig
+
+::: general_manager.search.config.SearchConfigProtocol
+
+::: general_manager.search.config.SearchConfigSpec
+
+::: general_manager.search.config.resolve_search_config
+
+::: general_manager.search.config.iter_index_names
+
+::: general_manager.search.backend.SearchDocument
+
+::: general_manager.search.backend.SearchHit
+
+::: general_manager.search.backend.SearchResult
+
+::: general_manager.search.backend.SearchBackend
+
+::: general_manager.search.backend.SearchBackendError
+
+::: general_manager.search.backend.SearchBackendNotConfiguredError
+
+::: general_manager.search.backend.SearchBackendNotImplementedError
+
+::: general_manager.search.backend.SearchBackendClientMissingError
+
+::: general_manager.search.backend_registry.configure_search_backend
+
+::: general_manager.search.backend_registry.configure_search_backend_from_settings
+
+::: general_manager.search.backend_registry.get_search_backend
+
+::: general_manager.search.indexer.SearchIndexer
+
+::: general_manager.search.backends.dev.DevSearchBackend
+
+::: general_manager.search.backends.meilisearch.MeilisearchBackend
+
+::: general_manager.search.backends.opensearch.OpenSearchBackend
+
+::: general_manager.search.backends.typesense.TypesenseBackend

--- a/docs/api/seeding.md
+++ b/docs/api/seeding.md
@@ -1,5 +1,13 @@
 # Seeding API
 
+::: general_manager.seeding.manager_landscape.InvalidSeedTargetError
+
+::: general_manager.seeding.manager_landscape.ManagerSelectionError
+
+::: general_manager.seeding.manager_landscape.SeedableManagerCollisionError
+
+::: general_manager.seeding.manager_landscape.ManagerSeedFailure
+
 ::: general_manager.seeding.manager_landscape.SeedTarget
 
 ::: general_manager.seeding.manager_landscape.SeedPlanRow

--- a/docs/api/seeding.md
+++ b/docs/api/seeding.md
@@ -1,0 +1,21 @@
+# Seeding API
+
+::: general_manager.seeding.manager_landscape.SeedTarget
+
+::: general_manager.seeding.manager_landscape.SeedPlanRow
+
+::: general_manager.seeding.manager_landscape.SeedFailure
+
+::: general_manager.seeding.manager_landscape.SeedExecutionResult
+
+::: general_manager.seeding.manager_landscape.parse_target_overrides
+
+::: general_manager.seeding.manager_landscape.discover_seedable_managers
+
+::: general_manager.seeding.manager_landscape.select_seed_targets
+
+::: general_manager.seeding.manager_landscape.order_targets_by_dependencies
+
+::: general_manager.seeding.manager_landscape.build_seed_plan
+
+::: general_manager.seeding.manager_landscape.execute_seed_plan

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,23 @@
+# Utilities API
+
+::: general_manager.utils.none_to_zero.none_to_zero
+
+::: general_manager.utils.args_to_kwargs.args_to_kwargs
+
+::: general_manager.utils.make_cache_key.make_cache_key
+
+::: general_manager.utils.filter_parser.parse_filters
+
+::: general_manager.utils.filter_parser.create_filter_function
+
+::: general_manager.utils.format_string.snake_to_pascal
+
+::: general_manager.utils.format_string.snake_to_camel
+
+::: general_manager.utils.format_string.pascal_to_snake
+
+::: general_manager.utils.format_string.camel_to_snake
+
+::: general_manager.utils.json_encoder.CustomJSONEncoder
+
+::: general_manager.utils.path_mapping.PathMap

--- a/docs/api/workflow.md
+++ b/docs/api/workflow.md
@@ -1,6 +1,6 @@
 # Workflow API
 
-::: general_manager.workflow.events.WorkflowEvent
+::: general_manager.workflow.event_registry.WorkflowEvent
 
 ::: general_manager.workflow.events.manager_created_event
 
@@ -49,15 +49,3 @@
 ::: general_manager.workflow.backends.celery.CeleryWorkflowEngine
 
 ::: general_manager.workflow.backends.n8n.N8nWorkflowEngine
-
-::: general_manager.workflow.tasks.publish_outbox_batch
-
-::: general_manager.workflow.tasks.route_outbox_event
-
-::: general_manager.workflow.tasks.route_outbox_claims_batch
-
-::: general_manager.workflow.tasks.execute_workflow_handler
-
-::: general_manager.workflow.tasks.resume_execution_task
-
-::: general_manager.workflow.tasks.cancel_execution_task

--- a/docs/api/workflow.md
+++ b/docs/api/workflow.md
@@ -2,6 +2,14 @@
 
 ::: general_manager.workflow.event_registry.WorkflowEvent
 
+::: general_manager.workflow.event_registry.WorkflowEventHandler
+
+::: general_manager.workflow.event_registry.EventPredicate
+
+::: general_manager.workflow.event_registry.DeadLetterHandler
+
+::: general_manager.workflow.event_registry.RetryPredicate
+
 ::: general_manager.workflow.events.manager_created_event
 
 ::: general_manager.workflow.events.manager_updated_event
@@ -20,11 +28,15 @@
 
 ::: general_manager.workflow.event_registry.get_event_registry
 
+::: general_manager.workflow.event_registry.publish_sync
+
 ::: general_manager.workflow.engine.WorkflowDefinition
 
 ::: general_manager.workflow.engine.WorkflowExecution
 
 ::: general_manager.workflow.engine.WorkflowEngine
+
+::: general_manager.workflow.engine.WorkflowState
 
 ::: general_manager.workflow.engine.WorkflowEngineError
 
@@ -36,6 +48,12 @@
 
 ::: general_manager.workflow.actions.Action
 
+::: general_manager.workflow.actions.ActionAlreadyRegisteredError
+
+::: general_manager.workflow.actions.ActionExecutionError
+
+::: general_manager.workflow.actions.ActionNotFoundError
+
 ::: general_manager.workflow.actions.ActionRegistry
 
 ::: general_manager.workflow.backend_registry.configure_workflow_engine
@@ -43,6 +61,12 @@
 ::: general_manager.workflow.backend_registry.configure_workflow_engine_from_settings
 
 ::: general_manager.workflow.backend_registry.get_workflow_engine
+
+::: general_manager.workflow.signal_bridge.configure_workflow_signal_bridge_from_settings
+
+::: general_manager.workflow.signal_bridge.connect_workflow_signal_bridge
+
+::: general_manager.workflow.signal_bridge.disconnect_workflow_signal_bridge
 
 ::: general_manager.workflow.backends.local.LocalWorkflowEngine
 

--- a/docs/api/workflow.md
+++ b/docs/api/workflow.md
@@ -1,0 +1,63 @@
+# Workflow API
+
+::: general_manager.workflow.events.WorkflowEvent
+
+::: general_manager.workflow.events.manager_created_event
+
+::: general_manager.workflow.events.manager_updated_event
+
+::: general_manager.workflow.events.manager_deleted_event
+
+::: general_manager.workflow.event_registry.EventRegistry
+
+::: general_manager.workflow.event_registry.InMemoryEventRegistry
+
+::: general_manager.workflow.event_registry.DatabaseEventRegistry
+
+::: general_manager.workflow.event_registry.configure_event_registry
+
+::: general_manager.workflow.event_registry.configure_event_registry_from_settings
+
+::: general_manager.workflow.event_registry.get_event_registry
+
+::: general_manager.workflow.engine.WorkflowDefinition
+
+::: general_manager.workflow.engine.WorkflowExecution
+
+::: general_manager.workflow.engine.WorkflowEngine
+
+::: general_manager.workflow.engine.WorkflowEngineError
+
+::: general_manager.workflow.engine.WorkflowExecutionNotFoundError
+
+::: general_manager.workflow.engine.WorkflowCancelledError
+
+::: general_manager.workflow.engine.WorkflowInvalidStateError
+
+::: general_manager.workflow.actions.Action
+
+::: general_manager.workflow.actions.ActionRegistry
+
+::: general_manager.workflow.backend_registry.configure_workflow_engine
+
+::: general_manager.workflow.backend_registry.configure_workflow_engine_from_settings
+
+::: general_manager.workflow.backend_registry.get_workflow_engine
+
+::: general_manager.workflow.backends.local.LocalWorkflowEngine
+
+::: general_manager.workflow.backends.celery.CeleryWorkflowEngine
+
+::: general_manager.workflow.backends.n8n.N8nWorkflowEngine
+
+::: general_manager.workflow.tasks.publish_outbox_batch
+
+::: general_manager.workflow.tasks.route_outbox_event
+
+::: general_manager.workflow.tasks.route_outbox_claims_batch
+
+::: general_manager.workflow.tasks.execute_workflow_handler
+
+::: general_manager.workflow.tasks.resume_execution_task
+
+::: general_manager.workflow.tasks.cancel_execution_task

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -96,6 +96,15 @@ def project_forecast(project_id: int) -> dict[str, float]:
 ```
 When `timeout` is set, the cache entry expires after the given duration no matter if the tracked dependencies change.
 
+## Manual dependency-index helpers
+
+Most application code should rely on CRUD signals and the `cached` decorator. For integration code and tests, the cache module also exposes lower-level dependency-index helpers:
+
+- `record_dependencies(cache_key, dependencies)` stores the dependency set for an already-computed cache entry.
+- `invalidate_cache_key(cache_key)` invalidates one cache key without recalculating dependency matches.
+- `remove_cache_key_from_index(cache_key)` removes dependency-index metadata for a key that should no longer participate in invalidation.
+
+These helpers are intentionally lower level than `cached`. Use them when building a custom cache backend or verifying invalidation behavior, not as the default application caching API.
 
 ## Recommended practices
 

--- a/docs/concepts/factories/index.md
+++ b/docs/concepts/factories/index.md
@@ -9,7 +9,7 @@ Use factories to populate development databases, seed GraphQL demos, or reproduc
 
 ## Lazy factory helpers
 
-The `general_manager.factory` module exports lazy helper functions for common generated values. They are intended for `AutoFactory` definitions and custom factory declarations where a field value should be generated at object creation time rather than module import time.
+The `general_manager.factory` module exports helper functions that return factory declarations and lazy values for common generated defaults. They are intended for `AutoFactory` definitions and custom factory declarations; when a generated component must vary per object, make that variation explicit in the factory attribute instead of relying on unset helper arguments.
 
 Use the helpers by value category:
 

--- a/docs/concepts/factories/index.md
+++ b/docs/concepts/factories/index.md
@@ -6,3 +6,18 @@ Factories help you create realistic test data for managers. GeneralManager integ
 - [Validation and clean hooks](validation_clean.md)
 
 Use factories to populate development databases, seed GraphQL demos, or reproduce edge cases quickly.
+
+## Lazy factory helpers
+
+The `general_manager.factory` module exports lazy helper functions for common generated values. They are intended for `AutoFactory` definitions and custom factory declarations where a field value should be generated at object creation time rather than module import time.
+
+Use the helpers by value category:
+
+- Dates and times: `lazy_date_today`, `lazy_date_between`, `lazy_date_time_between`, and `lazy_delta_date`.
+- Numbers and choices: `lazy_integer`, `lazy_decimal`, `lazy_choice`, `lazy_sequence`, and `lazy_boolean`.
+- Identifiers and text: `lazy_uuid`, `lazy_project_name`, `lazy_faker_name`, `lazy_faker_email`, `lazy_faker_sentence`, `lazy_faker_address`, and `lazy_faker_url`.
+- Measurements: `lazy_measurement` creates `Measurement` values compatible with measurement-backed fields.
+
+Prefer explicit factory attributes when a test needs a specific value. Use lazy helpers for realistic defaults, demo data, and load-test data where exact values are not the assertion target.
+
+See the [Factory API reference](../../api/factory.md) for signatures.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -6,6 +6,7 @@ The concept guides explain the building blocks that power GeneralManager. They p
 - [Domain modelling](models_entities.md) explores how to shape managers, buckets, and grouping utilities.
 - [Caching](caching.md) and [rule validation](rules_validation.md) discuss cross-cutting features that keep data fresh and trustworthy.
 - [Workflow](workflow.md) explains event routing, workflow engines, outbox delivery, and operational state.
+- [Public utilities](utils.md) describes exported helper functions for naming, filtering, JSON encoding, cache keys, and path mapping.
 - [Measurement handling](measurement/index.md), [permissions](permission/index.md), [interfaces](interfaces/index.md), [GraphQL](graphql/index.md), and [factories & testing](factories/index.md) provide deep dives into their respective subsystems.
 - [Seeding](seeding.md) explains dependency-aware manager landscape generation for demos, tests, and local development.
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -7,5 +7,6 @@ The concept guides explain the building blocks that power GeneralManager. They p
 - [Caching](caching.md) and [rule validation](rules_validation.md) discuss cross-cutting features that keep data fresh and trustworthy.
 - [Workflow](workflow.md) explains event routing, workflow engines, outbox delivery, and operational state.
 - [Measurement handling](measurement/index.md), [permissions](permission/index.md), [interfaces](interfaces/index.md), [GraphQL](graphql/index.md), and [factories & testing](factories/index.md) provide deep dives into their respective subsystems.
+- [Seeding](seeding.md) explains dependency-aware manager landscape generation for demos, tests, and local development.
 
 Use this section as a map; each page links to tutorials and API references relevant to the topic.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -5,6 +5,7 @@ The concept guides explain the building blocks that power GeneralManager. They p
 - [Core architecture](architecture.md) covers managers, buckets, dependency tracking, and the runtime lifecycle.
 - [Domain modelling](models_entities.md) explores how to shape managers, buckets, and grouping utilities.
 - [Caching](caching.md) and [rule validation](rules_validation.md) discuss cross-cutting features that keep data fresh and trustworthy.
+- [Workflow](workflow.md) explains event routing, workflow engines, outbox delivery, and operational state.
 - [Measurement handling](measurement/index.md), [permissions](permission/index.md), [interfaces](interfaces/index.md), [GraphQL](graphql/index.md), and [factories & testing](factories/index.md) provide deep dives into their respective subsystems.
 
 Use this section as a map; each page links to tutorials and API references relevant to the topic.

--- a/docs/concepts/models_entities.md
+++ b/docs/concepts/models_entities.md
@@ -30,6 +30,17 @@ All collection-returning APIs produce a `Bucket`. Buckets behave like Python ite
 - Slice (`bucket[0:10]`) or iterate lazily.
 - Merge buckets with the union operator (`bucket_a | bucket_b`).
 
+### Bucket variants
+
+`Bucket` is the common collection contract. Concrete bucket types preserve the source and evaluation semantics of the managers they contain:
+
+- `DatabaseBucket` wraps ORM-backed manager queries and supports database-side filtering, ordering, slicing, grouping, and dependency tracking.
+- `RequestBucket` represents request-backed manager collections. It compiles declared request filters into a remote request plan and keeps remote pagination and local fallback behavior explicit.
+- `CalculationBucket` evaluates calculation interfaces across compatible input domains and tracks dependencies from the buckets or managers feeding the calculation.
+- `GroupBucket` holds grouped bucket results from `group_by(...)`; each group key points to the bucket slice that belongs to that group.
+
+Most application code should depend on the shared bucket behavior returned by manager APIs. Reach for a concrete bucket type only when documenting source-specific behavior, testing evaluation semantics, or extending an interface.
+
 ### Grouped data
 
 Use `group_by()` to aggregate managers into `GroupedManager` instances. Grouped managers expose the grouping key and aggregate the remaining attributes according to their type (e.g., summing numbers, merging lists). See the example in [Cookbook: Volume curve](../examples/project_volume_curve.md).

--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -205,6 +205,18 @@ without running `search_index --reindex` manually.
 
 ## Backends
 
+### Backend contract and result models
+
+`SearchBackend` is the extension point for adapters. Backends receive index names, queries, filters, sorting, and pagination options, then return a `SearchResult`.
+
+Search result models have stable responsibilities:
+
+- `SearchDocument` is the indexed payload, including the type label, identification mapping, and data fields.
+- `SearchHit` is one matched document plus score and raw backend metadata.
+- `SearchResult` is the paginated response containing hits, totals, timing, and raw backend payloads.
+
+The backend registry functions `configure_search_backend`, `configure_search_backend_from_settings`, and `get_search_backend` centralize adapter selection so GraphQL, indexing tasks, and direct Python usage share the same backend instance.
+
 ### DevSearch backend (service-free)
 
 For local development, the built-in DevSearch backend stores documents in

--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -212,10 +212,10 @@ without running `search_index --reindex` manually.
 Search result models have stable responsibilities:
 
 - `SearchDocument` is the indexed payload, including the type label, identification mapping, and data fields.
-- `SearchHit` is one matched document plus score and raw backend metadata.
+- `SearchHit` is one matched document reference with its type label, identification mapping, optional score, index name, and returned data fields.
 - `SearchResult` is the paginated response containing hits, totals, timing, and raw backend payloads.
 
-The backend registry functions `configure_search_backend`, `configure_search_backend_from_settings`, and `get_search_backend` centralize adapter selection so GraphQL, indexing tasks, and direct Python usage share the same backend instance.
+The backend registry functions `configure_search_backend`, `configure_search_backend_from_settings`, and `get_search_backend` centralize adapter selection and lookup for GraphQL, indexing tasks, and direct Python usage, with same-process backend reuse where applicable.
 
 ### DevSearch backend (service-free)
 

--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -211,9 +211,9 @@ without running `search_index --reindex` manually.
 
 Search result models have stable responsibilities:
 
-- `SearchDocument` is the indexed payload, including the type label, identification mapping, and data fields.
-- `SearchHit` is one matched document reference with its type label, identification mapping, optional score, index name, and returned data fields.
-- `SearchResult` is the paginated response containing hits, totals, timing, and raw backend payloads.
+- `SearchDocument` represents the indexed payload, including the type label, identification mapping, and data fields.
+- `SearchHit` denotes one matched document reference with its type label, identification mapping, optional score, index name, and returned data fields.
+- `SearchResult` contains the paginated response with hits, totals, timing, and raw backend payloads.
 
 The backend registry functions `configure_search_backend`, `configure_search_backend_from_settings`, and `get_search_backend` centralize adapter selection and lookup for GraphQL, indexing tasks, and direct Python usage, with same-process backend reuse where applicable.
 

--- a/docs/concepts/seeding.md
+++ b/docs/concepts/seeding.md
@@ -1,0 +1,30 @@
+# Seeding
+
+GeneralManager seeding builds local, demo, and test data from managers that expose factories. It is dependency-aware enough to order selected managers by interface relationships, but explicit enough that it does not silently create unrelated data.
+
+## Seedable managers
+
+A manager is seedable when it exposes `Factory.create_batch`. Discovery is based on registered GeneralManager classes, then filtered to managers with that factory capability.
+
+## Targets and minimum counts
+
+Seed targets are minimum desired row counts. If a target asks for 10 `Project` rows and 12 already exist, seeding creates nothing for `Project`. If only 4 exist, it creates 6.
+
+Use `--target ManagerName=COUNT` to override the default count for one selected manager.
+
+## Dependency ordering
+
+The seeding planner orders selected managers so required database relations are created first when both sides are selected. It does not automatically add missing dependency managers. Select dependent managers explicitly when a factory expects related rows to exist.
+
+## Batching and failures
+
+`--batch-size` controls how many rows are created per transaction. By default, seeding stops on the first failure and reports the manager and batch size. With `--continue-on-error`, later managers continue and the final result includes partial progress and failures.
+
+## Dry runs
+
+Use `--dry-run` to inspect the selected managers, target counts, and missing dependencies without writing data.
+
+## Related references
+
+- [Bulk factory generation](../howto/factory_bulk_generate.md)
+- [Seeding API reference](../api/seeding.md)

--- a/docs/concepts/utils.md
+++ b/docs/concepts/utils.md
@@ -8,7 +8,7 @@ Use `snake_to_pascal`, `snake_to_camel`, `pascal_to_snake`, and `camel_to_snake`
 
 ## Filter helpers
 
-`parse_filters` and `create_filter_function` parse simple filter expressions into callable predicates. They are useful for tests, in-memory filtering, and adapter code. Prefer manager `filter()` and `exclude()` APIs for normal application queries.
+`parse_filters` parses simple filter expressions into structured criteria used by filtering helpers, including `filter_kwargs` for `GeneralManager`-typed fields. `create_filter_function` builds callable predicates for in-memory and filter-helper use where appropriate. Prefer manager `filter()` and `exclude()` APIs for normal application queries.
 
 ## Serialization and cache keys
 

--- a/docs/concepts/utils.md
+++ b/docs/concepts/utils.md
@@ -1,0 +1,21 @@
+# Public Utilities
+
+GeneralManager exposes a small set of utility helpers for projects that need the same parsing, formatting, JSON encoding, or cache-key behavior used internally by the package.
+
+## Naming helpers
+
+Use `snake_to_pascal`, `snake_to_camel`, `pascal_to_snake`, and `camel_to_snake` when project code needs to match GeneralManager's GraphQL and Python naming conventions.
+
+## Filter helpers
+
+`parse_filters` and `create_filter_function` parse simple filter expressions into callable predicates. They are useful for tests, in-memory filtering, and adapter code. Prefer manager `filter()` and `exclude()` APIs for normal application queries.
+
+## Serialization and cache keys
+
+`CustomJSONEncoder` serializes package-specific values such as measurements for JSON payloads. `make_cache_key` builds deterministic cache keys for values that need to align with GeneralManager cache behavior.
+
+## Path mapping and small transforms
+
+`PathMap` supports nested path mapping where integrations need stable source-to-target field paths. `args_to_kwargs` and `none_to_zero` are small compatibility helpers kept public for callers that need package-consistent behavior.
+
+See the [Utilities API reference](../api/utils.md) for signatures.

--- a/docs/concepts/workflow.md
+++ b/docs/concepts/workflow.md
@@ -36,9 +36,9 @@ Production mode uses the workflow outbox to claim, route, retry, and dead-letter
 
 ## Backends
 
-- `LocalWorkflowEngine` is the zero-setup development backend.
-- `CeleryWorkflowEngine` is the durable production-oriented backend.
-- `N8nWorkflowEngine` is an adapter stub for future remote orchestration support.
+- For zero-setup development, use `LocalWorkflowEngine`.
+- Durable production-oriented workflows use `CeleryWorkflowEngine`.
+- Future remote orchestration support is represented by the `N8nWorkflowEngine` adapter stub.
 
 Choose the backend in `GENERAL_MANAGER["WORKFLOW_ENGINE"]`, or rely on `WORKFLOW_MODE` defaults when they fit the environment.
 

--- a/docs/concepts/workflow.md
+++ b/docs/concepts/workflow.md
@@ -1,0 +1,49 @@
+# Workflow
+
+GeneralManager workflows connect manager-level events to durable automation. The workflow subsystem is intentionally separate from interface CRUD code: interfaces emit domain changes, event registries route those changes, and workflow engines execute or delegate orchestration.
+
+## Mental model
+
+A workflow has four layers:
+
+1. **Events** describe what happened. Helpers such as `manager_created_event`, `manager_updated_event`, and `manager_deleted_event` produce stable `WorkflowEvent` payloads.
+2. **Registries** route events to handlers. `InMemoryEventRegistry` is useful for local development and tests; `DatabaseEventRegistry` stores durable route state for production-style delivery.
+3. **Engines** execute workflow definitions. `LocalWorkflowEngine` runs in process, while `CeleryWorkflowEngine` persists executions and delegates async work through Celery tasks.
+4. **Actions** centralize reusable side effects behind `ActionRegistry`, so handlers call named operations instead of scattering integration logic.
+
+## Event routing
+
+Handlers can register against canonical event types such as `general_manager.manager.updated` or readable event names such as `manager_updated`. A registration can include a `when` predicate, a validator, retry settings, and a dead-letter callback. The registry isolates handler failures so one failed route does not stop other matching handlers.
+
+## Signal bridge
+
+When `GENERAL_MANAGER["WORKFLOW_SIGNAL_BRIDGE"] = True`, manager create, update, and delete signals are converted into workflow events. This is the automatic path for CRUD-driven automation. Service layers can also publish events explicitly through `get_event_registry().publish(event)` when signal coupling is not the right fit.
+
+## Execution state
+
+Workflow executions move through a bounded state model:
+
+- `pending`, `running`, and `waiting` are active states.
+- `completed`, `failed`, and `cancelled` are terminal states.
+- `resume(...)` is valid only for waiting executions.
+- `cancel(...)` is valid only for active executions.
+
+Use `correlation_id` when the same event should not start duplicate active or completed executions for the same workflow definition.
+
+## Outbox and delivery
+
+Production mode uses the workflow outbox to claim, route, retry, and dead-letter event delivery. The management commands `workflow_drain_outbox` and `workflow_replay_dead_letters` are operational tools for draining pending rows and replaying dead-lettered rows. Celery Beat can drain the outbox periodically when workflow beat settings are enabled.
+
+## Backends
+
+- `LocalWorkflowEngine` is the zero-setup development backend.
+- `CeleryWorkflowEngine` is the durable production-oriented backend.
+- `N8nWorkflowEngine` is an adapter stub for future remote orchestration support.
+
+Choose the backend in `GENERAL_MANAGER["WORKFLOW_ENGINE"]`, or rely on `WORKFLOW_MODE` defaults when they fit the environment.
+
+## Related guides
+
+- [Build workflow event triggers](../howto/workflow_events.md)
+- [Operate workflow outbox/dead letters](../howto/workflow_ops.md)
+- [Workflow API reference](../api/workflow.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
           - concepts/caching.md
           - concepts/search.md
           - concepts/rules_validation.md
+          - concepts/workflow.md
       - Measurement & Currency:
           - concepts/measurement/index.md
           - concepts/measurement/units_currency.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
           - concepts/factories/index.md
           - concepts/factories/performance_caching.md
           - concepts/factories/validation_clean.md
+          - concepts/seeding.md
   - Tutorials:
       - howto/index.md
       - howto/create_project.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
           - concepts/search.md
           - concepts/rules_validation.md
           - concepts/workflow.md
+          - concepts/utils.md
       - Measurement & Currency:
           - concepts/measurement/index.md
           - concepts/measurement/units_currency.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,14 @@ nav:
       - api/measurement.md
       - api/interface.md
       - api/permission.md
+      - api/graphql.md
+      - api/search.md
+      - api/cache.md
+      - api/factory.md
+      - api/workflow.md
+      - api/metrics.md
+      - api/seeding.md
+      - api/utils.md
   - Architecture Decisions:
       - adr/index.md
       - adr/0001-interface-skeletons.md

--- a/src/general_manager/interface/infrastructure/__init__.py
+++ b/src/general_manager/interface/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure registries for interface lifecycle hooks."""

--- a/src/general_manager/workflow/__init__.py
+++ b/src/general_manager/workflow/__init__.py
@@ -23,6 +23,7 @@ from general_manager.workflow.engine import (
 from general_manager.workflow.event_registry import (
     DatabaseEventRegistry,
     EventRegistry,
+    InMemoryEventRegistry,
     WorkflowEvent,
     WorkflowEventHandler,
     EventPredicate,
@@ -54,6 +55,7 @@ __all__ = [
     "DeadLetterHandler",
     "EventPredicate",
     "EventRegistry",
+    "InMemoryEventRegistry",
     "RetryPredicate",
     "WorkflowCancelledError",
     "WorkflowDefinition",

--- a/tests/docs/test_public_api_docs_coverage.py
+++ b/tests/docs/test_public_api_docs_coverage.py
@@ -6,11 +6,27 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SNAPSHOT = ROOT / "tests" / "snapshots" / "public_api_exports.json"
-DOC_PATHS = [ROOT / "README.md", *(ROOT / "docs").rglob("*.md")]
+DOCS_ROOT = ROOT / "docs"
+DOC_PATHS = [
+    ROOT / "README.md",
+    *[
+        path
+        for path in DOCS_ROOT.rglob("*.md")
+        if not path.relative_to(DOCS_ROOT).as_posix().startswith("superpowers/")
+    ],
+]
 
 
 def _docs_text() -> str:
     return "\n".join(path.read_text(encoding="utf-8") for path in DOC_PATHS)
+
+
+def test_unpublished_superpowers_docs_are_excluded_from_docs_corpus() -> None:
+    assert not any(
+        path.relative_to(DOCS_ROOT).as_posix().startswith("superpowers/")
+        for path in DOC_PATHS
+        if path.is_relative_to(DOCS_ROOT)
+    )
 
 
 def test_every_public_export_is_mentioned_in_documentation() -> None:

--- a/tests/docs/test_public_api_docs_coverage.py
+++ b/tests/docs/test_public_api_docs_coverage.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SNAPSHOT = ROOT / "tests" / "snapshots" / "public_api_exports.json"
+DOC_PATHS = [ROOT / "README.md", *(ROOT / "docs").rglob("*.md")]
+
+
+def _docs_text() -> str:
+    return "\n".join(path.read_text(encoding="utf-8") for path in DOC_PATHS)
+
+
+def test_every_public_export_is_mentioned_in_documentation() -> None:
+    exports = json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+    docs_text = _docs_text()
+
+    missing: dict[str, list[str]] = {}
+    for module_name, module_exports in exports.items():
+        missing_names = [
+            export_name
+            for export_name in module_exports
+            if export_name not in docs_text
+        ]
+        if missing_names:
+            missing[module_name] = missing_names
+
+    assert missing == {}

--- a/tests/docs/test_public_api_docs_coverage.py
+++ b/tests/docs/test_public_api_docs_coverage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from importlib import import_module
 from pathlib import Path
 
@@ -25,6 +26,15 @@ DOC_PATHS = [
 
 def _docs_text() -> str:
     return "\n".join(path.read_text(encoding="utf-8") for path in DOC_PATHS)
+
+
+def _mentions_export(docs_text: str, export_name: str) -> bool:
+    return (
+        re.search(
+            rf"(?<![A-Za-z0-9_]){re.escape(export_name)}(?![A-Za-z0-9_])", docs_text
+        )
+        is not None
+    )
 
 
 def _public_exports() -> dict[str, list[str]]:
@@ -56,7 +66,7 @@ def test_every_public_export_is_mentioned_in_documentation() -> None:
         missing_names = [
             export_name
             for export_name in module_exports
-            if export_name not in docs_text
+            if not _mentions_export(docs_text, export_name)
         ]
         if missing_names:
             missing[module_name] = missing_names

--- a/tests/docs/test_public_api_docs_coverage.py
+++ b/tests/docs/test_public_api_docs_coverage.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import json
+from importlib import import_module
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
 SNAPSHOT = ROOT / "tests" / "snapshots" / "public_api_exports.json"
 DOCS_ROOT = ROOT / "docs"
+ADDITIONAL_PUBLIC_MODULES = (
+    "general_manager.workflow",
+    "general_manager.metrics",
+    "general_manager.seeding",
+)
 DOC_PATHS = [
     ROOT / "README.md",
     *[
@@ -21,6 +27,18 @@ def _docs_text() -> str:
     return "\n".join(path.read_text(encoding="utf-8") for path in DOC_PATHS)
 
 
+def _public_exports() -> dict[str, list[str]]:
+    snapshot_exports = json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+    exports = {
+        module_name: list(module_exports)
+        for module_name, module_exports in snapshot_exports.items()
+    }
+    for module_name in ADDITIONAL_PUBLIC_MODULES:
+        module = import_module(module_name)
+        exports[module_name] = list(module.__all__)
+    return exports
+
+
 def test_unpublished_superpowers_docs_are_excluded_from_docs_corpus() -> None:
     assert not any(
         path.relative_to(DOCS_ROOT).as_posix().startswith("superpowers/")
@@ -30,7 +48,7 @@ def test_unpublished_superpowers_docs_are_excluded_from_docs_corpus() -> None:
 
 
 def test_every_public_export_is_mentioned_in_documentation() -> None:
-    exports = json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+    exports = _public_exports()
     docs_text = _docs_text()
 
     missing: dict[str, list[str]] = {}


### PR DESCRIPTION
## Summary
- Add API reference pages for search, cache, factory, workflow, GraphQL, metrics, seeding, and utilities.
- Add concept coverage for workflow, seeding, public utilities, bucket variants, factory helpers, cache helpers, and search backend/result models.
- Add a docs coverage test that checks public export mentions while excluding unpublished `docs/superpowers` files.

## Validation
- `python -m pytest tests/docs/test_public_api_docs_coverage.py -v` -> 2 passed
- `ruff check tests/docs/test_public_api_docs_coverage.py` -> passed
- `python -m mkdocs build --strict` -> passed
- `python -m pytest tests/unit/test_public_api_init_modules.py -v` -> 206 passed

## Notes
- Rebased on current `origin/main` (`30245b30`) before opening this PR.
- Added a minimal `general_manager.interface.infrastructure.__init__` so mkdocstrings can collect infrastructure API docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API reference docs (cache, factory, GraphQL, metrics, search, seeding, workflow, utils) and new conceptual guides (workflow, caching helpers, factory helpers, bucket variants, search backends, seeding, utilities). Navigation updated accordingly.
* **New Features**
  * Made InMemoryEventRegistry publicly available from the workflow package.
* **Tests**
  * Added a test to ensure every public API export is documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->