### PR TITLE
feat: add run-scoped ORM identity cache

### DIFF
--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -136,7 +136,15 @@ with CalculationRunContext() as context:
 Use `get_or_set(key, loader)` to load a value once, `has(key)` or `key in
 context` to check storage, `index(key=..., loader=..., index_by=...)` for
 one-row-per-key lookups, and `group_by(...)` or `index_many(...)` when multiple
-rows share the same key.
+rows share the same key. Use `discard_prefix(prefix)` when code that owns a
+structured key namespace needs to invalidate a group of run-scoped values.
+
+ORM-backed managers use this explicit run context to deduplicate repeated row
+materialization for the same manager identity. The optimization is active only
+inside an existing `CalculationRunContext`; constructing managers outside a run
+context continues to read from the database normally. Negative lookups are not
+cached, and ORM update/delete paths clear affected row entries in the active run
+context after successful mutations.
 
 ## Manual dependency-index helpers
 

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -53,6 +53,12 @@ class CalculationRunContext:
         """Store a value for the active run."""
         self._values[key] = value
 
+    def discard_prefix(self, prefix: tuple[Hashable, ...]) -> None:
+        """Discard tuple keys that start with the supplied prefix."""
+        for key in list(self._values):
+            if isinstance(key, tuple) and key[: len(prefix)] == prefix:
+                del self._values[key]
+
     def has(self, key: Hashable) -> bool:
         """Return whether key has a value in the active run."""
         return key in self._values

--- a/src/general_manager/interface/capabilities/orm/mutations.py
+++ b/src/general_manager/interface/capabilities/orm/mutations.py
@@ -340,13 +340,13 @@ class OrmUpdateCapability(BaseCapability):
                 creator_id=creator_id,
                 history_comment=history_comment,
             )
+            discard_orm_instance_cache(interface_instance.__class__, pk)
             mutation.apply_many_to_many(
                 interface_instance.__class__,
                 instance,
                 many_to_many_kwargs=normalized_many,
                 history_comment=history_comment,
             )
