### PR TITLE
[codex] Split calculation cache scopes

### DIFF
--- a/docs/concepts/interfaces/computed_data_interfaces.md
+++ b/docs/concepts/interfaces/computed_data_interfaces.md
@@ -23,7 +23,7 @@ class ProjectSummary(GeneralManager):
 
 ## Computing values
 
-Expose computed attributes with `@graph_ql_property`. On `CalculationInterface` managers, the decorator registers the method as a GraphQL field and caches results in the active run context by default. On database-backed managers, the default remains dependency-aware caching.
+Expose computed attributes with `@graph_ql_property`. The decorator registers the method as a GraphQL field and caches results in the active run context by default for every manager type.
 
 ```python
     @graph_ql_property
@@ -34,7 +34,7 @@ Expose computed attributes with `@graph_ql_property`. On `CalculationInterface` 
         )
 ```
 
-Use `@graph_ql_property(cache="dependency")` when a calculation should be reused across requests and invalidated when its source managers change. Use `cache="none"` for cheap values.
+Use `@graph_ql_property(cache="dependency")` when a value should be reused across requests and invalidated when its source managers change. Use `cache="none"` for cheap values.
 
 ## Iterating combinations
 

--- a/docs/concepts/interfaces/computed_data_interfaces.md
+++ b/docs/concepts/interfaces/computed_data_interfaces.md
@@ -23,7 +23,7 @@ class ProjectSummary(GeneralManager):
 
 ## Computing values
 
-Expose computed attributes with `@graph_ql_property`. The decorator registers the method as a GraphQL field and caches results per manager instance.
+Expose computed attributes with `@graph_ql_property`. On `CalculationInterface` managers, the decorator registers the method as a GraphQL field and caches results in the active run context by default. On database-backed managers, the default remains dependency-aware caching.
 
 ```python
     @graph_ql_property
@@ -34,6 +34,8 @@ Expose computed attributes with `@graph_ql_property`. The decorator registers th
         )
 ```
 
+Use `@graph_ql_property(cache="dependency")` when a calculation should be reused across requests and invalidated when its source managers change. Use `cache="none"` for cheap values.
+
 ## Iterating combinations
 
 Call `ProjectSummary.all()` to iterate through all possible input combinations. Filter inputs with keyword arguments:
@@ -43,7 +45,7 @@ for summary in ProjectSummary.filter(project=my_project):
     print(summary.date, summary.total_volume)
 ```
 
-Because calculation managers do not persist data, `create`, `update`, and `delete` are unavailable. They still participate in dependency tracking, so cached calculations refresh when related managers change.
+Because calculation managers do not persist data, `create`, `update`, and `delete` are unavailable. They still participate in dependency tracking when a property opts into dependency-aware caching.
 
 ## Input helpers
 

--- a/docs/concepts/interfaces/dependency_graph.md
+++ b/docs/concepts/interfaces/dependency_graph.md
@@ -10,7 +10,7 @@ CRUD operations on `GeneralManager` instances emit the `data_change` signal defi
 
 When an interface resolves related data (for example, fetching a bucket of child managers), it calls `DependencyTracker.track()`. Cached functions using `@cached` persist these dependencies so that mutations can invalidate the correct cache entries.
 
-Run-scoped calculation caching is separate from the dependency index. Values stored in `CalculationRunContext` are discarded at the end of the request or run, so they do not need invalidation and do not appear in the dependency index. Dependency-aware calculation properties opt in with `@graph_ql_property(cache="dependency")`.
+Run-scoped `@graph_ql_property` caching is separate from the dependency index. Values stored in `CalculationRunContext` are discarded at the end of the request or run, so they do not need invalidation and do not appear in the dependency index. Dependency-aware properties opt in with `@graph_ql_property(cache="dependency")`.
 
 ## Graph traversal
 

--- a/docs/concepts/interfaces/dependency_graph.md
+++ b/docs/concepts/interfaces/dependency_graph.md
@@ -10,6 +10,8 @@ CRUD operations on `GeneralManager` instances emit the `data_change` signal defi
 
 When an interface resolves related data (for example, fetching a bucket of child managers), it calls `DependencyTracker.track()`. Cached functions using `@cached` persist these dependencies so that mutations can invalidate the correct cache entries.
 
+Run-scoped calculation caching is separate from the dependency index. Values stored in `CalculationRunContext` are discarded at the end of the request or run, so they do not need invalidation and do not appear in the dependency index. Dependency-aware calculation properties opt in with `@graph_ql_property(cache="dependency")`.
+
 ## Graph traversal
 
 `general_manager.cache.dependency_index` maintains a mapping of cache keys to dependency tuples. In a multi-process deployment, store this index in a shared backend (Redis or PostgreSQL) so that background workers and web servers stay in sync. When a change occurs, the index reveals which cached keys require eviction.

--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -32,7 +32,7 @@ class ProjectSummary(GeneralManager):
 
 ## Step 2: Choose a cache scope
 
-Calculation `@graph_ql_property` methods use run-scoped caching by default. The value is reused within one GraphQL request, calculation graph, bulk operation, or background run, then discarded.
+`@graph_ql_property` methods use run-scoped caching by default on every manager type. The value is reused within one GraphQL request, calculation graph, bulk operation, or background run, then discarded.
 
 Use dependency-aware caching only when a calculation result is stable enough to reuse across requests:
 
@@ -91,3 +91,5 @@ def volume(self) -> int:
     )
     return rows_by_date[self.target_date].quantity
 ```
+
+Use `ensure_calculation_run_context` around custom bulk jobs or background tasks that should share the same run cache but may already execute inside a GraphQL request context.

--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -30,13 +30,29 @@ class ProjectSummary(GeneralManager):
         )
 ```
 
-## Step 2: Cache the computation
+## Step 2: Choose a cache scope
 
-GraphQlProperty computations are cached by default and exposed via the GraphQL API.
+Calculation `@graph_ql_property` methods use run-scoped caching by default. The value is reused within one GraphQL request, calculation graph, bulk operation, or background run, then discarded.
+
+Use dependency-aware caching only when a calculation result is stable enough to reuse across requests:
+
+```python
+@graph_ql_property(cache="dependency")
+def expensive_summary(self) -> int:
+    return self.project.derivative_list.filter(date=self.date).count()
+```
+
+Disable caching for cheap or intentionally volatile values:
+
+```python
+@graph_ql_property(cache="none")
+def cheap_label(self) -> str:
+    return f"{self.project.name}: {self.date:%Y-%m-%d}"
+```
 
 ## Step 4: Verify invalidation
 
-Update a derivative that contributes to the summary. The dependency tracker captures the relationship and invalidates the cache entry automatically.
+For dependency-aware properties, update a derivative that contributes to the summary. The dependency tracker captures the relationship and invalidates the cache entry automatically.
 
 ```python
 DerivativeVolume(id=volume_id).update(quantity=42)
