### PR TITLE
[codex] Improve calculation performance overhead

### DIFF
--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -6,6 +6,8 @@
 
 ::: general_manager.cache.cache_tracker.DependencyTracker
 
+::: general_manager.cache.run_context.CalculationRunContext
+
 ::: general_manager.cache.dependency_index.record_dependencies
 
 ::: general_manager.cache.dependency_index.invalidate_cache_key

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -32,7 +32,9 @@ Every data-changing operation emits signals captured by the dependency tracker (
 
 To take advantage of the tracker:
 
-- Wrap expensive resolvers with the `@cached` decorator or the `@graph_ql_property` decorator if you want to expose them in GraphQL.
+- Wrap expensive resolvers with `@cached(scope="dependency")` or `@graph_ql_property(cache="dependency")` when they should persist across runs and invalidate through the dependency index.
+- Use `@cached(scope="timeout", timeout=seconds)` when time-based expiry is enough and dependency tracking would add unnecessary overhead.
+- Use the default `@cached()` or `@graph_ql_property` run scope for helpers that only need reuse within one request, calculation graph, bulk operation, or background run.
 - Mark inputs and outputs clearly so dependencies can be resolved.
 - Configure a shared cache backend when you run multiple worker processes.
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -31,6 +31,9 @@ This deferred tracking applies to terminal bucket operations such as:
 - scalar indexing such as `bucket[0]`
 - membership checks such as `manager in bucket`
 
+Membership checks on ORM-backed buckets use a targeted `exists()` lookup for
+the checked primary key instead of materialising every row ID.
+
 Empty result sets still record dependencies. A cached `count() == 0` must invalidate when a later create or update makes the query match.
 
 ### Bucket transformations
@@ -71,12 +74,14 @@ Request-backed buckets are currently the exception. They still use eager `reques
 
 ## Caching helper
 
-Use the `@general_manager.cache.cache_decorator.cached` decorator to memoise expensive functions while automatically tracking dependencies:
+Use the `@general_manager.cache.cache_decorator.cached` decorator to memoise
+expensive helpers for the active request, calculation graph, bulk operation, or
+background run:
 
 ```python
 from general_manager.cache.cache_decorator import cached
 
-@cached
+@cached()
 def project_forecast(project_id: int) -> dict[str, float]:
     project = Project(id=project_id)
     return {
@@ -85,20 +90,59 @@ def project_forecast(project_id: int) -> dict[str, float]:
     }
 ```
 
-When the wrapped function runs, it records every manager it touches. Subsequent calls reuse the cached value until a tracked dependency changes.
+The default `scope="run"` stores values in `CalculationRunContext`. Values are
+discarded when the run ends and do not participate in dependency invalidation.
 
-You can also specify a timeout in seconds:
+Use dependency scope when a value should be reused across runs and invalidated
+when tracked managers change:
 
 ```python
-@cached(timeout=300)  # Cache for 5 minutes
+@cached(scope="dependency")
 def project_forecast(project_id: int) -> dict[str, float]:
     ...
 ```
-When `timeout` is set, the cache entry expires after the given duration no matter if the tracked dependencies change.
+
+When the wrapped dependency-scoped function runs, it records every manager it
+touches. Subsequent calls reuse the cached value until a tracked dependency
+changes.
+
+Use timeout scope when a value should be cached in the configured cache backend
+for a fixed duration without dependency tracking:
+
+```python
+@cached(scope="timeout", timeout=300)  # Cache for 5 minutes
+def project_forecast(project_id: int) -> dict[str, float]:
+    ...
+```
+
+`timeout` is required for `scope="timeout"` and is not accepted on the other
+scopes. The cache entry expires after the given duration and is not invalidated
+through the dependency index.
+
+## Run context storage
+
+`CalculationRunContext` exposes lightweight storage for one request,
+calculation graph, bulk operation, or background run. Use it for working sets
+that should not enter the dependency index:
+
+```python
+from general_manager.cache.run_context import CalculationRunContext
+
+with CalculationRunContext() as context:
+    context.set(("project", project_id), project)
+    project = context.get(("project", project_id))
+```
+
+Use `get_or_set(key, loader)` to load a value once, `has(key)` or `key in
+context` to check storage, `index(key=..., loader=..., index_by=...)` for
+one-row-per-key lookups, and `group_by(...)` or `index_many(...)` when multiple
+rows share the same key.
 
 ## Manual dependency-index helpers
 
-Most application code should rely on CRUD signals and the `cached` decorator. For integration code and tests, the cache module also exposes lower-level dependency-index helpers:
+Most application code should rely on CRUD signals and dependency-scoped
+`cached` calls. For integration code and tests, the cache module also exposes
+lower-level dependency-index helpers:
 
 - `record_dependencies(cache_key, dependencies)` stores the dependency set for an already-computed cache entry.
 - `invalidate_cache_key(cache_key)` invalidates one cache key without recalculating dependency matches.
@@ -108,11 +152,12 @@ These helpers are intentionally lower level than `cached`. Use them when buildin
 
 ## Recommended practices
 
-- Configure a shared cache backend (Redis or Memcached) in production so dependency signals reach all processes.
+- Configure a shared cache backend (Redis or Memcached) in production so dependency signals and timeout-scoped cache entries reach all processes.
 - Keep cache keys deterministic by relying on the built-in `make_cache_key` helper.
-- Avoid caching code paths that bypass permission checks. The cached decorator records dependencies, not the caller identity.
+- Avoid dependency-scoped caching for code paths that bypass permission checks. The cached decorator records dependencies, not the caller identity.
 - Prefer grouping logically inseparable lookup clauses into one `filter()` or `exclude()` call when you want them invalidated as one composite dependency.
 - Treat request-backed bucket caching separately from ORM-backed bucket caching when debugging invalidation behavior.
 - Regularly test cache invalidation by running workflows that update managers and verifying that cached results change accordingly.
 
-For low-latency APIs, combine the cached decorator with bucket-level prefetching and GraphQL data loaders.
+For low-latency APIs, combine run-scoped caching with bucket-level prefetching
+and GraphQL data loaders.

--- a/docs/concepts/interfaces/computed_data_interfaces.md
+++ b/docs/concepts/interfaces/computed_data_interfaces.md
@@ -21,6 +21,11 @@ class ProjectSummary(GeneralManager):
         date = Input(date)
 ```
 
+Resolved input values are memoized on each calculation instance. This includes
+manager inputs: repeated `self.project` access on one calculation returns the
+same wrapper, while a new calculation instance resolves a fresh wrapper from the
+current database state.
+
 ## Computing values
 
 Expose computed attributes with `@graph_ql_property`. The decorator registers the method as a GraphQL field and caches results in the active run context by default for every manager type.
@@ -56,6 +61,7 @@ Because calculation managers do not persist data, `create`, `update`, and `delet
 
 - Use `required=False` for optional inputs. Calculation metadata and parsing now treat those fields as nullable and default them to `None` when omitted.
 - Use `possible_values` to restrict input choices or provide a callable for dynamic options.
+- Callable or bucket-backed `possible_values` are not resolved during ordinary input casting unless a custom normalizer needs them. They are still resolved when enumerating calculation combinations or validating allowed values.
 - Use `min_value`, `max_value`, and `validator` for scalar constraints without eagerly enumerating every allowed value.
 - Employ `Input.date_range(...)`, `Input.monthly_date(...)`, and `Input.yearly_date(...)` for structured date domains such as month-end or year-start inputs.
 - Prefer domain objects such as `DateRangeDomain` and `NumericRangeDomain` when you need structured range metadata rather than an eager list.

--- a/docs/concepts/interfaces/db_based_interface.md
+++ b/docs/concepts/interfaces/db_based_interface.md
@@ -23,6 +23,11 @@ class Book(GeneralManager):
 
 You can use all field types, including custom fields like `MeasurementField`. Django validators, constraints, and signals run as usual.
 
+Foreign keys expose both the relation field and a raw ID helper. In the example
+above, `book.author` resolves the related object or manager, while
+`book.author_id` returns the stored foreign-key value directly. Prefer the raw
+ID helper in hot paths when you only need the identifier.
+
 ## CRUD operations
 
 Managers expose `create`, `update`, and `delete` methods that call the interface. Each method accepts `creator_id` and `history_comment` arguments for audit trails. `update()` refreshes the current manager in place and returns that same instance for chaining. `delete()` invalidates the current manager instance for later field reads.

--- a/docs/concepts/interfaces/dependency_graph.md
+++ b/docs/concepts/interfaces/dependency_graph.md
@@ -8,9 +8,9 @@ CRUD operations on `GeneralManager` instances emit the `data_change` signal defi
 
 ## Recording dependencies
 
-When an interface resolves related data (for example, fetching a bucket of child managers), it calls `DependencyTracker.track()`. Cached functions using `@cached` persist these dependencies so that mutations can invalidate the correct cache entries.
+When an interface resolves related data (for example, fetching a bucket of child managers), it calls `DependencyTracker.track()`. Cached functions using `@cached(scope="dependency")` persist these dependencies so that mutations can invalidate the correct cache entries.
 
-Run-scoped `@graph_ql_property` caching is separate from the dependency index. Values stored in `CalculationRunContext` are discarded at the end of the request or run, so they do not need invalidation and do not appear in the dependency index. Dependency-aware properties opt in with `@graph_ql_property(cache="dependency")`.
+Run-scoped `@cached()` and `@graph_ql_property` caching is separate from the dependency index. Values stored in `CalculationRunContext` are discarded at the end of the request or run, so they do not need invalidation and do not appear in the dependency index. Dependency-aware properties opt in with `@graph_ql_property(cache="dependency")`.
 
 ## Graph traversal
 

--- a/docs/concepts/models_entities.md
+++ b/docs/concepts/models_entities.md
@@ -49,6 +49,11 @@ Use `group_by()` to aggregate managers into `GroupedManager` instances. Grouped 
 
 Managers compare equal when their identification dictionaries match. Use `manager.identification` to inspect the underlying primary keys. Buckets support `get()` and `first()` helpers to retrieve specific instances.
 
+For ORM foreign keys, GeneralManager exposes raw ID helpers such as
+`project.customer_id` alongside relation accessors such as `project.customer`.
+Use the raw ID helper when you only need the stored identifier and want to avoid
+resolving the related manager.
+
 ## Pattern recommendations
 
 - Use descriptive attribute names that align with your GraphQL schema.

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -689,10 +689,12 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
 
         self._track_effective_dependencies()
         if isinstance(item, GeneralManager):
-            return item.identification.get("id", None) in self._data.values_list(
-                "pk", flat=True
-            )
-        return item.pk in self._data.values_list("pk", flat=True)
+            pk = item.identification.get("id", None)
+        else:
+            pk = item.pk
+        if pk is None:
+            return False
+        return self._data.filter(pk=pk).exists()
 
     def sort(
         self,

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -77,20 +77,24 @@ def cached(
     scope: CacheScope = "run",
 ) -> Callable[[FuncT], FuncT]:
     """
-    Cache a function call.
+    Decorator factory for caching a function call.
 
     By default, cached values are scoped to the active
     :class:`~general_manager.cache.run_context.CalculationRunContext` and are
     discarded when that run ends. Use ``scope="dependency"`` to persist values
-    in ``cache_backend`` and register dependency metadata for invalidation. Use
-    ``scope="timeout"`` for cache-backend storage with time-based expiry and no
-    dependency tracking.
+    in ``cache_backend`` and use ``record_fn`` to persist dependency metadata
+    for invalidation. Use ``scope="timeout"`` with ``timeout`` set for
+    cache-backend storage with time-based expiry; dependency recording is
+    ignored for timeout-scoped values.
 
     Parameters:
         timeout (int | None): Expiration in seconds for timeout-scoped cached values.
+            Required when ``scope`` is ``"timeout"`` and invalid with any other
+            ``CacheScope``.
         cache_backend (CacheBackend): Backend used to read and write cached results.
-        record_fn (RecordFn): Callback invoked to persist dependency metadata when no timeout is
-            defined.  Defaults to :func:`~general_manager.cache.dependency_index.record_dependencies`.
+        record_fn (RecordFn): Callback invoked to persist dependency metadata when
+            ``scope`` is ``"dependency"``. Defaults to
+            :func:`~general_manager.cache.dependency_index.record_dependencies`.
         scope (CacheScope): Cache storage strategy. ``"run"`` memoizes for the active run,
             ``"dependency"`` stores in ``cache_backend`` with dependency tracking,
             ``"timeout"`` stores in ``cache_backend`` with time-based expiry, and
@@ -100,6 +104,9 @@ def cached(
         Callable: Decorator that wraps the target function with caching behaviour.
 
     Raises:
+        ValueError: Raised for invalid ``scope``/``timeout`` combinations, including
+            unsupported ``CacheScope`` values, missing ``timeout`` for
+            ``scope="timeout"``, and ``timeout`` supplied for non-timeout scopes.
         DependencyLockTimeoutError: Propagated from ``record_fn`` (i.e.
             :func:`~general_manager.cache.dependency_index.record_dependencies`) when the
             dependency-index lock cannot be acquired within the configured timeout.  The cached

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -44,7 +44,7 @@ class CacheBackend(Protocol):
 
 RecordFn = Callable[[str, Set[Dependency]], None]
 FuncT = TypeVar("FuncT", bound=Callable[..., object])
-CacheScope = Literal["dependency", "run", "none"]
+CacheScope = Literal["dependency", "run", "timeout", "none"]
 
 _SENTINEL = object()
 logger = get_logger("cache.decorator")
@@ -57,21 +57,44 @@ class UnsupportedCacheScopeError(ValueError):
         super().__init__(f"Unsupported cache scope: {scope}")
 
 
+class CacheTimeoutConfigurationError(ValueError):
+    """Raised when timeout is used with an incompatible cache scope."""
+
+    @classmethod
+    def missing_timeout(cls) -> "CacheTimeoutConfigurationError":
+        return cls('scope="timeout" requires timeout')
+
+    @classmethod
+    def unexpected_timeout(cls) -> "CacheTimeoutConfigurationError":
+        return cls('timeout is only supported with scope="timeout"')
+
+
 def cached(
     timeout: Optional[int] = None,
     cache_backend: CacheBackend = django_cache,
     record_fn: RecordFn = record_dependencies,
     *,
-    scope: CacheScope = "dependency",
+    scope: CacheScope = "run",
 ) -> Callable[[FuncT], FuncT]:
     """
-    Cache a function call while registering its data dependencies.
+    Cache a function call.
+
+    By default, cached values are scoped to the active
+    :class:`~general_manager.cache.run_context.CalculationRunContext` and are
+    discarded when that run ends. Use ``scope="dependency"`` to persist values
+    in ``cache_backend`` and register dependency metadata for invalidation. Use
+    ``scope="timeout"`` for cache-backend storage with time-based expiry and no
+    dependency tracking.
 
     Parameters:
-        timeout (int | None): Expiration in seconds for cached values; `None` stores results until invalidated.
+        timeout (int | None): Expiration in seconds for timeout-scoped cached values.
         cache_backend (CacheBackend): Backend used to read and write cached results.
         record_fn (RecordFn): Callback invoked to persist dependency metadata when no timeout is
             defined.  Defaults to :func:`~general_manager.cache.dependency_index.record_dependencies`.
+        scope (CacheScope): Cache storage strategy. ``"run"`` memoizes for the active run,
+            ``"dependency"`` stores in ``cache_backend`` with dependency tracking,
+            ``"timeout"`` stores in ``cache_backend`` with time-based expiry, and
+            ``"none"`` disables caching.
 
     Returns:
         Callable: Decorator that wraps the target function with caching behaviour.
@@ -82,6 +105,12 @@ def cached(
             dependency-index lock cannot be acquired within the configured timeout.  The cached
             value has already been stored at that point; only the dependency metadata is lost.
     """
+    if scope not in {"dependency", "run", "timeout", "none"}:
+        raise UnsupportedCacheScopeError(scope)
+    if scope == "timeout" and timeout is None:
+        raise CacheTimeoutConfigurationError.missing_timeout()
+    if timeout is not None and scope != "timeout":
+        raise CacheTimeoutConfigurationError.unexpected_timeout()
 
     def decorator(func: FuncT) -> FuncT:
         @wraps(func)
@@ -94,10 +123,34 @@ def cached(
                 with ensure_calculation_run_context() as context:
                     return context.get_or_set(key, lambda: func(*args, **kwargs))
 
-            if scope != "dependency":
-                raise UnsupportedCacheScopeError(scope)
-
             key = make_cache_key(func, args, kwargs)
+
+            if scope == "timeout":
+                cached_result = cache_backend.get(key, _SENTINEL)
+                if cached_result is not _SENTINEL:
+                    logger.debug(
+                        "cache hit",
+                        context={
+                            "function": func.__qualname__,
+                            "key": key,
+                            "scope": scope,
+                        },
+                    )
+                    return cached_result
+
+                result = func(*args, **kwargs)
+                cache_backend.set(key, result, timeout)
+                logger.debug(
+                    "cache miss stored",
+                    context={
+                        "function": func.__qualname__,
+                        "key": key,
+                        "timeout": timeout,
+                        "scope": scope,
+                    },
+                )
+                return result
+
             deps_key = f"{key}:deps"
 
             cached_result = cache_backend.get(key, _SENTINEL)

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Callable, Hashable, Iterable
 from contextvars import ContextVar, Token
 from types import TracebackType
@@ -44,6 +45,22 @@ class CalculationRunContext:
             self._values[key] = loader()
         return self._values[key]  # type: ignore[return-value]
 
+    def get(self, key: Hashable, default: object = None) -> object:
+        """Return the stored value for key, or default when key is absent."""
+        return self._values.get(key, default)
+
+    def set(self, key: Hashable, value: object) -> None:
+        """Store a value for the active run."""
+        self._values[key] = value
+
+    def has(self, key: Hashable) -> bool:
+        """Return whether key has a value in the active run."""
+        return key in self._values
+
+    def __contains__(self, key: Hashable) -> bool:
+        """Return whether key has a value in the active run."""
+        return self.has(key)
+
     def index(
         self,
         *,
@@ -56,6 +73,33 @@ class CalculationRunContext:
             ("index", key),
             lambda: {index_by(row): row for row in loader()},
         )
+
+    def group_by(
+        self,
+        *,
+        key: Hashable,
+        loader: Callable[[], Iterable[T]],
+        group_by: Callable[[T], K],
+    ) -> dict[K, list[T]]:
+        """Load a working set once and group it by the supplied key function."""
+
+        def load_groups() -> dict[K, list[T]]:
+            grouped: defaultdict[K, list[T]] = defaultdict(list)
+            for row in loader():
+                grouped[group_by(row)].append(row)
+            return dict(grouped)
+
+        return self.get_or_set(("group_by", key), load_groups)
+
+    def index_many(
+        self,
+        *,
+        key: Hashable,
+        loader: Callable[[], Iterable[T]],
+        index_by: Callable[[T], K],
+    ) -> dict[K, list[T]]:
+        """Load a working set once and group rows sharing the same index key."""
+        return self.group_by(key=key, loader=loader, group_by=index_by)
 
 
 def current_calculation_run_context() -> CalculationRunContext | None:

--- a/src/general_manager/interface/capabilities/calculation/lifecycle.py
+++ b/src/general_manager/interface/capabilities/calculation/lifecycle.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, ClassVar
 
 from general_manager.bucket.calculation_bucket import CalculationBucket
+from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.dependency_index import serialize_dependency_identifier
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.input import Input
 
@@ -16,6 +18,15 @@ if TYPE_CHECKING:  # pragma: no cover
     from general_manager.interface.interfaces.calculation import (
         CalculationInterface,
     )
+
+
+def _track_cached_manager(value: Any) -> None:
+    if isinstance(value, GeneralManager):
+        DependencyTracker.track(
+            value.__class__.__name__,
+            "identification",
+            serialize_dependency_identifier(value.identification),
+        )
 
 
 class CalculationReadCapability(BaseCapability):
@@ -88,8 +99,8 @@ class CalculationReadCapability(BaseCapability):
             input_field = interface_cls.input_fields[field_name]
             if field_name in resolved_values:
                 cached_value = resolved_values[field_name]
-                if not isinstance(cached_value, GeneralManager):
-                    return cached_value
+                _track_cached_manager(cached_value)
+                return cached_value
 
             input_field = interface_cls.input_fields[field_name]
             dependency_values = {
@@ -103,8 +114,7 @@ class CalculationReadCapability(BaseCapability):
                 interface_instance.identification.get(field_name),
                 dependency_values,
             )
-            if not isinstance(value, GeneralManager):
-                resolved_values[field_name] = value
+            resolved_values[field_name] = value
             return value
 
         return {

--- a/src/general_manager/interface/capabilities/orm/support.py
+++ b/src/general_manager/interface/capabilities/orm/support.py
@@ -328,15 +328,28 @@ class OrmReadCapability(BaseCapability):
             field_name (str): Name of the field on the model.
 
         Returns:
-            type: The class used to represent the field's values: the related model's `_general_manager_class` when the field is a relation to a model that exposes that attribute, otherwise the Python type of the field object.
+            type: The Django field class for stored model fields, the related
+            model's `_general_manager_class` for managed relations, or descriptor
+            metadata for synthetic interface fields.
         """
-        descriptors = get_support_capability(interface_cls).get_field_descriptors(
-            interface_cls
-        )
-        descriptor = descriptors.get(field_name)
-        if descriptor is not None:
-            return descriptor.metadata["type"]
-        field = interface_cls._model._meta.get_field(field_name)
+        try:
+            field = interface_cls._model._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            descriptors = get_support_capability(interface_cls).get_field_descriptors(
+                interface_cls
+            )
+            descriptor = descriptors.get(field_name)
+            if descriptor is not None:
+                return descriptor.metadata["type"]
+            raise
+        if getattr(field, "name", field_name) != field_name:
+            descriptor = (
+                get_support_capability(interface_cls)
+                .get_field_descriptors(interface_cls)
+                .get(field_name)
+            )
+            if descriptor is not None:
+                return descriptor.metadata["type"]
         if (
             field.is_relation
             and field.related_model

--- a/src/general_manager/interface/capabilities/orm/support.py
+++ b/src/general_manager/interface/capabilities/orm/support.py
@@ -330,6 +330,12 @@ class OrmReadCapability(BaseCapability):
         Returns:
             type: The class used to represent the field's values: the related model's `_general_manager_class` when the field is a relation to a model that exposes that attribute, otherwise the Python type of the field object.
         """
+        descriptors = get_support_capability(interface_cls).get_field_descriptors(
+            interface_cls
+        )
+        descriptor = descriptors.get(field_name)
+        if descriptor is not None:
+            return descriptor.metadata["type"]
         field = interface_cls._model._meta.get_field(field_name)
         if (
             field.is_relation

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -227,6 +227,20 @@ class _FieldDescriptorBuilder:
                 relation_kind="direct",
                 filter_lookup=field.name,
             )
+            raw_id_name = getattr(field, "attname", f"{field.name}_id")
+            if raw_id_name not in self._descriptors:
+                target_field = getattr(field, "target_field", None)
+                raw_id_type = type(target_field) if target_field is not None else int
+                self._register(
+                    attribute_name=raw_id_name,
+                    raw_type=raw_id_type,
+                    is_required=not field.null,
+                    is_editable=False,
+                    default=default,
+                    is_derived=False,
+                    accessor=_instance_attribute_accessor(raw_id_name),
+                    filter_lookup=raw_id_name,
+                )
 
     def _add_reverse_one_to_one_relations(self) -> None:
         """Register snake_case aliases for reverse one-to-one relation accessors."""

--- a/src/general_manager/manager/input.py
+++ b/src/general_manager/manager/input.py
@@ -661,10 +661,18 @@ class Input(Generic[INPUT_TYPE]):
 
         if value is None:
             return None
-        possible_values = self.resolve_possible_values(identification)
+        possible_values = (
+            self.possible_values
+            if isinstance(self.possible_values, InputDomain)
+            else None
+        )
         if isinstance(possible_values, InputDomain):
             value = possible_values.normalize(value)
         if self.normalizer is not None:
+            if possible_values is None:
+                possible_values = self.resolve_possible_values(identification)
+                if isinstance(possible_values, InputDomain):
+                    value = possible_values.normalize(value)
             dependency_values = self._build_dependency_values(identification)
             return _invoke_callable(
                 self.normalizer,

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -665,9 +665,10 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
             actual_costs=Measurement(1200, "EUR"), ignore_permission=True
         )
 
-        self.assertFalse(commercials1.has_budget_buffer)
+        refreshed_commercials1 = self.TestCommercials(project=self.project1)
+        self.assertFalse(refreshed_commercials1.has_budget_buffer)
         self.assert_cache_miss()
-        self.assertEqual(commercials1.budget_left, Measurement(-200, "EUR"))
+        self.assertEqual(refreshed_commercials1.budget_left, Measurement(-200, "EUR"))
         self.assert_cache_hit()
 
     def test_contains_lookup_invalidation(self):

--- a/tests/integration/test_calculation_manager.py
+++ b/tests/integration/test_calculation_manager.py
@@ -5,6 +5,8 @@ from typing import ClassVar
 from django.contrib.auth import get_user_model
 from django.db.models import CASCADE, CharField, ForeignKey, IntegerField
 from django.utils.crypto import get_random_string
+from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.dependency_index import serialize_dependency_identifier
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface import CalculationInterface, DatabaseInterface
 from general_manager.utils.testing import GeneralManagerTransactionTestCase
@@ -171,6 +173,39 @@ class CustomMutationTest(GeneralManagerTransactionTestCase):
             grouped,
             self.TaxCalculation.all().group_by("employee"),
         )
+
+    def test_manager_inputs_are_cached_only_within_the_calculation_instance(self):
+        employee = self.Employee.create(
+            name="John Doe", salary=Measurement(3000, "EUR"), creator_id=self.user.id
+        )
+        calculation = self.TaxCalculation(employee=employee)
+
+        cached_employee = calculation.employee
+
+        employee.update(
+            salary=Measurement(4000, "EUR"),
+            creator_id=self.user.id,
+            ignore_permission=True,
+        )
+
+        with DependencyTracker() as dependencies:
+            repeated_employee = calculation.employee
+
+        self.assertIs(repeated_employee, cached_employee)
+        self.assertEqual(
+            dependencies,
+            {
+                (
+                    self.Employee.__name__,
+                    "identification",
+                    serialize_dependency_identifier(cached_employee.identification),
+                )
+            },
+        )
+
+        later_calculation = self.TaxCalculation(employee=employee)
+        self.assertEqual(later_calculation.employee.salary, Measurement(4000, "EUR"))
+        self.assertIsNot(later_calculation.employee, cached_employee)
 
     def test_entry_based_graphql_property_refreshes_after_update(self):
         employee = self.Employee.create(

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -347,6 +347,22 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(human_no_country.name, "David")
         self.assertIsNone(human_no_country.country)
 
+    def test_foreign_key_id_accessor_returns_raw_id_without_resolving_relation(self):
+        """
+        Foreign-key ID helpers expose the raw column value without building the related manager.
+        """
+        us_country_pk = self.TestCountry.Interface._model.objects.get(code="US").pk
+
+        with patch.object(
+            self.TestCountry,
+            "__init__",
+            side_effect=AssertionError("country relation should not resolve"),
+        ):
+            self.assertEqual(self.test_human1.country_id, us_country_pk)
+            self.assertIsNone(self.test_human2.country_id)
+
+        self.assertIs(self.TestHuman.country_id, int)
+
     def test_filter_operations(self):
         """
         Test various filter operations on GeneralManager instances.

--- a/tests/integration/test_remote_manager_interface.py
+++ b/tests/integration/test_remote_manager_interface.py
@@ -388,7 +388,7 @@ class RemoteManagerInterfaceIntegrationTests(GeneralManagerTransactionTestCase):
         self.assertEqual(cause.request_id, "gm-detail-999")
 
     def test_websocket_event_can_invalidate_cached_remote_queries(self) -> None:
-        @cached()
+        @cached(scope="dependency")
         def active_count() -> int:
             return self.RemoteProject.filter(status="active").count()
 
@@ -476,7 +476,7 @@ class RemoteManagerInterfaceIntegrationTests(GeneralManagerTransactionTestCase):
     def test_remote_invalidation_client_can_invalidate_cached_remote_queries(
         self,
     ) -> None:
-        @cached()
+        @cached(scope="dependency")
         def active_count() -> int:
             return self.RemoteProject.filter(status="active").count()
 

--- a/tests/integration/test_request_caching.py
+++ b/tests/integration/test_request_caching.py
@@ -131,11 +131,11 @@ class RequestCachingIntegrationTest(GeneralManagerTransactionTestCase):
         ]
 
     def test_request_query_dependencies_are_recorded_per_operation(self) -> None:
-        @cached()
+        @cached(scope="dependency")
         def active_count() -> int:
             return self.RemoteProject.filter(status="active").count()
 
-        @cached()
+        @cached(scope="dependency")
         def search_count() -> int:
             return self.RemoteProject.Interface.query_operation(
                 "search",
@@ -170,7 +170,7 @@ class RequestCachingIntegrationTest(GeneralManagerTransactionTestCase):
     def test_request_query_invalidation_is_safe_and_does_not_trigger_detail_reads(
         self,
     ) -> None:
-        @cached()
+        @cached(scope="dependency")
         def active_count() -> int:
             return self.RemoteProject.filter(status="active").count()
 

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -25,6 +25,7 @@ class FakeCacheBackend:
         Initializes the in-memory cache store.
         """
         self.store = {}
+        self.timeouts = {}
 
     def get(self, key, default=None):
         """
@@ -52,6 +53,7 @@ class FakeCacheBackend:
             timeout: Optional expiration time for the cache entry. This backend does not enforce expiration.
         """
         self.store[key] = pickle.dumps(value)
+        self.timeouts[key] = timeout
 
 
 class TestCacheDecoratorBackend(SimpleTestCase):
@@ -112,7 +114,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         Tests that the cached decorator does not alter the original function's return value.
         """
 
-        @cached(timeout=5)
+        @cached()
         def sample_function(x, y):
             return x + y
 
@@ -128,7 +130,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         Verifies that on the first call, the function result is cached and both cache.get and cache.set are called. On a subsequent call with the same arguments before expiration, only cache.get is called, confirming a cache hit.
         """
 
-        @cached(timeout=5)
+        @cached(scope="timeout", timeout=5)
         def sample_function(x, y):
             return x + y
 
@@ -160,7 +162,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         `cache.get` and `cache.set` to be called again.
         """
 
-        @cached(timeout=0.1)  # type: ignore
+        @cached(scope="timeout", timeout=0.1)  # type: ignore[arg-type]
         def sample_function(x, y):
             return x + y
 
@@ -191,7 +193,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         """
         custom_cache = FakeCacheBackend()
 
-        @cached(timeout=5, cache_backend=custom_cache)
+        @cached(scope="timeout", timeout=5, cache_backend=custom_cache)
         def sample_function(x, y):
             """
             Returns the sum of two values.
@@ -209,13 +211,19 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self.assertTrue(
             len(custom_cache.store) > 0, "Cache should have stored the result"
         )
+        key = make_cache_key(sample_function, (1, 2), {})
+        self.assertEqual(custom_cache.timeouts[key], 5)
 
     def test_cache_decorator_uses_real_tracker(self):
         """
         Tests that the cached decorator records dependencies using DependencyTracker on cache miss and invokes the record function, but does not record dependencies or call the record function on cache hit.
         """
 
-        @cached(timeout=None, cache_backend=self.fake_cache, record_fn=self.record_fn)
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
         def fn(x, y):
             # Record actual dependencies
             DependencyTracker.track("User", "identification", str(x))
@@ -251,7 +259,12 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         dependency recording function, and that cache hits do not trigger dependency recording.
         """
 
-        @cached(timeout=5, cache_backend=self.fake_cache, record_fn=self.record_fn)
+        @cached(
+            scope="timeout",
+            timeout=5,
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
         def fn(x, y):
             # Record actual dependencies
             DependencyTracker.track("User", "identification", str(x))
@@ -269,6 +282,8 @@ class TestCacheDecoratorBackend(SimpleTestCase):
 
         # no record_fn call because of timeout
         self.assertEqual(len(self.record_calls), 0)
+        self.assertNotIn(f"{key}:deps", self.fake_cache.store)
+        self.assertEqual(self.fake_cache.timeouts[key], 5)
         self.assertEqual(res, 5)
         self.assertEqual(self.record_calls, [])
 
@@ -285,12 +300,20 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         Ensures that both inner and outer functions store their computed results in the provided cache backend and that the recording function is invoked once per miss with the correct dependency sets (inner first, then outer). Also verifies that subsequent calls that hit the cache do not trigger dependency recording.
         """
 
-        @cached(cache_backend=self.fake_cache, record_fn=self.record_fn)
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
         def outer_function(x, y):
             DependencyTracker.track("User", "identification", str(x))
             return inner_function(x, y)
 
-        @cached(cache_backend=self.fake_cache, record_fn=self.record_fn)
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
         def inner_function(x, y):
             """
             Tracks a dependency and returns the sum of two values.
@@ -345,12 +368,20 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         Verifies that dependency recording occurs separately for inner and outer cached functions on cache misses, and that no dependency recording occurs on cache hits. Ensures cached results are correctly stored and retrieved from the custom cache backend.
         """
 
-        @cached(cache_backend=self.fake_cache, record_fn=self.record_fn)
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
         def outer_function(x, y):
             DependencyTracker.track("User", "identification", str(x))
             return inner_function(x, y)
 
-        @cached(cache_backend=self.fake_cache, record_fn=self.record_fn)
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
         def inner_function(x, y):
             """
             Tracks a dependency and returns the sum of two values.
@@ -405,6 +436,72 @@ class TestCacheDecoratorBackend(SimpleTestCase):
 
 
 class TestCacheDecoratorScopes(SimpleTestCase):
+    def test_timeout_scope_requires_timeout(self):
+        with self.assertRaisesRegex(ValueError, 'scope="timeout" requires timeout'):
+            cached(scope="timeout")
+
+    def test_set_timeout_is_only_valid_for_timeout_scope(self):
+        for scope in ("run", "dependency", "none"):
+            with (
+                self.subTest(scope=scope),
+                self.assertRaisesRegex(
+                    ValueError,
+                    'timeout is only supported with scope="timeout"',
+                ),
+            ):
+                cached(scope=scope, timeout=5)
+
+    def test_timeout_scope_uses_backend_without_dependency_recording(self):
+        fake_cache = FakeCacheBackend()
+        record_calls = []
+        calls = 0
+
+        def record_fn(key, deps):
+            record_calls.append((key, set(deps)))
+
+        @cached(
+            scope="timeout", timeout=5, cache_backend=fake_cache, record_fn=record_fn
+        )
+        def sample(value):
+            nonlocal calls
+            calls += 1
+            DependencyTracker.track("User", "identification", str(value))
+            return value * 2
+
+        self.assertEqual(sample(3), 6)
+        self.assertEqual(sample(3), 6)
+
+        key = make_cache_key(sample, (3,), {})
+        self.assertEqual(calls, 1)
+        self.assertIn(key, fake_cache.store)
+        self.assertEqual(fake_cache.timeouts[key], 5)
+        self.assertNotIn(f"{key}:deps", fake_cache.store)
+        self.assertEqual(record_calls, [])
+
+    def test_default_scope_reuses_value_inside_context_only(self):
+        fake_cache = FakeCacheBackend()
+        record_calls = []
+        calls = 0
+
+        def record_fn(key, deps):
+            record_calls.append((key, set(deps)))
+
+        @cached(cache_backend=fake_cache, record_fn=record_fn)
+        def sample(value):
+            nonlocal calls
+            calls += 1
+            DependencyTracker.track("User", "identification", str(value))
+            return value * 2
+
+        with CalculationRunContext():
+            self.assertEqual(sample(3), 6)
+            self.assertEqual(sample(3), 6)
+
+        self.assertEqual(sample(3), 6)
+        self.assertEqual(calls, 2)
+        self.assertEqual(fake_cache.store, {})
+        self.assertEqual(record_calls, [])
+
     def test_run_scope_reuses_value_inside_context_only(self):
         calls = 0
 

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -162,7 +162,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         `cache.get` and `cache.set` to be called again.
         """
 
-        @cached(scope="timeout", timeout=0.1)  # type: ignore[arg-type]
+        @cached(scope="timeout", timeout=1)
         def sample_function(x, y):
             return x + y
 
@@ -177,7 +177,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
                 set_spy.called, "At cache miss, cache.set() should be called"
             )
             # Wait for the cache to expire
-            time.sleep(0.15)
+            time.sleep(1.1)
             get_spy.reset_mock()
             set_spy.reset_mock()
 

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -28,6 +28,20 @@ def test_get_or_set_reuses_loaded_value_inside_context() -> None:
     assert calls == 1
 
 
+def test_public_storage_helpers_store_and_check_values() -> None:
+    with CalculationRunContext() as ctx:
+        assert ctx.get("missing") is None
+        assert ctx.get("missing", "fallback") == "fallback"
+        assert not ctx.has("answer")
+        assert "answer" not in ctx
+
+        ctx.set("answer", 42)
+
+        assert ctx.get("answer") == 42
+        assert ctx.has("answer")
+        assert "answer" in ctx
+
+
 def test_index_loads_once_and_groups_by_key() -> None:
     calls = 0
 
@@ -57,3 +71,34 @@ def test_index_loads_once_and_groups_by_key() -> None:
     assert first is second
     assert first["2026-06-10"].value == 10
     assert first["2026-06-11"].value == 11
+
+
+def test_group_by_loads_once_and_groups_rows() -> None:
+    calls = 0
+
+    class Row:
+        def __init__(self, project_id: int, value: int) -> None:
+            self.project_id = project_id
+            self.value = value
+
+    def loader() -> list[Row]:
+        nonlocal calls
+        calls += 1
+        return [Row(1, 10), Row(1, 11), Row(2, 20)]
+
+    with CalculationRunContext() as ctx:
+        first = ctx.group_by(
+            key=("rows", "project"),
+            loader=loader,
+            group_by=lambda row: row.project_id,
+        )
+        second = ctx.index_many(
+            key=("rows", "project"),
+            loader=loader,
+            index_by=lambda row: row.project_id,
+        )
+
+    assert calls == 1
+    assert first is second
+    assert [row.value for row in first[1]] == [10, 11]
+    assert [row.value for row in first[2]] == [20]

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -1,6 +1,7 @@
 # type: ignore
 
 from datetime import datetime
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.contrib.auth.models import User
@@ -432,6 +433,17 @@ class DatabaseBucketTestCase(TestCase):
         # not in
         fake = User(id=999)
         self.assertNotIn(fake, self.bucket)
+
+    def test_contains_uses_targeted_exists_lookup(self):
+        mgr = UserManager(self.u1.id)
+
+        with patch.object(
+            self.bucket._data,
+            "values_list",
+            side_effect=AssertionError("values_list should not be used"),
+        ):
+            self.assertIn(mgr, self.bucket)
+            self.assertIn(self.u1, self.bucket)
 
     def test_sort(self):
         # default ordering by username asc

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import Mock, patch
 
@@ -148,6 +149,37 @@ def test_build_field_descriptors_resolves_string_relation_targets() -> None:
     assert descriptors["members_list"].metadata["type"] is owner_manager
     assert get_model.call_count == 2
     get_model.assert_any_call("accounts", "OwnerModel")
+
+
+def test_build_field_descriptors_adds_raw_foreign_key_id_accessor() -> None:
+    class RawIdOwnerModel(models.Model):
+        class Meta:
+            app_label = "general_manager"
+
+    class RawIdChildModel(models.Model):
+        owner = models.ForeignKey(
+            RawIdOwnerModel,
+            on_delete=models.CASCADE,
+            null=True,
+        )
+
+        class Meta:
+            app_label = "general_manager"
+
+    interface_cls = type("InterfaceUnderTest", (), {"_model": RawIdChildModel})
+
+    descriptors = build_field_descriptors(
+        interface_cls,
+        resolve_many=lambda *_args: None,
+    )
+
+    assert "owner" in descriptors
+    assert "owner_id" in descriptors
+    assert descriptors["owner_id"].metadata["type"] is int
+
+    interface_instance = SimpleNamespace(_instance=RawIdChildModel(owner_id=42))
+
+    assert descriptors["owner_id"].accessor(interface_instance) == 42
 
 
 def test_build_field_descriptors_resolves_same_app_string_relation_targets() -> None:

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -411,6 +411,51 @@ class TestInput(TestCase):
         input_obj = Input(int, normalizer=round_to_nearest_10)
         self.assertEqual(input_obj.cast(47), 50)
 
+    def test_input_normalize_skips_callable_possible_values_without_normalizer(self):
+        calls = 0
+
+        def possible_values():
+            nonlocal calls
+            calls += 1
+            return [1, 2, 3]
+
+        input_obj = Input(int, possible_values=possible_values)
+
+        self.assertEqual(input_obj.cast("2"), 2)
+        self.assertEqual(calls, 0)
+
+    def test_input_normalize_resolves_possible_values_for_custom_normalizer(self):
+        calls = 0
+
+        def possible_values():
+            nonlocal calls
+            calls += 1
+            return [1, 2, 3]
+
+        def normalize_with_domain(value, *, domain):
+            return domain[-1] if value not in domain else value
+
+        input_obj = Input(
+            int,
+            possible_values=possible_values,
+            normalizer=normalize_with_domain,
+        )
+
+        self.assertEqual(input_obj.cast("4"), 3)
+        self.assertEqual(calls, 1)
+
+    def test_input_normalize_uses_static_domain_without_resolving_callable_values(self):
+        input_obj = Input(
+            date,
+            possible_values=DateRangeDomain(
+                date(2024, 1, 1),
+                date(2024, 3, 31),
+                frequency="month_end",
+            ),
+        )
+
+        self.assertEqual(input_obj.cast("2024-02-15"), date(2024, 2, 29))
+
     def test_input_validate_bounds_with_min_only(self):
         input_obj = Input(int, min_value=5)
         self.assertTrue(input_obj.validate_bounds(5))

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -196,7 +196,12 @@ def test_cached_decorator_logs_cache_hit_and_miss() -> None:
 
     with patch("general_manager.cache.cache_decorator.logger") as mock_logger:
 
-        @cached(timeout=None, cache_backend=fake_cache, record_fn=lambda _k, _d: None)
+        @cached(
+            scope="dependency",
+            timeout=None,
+            cache_backend=fake_cache,
+            record_fn=lambda _k, _d: None,
+        )
         def compute(x: int) -> int:
             return x * 2
 


### PR DESCRIPTION
## Summary

Closes #259.

This PR reduces framework overhead in calculation-heavy workloads by making run-scoped caching the default path for `@cached()`, adding an explicit timeout cache scope, and preserving dependency-aware caching behind `scope="dependency"`.

It also adds the lower-level performance helpers requested in the issue:

- skips callable/bucket `possible_values` resolution during ordinary `Input.normalize()` unless an `InputDomain` or custom normalizer needs it
- exposes public `CalculationRunContext` storage helpers: `get`, `set`, `has`, `in`, `group_by`, and `index_many`
- memoizes calculation manager inputs per calculation instance while preserving dependency tracking for cached manager wrappers
- exposes raw FK ID helper descriptors like `author_id` / `customer_id`
- changes ORM bucket membership checks to targeted `exists()` lookups
- updates docs and API reference for the new cache/run-context behavior

## Validation

- `python -m pytest tests/integration/test_calculation_manager.py tests/integration/test_request_caching.py tests/integration/test_database_manager.py tests/integration/test_remote_manager_interface.py tests/unit/test_cache_decorator.py tests/unit/test_calculation_run_context.py tests/unit/test_database_bucket.py tests/unit/test_field_descriptors.py tests/unit/test_input.py tests/unit/test_logging.py` — 203 passed
- `ruff check src tests`
- `mypy src`
- `mkdocs build --strict --site-dir /tmp/general_manager-docs-check`
- `git diff --check`
- pre-commit hooks during commit: ruff, ruff format, EOF/trailing whitespace/mixed-line checks, merge conflict check, debug statement check, mypy

## Notes

Point 4 from the issue is addressed by flipping the default `@cached()` behavior to run scope and documenting explicit dependency scope. Batching/deferred dependency recording remains a possible future optimization if profiling still shows dependency-index writes as a bottleneck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timeout-based cache scope for expiring entries without dependency tracking.
  * Added run-scoped storage helpers and grouping/indexing helpers for cached data.
  * Exposed raw foreign-key ID accessors to return stored IDs without resolving relations.

* **Documentation**
  * Clarified caching scopes, dependency vs run vs timeout behavior, and recommended practices.
  * Clarified interface input resolution and ORM foreign-key ID usage.

* **Bug Fixes**
  * Optimized bucket membership checks to use targeted existence lookups.

* **Tests**
  * Added and updated unit and integration tests covering caching scopes, run helpers, FK ID accessors, and dependency recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->