-            discard_orm_instance_cache(interface_instance.__class__, pk)
             return {"id": pk}
 
         return call_with_observability(

--- a/src/general_manager/interface/capabilities/orm/mutations.py
+++ b/src/general_manager/interface/capabilities/orm/mutations.py
@@ -21,7 +21,11 @@ from general_manager.interface.utils.errors import (
 from general_manager.interface.utils.models import model_has_field
 
 from ._compat import call_update_change_reason, call_with_observability
-from .support import get_support_capability, is_soft_delete_enabled
+from .support import (
+    discard_orm_instance_cache,
+    get_support_capability,
+    is_soft_delete_enabled,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from general_manager.interface.orm_interface import OrmInterfaceBase
@@ -342,6 +346,7 @@ class OrmUpdateCapability(BaseCapability):
                 many_to_many_kwargs=normalized_many,
                 history_comment=history_comment,
             )
+            discard_orm_instance_cache(interface_instance.__class__, pk)
             return {"id": pk}
 
         return call_with_observability(
@@ -419,6 +424,7 @@ class OrmDeleteCapability(BaseCapability):
                     creator_id=creator_id,
                     history_comment=history_comment_local,
                 )
+                discard_orm_instance_cache(interface_instance.__class__, pk)
                 return {"id": pk}
 
             history_comment_local = (
@@ -443,6 +449,9 @@ class OrmDeleteCapability(BaseCapability):
                     instance.delete(using=database_alias)
                 else:
                     instance.delete()
+            discard_orm_instance_cache(
+                interface_instance.__class__, interface_instance.pk
+            )
             return {"id": interface_instance.pk}
 
         return call_with_observability(

--- a/src/general_manager/interface/capabilities/orm/support.py
+++ b/src/general_manager/interface/capabilities/orm/support.py
@@ -12,6 +12,7 @@ from django.db import models
 from django.db.models import Subquery
 from django.utils import timezone
 from general_manager.bucket.database_bucket import DatabaseBucket
+from general_manager.cache.run_context import current_calculation_run_context
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.interface.capabilities.base import CapabilityName
 from general_manager.interface.capabilities.builtin import BaseCapability
@@ -270,11 +271,21 @@ class OrmReadCapability(BaseCapability):
                 raise missing_error
             raise model_cls.DoesNotExist  # type: ignore[attr-defined]
 
+        context = current_calculation_run_context()
+        read_func = (
+            _perform
+            if context is None
+            else lambda: context.get_or_set(
+                _orm_instance_cache_key(interface_instance),
+                _perform,
+            )
+        )
+
         return call_with_observability(
             interface_instance,
             operation="read",
             payload={"pk": interface_instance.pk},
-            func=_perform,
+            func=read_func,
         )
 
     def get_attribute_types(
@@ -843,3 +854,26 @@ def _history_capability_for(
         "history",
         expected_type=OrmHistoryCapability,
     )
+
+
+def _orm_instance_cache_key(interface_instance: "OrmInterfaceBase") -> tuple[Any, ...]:
+    interface_cls = interface_instance.__class__
+    support = get_support_capability(interface_cls)
+    only_active = not is_soft_delete_enabled(interface_cls)
+    return (
+        "orm_instance",
+        interface_cls,
+        interface_instance.pk,
+        support.get_database_alias(interface_cls),
+        only_active,
+        interface_instance._search_date,
+    )
+
+
+def discard_orm_instance_cache(
+    interface_cls: type["OrmInterfaceBase"],
+    pk: Any,
+) -> None:
+    context = current_calculation_run_context()
+    if context is not None:
+        context.discard_prefix(("orm_instance", interface_cls, pk))

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface import DatabaseInterface, ReadOnlyInterface
 from general_manager.bucket.base_bucket import Bucket
+from general_manager.cache.run_context import CalculationRunContext
 
 from general_manager.utils.testing import (
     GeneralManagerTransactionTestCase,
@@ -292,6 +293,42 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             self.test_family.update(name="Mutated After Delete", ignore_permission=True)
         with self.assertRaises(InvalidManagerStateError):
             self.test_family.delete(ignore_permission=True)
+
+    def test_update_invalidates_run_scoped_orm_identity_cache(self):
+        with CalculationRunContext():
+            cached_human = self.TestHuman(id=self.test_human1.id)
+            self.assertEqual(cached_human.name, "Alice")
+
+            cached_human.update(name="Alice Updated", ignore_permission=True)
+
+            self.assertEqual(cached_human.name, "Alice Updated")
+            self.assertEqual(
+                self.TestHuman(id=self.test_human1.id).name,
+                "Alice Updated",
+            )
+
+    def test_delete_invalidates_run_scoped_orm_identity_cache(self):
+        human_id = self.test_human2.id
+
+        with CalculationRunContext():
+            cached_human = self.TestHuman(id=human_id)
+            self.assertEqual(cached_human.name, "Bob")
+
+            cached_human.delete(ignore_permission=True)
+
+            with self.assertRaises(self.TestHuman.Interface._model.DoesNotExist):
+                self.TestHuman(id=human_id)
+
+    def test_soft_delete_invalidates_run_scoped_orm_identity_cache(self):
+        family_id = self.test_family.id
+
+        with CalculationRunContext():
+            cached_family = self.TestFamily(id=family_id)
+            self.assertTrue(cached_family.is_active)
+
+            cached_family.delete(ignore_permission=True)
+
+            self.assertFalse(self.TestFamily(id=family_id).is_active)
 
     def test_manager_connections(self):
         """

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -42,6 +42,21 @@ def test_public_storage_helpers_store_and_check_values() -> None:
         assert "answer" in ctx
 
 
+def test_discard_prefix_removes_matching_tuple_keys_only() -> None:
+    with CalculationRunContext() as ctx:
+        ctx.set(("orm_instance", "Human", 1, "default"), "alice")
+        ctx.set(("orm_instance", "Human", 2, "default"), "bob")
+        ctx.set(("other", "Human", 1), "other")
+        ctx.set("plain", "value")
+
+        ctx.discard_prefix(("orm_instance", "Human", 1))
+
+        assert not ctx.has(("orm_instance", "Human", 1, "default"))
+        assert ctx.get(("orm_instance", "Human", 2, "default")) == "bob"
+        assert ctx.get(("other", "Human", 1)) == "other"
+        assert ctx.get("plain") == "value"
+
+
 def test_index_loads_once_and_groups_by_key() -> None:
     calls = 0
 

--- a/tests/unit/test_orm_capabilities_comprehensive.py
+++ b/tests/unit/test_orm_capabilities_comprehensive.py
@@ -11,6 +11,7 @@ from django.apps import apps
 from django.db import models
 from django.utils import timezone
 
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.interface.capabilities.orm import (
     HistoryNotSupportedError,
     OrmHistoryCapability,
@@ -156,6 +157,56 @@ class TestOrmPersistenceSupportCapability:
 
 class TestOrmReadCapability:
     """Tests for ORM read capability."""
+
+    def test_get_data_reuses_instance_inside_calculation_run_context(self):
+        """Test that repeated ORM reads reuse the row within an explicit run context."""
+        capability = OrmReadCapability()
+
+        class DoesNotExist(Exception):
+            pass
+
+        class Model:
+            pass
+
+        Model.DoesNotExist = DoesNotExist
+
+        class InterfaceInstance:
+            _model = Model
+            database = "secondary"
+            historical_lookup_buffer_seconds = 0
+
+            def __init__(self, pk: int) -> None:
+                self.pk = pk
+                self._search_date = None
+
+        model_instance = object()
+        first = InterfaceInstance(pk=42)
+        second = InterfaceInstance(pk=42)
+
+        mock_manager = Mock()
+        mock_manager.get = Mock(return_value=model_instance)
+
+        with patch(
+            "general_manager.interface.capabilities.orm.support.get_support_capability"
+        ) as mock_get_support:
+            mock_support = Mock()
+            mock_support.get_database_alias = Mock(return_value="secondary")
+            mock_support.get_manager = Mock(return_value=mock_manager)
+            mock_get_support.return_value = mock_support
+
+            with patch(
+                "general_manager.interface.capabilities.orm.support.is_soft_delete_enabled",
+                return_value=False,
+            ):
+                with patch(
+                    "general_manager.interface.capabilities.orm.with_observability",
+                    side_effect=lambda *_args, **kwargs: kwargs["func"](),
+                ):
+                    with CalculationRunContext():
+                        assert capability.get_data(first) is model_instance
+                        assert capability.get_data(second) is model_instance
+
+        mock_manager.get.assert_called_once_with(pk=42)
 
     def test_get_data_retrieves_instance_by_pk(self):
         """Test that get_data retrieves model instance by primary key."""


### PR DESCRIPTION
## Summary
- Add explicit `CalculationRunContext`-scoped ORM row materialization reuse for repeated manager identities.
- Clear affected run-scoped ORM row entries after update, hard delete, and soft delete mutations.
- Document the explicit run-context behavior, negative lookup behavior, and invalidation semantics.

## Test Plan
- `python -m pytest`
- pre-commit hooks during commit: Ruff lint, Ruff format, EOF/trailing whitespace/merge conflict/debug checks, mypy

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified run-scoped ORM caching and deduplication behavior in "Run context storage" section.

* **New Features**
  * Enhanced ORM caching to reduce redundant database reads within calculation runs.
  * Automatic cache invalidation after record updates and deletions ensures data consistency.

* **Tests**
  * Added comprehensive tests for cache invalidation during ORM mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->