### PR TITLE
[codex] fix configured user instance permission resolution

### DIFF
--- a/src/general_manager/permission/base_permission.py
+++ b/src/general_manager/permission/base_permission.py
@@ -437,7 +437,10 @@ class BasePermission(ABC):
         """
         Resolve a user identifier or user-like object to a Django User or AnonymousUser instance.
 
-        If the input is already an AbstractBaseUser or AnonymousUser, it is returned unchanged. If the input is a primary key (or other value used to look up a User by id), the corresponding User is returned; if no such User exists, an AnonymousUser is returned.
+        If the input is already an AbstractBaseUser, AnonymousUser, or configured
+        user-model instance, it is returned unchanged. If the input is a primary
+        key (or other value used to look up a User by id), the corresponding User
+        is returned; if no such User exists, an AnonymousUser is returned.
 
         Parameters:
             user (Any | UserLike): A user object or a value to look up a User by primary key.
@@ -454,7 +457,7 @@ class BasePermission(ABC):
             user = lazy_user._wrapped
 
         User = get_user_model()
-        if isinstance(user, (AbstractBaseUser, AnonymousUser)):
+        if isinstance(user, (AbstractBaseUser, AnonymousUser, User)):
             return user
         try:
             return User.objects.get(pk=user)

--- a/tests/unit/test_base_permission.py
+++ b/tests/unit/test_base_permission.py
@@ -378,6 +378,39 @@ class BasePermissionTests(TestCase):
         result = BasePermission.get_user_with_id(user)
         self.assertEqual(result, user)
 
+    def test_get_user_with_id_preserves_configured_user_model_instance(self) -> None:
+        """Already-resolved configured user instances should not be re-queried."""
+
+        class PlainConfiguredUserManager:
+            def __init__(self) -> None:
+                self.calls: list[object] = []
+
+            def get(self, *, pk: object) -> object:
+                self.calls.append(pk)
+                raise TypeError
+
+        manager = PlainConfiguredUserManager()
+
+        class PlainConfiguredUser:
+            class DoesNotExist(Exception):
+                pass
+
+            objects = manager
+
+            id = 21
+            is_authenticated = True
+            is_superuser = False
+
+        user = PlainConfiguredUser()
+
+        with patch(
+            "django.contrib.auth.get_user_model", return_value=PlainConfiguredUser
+        ):
+            result = BasePermission.get_user_with_id(user)
+
+        self.assertIs(result, user)
+        self.assertEqual(manager.calls, [])
+
     def test_get_user_with_id_anonymous(self):
         """Test get_user_with_id with anonymous user."""
         user = AnonymousUser()


### PR DESCRIPTION
## Summary

- Preserve already-resolved instances of the active `get_user_model()` class in `BasePermission.get_user_with_id()`.
- Add a regression test for non-`AbstractBaseUser` configured user model instances so they are not treated as primary keys and degraded to `AnonymousUser`.

Fixes #255.

## Root cause

`check_update_permission()` resolves `creator_id` to a user, then permission construction resolves that same object again. The second pass only treated `AbstractBaseUser` and `AnonymousUser` as already-resolved users, so a configured user model instance outside that inheritance tree fell through to `User.objects.get(pk=<user object>)`, caught `TypeError`, and returned `AnonymousUser`.

## Validation

- `python -m pytest tests/unit/test_base_permission.py::BasePermissionTests::test_get_user_with_id_preserves_configured_user_model_instance` failed before the fix and passes after it.
- `python -m pytest tests/unit/test_base_permission.py`
- `ruff format src/general_manager/permission/base_permission.py tests/unit/test_base_permission.py`
- `ruff check`
- `mypy`
- `python -m pytest` (`2404 passed, 1 skipped, 1 warning`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized user permission checks to reduce unnecessary database queries when handling already-resolved user instances.

* **Tests**
  * Added unit test coverage for permission validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->