@@ -45,3 +61,33 @@ DerivativeVolume(id=volume_id).update(quantity=42)
 ## Step 5: Monitor cache usage
 
 Enable Django cache logging or use Redis monitoring tools to ensure cache hits increase and invalidations behave as expected.
+
+## Working-set reuse
+
+For bulk-style calculations, prefer loading related rows once and indexing them in the active run context:
+
+```python
+from general_manager.cache import current_calculation_run_context
+
+@graph_ql_property
+def volume(self) -> int:
+    ctx = current_calculation_run_context()
+    if ctx is None:
+        rows = DerivativeVolume.filter(
+            derivative=self.derivative,
+            revision=self.revision,
+            search_date=self.search_date,
+        )
+        return rows.get(volume_date=self.target_date).quantity
+
+    rows_by_date = ctx.index(
+        key=("volume_rows", self.derivative.id, self.revision.id, self.search_date),
+        loader=lambda: DerivativeVolume.filter(
+            derivative=self.derivative,
+            revision=self.revision,
+            search_date=self.search_date,
+        ),
+        index_by=lambda row: row.volume_date,
+    )
+    return rows_by_date[self.target_date].quantity
+```

--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -50,7 +50,7 @@ def cheap_label(self) -> str:
     return f"{self.project.name}: {self.date:%Y-%m-%d}"
 ```
 
-## Step 4: Verify invalidation
+## Step 3: Verify invalidation
 
 For dependency-aware properties, update a derivative that contributes to the summary. The dependency tracker captures the relationship and invalidates the cache entry automatically.
 
@@ -58,7 +58,7 @@ For dependency-aware properties, update a derivative that contributes to the sum
 DerivativeVolume(id=volume_id).update(quantity=42)
 ```
 
-## Step 5: Monitor cache usage
+## Step 4: Monitor cache usage
 
 Enable Django cache logging or use Redis monitoring tools to ensure cache hits increase and invalidations behave as expected.
 

