### PR TITLE
[codex] fix calculation manager id filters

### DIFF
--- a/docs/concepts/interfaces/computed_data_interfaces.md
+++ b/docs/concepts/interfaces/computed_data_interfaces.md
@@ -43,7 +43,12 @@ Call `ProjectSummary.all()` to iterate through all possible input combinations. 
 ```python
 for summary in ProjectSummary.filter(project=my_project):
     print(summary.date, summary.total_volume)
+
+for summary in ProjectSummary.filter(project_id=my_project.id):
+    print(summary.date, summary.total_volume)
 ```
+
+For manager-typed inputs, filters accept either the manager instance (`project=...`) or its identifier (`project_id=...`). Nested lookups such as `project__name__icontains=...` continue to target fields on the input manager.
 
 Because calculation managers do not persist data, `create`, `update`, and `delete` are unavailable. They still participate in dependency tracking when a property opts into dependency-aware caching.
 

--- a/src/general_manager/utils/filter_parser.py
+++ b/src/general_manager/utils/filter_parser.py
@@ -42,11 +42,26 @@ def parse_filters(
     for kwarg, value in filter_kwargs.items():
         parts = kwarg.split("__")
         field_name = parts[0]
+        id_alias_lookup_prefix = ""
+        if field_name not in possible_values and field_name.endswith("_id"):
+            alias_field_name = field_name.removesuffix("_id")
+            if alias_field_name in possible_values and issubclass(
+                possible_values[alias_field_name].type,
+                GeneralManager,
+            ):
+                field_name = alias_field_name
+                id_alias_lookup_prefix = "id"
         if field_name not in possible_values:
             raise UnknownInputFieldError(field_name)
         input_field = possible_values[field_name]
 
         lookup = "__".join(parts[1:]) if len(parts) > 1 else ""
+        if id_alias_lookup_prefix:
+            lookup = (
+                id_alias_lookup_prefix
+                if lookup == ""
+                else f"{id_alias_lookup_prefix}__{lookup}"
+            )
 
         if issubclass(input_field.type, GeneralManager):
             # Collect filter keyword arguments for the input field

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -488,6 +488,11 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(tax_calculation_bucket_filtered1[0].employee.name, "Tim")
         self.assertEqual(tax_calculation_bucket_filtered1[1].employee.name, "Tina")
 
+        tim = tax_calculation_bucket_filtered1[0].employee
+        tax_calculation_by_id = self.TaxCalculation.filter(employee_id=tim.id)
+        self.assertEqual(len(tax_calculation_by_id), 1)
+        self.assertEqual(tax_calculation_by_id[0].employee.name, "Tim")
+
         tax_calculation_bucket_filtered2 = tax_calculation_bucket_filtered1.filter(
             calculated_tax=Measurement(3000, "EUR") * 0.2
         )

--- a/tests/unit/test_filter_parser.py
+++ b/tests/unit/test_filter_parser.py
@@ -102,6 +102,22 @@ class TestFilterParser(TestCase):
                 {"id": mock_manager.id},
             )
 
+            filters = parse_filters({"manager_id": mock_manager.id}, possible_values)
+            self.assertEqual(len(filters), 1)
+            self.assertEqual(
+                filters["manager"]["filter_kwargs"],
+                {"id": mock_manager.id},
+            )
+
+            filters = parse_filters(
+                {"manager_id__in": [mock_manager.id, 2]}, possible_values
+            )
+            self.assertEqual(len(filters), 1)
+            self.assertEqual(
+                filters["manager"]["filter_kwargs"],
+                {"id__in": [mock_manager.id, 2]},
+            )
+
     def test_parse_filters_invalid_field(self):
         """
         Tests that parse_filters raises a ValueError when an unknown field is provided.
@@ -112,6 +128,8 @@ class TestFilterParser(TestCase):
         }
         with self.assertRaises(ValueError):
             parse_filters({"unknown_field__exact": "value"}, possible_values)
+        with self.assertRaises(ValueError):
+            parse_filters({"unknown_field_id": "value"}, possible_values)
 
     def test_filter_function_with_deep_lookup(self):
         """


### PR DESCRIPTION
Fixes #258.

## Summary
- Support `<manager_input>_id` aliases in calculation filter parsing for `GeneralManager`-typed inputs.
- Add unit and integration regression coverage for calculation filters using manager IDs.
- Document that computed data interfaces accept both manager instances and identifiers in filters.

## Root cause
`CalculationInterface.filter(...)` passed raw kwargs into `parse_filters()`. A key like `employee_id` was treated as an input named `employee_id`, so parsing failed before the existing manager-input `id` lookup path could run. ORM-backed `DatabaseInterface` filters already normalize relation IDs separately.

## Validation
- `python -m pytest -q tests/unit/test_filter_parser.py`
- `python -m pytest -q tests/integration/test_calculation_manager.py`
- `ruff check`
- `ruff format --check src/general_manager/utils/filter_parser.py tests/unit/test_filter_parser.py tests/integration/test_calculation_manager.py`
- `mypy`
- `python -m pytest -q` (`2403 passed, 1 skipped, 1 warning, 1733 subtests passed`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filters now support `field_id` format for manager-typed fields, enabling more flexible filtering syntax.

* **Documentation**
  * Updated examples demonstrating the new filtering approach with field identifiers.

* **Tests**
  * Added tests validating ID-based filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->