### PR TITLE
[codex] add manager get shortcut

### DIFF
--- a/docs/concepts/interfaces/request_interface.md
+++ b/docs/concepts/interfaces/request_interface.md
@@ -1,6 +1,6 @@
 # Request Interfaces
 
-`RequestInterface` lets a manager read and query data from a remote HTTP-style service while keeping the familiar GeneralManager API (`filter()`, `exclude()`, `all()`, manager attribute access, and named collection operations).
+`RequestInterface` lets a manager read and query data from a remote HTTP-style service while keeping the familiar GeneralManager API (`filter()`, `get()`, `exclude()`, `all()`, manager attribute access, and named collection operations).
 
 If both services use GeneralManager, prefer `RemoteManagerInterface` for the client side and `RemoteAPI` on the server side. That layer builds on top of `RequestInterface` and synthesizes the standard GeneralManager REST contract for you.
 
@@ -27,7 +27,7 @@ Do not use it as a generic ad hoc HTTP client. Request interfaces are resource-f
 
 A request-backed manager has five layers:
 
-1. Manager API: callers use `Project.filter(status="active")`, `Project.exclude(...)`, `Project.all()`, or `Project.Interface.query_operation("search", ...)`.
+1. Manager API: callers use `Project.filter(status="active")`, `Project.get(id=7)`, `Project.exclude(...)`, `Project.all()`, or `Project.Interface.query_operation("search", ...)`.
 2. Field schema: `RequestField` class attributes define the remote resource shape exposed by the manager.
 3. Filter and operation config: `Interface.Meta` declares filters, query operations, mutation operations, auth provider, retry policy, and serializers.
 4. Request plan: GeneralManager builds a `RequestQueryPlan` with method, path, query params, headers, body, path params, and optional local predicates.

--- a/docs/concepts/models_entities.md
+++ b/docs/concepts/models_entities.md
@@ -25,6 +25,7 @@ class Project(GeneralManager):
 All collection-returning APIs produce a `Bucket`. Buckets behave like Python iterables while preserving metadata such as applied filters and ordering. You can:
 
 - Call `filter()` and `exclude()` to refine the dataset using Django-style lookups.
+- Call `get()` when the lookup must return exactly one manager.
 - Pass `search_date=...` to `filter()` or `exclude()` to query historical state at a specific point in time.
 - Chain `sort()` calls for deterministic ordering.
 - Slice (`bucket[0:10]`) or iterate lazily.
@@ -47,7 +48,7 @@ Use `group_by()` to aggregate managers into `GroupedManager` instances. Grouped 
 
 ## Identity and equality
 
-Managers compare equal when their identification dictionaries match. Use `manager.identification` to inspect the underlying primary keys. Buckets support `get()` and `first()` helpers to retrieve specific instances.
+Managers compare equal when their identification dictionaries match. Use `manager.identification` to inspect the underlying primary keys. Call `Project.get(name="Apollo")` as a shortcut for `Project.filter(name="Apollo").get()` when you expect one match, or use bucket helpers such as `first()` when zero matches are acceptable.
 
 For ORM foreign keys, GeneralManager exposes raw ID helpers such as
 `project.customer_id` alongside relation accessors such as `project.customer`.

--- a/docs/howto/custom_user_model.md
+++ b/docs/howto/custom_user_model.md
@@ -83,6 +83,7 @@ Avoid importing `accounts.models.User` when you expect GeneralManager APIs like:
 
 - `User.create(...)`
 - `User.filter(...)`
+- `User.get(...)`
 - `User.Factory.create()`
 
 `manage.py shell` and similar tools naturally surface Django models from `models.py`, so `accounts.managers.User` should be your canonical GeneralManager import path.

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -348,6 +348,16 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         return cls.Interface.filter(**kwargs)
 
     @classmethod
+    def get(cls, **kwargs: Any) -> Self:
+        """
+        Return the single manager matching the provided lookup expressions.
+
+        This is a convenience wrapper around ``filter(...).get()`` and preserves
+        the underlying bucket's single-item exception behavior.
+        """
+        return cls.filter(**kwargs).get()
+
+    @classmethod
     def exclude(cls, **kwargs: Any) -> Bucket[Self]:
         """
         Return a bucket excluding managers that match the provided lookups.

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -282,6 +282,20 @@ class GeneralManagerTestCase(TestCase):
             mock_filter.assert_called_once_with(id__in=["dummy_id", 123])
             self.assertEqual(result, [])
 
+    def test_classmethod_get(self):
+        """
+        Tests that the GeneralManager.get class method delegates through the
+        filtered bucket's get method with the provided lookup arguments.
+        """
+        expected_manager = self.manager()
+        bucket = Mock()
+        bucket.get.return_value = expected_manager
+        with patch.object(DummyInterface, "filter", return_value=bucket) as mock_filter:
+            result = self.manager.get(name="Test Manager")
+            mock_filter.assert_called_once_with(name="Test Manager")
+            bucket.get.assert_called_once_with()
+            self.assertIs(result, expected_manager)
+
     def test_classmethod_exclude(self):
         # Test the exclude class method
         """


### PR DESCRIPTION
## Summary

- Add `GeneralManager.get(**kwargs)` as a convenience wrapper around `filter(**kwargs).get()`.
- Preserve existing bucket-specific single-item behavior and exceptions.
- Document the class-level `get()` API in manager/bucket concepts, request interface guidance, and the custom user wrapper guide.

Closes #257.

## Validation

- `python -m pytest tests/unit/test_general_manager.py`
- `ruff check src/general_manager/manager/general_manager.py tests/unit/test_general_manager.py`
- `mypy src/general_manager/manager/general_manager.py`
- pre-commit on commit: ruff lint/format, EOF, trailing whitespace, mixed line endings, merge conflict check, debug check, mypy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a convenient `get()` method for performing single-item lookups directly, replacing the need for chained filter operations.

* **Documentation**
  * Updated documentation to clarify `get()` as the recommended approach for lookups that require exactly one result.
  * Refined guides with improved examples and best practices for API usage.

* **Tests**
  * Added test coverage to verify the new `get()` method works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->