--- a/src/general_manager/_types/cache.py
+++ b/src/general_manager/_types/cache.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 __all__ = [
     "CacheBackend",
+    "CalculationRunContext",
     "DependencyTracker",
     "cached",
+    "current_calculation_run_context",
+    "ensure_calculation_run_context",
     "invalidate_cache_key",
     "record_dependencies",
     "remove_cache_key_from_index",
@@ -14,6 +17,9 @@ __all__ = [
 from general_manager.cache.cache_decorator import CacheBackend
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.cache_decorator import cached
+from general_manager.cache.run_context import CalculationRunContext
+from general_manager.cache.run_context import current_calculation_run_context
+from general_manager.cache.run_context import ensure_calculation_run_context
 from general_manager.cache.dependency_index import invalidate_cache_key
 from general_manager.cache.dependency_index import record_dependencies
 from general_manager.cache.dependency_index import remove_cache_key_from_index

--- a/src/general_manager/api/graphql_subscription_consumer.py
+++ b/src/general_manager/api/graphql_subscription_consumer.py
@@ -15,6 +15,7 @@ from graphql import (
 )
 
 from general_manager.api.graphql import GraphQL
+from general_manager.cache.run_context import ensure_calculation_run_context
 
 
 RECOVERABLE_SUBSCRIPTION_ERRORS: tuple[type[Exception], ...] = (
@@ -225,13 +226,14 @@ class GraphQLSubscriptionConsumer(AsyncJsonWebsocketConsumer):
         context = self._build_context()
 
         try:
-            subscription = await subscribe(
-                schema.graphql_schema,
-                document,
-                variable_values=variables,
-                operation_name=operation_name,
-                context_value=context,
-            )
+            with ensure_calculation_run_context():
+                subscription = await subscribe(
+                    schema.graphql_schema,
+                    document,
+                    variable_values=variables,
+                    operation_name=operation_name,
+                    context_value=context,
+                )
         except GraphQLError as error:
             await self._send_protocol_message(
                 {
@@ -295,9 +297,14 @@ class GraphQLSubscriptionConsumer(AsyncJsonWebsocketConsumer):
         Raises:
             asyncio.CancelledError: Propagated when the surrounding subscription task is cancelled.
         """
+        iterator = async_iterator.__aiter__()
         try:
-            async for result in async_iterator:
-                await self._send_execution_result(operation_id, result)
+            while True:
+                with ensure_calculation_run_context():
+                    result = await iterator.__anext__()
+                    await self._send_execution_result(operation_id, result)
+        except StopAsyncIteration:
+            pass
         except asyncio.CancelledError:
             raise
         except (

--- a/src/general_manager/api/graphql_view.py
+++ b/src/general_manager/api/graphql_view.py
@@ -9,6 +9,7 @@ from graphene_django.constants import MUTATION_ERRORS_FLAG  # type: ignore[impor
 from graphene_django.utils.utils import set_rollback  # type: ignore[import-untyped]
 from graphene_django.views import GraphQLView  # type: ignore[import-untyped]
 
+from general_manager.cache.run_context import ensure_calculation_run_context
 from general_manager.metrics.graphql import (
     GraphQLResolverTimingMiddleware,
     extract_error_code,
@@ -44,9 +45,10 @@ class GeneralManagerGraphQLView(GraphQLView):
         )
 
         start = time.perf_counter()
-        execution_result = self.execute_graphql_request(
-            request, data, query, variables, operation_name, show_graphiql
-        )
+        with ensure_calculation_run_context():
+            execution_result = self.execute_graphql_request(
+                request, data, query, variables, operation_name, show_graphiql
+            )
         duration = time.perf_counter() - start
 
         if getattr(request, MUTATION_ERRORS_FLAG, False) is True:

--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -89,21 +89,12 @@ class GraphQLProperty(property):
         self._name = name
         self._cached_fget = self._build_cached_fget(owner)
 
-    def _build_cached_fget(self, owner: type) -> Callable[..., Any]:
+    def _build_cached_fget(self, _owner: type) -> Callable[..., Any]:
         from general_manager.cache.cache_decorator import cached
-        from general_manager.interface.interfaces.calculation import (
-            CalculationInterface,
-        )
 
         selected_cache = self.cache
         if selected_cache == "auto":
-            interface_cls = getattr(owner, "Interface", None)
-            if isinstance(interface_cls, type) and issubclass(
-                interface_cls, CalculationInterface
-            ):
-                selected_cache = "run"
-            else:
-                selected_cache = "dependency"
+            selected_cache = "run"
         if selected_cache == "none":
             return self._raw_fget
         return cached(scope=cast(Literal["dependency", "run"], selected_cache))(

--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Callable, Literal, TypeVar, cast, get_type_hints, overload
 
 T = TypeVar("T", bound=Callable[..., Any])
-GraphQLPropertyCache = Literal["dependency", "run", "none", "auto"]
+GraphQLPropertyCache = Literal["dependency", "run", "none"]
 
 
 class GraphQLPropertyReturnAnnotationError(TypeError):
@@ -93,8 +93,6 @@ class GraphQLProperty(property):
         from general_manager.cache.cache_decorator import cached
 
         selected_cache = self.cache
-        if selected_cache == "auto":
-            selected_cache = "run"
         if selected_cache == "none":
             return self._raw_fget
         return cached(scope=cast(Literal["dependency", "run"], selected_cache))(
@@ -148,7 +146,7 @@ def graph_ql_property(
     sortable: bool = False,
     filterable: bool = False,
     query_annotation: Any | None = None,
-    cache: GraphQLPropertyCache = "auto",
+    cache: GraphQLPropertyCache = "run",
 ) -> Callable[[T], GraphQLProperty]: ...
 
 
@@ -158,7 +156,7 @@ def graph_ql_property(
     sortable: bool = False,
     filterable: bool = False,
     query_annotation: Any | None = None,
-    cache: GraphQLPropertyCache = "auto",
+    cache: GraphQLPropertyCache = "run",
 ) -> GraphQLProperty | Callable[[T], GraphQLProperty]:
     """
     Decorate a resolver to return a cached ``GraphQLProperty`` descriptor.

--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -1,9 +1,11 @@
 """GraphQL-aware property descriptor used by GeneralManager classes."""
 
+from functools import wraps
 import sys
-from typing import Any, Callable, TypeVar, get_type_hints, overload
+from typing import Any, Callable, Literal, TypeVar, cast, get_type_hints, overload
 
 T = TypeVar("T", bound=Callable[..., Any])
+GraphQLPropertyCache = Literal["dependency", "run", "none", "auto"]
 
 
 class GraphQLPropertyReturnAnnotationError(TypeError):
@@ -35,6 +37,7 @@ class GraphQLProperty(property):
         sortable: bool = False,
         filterable: bool = False,
         query_annotation: Any | None = None,
+        cache: GraphQLPropertyCache = "auto",
     ) -> None:
         """
         Initialize the GraphQLProperty descriptor with GraphQL-specific metadata.
@@ -49,7 +52,14 @@ class GraphQLProperty(property):
         Raises:
             GraphQLPropertyReturnAnnotationError: If the underlying resolver function does not declare a return type annotation.
         """
-        super().__init__(fget, doc=doc)
+        self._raw_fget = fget
+        self._cached_fget: Callable[..., Any] | None = None
+
+        @wraps(fget)
+        def resolver(instance: Any) -> Any:
+            return self._get_cached_fget()(instance)
+
+        super().__init__(resolver, doc=doc)
         self.is_graphql_resolver = True
         self._owner: type | None = None
         self._name: str | None = None
@@ -58,6 +68,7 @@ class GraphQLProperty(property):
         self.sortable = sortable
         self.filterable = filterable
         self.query_annotation = query_annotation
+        self.cache = cache
 
         orig = getattr(
             fget, "__wrapped__", fget
@@ -76,6 +87,36 @@ class GraphQLProperty(property):
         """
         self._owner = owner
         self._name = name
+        self._cached_fget = self._build_cached_fget(owner)
+
+    def _build_cached_fget(self, owner: type) -> Callable[..., Any]:
+        from general_manager.cache.cache_decorator import cached
+        from general_manager.interface.interfaces.calculation import (
+            CalculationInterface,
+        )
+
+        selected_cache = self.cache
+        if selected_cache == "auto":
+            interface_cls = getattr(owner, "Interface", None)
+            if isinstance(interface_cls, type) and issubclass(
+                interface_cls, CalculationInterface
+            ):
+                selected_cache = "run"
+            else:
+                selected_cache = "dependency"
+        if selected_cache == "none":
+            return self._raw_fget
+        return cached(scope=cast(Literal["dependency", "run"], selected_cache))(
+            self._raw_fget
+        )
+
+    def _get_cached_fget(self) -> Callable[..., Any]:
+        if self._cached_fget is None:
+            if self._owner is None:
+                self._cached_fget = self._raw_fget
+            else:
+                self._cached_fget = self._build_cached_fget(self._owner)
+        return self._cached_fget
 
     def _try_resolve_type_hint(self) -> None:
         """
@@ -116,6 +157,7 @@ def graph_ql_property(
     sortable: bool = False,
     filterable: bool = False,
     query_annotation: Any | None = None,
+    cache: GraphQLPropertyCache = "auto",
 ) -> Callable[[T], GraphQLProperty]: ...
 
 
@@ -125,9 +167,8 @@ def graph_ql_property(
     sortable: bool = False,
     filterable: bool = False,
     query_annotation: Any | None = None,
+    cache: GraphQLPropertyCache = "auto",
 ) -> GraphQLProperty | Callable[[T], GraphQLProperty]:
-    from general_manager.cache.cache_decorator import cached
-
     """
     Decorate a resolver to return a cached ``GraphQLProperty`` descriptor.
 
@@ -143,10 +184,11 @@ def graph_ql_property(
 
     def wrapper(f: Callable[..., Any]) -> GraphQLProperty:
         return GraphQLProperty(
-            cached()(f),
+            f,
             sortable=sortable,
             query_annotation=query_annotation,
             filterable=filterable,
+            cache=cache,
         )
 
     if func is None:

--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -37,7 +37,7 @@ class GraphQLProperty(property):
         sortable: bool = False,
         filterable: bool = False,
         query_annotation: Any | None = None,
-        cache: GraphQLPropertyCache = "auto",
+        cache: GraphQLPropertyCache = "none",
     ) -> None:
         """
         Initialize the GraphQLProperty descriptor with GraphQL-specific metadata.

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -507,6 +507,8 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         """
 
         if self._data is None:
+            from general_manager.cache.run_context import ensure_calculation_run_context
+
             sorted_inputs = self.topological_sort_inputs()
             sorted_filters = self._sort_filters(sorted_inputs)
             current_combinations = self._generate_input_combinations(
@@ -521,29 +523,34 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                 or not self._sort_uses_only_inputs(sort_key)
             )
 
-            if needs_manager_access:
-                manager_combinations = self._manager_combinations(current_combinations)
-                manager_combinations = self._filter_prop_combinations(
-                    manager_combinations,
-                    sorted_filters["prop_filters"],
-                    sorted_filters["prop_excludes"],
-                )
-                if sort_key is not None:
-                    getters = [attrgetter(key) for key in sort_key]
-                    manager_combinations = sorted(
+            with ensure_calculation_run_context():
+                if needs_manager_access:
+                    manager_combinations = self._manager_combinations(
+                        current_combinations
+                    )
+                    manager_combinations = self._filter_prop_combinations(
                         manager_combinations,
-                        key=lambda manager_obj: tuple(
-                            getter(manager_obj) for getter in getters
-                        ),
+                        sorted_filters["prop_filters"],
+                        sorted_filters["prop_excludes"],
                     )
-                identifications = self._manager_identifications(manager_combinations)
-            else:
-                identifications = current_combinations
-                if sort_key is not None:
-                    identifications = self._sort_dict_combinations(
-                        identifications,
-                        sort_key,
+                    if sort_key is not None:
+                        getters = [attrgetter(key) for key in sort_key]
+                        manager_combinations = sorted(
+                            manager_combinations,
+                            key=lambda manager_obj: tuple(
+                                getter(manager_obj) for getter in getters
+                            ),
+                        )
+                    identifications = self._manager_identifications(
+                        manager_combinations
                     )
+                else:
+                    identifications = current_combinations
+                    if sort_key is not None:
+                        identifications = self._sort_dict_combinations(
+                            identifications,
+                            sort_key,
+                        )
 
             if self.reverse:
                 identifications.reverse()

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -1,12 +1,16 @@
 """Helpers for caching GeneralManager computations with dependency tracking."""
 
 from functools import wraps
-from typing import Any, Callable, Optional, Protocol, Set, TypeVar, cast
+from typing import Any, Callable, Literal, Optional, Protocol, Set, TypeVar, cast
 
 from django.core.cache import cache as django_cache
 
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import Dependency, record_dependencies
+from general_manager.cache.run_context import (
+    current_calculation_run_context,
+    ensure_calculation_run_context,
+)
 from general_manager.cache.model_dependency_collector import ModelDependencyCollector
 from general_manager.logging import get_logger
 from general_manager.utils.make_cache_key import make_cache_key
@@ -43,15 +47,25 @@ class CacheBackend(Protocol):
 
 RecordFn = Callable[[str, Set[Dependency]], None]
 FuncT = TypeVar("FuncT", bound=Callable[..., object])
+CacheScope = Literal["dependency", "run", "none"]
 
 _SENTINEL = object()
 logger = get_logger("cache.decorator")
+
+
+class UnsupportedCacheScopeError(ValueError):
+    """Raised when a cache decorator receives an unsupported scope."""
+
+    def __init__(self, scope: object) -> None:
+        super().__init__(f"Unsupported cache scope: {scope}")
 
 
 def cached(
     timeout: Optional[int] = None,
     cache_backend: CacheBackend = django_cache,
     record_fn: RecordFn = record_dependencies,
+    *,
+    scope: CacheScope = "dependency",
 ) -> Callable[[FuncT], FuncT]:
     """
     Cache a function call while registering its data dependencies.
@@ -75,6 +89,22 @@ def cached(
     def decorator(func: FuncT) -> FuncT:
         @wraps(func)
         def wrapper(*args: object, **kwargs: object) -> object:
+            if scope == "none":
+                return func(*args, **kwargs)
+
+            if scope == "run":
+                key = make_cache_key(func, args, kwargs)
+                current_context = current_calculation_run_context()
+                if current_context is not None:
+                    return current_context.get_or_set(
+                        key, lambda: func(*args, **kwargs)
+                    )
+                with ensure_calculation_run_context() as context:
+                    return context.get_or_set(key, lambda: func(*args, **kwargs))
+
+            if scope != "dependency":
+                raise UnsupportedCacheScopeError(scope)
+
             key = make_cache_key(func, args, kwargs)
             deps_key = f"{key}:deps"
 

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -7,10 +7,7 @@ from django.core.cache import cache as django_cache
 
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import Dependency, record_dependencies
-from general_manager.cache.run_context import (
-    current_calculation_run_context,
-    ensure_calculation_run_context,
-)
+from general_manager.cache.run_context import ensure_calculation_run_context
 from general_manager.cache.model_dependency_collector import ModelDependencyCollector
 from general_manager.logging import get_logger
 from general_manager.utils.make_cache_key import make_cache_key
@@ -94,11 +91,6 @@ def cached(
 
             if scope == "run":
                 key = make_cache_key(func, args, kwargs)
-                current_context = current_calculation_run_context()
-                if current_context is not None:
-                    return current_context.get_or_set(
-                        key, lambda: func(*args, **kwargs)
-                    )
                 with ensure_calculation_run_context() as context:
                     return context.get_or_set(key, lambda: func(*args, **kwargs))
 

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -1,0 +1,84 @@
+"""Run-scoped cache context for calculation workloads."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Iterable
+from contextvars import ContextVar, Token
+from types import TracebackType
+from typing import TypeVar
+
+K = TypeVar("K", bound=Hashable)
+T = TypeVar("T")
+
+_active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
+    "general_manager_calculation_run_context",
+    default=None,
+)
+
+
+class CalculationRunContext:
+    """Cache calculation work for one request, graph, bulk operation, or task."""
+
+    def __init__(self) -> None:
+        self._values: dict[Hashable, object] = {}
+        self._token: Token[CalculationRunContext | None] | None = None
+
+    def __enter__(self) -> "CalculationRunContext":
+        self._token = _active_context.set(self)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self._token is not None:
+            _active_context.reset(self._token)
+            self._token = None
+        self._values.clear()
+
+    def get_or_set(self, key: Hashable, loader: Callable[[], T]) -> T:
+        """Return a cached value for key, loading it once per active context."""
+        if key not in self._values:
+            self._values[key] = loader()
+        return self._values[key]  # type: ignore[return-value]
+
+    def index(
+        self,
+        *,
+        key: Hashable,
+        loader: Callable[[], Iterable[T]],
+        index_by: Callable[[T], K],
+    ) -> dict[K, T]:
+        """Load a working set once and index it by the supplied key function."""
+        return self.get_or_set(
+            ("index", key),
+            lambda: {index_by(row): row for row in loader()},
+        )
+
+
+def current_calculation_run_context() -> CalculationRunContext | None:
+    """Return the active calculation run context, if any."""
+    return _active_context.get()
+
+
+class ensure_calculation_run_context:
+    """Use the current run context or create one for the wrapped block."""
+
+    def __enter__(self) -> CalculationRunContext:
+        current = current_calculation_run_context()
+        if current is not None:
+            self._owned_context = None
+            return current
+        self._owned_context = CalculationRunContext()
+        return self._owned_context.__enter__()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self._owned_context is not None:
+            self._owned_context.__exit__(exc_type, exc_val, exc_tb)

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Hashable, Iterable
 from contextvars import ContextVar, Token
 from types import TracebackType
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 K = TypeVar("K", bound=Hashable)
 T = TypeVar("T")
@@ -65,6 +65,9 @@ def current_calculation_run_context() -> CalculationRunContext | None:
 
 class ensure_calculation_run_context:
     """Use the current run context or create one for the wrapped block."""
+
+    def __init__(self) -> None:
+        self._owned_context: Optional[CalculationRunContext] = None
 
     def __enter__(self) -> CalculationRunContext:
         current = current_calculation_run_context()

--- a/src/general_manager/public_api_registry.py
+++ b/src/general_manager/public_api_registry.py
@@ -359,6 +359,18 @@ CACHE_EXPORTS: LazyExportMap = {
     "cached": ("general_manager.cache.cache_decorator", "cached"),
     "CacheBackend": ("general_manager.cache.cache_decorator", "CacheBackend"),
     "DependencyTracker": ("general_manager.cache.cache_tracker", "DependencyTracker"),
+    "CalculationRunContext": (
+        "general_manager.cache.run_context",
+        "CalculationRunContext",
+    ),
+    "current_calculation_run_context": (
+        "general_manager.cache.run_context",
+        "current_calculation_run_context",
+    ),
+    "ensure_calculation_run_context": (
+        "general_manager.cache.run_context",
+        "ensure_calculation_run_context",
+    ),
     "record_dependencies": (
         "general_manager.cache.dependency_index",
         "record_dependencies",

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -70,7 +70,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     possible_values=lambda: TestProjectForCommercials.all(),
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def budget_left(self) -> Measurement:
                 """
                 Compute the project's remaining budget.
@@ -80,7 +80,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 """
                 return self.project.budget - self.project.actual_costs
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def budget_used(self) -> Measurement:
                 """
                 Compute the project's used budget as a percentage.
@@ -90,21 +90,21 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 """
                 return (self.project.actual_costs / self.project.budget).to("percent")
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def project_name(self) -> str:
                 """
                 Return the associated project name for deterministic calculation sorting.
                 """
                 return self.project.name
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def is_over_budget(self) -> bool:
                 """
                 Return True if the project's actual costs exceed its budget, otherwise False.
                 """
                 return self.project.actual_costs > self.project.budget
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def has_duplicate_name(self) -> bool:
                 """
                 Determine whether another project has the same name as this instance.
@@ -117,7 +117,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 ).count()
                 return matching_count > 1
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def other_project_count(self) -> int:
                 """
                 Return the count of projects whose `number` differs from this instance's project's `number`.
@@ -129,7 +129,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     number=self.project.number
                 ).count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def has_budget_buffer(self) -> bool:
                 """
                 Indicates whether the project has a positive remaining budget.
@@ -139,7 +139,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 """
                 return self.budget_left > Measurement(0, "EUR")
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def similar_name_count(self) -> int:
                 """
                 Count projects whose names contain the first word of this instance's associated project's name.
@@ -152,14 +152,14 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     name__contains=search_term
                 ).count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def active_project_count(self) -> int:
                 """
                 Count all active projects to ensure deactivation triggers cache invalidation.
                 """
                 return TestProjectForCommercials.filter(is_active=True).count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def same_name_excluding_self(self) -> int:
                 """
                 Count projects that have the same name as the current project's name, excluding the current project by its number.
@@ -173,7 +173,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     .count()
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def project_keyword_number_range_count(self) -> int:
                 """
                 Count projects whose name contains "Project" and whose number is between 1 and 3 inclusive.
@@ -188,7 +188,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     number__in=[1, 2, 3],
                 ).count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def exact_start_date_count(self) -> int:
                 """
                 Count projects sharing the exact same start date as the current project.
@@ -197,7 +197,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     start_date=self.project.start_date
                 ).count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def recent_project_window_count(self) -> int:
                 """
                 Count projects whose start_date falls within seven days before or after this instance's project.start_date and whose completion_at is no later than seven days after this instance's project.completion_at.
@@ -216,7 +216,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     completion_at__lte=completion_threshold,
                 ).count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def staged_bucket_count(self) -> int:
                 """
                 Count TestProjectForCommercials that match a specific sequence of chained filters relative to this instance's project.
@@ -234,7 +234,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 )
                 return bucket.count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def narrowed_all_bucket_count(self) -> int:
                 """
                 Count projects via an ``all().filter().exclude()`` chain.
@@ -246,7 +246,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     .count()
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def empty_all_bucket_count(self) -> int:
                 """
                 Count projects for a query that initially matches no rows.
@@ -257,14 +257,14 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     .count()
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def exclude_only_project_count(self) -> int:
                 """
                 Count projects through an exclude-only bucket.
                 """
                 return TestProjectForCommercials.all().exclude(number=999).count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def unique_name_bucket_length(self) -> int:
                 """
                 Return the length of a narrowed bucket without iterating it.
@@ -273,7 +273,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     TestProjectForCommercials.all().filter(name="Another Project")
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def unique_name_bucket_first_name(self) -> str | None:
                 """
                 Return the first name from a narrowed bucket without iterating it.
@@ -285,7 +285,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 )
                 return None if match is None else match.name
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def unique_name_bucket_get_name(self) -> str:
                 """
                 Return the unique match from a narrowed bucket via ``get()``.
@@ -297,7 +297,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     .name
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def unique_name_bucket_index_name(self) -> str:
                 """
                 Return the first narrowed bucket entry via scalar indexing.
@@ -308,7 +308,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     .name
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def unique_name_bucket_contains_self_project(self) -> bool:
                 """
                 Check membership against a narrowed bucket without iterating it.
@@ -317,21 +317,21 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     name="Another Project"
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def grouped_project_name_count(self) -> int:
                 """
                 Count project groups built from ``all().group_by()``.
                 """
                 return TestProjectForCommercials.all().group_by("name").count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def available_commercial_count(self) -> int:
                 """
                 Count calculation-bucket combinations for all commercials.
                 """
                 return self.__class__.all().count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def deeply_chained_bucket_count(self) -> int:
                 """
                 Count projects through a deeper ``all().filter().exclude().filter()`` chain.
@@ -342,7 +342,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 bucket = bucket.filter(start_date=self.project.start_date.isoformat())
                 return bucket.count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def empty_chain_bucket_count(self) -> int:
                 """
                 Count projects in a chained query that initially resolves to zero rows.
@@ -354,7 +354,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     .count()
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def chained_first_project_name(self) -> str | None:
                 """
                 Return the first project name from a chained all/filter/exclude query.
@@ -370,7 +370,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     return None
                 return first_match.name
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def grouped_filtered_project_count(self) -> int:
                 """
                 Count grouped project names after narrowing via all/filter chaining.
@@ -382,7 +382,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     .count()
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def mixed_terminal_bucket_summary(
                 self,
             ) -> tuple[int, str | None, str | None, bool]:
@@ -396,7 +396,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     return (count, None, None, False)
                 return (count, first.name, bucket[0].name, first in bucket)
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def sliced_sorted_bucket_first_number(self) -> int | None:
                 """
                 Evaluate a sliced narrowed bucket after sorting.
@@ -409,7 +409,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 first = bucket.first()
                 return None if first is None else first.number
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def sorted_project_bucket_summary(self) -> tuple[int, int | None]:
                 """
                 Evaluate count and first() on a sorted narrowed bucket.
@@ -422,7 +422,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 first = bucket.first()
                 return bucket.count(), None if first is None else first.number
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def python_filtered_negative_number_count(self) -> int:
                 """
                 Count rows through a python-only filterable property.
@@ -431,7 +431,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     TestProjectForCommercials.all().filter(negative_number=-2).count()
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def historical_original_name_count(self) -> int:
                 """
                 Count historical rows using ``search_date`` and the original project name.
@@ -445,7 +445,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     name="Test Project",
                 ).count()
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def grouped_project_terminal_summary(self) -> tuple[str | None, str, bool]:
                 """
                 Exercise non-count terminal operations on a grouped bucket.
@@ -459,7 +459,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                     self.project in grouped,
                 )
 
-            @graph_ql_property
+            @graph_ql_property(cache="dependency")
             def calculation_bucket_terminal_summary(
                 self,
             ) -> tuple[str | None, str, int, bool]:

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -9,6 +9,7 @@ from general_manager.utils.testing import GeneralManagerTransactionTestCase
 from general_manager.measurement import MeasurementField, Measurement
 from general_manager.manager.input import Input
 from general_manager.api.property import graph_ql_property
+from general_manager.cache.run_context import CalculationRunContext
 
 
 class CustomMutationTest(GeneralManagerTransactionTestCase):
@@ -199,6 +200,104 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         self.assertResponseNoErrors(response)
         data = response.json()["data"]["taxcalculation"]
         self.assertEqual(data["calculatedTax"]["value"], 800)
+
+    def test_calculation_graphql_property_defaults_to_run_scope(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+        calls = 0
+
+        class RunScopedCalculation(GeneralManager):
+            employee: self.Employee
+
+            class Interface(CalculationInterface):
+                employee = Input(
+                    self.Employee, possible_values=lambda: self.Employee.all()
+                )
+
+            @graph_ql_property
+            def computed_value(self) -> int:
+                nonlocal calls
+                calls += 1
+                return int(self.employee.salary.quantity.magnitude)
+
+        with CalculationRunContext():
+            first = RunScopedCalculation(employee=employee)
+            second = RunScopedCalculation(employee=employee)
+            self.assertEqual(first.computed_value, 3000)
+            self.assertEqual(second.computed_value, 3000)
+
+        self.assertEqual(calls, 1)
+
+        third = RunScopedCalculation(employee=employee)
+        fourth = RunScopedCalculation(employee=employee)
+        self.assertEqual(third.computed_value, 3000)
+        self.assertEqual(fourth.computed_value, 3000)
+        self.assertEqual(calls, 3)
+
+    def test_calculation_graphql_property_can_opt_into_dependency_cache(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+        calls = 0
+
+        class DependencyCachedCalculation(GeneralManager):
+            employee: self.Employee
+
+            class Interface(CalculationInterface):
+                employee = Input(
+                    self.Employee, possible_values=lambda: self.Employee.all()
+                )
+
+            @graph_ql_property(cache="dependency")
+            def computed_value(self) -> int:
+                nonlocal calls
+                calls += 1
+                return int(self.employee.salary.quantity.magnitude)
+
+        first = DependencyCachedCalculation(employee=employee)
+        second = DependencyCachedCalculation(employee=employee)
+        self.assertEqual(first.computed_value, 3000)
+        self.assertEqual(second.computed_value, 3000)
+        self.assertEqual(calls, 1)
+
+        employee.update(
+            salary=Measurement(4000, "EUR"),
+            creator_id=self.user.id,
+            ignore_permission=True,
+        )
+
+        refreshed = DependencyCachedCalculation(employee=employee)
+        self.assertEqual(refreshed.computed_value, 4000)
+        self.assertEqual(calls, 2)
+
+    def test_calculation_graphql_property_can_disable_caching(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+        calls = 0
+
+        class UncachedCalculation(GeneralManager):
+            employee: self.Employee
+
+            class Interface(CalculationInterface):
+                employee = Input(
+                    self.Employee, possible_values=lambda: self.Employee.all()
+                )
+
+            @graph_ql_property(cache="none")
+            def computed_value(self) -> int:
+                nonlocal calls
+                calls += 1
+                return int(self.employee.salary.quantity.magnitude)
+
+        with CalculationRunContext():
+            first = UncachedCalculation(employee=employee)
+            second = UncachedCalculation(employee=employee)
+            self.assertEqual(first.computed_value, 3000)
+            self.assertEqual(second.computed_value, 3000)
+
+        self.assertEqual(calls, 2)
 
     def test_calculation_property_can_traverse_database_reverse_relation(self):
         employee = self.Employee.create(

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -31,6 +31,7 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
             id: int
             name: str
             salary: Measurement
+            salary_rate_calls: ClassVar[int] = 0
 
             class Interface(DatabaseInterface):
                 name = CharField(max_length=100)
@@ -38,6 +39,7 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
 
             @graph_ql_property()
             def salary_rate(self) -> float:
+                type(self).salary_rate_calls += 1
                 return float(self.salary.quantity.magnitude / 100)
 
         class TaxCalculation(GeneralManager):
@@ -195,6 +197,30 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         response = self.query(query, variables={"id": employee.id})
         self.assertResponseNoErrors(response)
         self.assertEqual(response.json()["data"]["employee"]["salaryRate"], 40)
+
+    def test_database_graphql_property_defaults_to_run_scope(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+        query = """
+        query($id: ID!) {
+            employee(id: $id) {
+                salaryRate
+            }
+        }
+        """
+
+        self.Employee.salary_rate_calls = 0
+
+        response = self.query(query, variables={"id": employee.id})
+        self.assertResponseNoErrors(response)
+        self.assertEqual(response.json()["data"]["employee"]["salaryRate"], 30)
+        self.assertEqual(self.Employee.salary_rate_calls, 1)
+
+        response = self.query(query, variables={"id": employee.id})
+        self.assertResponseNoErrors(response)
+        self.assertEqual(response.json()["data"]["employee"]["salaryRate"], 30)
+        self.assertEqual(self.Employee.salary_rate_calls, 2)
 
     def test_calculation_graphql_property_refreshes_after_entry_update(self):
         employee = self.Employee.create(

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -204,7 +204,10 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         )
         query = """
         query($id: ID!) {
-            employee(id: $id) {
+            employeeA: employee(id: $id) {
+                salaryRate
+            }
+            employeeB: employee(id: $id) {
                 salaryRate
             }
         }
@@ -214,12 +217,16 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
 
         response = self.query(query, variables={"id": employee.id})
         self.assertResponseNoErrors(response)
-        self.assertEqual(response.json()["data"]["employee"]["salaryRate"], 30)
+        data = response.json()["data"]
+        self.assertEqual(data["employeeA"]["salaryRate"], 30)
+        self.assertEqual(data["employeeB"]["salaryRate"], 30)
         self.assertEqual(self.Employee.salary_rate_calls, 1)
 
         response = self.query(query, variables={"id": employee.id})
         self.assertResponseNoErrors(response)
-        self.assertEqual(response.json()["data"]["employee"]["salaryRate"], 30)
+        data = response.json()["data"]
+        self.assertEqual(data["employeeA"]["salaryRate"], 30)
+        self.assertEqual(data["employeeB"]["salaryRate"], 30)
         self.assertEqual(self.Employee.salary_rate_calls, 2)
 
     def test_calculation_graphql_property_refreshes_after_entry_update(self):

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -1,5 +1,7 @@
 # type: ignore
 
+from typing import ClassVar
+
 from django.contrib.auth import get_user_model
 from django.db.models import CASCADE, CharField, ForeignKey, IntegerField
 from django.utils.crypto import get_random_string
@@ -75,16 +77,30 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
             def total_bonus(self) -> int:
                 return sum(bonus.amount for bonus in self.employee.bonus_list)
 
+        class RequestScopedCalculation(GeneralManager):
+            employee: Employee
+            computed_calls: ClassVar[int] = 0
+
+            class Interface(CalculationInterface):
+                employee = Input(Employee, possible_values=lambda: Employee.all())
+
+            @graph_ql_property
+            def computed_value(self) -> int:
+                type(self).computed_calls += 1
+                return int(self.employee.salary.quantity.magnitude)
+
         cls.Employee = Employee
         cls.TaxCalculation = TaxCalculation
         cls.Bonus = Bonus
         cls.BonusCalculation = BonusCalculation
+        cls.RequestScopedCalculation = RequestScopedCalculation
 
         cls.general_manager_classes = [
             Employee,
             TaxCalculation,
             Bonus,
             BonusCalculation,
+            RequestScopedCalculation,
         ]
 
     def setUp(self):
@@ -298,6 +314,31 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
             self.assertEqual(second.computed_value, 3000)
 
         self.assertEqual(calls, 2)
+
+    def test_graphql_request_shares_run_cache_across_repeated_calculation_fields(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+        self.RequestScopedCalculation.computed_calls = 0
+
+        query = """
+        query($employeeId: ID!) {
+            first: requestscopedcalculation(employeeId: $employeeId) {
+                computedValue
+            }
+            second: requestscopedcalculation(employeeId: $employeeId) {
+                computedValue
+            }
+        }
+        """
+
+        response = self.query(query, variables={"employeeId": employee.id})
+
+        self.assertResponseNoErrors(response)
+        data = response.json()["data"]
+        self.assertEqual(data["first"]["computedValue"], 3000)
+        self.assertEqual(data["second"]["computedValue"], 3000)
+        self.assertEqual(self.RequestScopedCalculation.computed_calls, 1)
 
     def test_calculation_property_can_traverse_database_reverse_relation(self):
         employee = self.Employee.create(

--- a/tests/snapshots/public_api_exports.json
+++ b/tests/snapshots/public_api_exports.json
@@ -170,6 +170,10 @@
       "general_manager.cache.cache_decorator",
       "CacheBackend"
     ],
+    "CalculationRunContext": [
+      "general_manager.cache.run_context",
+      "CalculationRunContext"
+    ],
     "DependencyTracker": [
       "general_manager.cache.cache_tracker",
       "DependencyTracker"
@@ -177,6 +181,14 @@
     "cached": [
       "general_manager.cache.cache_decorator",
       "cached"
+    ],
+    "current_calculation_run_context": [
+      "general_manager.cache.run_context",
+      "current_calculation_run_context"
+    ],
+    "ensure_calculation_run_context": [
+      "general_manager.cache.run_context",
+      "ensure_calculation_run_context"
     ],
     "invalidate_cache_key": [
       "general_manager.cache.dependency_index",

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -2,6 +2,7 @@ from django.test import SimpleTestCase
 from django.core.cache import cache
 from unittest import mock
 from general_manager.cache.cache_decorator import cached, DependencyTracker
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.utils.make_cache_key import make_cache_key
 import pickle
 import time
@@ -401,3 +402,49 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         res2 = outer_function(2, 3)
         self.assertEqual(res2, 5)
         self.assertEqual(self.record_calls, [])
+
+
+class TestCacheDecoratorScopes(SimpleTestCase):
+    def test_run_scope_reuses_value_inside_context_only(self):
+        calls = 0
+
+        @cached(scope="run")
+        def sample(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        with CalculationRunContext():
+            self.assertEqual(sample(3), 6)
+            self.assertEqual(sample(3), 6)
+
+        self.assertEqual(sample(3), 6)
+        self.assertEqual(calls, 2)
+
+    def test_run_scope_creates_context_when_missing_for_single_call(self):
+        calls = 0
+
+        @cached(scope="run")
+        def sample(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        self.assertEqual(sample(3), 6)
+        self.assertEqual(sample(3), 6)
+        self.assertEqual(calls, 2)
+
+    def test_none_scope_never_uses_cache_backend(self):
+        fake_cache = FakeCacheBackend()
+        calls = 0
+
+        @cached(scope="none", cache_backend=fake_cache)
+        def sample(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        self.assertEqual(sample(3), 6)
+        self.assertEqual(sample(3), 6)
+        self.assertEqual(calls, 2)
+        self.assertEqual(fake_cache.store, {})

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -1,0 +1,59 @@
+from general_manager.cache.run_context import (
+    CalculationRunContext,
+    current_calculation_run_context,
+)
+
+
+def test_context_is_active_only_inside_with_block() -> None:
+    assert current_calculation_run_context() is None
+
+    with CalculationRunContext() as ctx:
+        assert current_calculation_run_context() is ctx
+
+    assert current_calculation_run_context() is None
+
+
+def test_get_or_set_reuses_loaded_value_inside_context() -> None:
+    calls = 0
+
+    def loader() -> int:
+        nonlocal calls
+        calls += 1
+        return 42
+
+    with CalculationRunContext() as ctx:
+        assert ctx.get_or_set(("answer",), loader) == 42
+        assert ctx.get_or_set(("answer",), loader) == 42
+
+    assert calls == 1
+
+
+def test_index_loads_once_and_groups_by_key() -> None:
+    calls = 0
+
+    class Row:
+        def __init__(self, day: str, value: int) -> None:
+            self.day = day
+            self.value = value
+
+    def loader() -> list[Row]:
+        nonlocal calls
+        calls += 1
+        return [Row("2026-06-10", 10), Row("2026-06-11", 11)]
+
+    with CalculationRunContext() as ctx:
+        first = ctx.index(
+            key=("rows", 1),
+            loader=loader,
+            index_by=lambda row: row.day,
+        )
+        second = ctx.index(
+            key=("rows", 1),
+            loader=loader,
+            index_by=lambda row: row.day,
+        )
+
+    assert calls == 1
+    assert first is second
+    assert first["2026-06-10"].value == 10
+    assert first["2026-06-11"].value == 11

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -3,12 +3,13 @@
 import json
 from decimal import Decimal
 from datetime import date, datetime
+from inspect import signature
 import graphene
 from django.test import TestCase, override_settings
 from django.db.models import NOT_PROVIDED
 from unittest.mock import MagicMock, patch
 from django.contrib.auth.models import AnonymousUser
-from typing import Any, ClassVar
+from typing import Any, ClassVar, get_args
 
 from general_manager import bootstrap as gm_bootstrap
 from general_manager.api.graphql import (
@@ -24,7 +25,11 @@ from general_manager.api.graphql_view import GeneralManagerGraphQLView
 from general_manager.measurement.measurement import Measurement
 from general_manager.manager.general_manager import GeneralManager, GeneralManagerMeta
 from general_manager.manager.input import Input
-from general_manager.api.property import GraphQLProperty
+from general_manager.api.property import (
+    GraphQLProperty,
+    GraphQLPropertyCache,
+    graph_ql_property,
+)
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.interface.orm_interface import OrmInterfaceBase  # noqa: F401
 from general_manager.permission.base_permission import ReadPermissionPlan
@@ -53,6 +58,14 @@ class GraphQLPropertyTests(TestCase):
 
         prop = GraphQLProperty(mock_getter)
         self.assertEqual(prop.graphql_type_hint, str)
+
+    def test_graphql_property_cache_options_exclude_auto(self):
+        self.assertEqual(
+            set(get_args(GraphQLPropertyCache)), {"dependency", "run", "none"}
+        )
+        self.assertEqual(
+            signature(graph_ql_property).parameters["cache"].default, "run"
+        )
 
 
 class MeasurementTypeTests(TestCase):


### PR DESCRIPTION
## Summary
- Add `CalculationRunContext` for request/run-scoped calculation memoization and working-set indexes.
- Add explicit cache scopes for `@cached` and `@graph_ql_property`: `dependency`, `run`, and `none`.
- Default `CalculationInterface` GraphQL properties to run-scoped caching while preserving dependency-aware opt-in.
- Wrap GraphQL request/subscription execution and calculation bucket evaluation in run contexts.
- Update docs and public API snapshots for the new cache layer.

## Validation
- `PYTHONPATH=src python -m pytest` -> `2399 passed, 1 skipped`
- `ruff check ...` -> passed
- `ruff format ...` -> unchanged
- `mypy src/general_manager` -> passed

## Notes
- This intentionally changes the default caching behavior for `CalculationInterface` properties before a stable release.
- Local verification used `PYTHONPATH=src` to avoid a stale editable install from another worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Computed GraphQL fields now support configurable caching via `cache` parameter: run-scoped (default, per-request), dependency-aware (cross-request with invalidation), or disabled
  * New public APIs (`CalculationRunContext`, `current_calculation_run_context`, `ensure_calculation_run_context`) for managing cached values within requests and background tasks

* **Documentation**
  * Updated guides clarifying computed field caching behavior and configuration options, including cross-request reuse strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->