### PR TITLE
[codex] Use camelCase GraphQL root names

### DIFF
--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -49,12 +49,16 @@ The intended behavior is that startup and schema registration remain reviewable 
 
 ## Relation Filters
 
+Generated root query fields use the same public camelCase convention as nested
+fields. For example, `PartSoldType` is exposed as `partSoldType` and
+`partSoldTypeList`, not `partsoldtype` or `partsoldtypeList`.
+
 Generated list queries expose scalar filters and relation filters. Direct
 relations such as foreign keys and one-to-one fields use nested filter input:
 
 ```graphql
 query {
-  changerequestfeasibilityList(filter: {
+  changeRequestFeasibilityList(filter: {
     changeRequest: { title: "Primary" }
   }) {
     items { id score }
@@ -67,7 +71,7 @@ Collection relations such as reverse foreign keys and many-to-many fields expose
 
 ```graphql
 query {
-  changerequestList(filter: {
+  changeRequestList(filter: {
     changeRequestFeasibilityList: {
       any: { score_Gte: 7 }
     }

--- a/docs/concepts/graphql/subscriptions.md
+++ b/docs/concepts/graphql/subscriptions.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-For each manager class (e.g. `Project`), GraphQL exposes a subscription field named `on<ManagerClass>Change` (e.g. `onProjectChange`). The resolver:
+For each manager class (e.g. `Project`), GraphQL exposes a subscription field named `on<ManagerClass>Change` (e.g. `onProjectChange`). Multi-word manager names keep their word boundaries in camelCase, such as `TaxCalculation` becoming `onTaxCalculationChange`. The resolver:
 
 1. Validates the identification arguments (e.g. `id`, other interface inputs).
 2. Instantiates the manager and emits an initial `snapshot` event.
@@ -23,7 +23,7 @@ subscription ($id: ID!) {
 }
 ```
 
-For class-wide streams, GraphQL also exposes `on<ManagerClass>ClassChange` (e.g. `onProjectClassChange`). This field takes no identification arguments and emits one changed item per event:
+For class-wide streams, GraphQL also exposes `on<ManagerClass>ClassChange` (e.g. `onProjectClassChange` or `onTaxCalculationClassChange`). This field takes no identification arguments and emits one changed item per event:
 
 ```graphql
 subscription {

--- a/docs/superpowers/plans/2026-06-08-graphql-id-filter-consistency.md
+++ b/docs/superpowers/plans/2026-06-08-graphql-id-filter-consistency.md
@@ -29,10 +29,10 @@ Add this method to `GraphQLRelationFilterIntegrationTests`:
 def test_reuses_id_variable_for_detail_and_relation_filter(self):
     query = """
     query Issue247($id: ID!) {
-        changerequest(id: $id) {
+        changeRequest(id: $id) {
             id
         }
-        changerequestfeasibilityList(
+        changeRequestFeasibilityList(
             filter: {changeRequest: {id: $id}}
         ) {
             items {
@@ -47,9 +47,9 @@ def test_reuses_id_variable_for_detail_and_relation_filter(self):
 
     self.assertResponseNoErrors(response)
     payload = response.json()["data"]
-    self.assertEqual(payload["changerequest"]["id"], str(self.primary.id))
+    self.assertEqual(payload["changeRequest"]["id"], str(self.primary.id))
     self.assertEqual(
-        [item["id"] for item in payload["changerequestfeasibilityList"]["items"]],
+        [item["id"] for item in payload["changeRequestFeasibilityList"]["items"]],
         [str(self.high_feasibility.id)],
     )
 ```

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -48,6 +48,7 @@ from general_manager.permission.graphql_capabilities import (
     get_capability_context,
     get_graphql_capabilities,
 )
+from general_manager.utils.format_string import pascal_to_snake
 from general_manager.utils.type_checks import safe_issubclass
 
 from graphql import GraphQLError
@@ -969,7 +970,8 @@ class GraphQL:
             cls._query_fields = cast(dict[str, Any], {})
 
         # resolver and field for the list query
-        list_field_name = f"{generalManagerClass.__name__.lower()}_list"
+        manager_field_name = pascal_to_snake(generalManagerClass.__name__)
+        list_field_name = f"{manager_field_name}_list"
         attributes: dict[str, Any] = {
             "reverse": graphene.Boolean(),
             "page": graphene.Int(),
@@ -1013,7 +1015,7 @@ class GraphQL:
         cls._query_fields[f"resolve_{list_field_name}"] = list_resolver
 
         # resolver and field for the single item query
-        item_field_name = generalManagerClass.__name__.lower()
+        item_field_name = manager_field_name
         identification_fields = cls._build_identification_arguments(generalManagerClass)
         item_field = graphene.Field(graphene_type, **identification_fields)
 
@@ -1127,8 +1129,9 @@ class GraphQL:
         - The subscribe coroutine yields SubscriptionEvent objects with fields `item` (the current instance or None if it cannot be instantiated) and `action` (a string such as `"snapshot"` or other change actions).
         - On termination the subscription cleans up listener tasks and unsubscribes from channel groups.
         """
-        field_name = f"on_{generalManagerClass.__name__.lower()}_change"
-        class_field_name = f"on_{generalManagerClass.__name__.lower()}_class_change"
+        manager_field_name = pascal_to_snake(generalManagerClass.__name__)
+        field_name = f"on_{manager_field_name}_change"
+        class_field_name = f"on_{manager_field_name}_class_change"
         if (
             field_name in cls._subscription_fields
             and class_field_name in cls._subscription_fields

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -119,7 +119,7 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         self.client.force_login(self.user)
         self.mutation = """
         query($employeeId: ID!) {
-            taxcalculation(employeeId: $employeeId) {
+            taxCalculation(employeeId: $employeeId) {
                 calculatedTax {
                     value
                     unit
@@ -140,7 +140,7 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
         variables = {"employeeId": employee.id}
         response = self.query(self.mutation, variables=variables)
         self.assertResponseNoErrors(response)
-        data = response.json()["data"]["taxcalculation"]
+        data = response.json()["data"]["taxCalculation"]
         self.assertEqual(data["calculatedTax"]["value"], 600)
         self.assertEqual(data["calculatedTax"]["unit"], "EUR")
 
@@ -236,7 +236,7 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
 
         response = self.query(self.mutation, variables={"employeeId": employee.id})
         self.assertResponseNoErrors(response)
-        data = response.json()["data"]["taxcalculation"]
+        data = response.json()["data"]["taxCalculation"]
         self.assertEqual(data["calculatedTax"]["value"], 600)
 
         employee.update(
@@ -247,7 +247,7 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
 
         response = self.query(self.mutation, variables={"employeeId": employee.id})
         self.assertResponseNoErrors(response)
-        data = response.json()["data"]["taxcalculation"]
+        data = response.json()["data"]["taxCalculation"]
         self.assertEqual(data["calculatedTax"]["value"], 800)
 
     def test_calculation_graphql_property_defaults_to_run_scope(self):
@@ -356,10 +356,10 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
 
         query = """
         query($employeeId: ID!) {
-            first: requestscopedcalculation(employeeId: $employeeId) {
+            first: requestScopedCalculation(employeeId: $employeeId) {
                 computedValue
             }
-            second: requestscopedcalculation(employeeId: $employeeId) {
+            second: requestScopedCalculation(employeeId: $employeeId) {
                 computedValue
             }
         }

--- a/tests/integration/test_default_mutations.py
+++ b/tests/integration/test_default_mutations.py
@@ -374,7 +374,7 @@ class DefaultUpdateMutationTest(GeneralManagerTransactionTestCase):
             """
         self.query_number_rate = """
             query Project($id: ID!) {
-                testproject(id: $id) {
+                testProject(id: $id) {
                     numberRate
                 }
             }
@@ -434,7 +434,7 @@ class DefaultUpdateMutationTest(GeneralManagerTransactionTestCase):
             variables={"id": self.project.id},
         )
         self.assertResponseNoErrors(response)
-        self.assertEqual(response.json()["data"]["testproject"]["numberRate"], 0.01)
+        self.assertEqual(response.json()["data"]["testProject"]["numberRate"], 0.01)
 
         self.project = self.project.update(number=200, ignore_permission=True)
 
@@ -443,7 +443,7 @@ class DefaultUpdateMutationTest(GeneralManagerTransactionTestCase):
             variables={"id": self.project.id},
         )
         self.assertResponseNoErrors(response)
-        self.assertEqual(response.json()["data"]["testproject"]["numberRate"], 2)
+        self.assertEqual(response.json()["data"]["testProject"]["numberRate"], 2)
 
     def test_update_project_without_budget(self):
         """

--- a/tests/integration/test_graphql_calculation_input_options.py
+++ b/tests/integration/test_graphql_calculation_input_options.py
@@ -171,7 +171,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
     def test_optional_input_is_nullable_in_graphql_queries(self) -> None:
         query = """
         query($employeeId: ID!) {
-            optionalinputcalculation(employeeId: $employeeId) {
+            optionalInputCalculation(employeeId: $employeeId) {
                 employee {
                     name
                 }
@@ -183,14 +183,14 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
         response = self.query(query, variables={"employeeId": self.employee_a.id})
 
         self.assertResponseNoErrors(response)
-        data = response.json()["data"]["optionalinputcalculation"]
+        data = response.json()["data"]["optionalInputCalculation"]
         self.assertEqual(data["employee"]["name"], "Alice")
         self.assertIsNone(data["asOf"])
 
     def test_optional_input_accepts_explicit_value_in_graphql_queries(self) -> None:
         query = """
         query($employeeId: ID!, $asOf: Date) {
-            optionalinputcalculation(employeeId: $employeeId, asOf: $asOf) {
+            optionalInputCalculation(employeeId: $employeeId, asOf: $asOf) {
                 employee {
                     name
                 }
@@ -205,7 +205,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
         )
 
         self.assertResponseNoErrors(response)
-        data = response.json()["data"]["optionalinputcalculation"]
+        data = response.json()["data"]["optionalInputCalculation"]
         self.assertEqual(data["employee"]["name"], "Alice")
         self.assertEqual(data["asOf"], "2024-02-10")
 
@@ -223,7 +223,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
     def test_min_value_constraint_is_enforced_via_graphql(self) -> None:
         query = """
         query($quantity: Int!) {
-            minvaluecalculation(quantity: $quantity) {
+            minValueCalculation(quantity: $quantity) {
                 quantity
             }
         }
@@ -231,7 +231,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
 
         response = self.query(query, variables={"quantity": 2})
         self.assertResponseNoErrors(response)
-        self.assertEqual(response.json()["data"]["minvaluecalculation"]["quantity"], 2)
+        self.assertEqual(response.json()["data"]["minValueCalculation"]["quantity"], 2)
 
         invalid_response = self.query(query, variables={"quantity": 1})
         self._assert_error_contains(invalid_response, "Invalid value for quantity")
@@ -239,7 +239,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
     def test_max_value_constraint_is_enforced_via_graphql(self) -> None:
         query = """
         query($quantity: Int!) {
-            maxvaluecalculation(quantity: $quantity) {
+            maxValueCalculation(quantity: $quantity) {
                 quantity
             }
         }
@@ -247,7 +247,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
 
         response = self.query(query, variables={"quantity": 5})
         self.assertResponseNoErrors(response)
-        self.assertEqual(response.json()["data"]["maxvaluecalculation"]["quantity"], 5)
+        self.assertEqual(response.json()["data"]["maxValueCalculation"]["quantity"], 5)
 
         invalid_response = self.query(query, variables={"quantity": 6})
         self._assert_error_contains(invalid_response, "Invalid value for quantity")
@@ -255,7 +255,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
     def test_validator_is_enforced_via_graphql(self) -> None:
         query = """
         query($code: String!) {
-            validatorcalculation(code: $code) {
+            validatorCalculation(code: $code) {
                 code
             }
         }
@@ -264,7 +264,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
         response = self.query(query, variables={"code": "OK-123"})
         self.assertResponseNoErrors(response)
         self.assertEqual(
-            response.json()["data"]["validatorcalculation"]["code"], "OK-123"
+            response.json()["data"]["validatorCalculation"]["code"], "OK-123"
         )
 
         invalid_response = self.query(query, variables={"code": "BAD-123"})
@@ -273,7 +273,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
     def test_normalizer_is_applied_via_graphql(self) -> None:
         query = """
         query($code: String!) {
-            normalizercalculation(code: $code) {
+            normalizerCalculation(code: $code) {
                 code
             }
         }
@@ -283,13 +283,13 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
 
         self.assertResponseNoErrors(response)
         self.assertEqual(
-            response.json()["data"]["normalizercalculation"]["code"], "ABC"
+            response.json()["data"]["normalizerCalculation"]["code"], "ABC"
         )
 
     def test_date_range_helper_is_enforced_via_graphql(self) -> None:
         query = """
         query($asOf: Date!) {
-            daterangecalculation(asOf: $asOf) {
+            dateRangeCalculation(asOf: $asOf) {
                 asOf
             }
         }
@@ -298,7 +298,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
         response = self.query(query, variables={"asOf": "2024-01-15"})
         self.assertResponseNoErrors(response)
         self.assertEqual(
-            response.json()["data"]["daterangecalculation"]["asOf"], "2024-01-15"
+            response.json()["data"]["dateRangeCalculation"]["asOf"], "2024-01-15"
         )
 
         invalid_response = self.query(query, variables={"asOf": "2024-02-01"})
@@ -307,7 +307,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
     def test_monthly_date_helper_normalizes_via_graphql(self) -> None:
         query = """
         query($asOf: Date!) {
-            monthlydatecalculation(asOf: $asOf) {
+            monthlyDateCalculation(asOf: $asOf) {
                 asOf
             }
         }
@@ -317,14 +317,14 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
 
         self.assertResponseNoErrors(response)
         self.assertEqual(
-            response.json()["data"]["monthlydatecalculation"]["asOf"],
+            response.json()["data"]["monthlyDateCalculation"]["asOf"],
             "2024-02-29",
         )
 
     def test_yearly_date_helper_normalizes_via_graphql(self) -> None:
         query = """
         query($asOf: Date!) {
-            yearlydatecalculation(asOf: $asOf) {
+            yearlyDateCalculation(asOf: $asOf) {
                 asOf
             }
         }
@@ -334,14 +334,14 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
 
         self.assertResponseNoErrors(response)
         self.assertEqual(
-            response.json()["data"]["yearlydatecalculation"]["asOf"],
+            response.json()["data"]["yearlyDateCalculation"]["asOf"],
             "2024-12-31",
         )
 
     def test_date_range_domain_is_enforced_via_graphql(self) -> None:
         query = """
         query($asOf: Date!) {
-            datedomaincalculation(asOf: $asOf) {
+            dateDomainCalculation(asOf: $asOf) {
                 asOf
             }
         }
@@ -350,7 +350,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
         response = self.query(query, variables={"asOf": "2024-02-10"})
         self.assertResponseNoErrors(response)
         self.assertEqual(
-            response.json()["data"]["datedomaincalculation"]["asOf"],
+            response.json()["data"]["dateDomainCalculation"]["asOf"],
             "2024-02-29",
         )
 
@@ -360,7 +360,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
     def test_numeric_range_domain_is_enforced_via_graphql(self) -> None:
         query = """
         query($amount: Int!) {
-            numericdomaincalculation(amount: $amount) {
+            numericDomainCalculation(amount: $amount) {
                 amount
             }
         }
@@ -369,7 +369,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
         response = self.query(query, variables={"amount": 3})
         self.assertResponseNoErrors(response)
         self.assertEqual(
-            response.json()["data"]["numericdomaincalculation"]["amount"], 3
+            response.json()["data"]["numericDomainCalculation"]["amount"], 3
         )
 
         invalid_response = self.query(query, variables={"amount": 4})
@@ -378,7 +378,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
     def test_from_manager_query_is_enforced_via_graphql(self) -> None:
         query = """
         query($departmentId: ID!, $employeeId: ID!) {
-            managerquerycalculation(
+            managerQueryCalculation(
                 departmentId: $departmentId
                 employeeId: $employeeId
             ) {
@@ -397,7 +397,7 @@ class TestGraphQLCalculationInputOptions(GeneralManagerTransactionTestCase):
             },
         )
         self.assertResponseNoErrors(response)
-        data = response.json()["data"]["managerquerycalculation"]
+        data = response.json()["data"]["managerQueryCalculation"]
         self.assertEqual(data["department"]["name"], "Alpha")
 
         invalid_response = self.query(

--- a/tests/integration/test_graphql_metrics.py
+++ b/tests/integration/test_graphql_metrics.py
@@ -55,7 +55,7 @@ class TestGraphQLMetrics(GeneralManagerTransactionTestCase):
     def test_graphql_request_metrics_success(self):
         query = """
         query MetricsQuery {
-            metricprojectList {
+            metricProjectList {
                 items {
                     id
                     name
@@ -90,7 +90,7 @@ class TestGraphQLMetrics(GeneralManagerTransactionTestCase):
     def test_graphql_error_metrics(self):
         query = """
         query BadQuery {
-            metricprojectList {
+            metricProjectList {
                 items {
                     doesNotExist
                 }
@@ -121,7 +121,7 @@ class TestGraphQLMetrics(GeneralManagerTransactionTestCase):
     def test_graphql_unknown_operation_name(self):
         query = """
         query {
-            metricprojectList {
+            metricProjectList {
                 items {
                     id
                 }
@@ -175,12 +175,12 @@ class TestGraphQLResolverTimingMetrics(GeneralManagerTransactionTestCase):
     def test_resolver_timing_metrics(self):
         query = """
         query MetricsQuery {
-            metricprojectList {
+            metricProjectList {
                 items { id name }
             }
         }
         """
-        field_name = normalize_field_name("Query.metricprojectList")
+        field_name = normalize_field_name("Query.metricProjectList")
         labels = {"field_name": field_name}
         before = self._get_sample_value(
             "graphql_resolver_duration_seconds_count", labels

--- a/tests/integration/test_graphql_query.py
+++ b/tests/integration/test_graphql_query.py
@@ -241,7 +241,7 @@ class TestGraphQLIncludeInactive(GeneralManagerTransactionTestCase):
     def test_query_include_inactive_returns_soft_deleted_rows(self):
         query_default = """
         query {
-            softfamilyList {
+            softFamilyList {
                 items {
                     id
                     name
@@ -254,14 +254,14 @@ class TestGraphQLIncludeInactive(GeneralManagerTransactionTestCase):
         """
         default_response = self.query(query_default)
         self.assertResponseNoErrors(default_response)
-        default_data = default_response.json()["data"]["softfamilyList"]
+        default_data = default_response.json()["data"]["softFamilyList"]
         default_names = {item["name"] for item in default_data["items"]}
         self.assertEqual(default_names, {"Active Family"})
         self.assertEqual(default_data["pageInfo"]["totalCount"], 1)
 
         query_with_inactive = """
         query {
-            softfamilyList(includeInactive: true) {
+            softFamilyList(includeInactive: true) {
                 items {
                     id
                     name
@@ -274,7 +274,7 @@ class TestGraphQLIncludeInactive(GeneralManagerTransactionTestCase):
         """
         include_response = self.query(query_with_inactive)
         self.assertResponseNoErrors(include_response)
-        include_data = include_response.json()["data"]["softfamilyList"]
+        include_data = include_response.json()["data"]["softFamilyList"]
         include_names = {item["name"] for item in include_data["items"]}
         self.assertEqual(include_names, {"Active Family", "Inactive Family"})
         self.assertEqual(include_data["pageInfo"]["totalCount"], 2)
@@ -305,7 +305,7 @@ class TestGraphQLQueryReadHardening(GeneralManagerTransactionTestCase):
     def test_non_admin_list_query_hides_rows_and_total_count(self):
         query = """
         query {
-            internalrecordList {
+            internalRecordList {
                 items {
                     id
                     name
@@ -319,14 +319,14 @@ class TestGraphQLQueryReadHardening(GeneralManagerTransactionTestCase):
 
         response = self.query(query)
         self.assertResponseNoErrors(response)
-        payload = response.json()["data"]["internalrecordList"]
+        payload = response.json()["data"]["internalRecordList"]
         self.assertEqual(payload["items"], [])
         self.assertEqual(payload["pageInfo"]["totalCount"], 0)
 
     def test_non_admin_list_query_logs_aggregate_read_summary(self):
         query = """
         query {
-            internalrecordList {
+            internalRecordList {
                 pageInfo {
                     totalCount
                 }
@@ -359,7 +359,7 @@ class TestGraphQLQueryReadHardening(GeneralManagerTransactionTestCase):
         self.user.save(update_fields=["is_staff"])
         query = """
         query {
-            internalrecordList {
+            internalRecordList {
                 items {
                     id
                 }
@@ -433,7 +433,7 @@ class TestGraphQLQueryBasedOnReadHardening(GeneralManagerTransactionTestCase):
     def test_non_admin_list_query_hides_based_on_denied_rows_and_total_count(self):
         query = """
         query {
-            delegateddocumentList {
+            delegatedDocumentList {
                 items {
                     id
                     title
@@ -447,7 +447,7 @@ class TestGraphQLQueryBasedOnReadHardening(GeneralManagerTransactionTestCase):
 
         response = self.query(query)
         self.assertResponseNoErrors(response)
-        payload = response.json()["data"]["delegateddocumentList"]
+        payload = response.json()["data"]["delegatedDocumentList"]
         self.assertEqual(payload["items"], [])
         self.assertEqual(payload["pageInfo"]["totalCount"], 0)
 
@@ -456,7 +456,7 @@ class TestGraphQLQueryBasedOnReadHardening(GeneralManagerTransactionTestCase):
         self.user.save(update_fields=["is_staff"])
         query = """
         query {
-            delegateddocumentList {
+            delegatedDocumentList {
                 items {
                     id
                 }
@@ -513,7 +513,7 @@ class TestGraphQLIncludeInactiveValidation(GeneralManagerTransactionTestCase):
     def test_query_include_inactive_fails_without_soft_delete(self):
         query = """
         query {
-            hardfamilyList(includeInactive: true) {
+            hardFamilyList(includeInactive: true) {
                 items {
                     id
                     name

--- a/tests/integration/test_graphql_relation_filters.py
+++ b/tests/integration/test_graphql_relation_filters.py
@@ -128,12 +128,41 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
     def _titles_from_response(self, response) -> list[str]:
         self.assertResponseNoErrors(response)
         payload = response.json()
-        return [item["title"] for item in payload["data"]["changerequestList"]["items"]]
+        return [item["title"] for item in payload["data"]["changeRequestList"]["items"]]
+
+    def test_multiword_root_query_fields_use_camel_case_names(self):
+        query = """
+        query {
+            __schema {
+                queryType {
+                    fields {
+                        name
+                    }
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        fields = [
+            field["name"]
+            for field in response.json()["data"]["__schema"]["queryType"]["fields"]
+        ]
+        self.assertIn("changeRequest", fields)
+        self.assertIn("changeRequestList", fields)
+        self.assertIn("changeRequestFeasibility", fields)
+        self.assertIn("changeRequestFeasibilityList", fields)
+        self.assertNotIn("changerequest", fields)
+        self.assertNotIn("changerequestList", fields)
+        self.assertNotIn("changerequestfeasibility", fields)
+        self.assertNotIn("changerequestfeasibilityList", fields)
 
     def test_filters_by_direct_foreign_key_relation(self):
         query = """
         query {
-            changerequestfeasibilityList(filter: {
+            changeRequestFeasibilityList(filter: {
                 changeRequest: { title: "Primary" }
             }) {
                 items {
@@ -148,7 +177,7 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
         response = self.query(query)
 
         self.assertResponseNoErrors(response)
-        items = response.json()["data"]["changerequestfeasibilityList"]["items"]
+        items = response.json()["data"]["changeRequestFeasibilityList"]["items"]
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]["score"], 9)
         self.assertEqual(items[0]["changeRequest"]["title"], "Primary")
@@ -198,10 +227,10 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
     def test_reuses_id_variable_for_detail_and_relation_filter(self):
         query = """
         query Issue247($id: ID!) {
-            changerequest(id: $id) {
+            changeRequest(id: $id) {
                 id
             }
-            changerequestfeasibilityList(
+            changeRequestFeasibilityList(
                 filter: {changeRequest: {id: $id}}
             ) {
                 items {
@@ -216,9 +245,9 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
 
         self.assertResponseNoErrors(response)
         payload = response.json()["data"]
-        self.assertEqual(payload["changerequest"]["id"], self.primary.id)
+        self.assertEqual(payload["changeRequest"]["id"], self.primary.id)
         self.assertEqual(
-            [item["id"] for item in payload["changerequestfeasibilityList"]["items"]],
+            [item["id"] for item in payload["changeRequestFeasibilityList"]["items"]],
             [self.high_feasibility.id],
         )
 
@@ -248,7 +277,7 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
     def test_filters_by_reverse_relation_any(self):
         query = """
         query {
-            changerequestList(filter: {
+            changeRequestList(filter: {
                 changeRequestFeasibilityList: { any: { score_Gte: 7 } }
             }) {
                 items { id title }
@@ -263,7 +292,7 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
     def test_filters_by_nested_reverse_relation_any(self):
         query = """
         query {
-            changerequestList(filter: {
+            changeRequestList(filter: {
                 changeRequestFeasibilityList: {
                     any: {
                         changeRequestTeamList: {
@@ -284,7 +313,7 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
     def test_filters_by_reverse_relation_none(self):
         query = """
         query {
-            changerequestList(filter: {
+            changeRequestList(filter: {
                 changeRequestFeasibilityList: { none: { score_Gte: 7 } }
             }) {
                 items { id title }
@@ -299,7 +328,7 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
     def test_exclude_rejects_reverse_relation_none(self):
         query = """
         query {
-            changerequestList(exclude: {
+            changeRequestList(exclude: {
                 changeRequestFeasibilityList: { none: { score_Gte: 7 } }
             }) {
                 items { id title }

--- a/tests/integration/test_graphql_subscriptions.py
+++ b/tests/integration/test_graphql_subscriptions.py
@@ -171,7 +171,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         """
         Verify a calculation GraphQL subscription updates when an underlying dependency changes.
 
-        Subscribes to `onTaxcalculationChange` for a created employee, asserts the initial snapshot contains the expected calculated tax, updates the employee's salary to provoke a recalculation, and asserts the subsequent update event reflects the new calculated tax and that `calculatedTax` was accessed.
+        Subscribes to `onTaxCalculationChange` for a created employee, asserts the initial snapshot contains the expected calculated tax, updates the employee's salary to provoke a recalculation, and asserts the subsequent update event reflects the new calculated tax and that `calculatedTax` was accessed.
         """
         employee = self.Employee.create(
             name="Alice",
@@ -182,7 +182,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         context = SimpleNamespace(user=self.user)
         subscription = """
             subscription ($employeeId: ID!) {
-                onTaxcalculationChange(employeeId: $employeeId) {
+                onTaxCalculationChange(employeeId: $employeeId) {
                     action
                     item {
                         calculatedTax {
@@ -228,13 +228,13 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         first_event, second_event = asyncio.run(run_subscription())
 
         self.assertIsNone(first_event.errors)
-        snapshot = first_event.data["onTaxcalculationChange"]
+        snapshot = first_event.data["onTaxCalculationChange"]
         self.assertEqual(snapshot["action"], "snapshot")
         self.assertAlmostEqual(snapshot["item"]["calculatedTax"]["value"], 600)
         self.assertEqual(snapshot["item"]["calculatedTax"]["unit"], "EUR")
 
         self.assertIsNone(second_event.errors)
-        update = second_event.data["onTaxcalculationChange"]
+        update = second_event.data["onTaxCalculationChange"]
         self.assertEqual(update["action"], "update")
         self.assertAlmostEqual(update["item"]["calculatedTax"]["value"], 800)
         self.assertEqual(update["item"]["calculatedTax"]["unit"], "EUR")
@@ -246,7 +246,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         """
         Verify that a GraphQL subscription using a fragment updates calculated GraphQL properties when their backend dependency changes.
 
-        Subscribes to onTaxcalculationChange for a created employee with a fragment that selects `configuredTax`, asserts the initial snapshot value and unit (reflecting the initial TaxRule multiplier), updates the TaxRule multiplier, and asserts the subsequent update event reflects the new computed `configuredTax` value and unit. Also verifies that `TaxCalculation.access_log` records access to `configuredTax` and does not contain `unusedTax`.
+        Subscribes to onTaxCalculationChange for a created employee with a fragment that selects `configuredTax`, asserts the initial snapshot value and unit (reflecting the initial TaxRule multiplier), updates the TaxRule multiplier, and asserts the subsequent update event reflects the new computed `configuredTax` value and unit. Also verifies that `TaxCalculation.access_log` records access to `configuredTax` and does not contain `unusedTax`.
         """
         employee = self.Employee.create(
             name="Alice",
@@ -257,7 +257,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         context = SimpleNamespace(user=self.user)
         subscription = """
             subscription ($employeeId: ID!) {
-                onTaxcalculationChange(employeeId: $employeeId) {
+                onTaxCalculationChange(employeeId: $employeeId) {
                     action
                     item {
                         ...ConfiguredTaxFields
@@ -304,13 +304,13 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         first_event, second_event = asyncio.run(run_subscription())
 
         self.assertIsNone(first_event.errors)
-        snapshot = first_event.data["onTaxcalculationChange"]
+        snapshot = first_event.data["onTaxCalculationChange"]
         self.assertEqual(snapshot["action"], "snapshot")
         self.assertAlmostEqual(snapshot["item"]["configuredTax"]["value"], 600)
         self.assertEqual(snapshot["item"]["configuredTax"]["unit"], "EUR")
 
         self.assertIsNone(second_event.errors)
-        update = second_event.data["onTaxcalculationChange"]
+        update = second_event.data["onTaxCalculationChange"]
         self.assertEqual(update["action"], "update")
         self.assertAlmostEqual(update["item"]["configuredTax"]["value"], 750)
         self.assertEqual(update["item"]["configuredTax"]["unit"], "EUR")
@@ -323,7 +323,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         """
         Verify that a GraphQL subscription updates when a calculation's GraphQL property depends on another model.
 
-        Subscribes to onTaxcalculationChange for a created employee and asserts the initial snapshot and subsequent update reflect changes to the TaxRule multiplier used by the `configuredTax` calculation. Confirms the reported `value` and `unit` for `configuredTax` in the snapshot and update events and that `configuredTax` was accessed while `unusedTax` was not recorded in the calculation access log.
+        Subscribes to onTaxCalculationChange for a created employee and asserts the initial snapshot and subsequent update reflect changes to the TaxRule multiplier used by the `configuredTax` calculation. Confirms the reported `value` and `unit` for `configuredTax` in the snapshot and update events and that `configuredTax` was accessed while `unusedTax` was not recorded in the calculation access log.
         """
         employee = self.Employee.create(
             name="Alice",
@@ -334,7 +334,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         context = SimpleNamespace(user=self.user)
         subscription = """
             subscription ($employeeId: ID!) {
-                onTaxcalculationChange(employeeId: $employeeId) {
+                onTaxCalculationChange(employeeId: $employeeId) {
                     action
                     item {
                         configuredTax {
@@ -377,13 +377,13 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         first_event, second_event = asyncio.run(run_subscription())
 
         self.assertIsNone(first_event.errors)
-        snapshot = first_event.data["onTaxcalculationChange"]
+        snapshot = first_event.data["onTaxCalculationChange"]
         self.assertEqual(snapshot["action"], "snapshot")
         self.assertAlmostEqual(snapshot["item"]["configuredTax"]["value"], 600)
         self.assertEqual(snapshot["item"]["configuredTax"]["unit"], "EUR")
 
         self.assertIsNone(second_event.errors)
-        update = second_event.data["onTaxcalculationChange"]
+        update = second_event.data["onTaxCalculationChange"]
         self.assertEqual(update["action"], "update")
         self.assertAlmostEqual(update["item"]["configuredTax"]["value"], 750)
         self.assertEqual(update["item"]["configuredTax"]["unit"], "EUR")
@@ -394,7 +394,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         """
         Verify GraphQL subscription handles aliases for calculation properties.
 
-        Subscribes to onTaxcalculationChange requesting `configuredTax` aliased as `primaryTax`, asserts the initial snapshot and subsequent update reflect the TaxRule multiplier change (values 600 → 900 with unit "EUR"), and verifies that `configuredTax` was accessed while `unusedTax` was not.
+        Subscribes to onTaxCalculationChange requesting `configuredTax` aliased as `primaryTax`, asserts the initial snapshot and subsequent update reflect the TaxRule multiplier change (values 600 → 900 with unit "EUR"), and verifies that `configuredTax` was accessed while `unusedTax` was not.
         """
         employee = self.Employee.create(
             name="Alice",
@@ -405,7 +405,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         context = SimpleNamespace(user=self.user)
         subscription = """
             subscription ($employeeId: ID!) {
-                onTaxcalculationChange(employeeId: $employeeId) {
+                onTaxCalculationChange(employeeId: $employeeId) {
                     action
                     item {
                         primaryTax: configuredTax {
@@ -453,13 +453,13 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         first_event, second_event = asyncio.run(run_subscription())
 
         self.assertIsNone(first_event.errors)
-        snapshot = first_event.data["onTaxcalculationChange"]
+        snapshot = first_event.data["onTaxCalculationChange"]
         self.assertEqual(snapshot["action"], "snapshot")
         self.assertAlmostEqual(snapshot["item"]["primaryTax"]["value"], 600)
         self.assertEqual(snapshot["item"]["primaryTax"]["unit"], "EUR")
 
         self.assertIsNone(second_event.errors)
-        update = second_event.data["onTaxcalculationChange"]
+        update = second_event.data["onTaxCalculationChange"]
         self.assertEqual(update["action"], "update")
         self.assertAlmostEqual(update["item"]["primaryTax"]["value"], 900)
         self.assertEqual(update["item"]["primaryTax"]["unit"], "EUR")
@@ -470,7 +470,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         """
         Verifies that a subscription requesting only the `action` field emits a snapshot and an update without resolving item payloads.
 
-        Subscribes to `onTaxcalculationChange` for an employee, receives an initial snapshot event, updates the employee's salary to trigger a change event, and asserts:
+        Subscribes to `onTaxCalculationChange` for an employee, receives an initial snapshot event, updates the employee's salary to trigger a change event, and asserts:
         - the first event's action is "snapshot",
         - the second event's action is "update",
         - no calculation GraphQL properties were accessed (TaxCalculation.access_log remains empty).
@@ -484,7 +484,7 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         context = SimpleNamespace(user=self.user)
         subscription = """
             subscription ($employeeId: ID!) {
-                onTaxcalculationChange(employeeId: $employeeId) {
+                onTaxCalculationChange(employeeId: $employeeId) {
                     action
                 }
             }
@@ -526,10 +526,10 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         first_event, second_event = asyncio.run(run_subscription())
 
         self.assertIsNone(first_event.errors)
-        snapshot = first_event.data["onTaxcalculationChange"]
+        snapshot = first_event.data["onTaxCalculationChange"]
         self.assertEqual(snapshot["action"], "snapshot")
 
         self.assertIsNone(second_event.errors)
-        update = second_event.data["onTaxcalculationChange"]
+        update = second_event.data["onTaxCalculationChange"]
         self.assertEqual(update["action"], "update")
         self.assertEqual(self.TaxCalculation.access_log, [])

--- a/tests/integration/test_manager_based_permission.py
+++ b/tests/integration/test_manager_based_permission.py
@@ -347,7 +347,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.TestCountry.Permission.__read__ = ["matches:code:DE"]
         gql_query = """
         query {
-            testcountry1List(filter: {code: "DE"}) {
+            testCountry1List(filter: {code: "DE"}) {
                 items {
                     code
                     name
@@ -359,11 +359,11 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertResponseNoErrors(response)
         response = response.json()
         data = response.get("data", {})
-        self.assertEqual(len(data["testcountry1List"]["items"]), 1)
+        self.assertEqual(len(data["testCountry1List"]["items"]), 1)
 
         gql_query_2 = """
         query {
-            testcountry1List(filter: {code: "US"}) {
+            testCountry1List(filter: {code: "US"}) {
                 items {
                     code
                     name
@@ -375,7 +375,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertResponseNoErrors(response_2)
         response_2 = response_2.json()
         data_2 = response_2.get("data", {})
-        self.assertEqual(len(data_2["testcountry1List"]["items"]), 0)
+        self.assertEqual(len(data_2["testCountry1List"]["items"]), 0)
 
     def test_edge_case_empty_relationships(self):
         """

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -365,7 +365,7 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         context = SimpleNamespace(user=self.user)
         subscription = """
             subscription {
-                onSoftemployeeClassChange {
+                onSoftEmployeeClassChange {
                     action
                     item {
                         id
@@ -396,7 +396,7 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         event = asyncio.run(run_subscription())
 
         self.assertIsNone(event.errors)
-        payload = event.data["onSoftemployeeClassChange"]
+        payload = event.data["onSoftEmployeeClassChange"]
         self.assertEqual(payload["action"], "delete")
         self.assertEqual(payload["item"]["name"], "Soft")
 
@@ -1161,19 +1161,19 @@ class GraphQLAddSubscriptionFieldTests(unittest.TestCase):
 
         GraphQL._add_subscription_field(graphene_type, TestManager)
 
-        self.assertIn("on_testmanager_change", GraphQL._subscription_fields)
-        self.assertIn("subscribe_on_testmanager_change", GraphQL._subscription_fields)
-        self.assertIn("resolve_on_testmanager_change", GraphQL._subscription_fields)
-        self.assertIn("on_testmanager_class_change", GraphQL._subscription_fields)
+        self.assertIn("on_test_manager_change", GraphQL._subscription_fields)
+        self.assertIn("subscribe_on_test_manager_change", GraphQL._subscription_fields)
+        self.assertIn("resolve_on_test_manager_change", GraphQL._subscription_fields)
+        self.assertIn("on_test_manager_class_change", GraphQL._subscription_fields)
         self.assertIn(
-            "subscribe_on_testmanager_class_change", GraphQL._subscription_fields
+            "subscribe_on_test_manager_class_change", GraphQL._subscription_fields
         )
         self.assertIn(
-            "resolve_on_testmanager_class_change", GraphQL._subscription_fields
+            "resolve_on_test_manager_class_change", GraphQL._subscription_fields
         )
 
-        entity_field = GraphQL._subscription_fields["on_testmanager_change"]
-        class_field = GraphQL._subscription_fields["on_testmanager_class_change"]
+        entity_field = GraphQL._subscription_fields["on_test_manager_change"]
+        class_field = GraphQL._subscription_fields["on_test_manager_class_change"]
         self.assertIn("id", entity_field.args)
         self.assertEqual(class_field.args, {})
 


### PR DESCRIPTION
## Summary
- Generate GraphQL root query fields from PascalCase manager names via snake_case internals so Graphene exposes camelCase names like `partSoldType` and `partSoldTypeList`.
- Apply the same word-boundary-preserving naming to generated subscription fields such as `onTaxCalculationChange`.
- Update GraphQL docs and tests to drop legacy fully-lowercase names like `partsoldtype` and `changerequestList`.

## Root Cause
Root query and subscription field names previously used `generalManagerClass.__name__.lower()`, which collapsed multi-word manager names before Graphene applied camelCase conversion. Nested fields retained snake_case word boundaries, causing root fields like `partsoldtype` while relation fields exposed `partSoldType`.

## Validation
- `python -m pytest` -> 2404 passed, 1 skipped
- `ruff check src/general_manager/api/graphql.py tests/integration/test_graphql_relation_filters.py tests/integration/test_graphql_query.py tests/integration/test_graphql_metrics.py tests/integration/test_graphql_subscriptions.py tests/unit/test_graphql_subscriptions.py tests/integration/test_calculation_manager.py tests/integration/test_default_mutations.py tests/integration/test_graphql_calculation_input_options.py tests/integration/test_manager_based_permission.py`
- `ruff format --check src/general_manager/api/graphql.py tests/integration/test_graphql_relation_filters.py tests/integration/test_graphql_query.py tests/integration/test_graphql_metrics.py tests/integration/test_graphql_subscriptions.py tests/unit/test_graphql_subscriptions.py tests/integration/test_calculation_manager.py tests/integration/test_default_mutations.py tests/integration/test_graphql_calculation_input_options.py tests/integration/test_manager_based_permission.py`

Fixes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified GraphQL field naming conventions for generated schemas, specifying that manager classes generate camelCase field names (e.g., `TaxCalculation` → `taxCalculation`)

* **Bug Fixes**
  * Updated GraphQL field name generation to consistently use camelCase format across list queries, single-item queries, and subscription fields throughout the API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->