### PR TITLE
Fix dependency cache coherency

### DIFF
--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -106,6 +106,24 @@ When the wrapped dependency-scoped function runs, it records every manager it
 touches. Subsequent calls reuse the cached value until a tracked dependency
 changes.
 
+Dependency-scoped cache entries are published through a guarded write path:
+
+- a mutation generation is read before computation starts
+- data-changing operations raise the generation and hold a publish barrier while invalidation runs
+- the dependency index, dependency metadata, and visible cached value are written under the dependency-index lock
+- dependency metadata is published before the cached value, so a visible value is already reachable by later invalidation
+- if the generation changed or the publish barrier is active, the fresh function result is returned to the caller but is not stored
+
+This means a dependency-scoped value is only shared after GeneralManager can
+prove that no data mutation overlapped the computation and publish step.
+
+Concurrent workers for the same dependency-scoped cache key coordinate with a
+short-lived compute lease. The worker that acquires the lease performs the
+function body and publishes the value. Other workers wait for that value to
+appear and then reuse it instead of repeating the same CPU work. If the
+computing worker fails before publishing, the lease expires and a later worker
+can retry the computation.
+
 Use timeout scope when a value should be cached in the configured cache backend
 for a fixed duration without dependency tracking:
 

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -1,12 +1,33 @@
 """Helpers for caching GeneralManager computations with dependency tracking."""
 
 from functools import wraps
-from typing import Any, Callable, Literal, Optional, Protocol, Set, TypeVar, cast
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Literal,
+    Optional,
+    Protocol,
+    Set,
+    TypeVar,
+    cast,
+)
 
 from django.core.cache import cache as django_cache
 
 from general_manager.cache.cache_tracker import DependencyTracker
-from general_manager.cache.dependency_index import Dependency, record_dependencies
+from general_manager.cache.dependency_index import (
+    Dependency,
+    get_dependency_generation,
+    record_dependencies,
+)
+from general_manager.cache.dependency_publish import (
+    CachePublishAborted,
+    acquire_compute_lease,
+    publish_dependency_cache_entry,
+    release_compute_lease,
+    wait_for_cached_dependency_value,
+)
 from general_manager.cache.run_context import ensure_calculation_run_context
 from general_manager.cache.model_dependency_collector import ModelDependencyCollector
 from general_manager.logging import get_logger
@@ -160,32 +181,86 @@ def cached(
 
             deps_key = f"{key}:deps"
 
-            cached_result = cache_backend.get(key, _SENTINEL)
-            if cached_result is not _SENTINEL:
-                # saved dependencies are added to the current tracker
+            def track_cached_dependencies() -> None:
                 cached_deps = cache_backend.get(deps_key)
                 if cached_deps:
                     for class_name, operation, identifier in cached_deps:
                         DependencyTracker.track(class_name, operation, identifier)
+
+            cached_result = cache_backend.get(key, _SENTINEL)
+            if cached_result is not _SENTINEL:
+                track_cached_dependencies()
                 logger.debug(
                     "cache hit",
                     context={
                         "function": func.__qualname__,
                         "key": key,
-                        "dependency_count": len(cached_deps) if cached_deps else 0,
+                        "scope": scope,
                     },
                 )
                 return cached_result
 
-            with DependencyTracker() as dependencies:
-                result = func(*args, **kwargs)
-                ModelDependencyCollector.add_args(dependencies, args, kwargs)
+            lease = acquire_compute_lease(key)
+            while lease is None:
+                cached_result = wait_for_cached_dependency_value(
+                    cache_backend,
+                    key,
+                    sentinel=_SENTINEL,
+                )
+                if cached_result is not _SENTINEL:
+                    track_cached_dependencies()
+                    logger.debug(
+                        "cache hit after waiting for dependency publish",
+                        context={
+                            "function": func.__qualname__,
+                            "key": key,
+                            "scope": scope,
+                        },
+                    )
+                    return cached_result
+                lease = acquire_compute_lease(key)
 
-                cache_backend.set(key, result, timeout)
-                cache_backend.set(deps_key, dependencies, timeout)
+            try:
+                cached_result = cache_backend.get(key, _SENTINEL)
+                if cached_result is not _SENTINEL:
+                    track_cached_dependencies()
+                    return cached_result
 
-                if dependencies and timeout is None:
-                    record_fn(key, dependencies)
+                started_generation = get_dependency_generation()
+                with DependencyTracker() as dependencies:
+                    result = func(*args, **kwargs)
+                    ModelDependencyCollector.add_args(dependencies, args, kwargs)
+
+                def record_many(
+                    entries: Iterable[tuple[str, Iterable[Dependency]]],
+                ) -> None:
+                    for entry_key, entry_dependencies in entries:
+                        record_fn(entry_key, set(entry_dependencies))
+
+                try:
+                    publish_dependency_cache_entry(
+                        cache_key=key,
+                        deps_key=deps_key,
+                        result=result,
+                        dependencies=dependencies,
+                        cache_backend=cache_backend,
+                        timeout=timeout,
+                        started_generation=started_generation,
+                        record_many_fn=(
+                            None if record_fn is record_dependencies else record_many
+                        ),
+                    )
+                except CachePublishAborted:
+                    logger.debug(
+                        "dependency cache publish aborted",
+                        context={
+                            "function": func.__qualname__,
+                            "key": key,
+                            "scope": scope,
+                        },
+                    )
+            finally:
+                release_compute_lease(lease)
 
             logger.debug(
                 "cache miss recorded",

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -120,7 +120,7 @@ def _get_dependency_data_change_count() -> int:
 
 
 def _set_dependency_data_change_count(count: int) -> int:
-    cache.set(DATA_CHANGE_COUNT_KEY, count, LOCK_TIMEOUT)
+    cache.set(DATA_CHANGE_COUNT_KEY, count, None)
     return count
 
 
@@ -135,7 +135,7 @@ def begin_dependency_data_change() -> int:
     try:
         generation = _set_dependency_generation(get_dependency_generation() + 1)
         _set_dependency_data_change_count(_get_dependency_data_change_count() + 1)
-        cache.set(DATA_CHANGE_LOCK_KEY, "1", LOCK_TIMEOUT)
+        cache.set(DATA_CHANGE_LOCK_KEY, "1", None)
         return generation
     finally:
         release_lock()
@@ -151,7 +151,7 @@ def end_dependency_data_change() -> None:
         if count == 0:
             cache.delete(DATA_CHANGE_LOCK_KEY)
         else:
-            cache.set(DATA_CHANGE_LOCK_KEY, "1", LOCK_TIMEOUT)
+            cache.set(DATA_CHANGE_LOCK_KEY, "1", None)
     finally:
         release_lock()
 
@@ -575,7 +575,6 @@ def capture_old_values(
     Parameters:
         instance (GeneralManager | None): Manager instance about to change; if provided, this function sets instance._old_values to a mapping of lookup keys to their current values for use by post-change invalidation logic.
     """
-    begin_dependency_data_change()
     if instance is None:
         return
     manager_name = sender.__name__
@@ -628,539 +627,530 @@ def generic_cache_invalidation(
         instance (GeneralManager): The manager instance that was changed.
         old_relevant_values (dict[str, Any]): Mapping of lookup paths (joined by "__") to their values as captured before the change; used to compare old vs. new values for invalidation decisions.
     """
-    try:
-        manager_name = sender.__name__
-        invalidated_request_query_keys = invalidate_request_query_dependencies(
-            manager_name
+    manager_name = sender.__name__
+    invalidated_request_query_keys = invalidate_request_query_dependencies(manager_name)
+    for cache_key in invalidated_request_query_keys:
+        logger.info(
+            "invalidating request query cache key",
+            context={
+                "manager": manager_name,
+                "key": cache_key,
+                "action": REQUEST_QUERY_ACTION,
+            },
         )
-        for cache_key in invalidated_request_query_keys:
-            logger.info(
-                "invalidating request query cache key",
-                context={
-                    "manager": manager_name,
-                    "key": cache_key,
-                    "action": REQUEST_QUERY_ACTION,
-                },
-            )
-        idx = get_full_index()
-        all_cache_keys = tuple(
-            cast(dict[str, set[str]], idx.get("all", {})).get(manager_name, set())
+    idx = get_full_index()
+    all_cache_keys = tuple(
+        cast(dict[str, set[str]], idx.get("all", {})).get(manager_name, set())
+    )
+    for cache_key in all_cache_keys:
+        logger.info(
+            "invalidating cache key",
+            context={
+                "manager": manager_name,
+                "key": cache_key,
+                "action": "all",
+            },
         )
-        for cache_key in all_cache_keys:
-            logger.info(
-                "invalidating cache key",
-                context={
-                    "manager": manager_name,
-                    "key": cache_key,
-                    "action": "all",
-                },
-            )
-            invalidate_cache_key(cache_key)
-            remove_cache_key_from_index(cache_key)
+        invalidate_cache_key(cache_key)
+        remove_cache_key_from_index(cache_key)
 
-        def _json_loads_val_key(val_key: Any) -> Any:
-            if isinstance(val_key, str):
-                try:
-                    return json.loads(val_key)
-                except (json.JSONDecodeError, ValueError):
-                    return val_key  # treat as opaque string
-            return val_key
+    def _json_loads_val_key(val_key: Any) -> Any:
+        if isinstance(val_key, str):
+            try:
+                return json.loads(val_key)
+            except (json.JSONDecodeError, ValueError):
+                return val_key  # treat as opaque string
+        return val_key
 
-        def _repr_marker(raw: Any) -> str | None:
-            if isinstance(raw, dict) and set(raw.keys()) == {"__repr__"}:
-                marker = raw.get("__repr__")
-                return marker if isinstance(marker, str) else None
+    def _repr_marker(raw: Any) -> str | None:
+        if isinstance(raw, dict) and set(raw.keys()) == {"__repr__"}:
+            marker = raw.get("__repr__")
+            return marker if isinstance(marker, str) else None
+        return None
+
+    def _coerce_to_type(sample: Any, raw: Any) -> Any | None:
+        """
+        Coerces a raw value to match the type and semantics of a sample value.
+
+        Attempts to convert `raw` into the same type as `sample`. Handles:
+        - datetimes: parses ISO-like strings, preserves or aligns timezone info with `sample`,
+        - dates: parses ISO date strings,
+        - booleans: recognizes common textual and numeric boolean representations,
+        - other types: attempts to call the sample's type on `raw`.
+
+        Parameters:
+            sample: A value whose type and semantics should be used as the target.
+            raw: The input value to coerce.
+
+        Returns:
+            The coerced value of the same type as `sample`, or `None` if `raw` cannot be sensibly converted.
+        """
+        if sample is None:
             return None
 
-        def _coerce_to_type(sample: Any, raw: Any) -> Any | None:
-            """
-            Coerces a raw value to match the type and semantics of a sample value.
-
-            Attempts to convert `raw` into the same type as `sample`. Handles:
-            - datetimes: parses ISO-like strings, preserves or aligns timezone info with `sample`,
-            - dates: parses ISO date strings,
-            - booleans: recognizes common textual and numeric boolean representations,
-            - other types: attempts to call the sample's type on `raw`.
-
-            Parameters:
-                sample: A value whose type and semantics should be used as the target.
-                raw: The input value to coerce.
-
-            Returns:
-                The coerced value of the same type as `sample`, or `None` if `raw` cannot be sensibly converted.
-            """
-            if sample is None:
-                return None
-
-            if isinstance(sample, datetime):
-                if isinstance(raw, datetime):
-                    parsed = raw
-                elif isinstance(raw, str):
-                    candidate = raw.replace("Z", "+00:00")
-                    candidate = candidate.replace(" ", "T", 1)
-                    try:
-                        parsed = datetime.fromisoformat(candidate)
-                    except ValueError:
-                        return None
-                else:
+        if isinstance(sample, datetime):
+            if isinstance(raw, datetime):
+                parsed = raw
+            elif isinstance(raw, str):
+                candidate = raw.replace("Z", "+00:00")
+                candidate = candidate.replace(" ", "T", 1)
+                try:
+                    parsed = datetime.fromisoformat(candidate)
+                except ValueError:
                     return None
-
-                if sample.tzinfo and parsed.tzinfo is None:
-                    parsed = parsed.replace(tzinfo=sample.tzinfo)
-                elif not sample.tzinfo and parsed.tzinfo is not None:
-                    parsed = parsed.replace(tzinfo=None)
-                return parsed
-
-            if isinstance(sample, date) and not isinstance(sample, datetime):
-                if isinstance(raw, date) and not isinstance(raw, datetime):
-                    return raw
-                if isinstance(raw, str):
-                    try:
-                        return date.fromisoformat(raw)
-                    except ValueError:
-                        return None
+            else:
                 return None
 
-            # Booleans: avoid bool("False") == True
-            if isinstance(sample, bool):
-                if isinstance(raw, bool):
-                    return raw
-                if isinstance(raw, (int,)):
-                    return bool(raw)
-                if isinstance(raw, str):
-                    s = raw.strip().lower()
-                    if s in {"true", "1", "yes", "y", "t"}:
-                        return True
-                    if s in {"false", "0", "no", "n", "f"}:
-                        return False
-                return None
+            if sample.tzinfo and parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=sample.tzinfo)
+            elif not sample.tzinfo and parsed.tzinfo is not None:
+                parsed = parsed.replace(tzinfo=None)
+            return parsed
+
+        if isinstance(sample, date) and not isinstance(sample, datetime):
+            if isinstance(raw, date) and not isinstance(raw, datetime):
+                return raw
+            if isinstance(raw, str):
+                try:
+                    return date.fromisoformat(raw)
+                except ValueError:
+                    return None
+            return None
+
+        # Booleans: avoid bool("False") == True
+        if isinstance(sample, bool):
+            if isinstance(raw, bool):
+                return raw
+            if isinstance(raw, (int,)):
+                return bool(raw)
+            if isinstance(raw, str):
+                s = raw.strip().lower()
+                if s in {"true", "1", "yes", "y", "t"}:
+                    return True
+                if s in {"false", "0", "no", "n", "f"}:
+                    return False
+            return None
+        try:
+            return type(sample)(raw)  # type: ignore
+        except (TypeError, ValueError):
+            if isinstance(raw, type(sample)):
+                return raw
+            return None
+
+    def matches(op: str, value: Any, val_key: Any) -> bool:
+        """
+        Evaluate whether a given value satisfies a lookup operation described by `op` and `val_key`.
+
+        Supports operators:
+        - "eq": equality; attempts to interpret `val_key` as a literal and coerce it to `value`'s type before comparing.
+        - "in": membership; expects `val_key` to be a literal iterable and checks if any coerced element equals `value`.
+        - "gt", "gte", "lt", "lte": numeric/date comparisons; `val_key` is interpreted as a literal and coerced to `value`'s type.
+        - "contains", "startswith", "endswith": string containment/prefix/suffix checks; both sides are compared as strings.
+        - "regex": treats `val_key` as a regular expression pattern and tests it against the string form of `value`.
+
+        Behavior notes:
+        - If `value` is None the function only matches explicit null equality
+          or membership checks.
+        - ``val_key`` is a JSON-serialised string produced by
+          :func:`json.dumps`.  Parsing is done with :func:`json.loads`; if
+          JSON parsing or type coercion fails, the function falls back to
+          conservative comparisons or returns ``False`` where appropriate.
+        - Regex patterns that fail to compile are treated as non-matching.
+
+        Parameters:
+            op (str): The lookup operator name (one of the supported operators above).
+            value (Any): The runtime value to test.
+            val_key (Any): The stored comparison key (often a string representation) to interpret for the comparison.
+
+        Returns:
+            bool: `True` if the comparison defined by `op` and `val_key` matches `value`, `False` otherwise.
+        """
+        # eq
+        if op == "eq":
+            literal_val = _json_loads_val_key(val_key)
+            if literal_val is None:
+                return value is None
+            repr_marker = _repr_marker(literal_val)
+            if repr_marker is not None:
+                return repr(value) == repr_marker
+            comparable = _coerce_to_type(value, literal_val)
+            if comparable is None:
+                return repr(value) == val_key
+            return value == comparable
+
+        # in
+        if op == "in":
             try:
-                return type(sample)(raw)  # type: ignore
-            except (TypeError, ValueError):
-                if isinstance(raw, type(sample)):
-                    return raw
-                return None
-
-        def matches(op: str, value: Any, val_key: Any) -> bool:
-            """
-            Evaluate whether a given value satisfies a lookup operation described by `op` and `val_key`.
-
-            Supports operators:
-            - "eq": equality; attempts to interpret `val_key` as a literal and coerce it to `value`'s type before comparing.
-            - "in": membership; expects `val_key` to be a literal iterable and checks if any coerced element equals `value`.
-            - "gt", "gte", "lt", "lte": numeric/date comparisons; `val_key` is interpreted as a literal and coerced to `value`'s type.
-            - "contains", "startswith", "endswith": string containment/prefix/suffix checks; both sides are compared as strings.
-            - "regex": treats `val_key` as a regular expression pattern and tests it against the string form of `value`.
-
-            Behavior notes:
-            - If `value` is None the function only matches explicit null equality
-              or membership checks.
-            - ``val_key`` is a JSON-serialised string produced by
-              :func:`json.dumps`.  Parsing is done with :func:`json.loads`; if
-              JSON parsing or type coercion fails, the function falls back to
-              conservative comparisons or returns ``False`` where appropriate.
-            - Regex patterns that fail to compile are treated as non-matching.
-
-            Parameters:
-                op (str): The lookup operator name (one of the supported operators above).
-                value (Any): The runtime value to test.
-                val_key (Any): The stored comparison key (often a string representation) to interpret for the comparison.
-
-            Returns:
-                bool: `True` if the comparison defined by `op` and `val_key` matches `value`, `False` otherwise.
-            """
-            # eq
-            if op == "eq":
-                literal_val = _json_loads_val_key(val_key)
-                if literal_val is None:
-                    return value is None
-                repr_marker = _repr_marker(literal_val)
+                seq = json.loads(val_key)
+            except (json.JSONDecodeError, ValueError):
+                return False
+            for item in seq:
+                if item is None:
+                    if value is None:
+                        return True
+                    continue
+                repr_marker = _repr_marker(item)
                 if repr_marker is not None:
-                    return repr(value) == repr_marker
-                comparable = _coerce_to_type(value, literal_val)
-                if comparable is None:
-                    return repr(value) == val_key
-                return value == comparable
-
-            # in
-            if op == "in":
-                try:
-                    seq = json.loads(val_key)
-                except (json.JSONDecodeError, ValueError):
-                    return False
-                for item in seq:
-                    if item is None:
-                        if value is None:
-                            return True
-                        continue
-                    repr_marker = _repr_marker(item)
-                    if repr_marker is not None:
-                        if repr(value) == repr_marker:
-                            return True
-                        continue
-                    comparable = _coerce_to_type(value, item)
-                    if comparable is not None:
-                        if value == comparable:
-                            return True
-                    elif repr(value) == repr(item):
+                    if repr(value) == repr_marker:
                         return True
-                return False
-
-            # range comparisons
-            if op in ("gt", "gte", "lt", "lte"):
-                if value is None:
-                    return False
-                literal_val = _json_loads_val_key(val_key)
-                thr = _coerce_to_type(value, literal_val)
-                if thr is None:
-                    return False
-                if op == "gt":
-                    return value > thr
-                if op == "gte":
-                    return value >= thr
-                if op == "lt":
-                    return value < thr
-                if op == "lte":
-                    return value <= thr
-
-            # wildcard / regex comparisons
-            if op in ("contains", "startswith", "endswith", "regex"):
-                if value is None:
-                    return False
-                try:
-                    literal = json.loads(val_key)
-                except (json.JSONDecodeError, ValueError):
-                    literal = val_key
-
-                # ensure we always work with strings to avoid TypeErrors
-                text = "" if value is None else str(value)
-                if op == "contains":
-                    return literal in text
-                if op == "startswith":
-                    return text.startswith(literal)
-                if op == "endswith":
-                    return text.endswith(literal)
-                # regex: treat the stored key as the regex pattern
-                if op == "regex":
-                    try:
-                        pattern_source = (
-                            literal if isinstance(literal, str) else str(literal)
-                        )
-                        pattern = re.compile(pattern_source)
-                    except re.error:
-                        return False
-                    return bool(pattern.search(text))
-
+                    continue
+                comparable = _coerce_to_type(value, item)
+                if comparable is not None:
+                    if value == comparable:
+                        return True
+                elif repr(value) == repr(item):
+                    return True
             return False
 
-        def current_value_for_path(path: list[str]) -> Any:
-            """
-            Fetches the current value from the captured `instance` by following a sequence of attribute names.
+        # range comparisons
+        if op in ("gt", "gte", "lt", "lte"):
+            if value is None:
+                return False
+            literal_val = _json_loads_val_key(val_key)
+            thr = _coerce_to_type(value, literal_val)
+            if thr is None:
+                return False
+            if op == "gt":
+                return value > thr
+            if op == "gte":
+                return value >= thr
+            if op == "lt":
+                return value < thr
+            if op == "lte":
+                return value <= thr
 
-            Parameters:
-                path (list[str]): Ordered attribute names to traverse on the instance (e.g., ["user", "profile", "email"]).
+        # wildcard / regex comparisons
+        if op in ("contains", "startswith", "endswith", "regex"):
+            if value is None:
+                return False
+            try:
+                literal = json.loads(val_key)
+            except (json.JSONDecodeError, ValueError):
+                literal = val_key
 
-            Returns:
-                The value found at the end of the attribute path, or `None` if any attribute along the path is missing.
-            """
-            current: object = instance
-            for attr in path:
-                current = getattr(current, attr, UNDEFINED)
-                if current is UNDEFINED:
-                    return None
-            return current
-
-        def evaluate_composite(
-            cache_key: str,
-            lookup_key: str,
-            action: Literal["filter", "exclude"],
-            model_section: dict[str, dict[str, set[str]]],
-        ) -> bool | None:
-            """
-            Determine whether a composite dependency (multiple lookup params grouped under a single identifier)
-            for a given cache key and lookup should cause cache invalidation.
-
-            Parameters:
-                cache_key (str): The cache key being evaluated.
-                lookup_key (str): The specific lookup (operator and attribute path joined by `"__"`) that prompted evaluation.
-                action (Literal["filter", "exclude"]): The dependency action context; "filter" treats a match as cause for invalidation,
-                    "exclude" treats a change in match membership as cause for invalidation.
-                model_section (dict[str, dict[str, set[str]]]): The index section for the model containing lookup maps and an
-                    optional "__cache_dependencies__" mapping from cache keys to sets of identifier strings (each identifier
-                    encodes multiple lookup parameters).
-
-            Returns:
-                bool | None: `True` if the composite dependency indicates the cache entry should be invalidated,
-                `False` if it indicates no invalidation is required, or `None` if there are no composite identifiers
-                registered for `cache_key`.
-            """
-            cache_dependencies = model_section.get("__cache_dependencies__", {})
-            identifiers = (
-                cache_dependencies.get(cache_key) if cache_dependencies else None
-            )
-            if not identifiers:
-                return None
-
-            for identifier in identifiers:
-                params = parse_dependency_identifier(identifier)
-                if not isinstance(params, dict):
-                    continue
-                if lookup_key not in params:
-                    continue
-                old_all = True
-                new_all = True
-                for param_lookup, expected in params.items():
-                    parts_param = param_lookup.split("__")
-                    if parts_param[-1] in (
-                        "gt",
-                        "gte",
-                        "lt",
-                        "lte",
-                        "in",
-                        "contains",
-                        "startswith",
-                        "endswith",
-                        "regex",
-                    ):
-                        op_param = parts_param[-1]
-                        attr_path_param = parts_param[:-1]
-                    else:
-                        op_param = "eq"
-                        attr_path_param = parts_param
-                    expected_key = json.dumps(
-                        _normalize_dependency_identifier(expected), sort_keys=True
+            # ensure we always work with strings to avoid TypeErrors
+            text = "" if value is None else str(value)
+            if op == "contains":
+                return literal in text
+            if op == "startswith":
+                return text.startswith(literal)
+            if op == "endswith":
+                return text.endswith(literal)
+            # regex: treat the stored key as the regex pattern
+            if op == "regex":
+                try:
+                    pattern_source = (
+                        literal if isinstance(literal, str) else str(literal)
                     )
-                    old_val_param = old_relevant_values.get("__".join(attr_path_param))
-                    new_val_param = current_value_for_path(attr_path_param)
-                    if not matches(op_param, old_val_param, expected_key):
-                        old_all = False
-                    if not matches(op_param, new_val_param, expected_key):
-                        new_all = False
-                    if not old_all and not new_all and action == "filter":
-                        break
-                if action == "filter":
-                    if old_all or new_all:
-                        return True
-                else:  # exclude
-                    if old_all != new_all:
-                        return True
+                    pattern = re.compile(pattern_source)
+                except re.error:
+                    return False
+                return bool(pattern.search(text))
+
+        return False
+
+    def current_value_for_path(path: list[str]) -> Any:
+        """
+        Fetches the current value from the captured `instance` by following a sequence of attribute names.
+
+        Parameters:
+            path (list[str]): Ordered attribute names to traverse on the instance (e.g., ["user", "profile", "email"]).
+
+        Returns:
+            The value found at the end of the attribute path, or `None` if any attribute along the path is missing.
+        """
+        current: object = instance
+        for attr in path:
+            current = getattr(current, attr, UNDEFINED)
+            if current is UNDEFINED:
+                return None
+        return current
+
+    def evaluate_composite(
+        cache_key: str,
+        lookup_key: str,
+        action: Literal["filter", "exclude"],
+        model_section: dict[str, dict[str, set[str]]],
+    ) -> bool | None:
+        """
+        Determine whether a composite dependency (multiple lookup params grouped under a single identifier)
+        for a given cache key and lookup should cause cache invalidation.
+
+        Parameters:
+            cache_key (str): The cache key being evaluated.
+            lookup_key (str): The specific lookup (operator and attribute path joined by `"__"`) that prompted evaluation.
+            action (Literal["filter", "exclude"]): The dependency action context; "filter" treats a match as cause for invalidation,
+                "exclude" treats a change in match membership as cause for invalidation.
+            model_section (dict[str, dict[str, set[str]]]): The index section for the model containing lookup maps and an
+                optional "__cache_dependencies__" mapping from cache keys to sets of identifier strings (each identifier
+                encodes multiple lookup parameters).
+
+        Returns:
+            bool | None: `True` if the composite dependency indicates the cache entry should be invalidated,
+            `False` if it indicates no invalidation is required, or `None` if there are no composite identifiers
+            registered for `cache_key`.
+        """
+        cache_dependencies = model_section.get("__cache_dependencies__", {})
+        identifiers = cache_dependencies.get(cache_key) if cache_dependencies else None
+        if not identifiers:
+            return None
+
+        for identifier in identifiers:
+            params = parse_dependency_identifier(identifier)
+            if not isinstance(params, dict):
+                continue
+            if lookup_key not in params:
+                continue
+            old_all = True
+            new_all = True
+            for param_lookup, expected in params.items():
+                parts_param = param_lookup.split("__")
+                if parts_param[-1] in (
+                    "gt",
+                    "gte",
+                    "lt",
+                    "lte",
+                    "in",
+                    "contains",
+                    "startswith",
+                    "endswith",
+                    "regex",
+                ):
+                    op_param = parts_param[-1]
+                    attr_path_param = parts_param[:-1]
+                else:
+                    op_param = "eq"
+                    attr_path_param = parts_param
+                expected_key = json.dumps(
+                    _normalize_dependency_identifier(expected), sort_keys=True
+                )
+                old_val_param = old_relevant_values.get("__".join(attr_path_param))
+                new_val_param = current_value_for_path(attr_path_param)
+                if not matches(op_param, old_val_param, expected_key):
+                    old_all = False
+                if not matches(op_param, new_val_param, expected_key):
+                    new_all = False
+                if not old_all and not new_all and action == "filter":
+                    break
+            if action == "filter":
+                if old_all or new_all:
+                    return True
+            else:  # exclude
+                if old_all != new_all:
+                    return True
+        return False
+
+    def bucket_membership_matches(
+        params: dict[str, Any],
+        *,
+        use_old_values: bool,
+    ) -> bool:
+        """
+        Check whether the changed row belongs to a bucket described by filters/excludes.
+        """
+        filters = params.get("filters", {})
+        excludes = params.get("excludes", {})
+        if not isinstance(filters, dict) or not isinstance(excludes, dict):
             return False
 
-        def bucket_membership_matches(
-            params: dict[str, Any],
-            *,
-            use_old_values: bool,
-        ) -> bool:
-            """
-            Check whether the changed row belongs to a bucket described by filters/excludes.
-            """
-            filters = params.get("filters", {})
-            excludes = params.get("excludes", {})
-            if not isinstance(filters, dict) or not isinstance(excludes, dict):
+        def value_for_lookup(attr_path: list[str]) -> Any:
+            if use_old_values:
+                return old_relevant_values.get("__".join(attr_path))
+            return current_value_for_path(attr_path)
+
+        for lookup, expected in filters.items():
+            parts = lookup.split("__")
+            if parts[-1] in (
+                "gt",
+                "gte",
+                "lt",
+                "lte",
+                "in",
+                "contains",
+                "startswith",
+                "endswith",
+                "regex",
+            ):
+                op = parts[-1]
+                attr_path = parts[:-1]
+            else:
+                op = "eq"
+                attr_path = parts
+            expected_key = json.dumps(
+                _normalize_dependency_identifier(expected), sort_keys=True
+            )
+            if not matches(op, value_for_lookup(attr_path), expected_key):
                 return False
 
-            def value_for_lookup(attr_path: list[str]) -> Any:
-                if use_old_values:
-                    return old_relevant_values.get("__".join(attr_path))
-                return current_value_for_path(attr_path)
-
-            for lookup, expected in filters.items():
-                parts = lookup.split("__")
-                if parts[-1] in (
-                    "gt",
-                    "gte",
-                    "lt",
-                    "lte",
-                    "in",
-                    "contains",
-                    "startswith",
-                    "endswith",
-                    "regex",
-                ):
-                    op = parts[-1]
-                    attr_path = parts[:-1]
-                else:
-                    op = "eq"
-                    attr_path = parts
-                expected_key = json.dumps(
-                    _normalize_dependency_identifier(expected), sort_keys=True
-                )
-                if not matches(op, value_for_lookup(attr_path), expected_key):
-                    return False
-
-            for lookup, expected in excludes.items():
-                parts = lookup.split("__")
-                if parts[-1] in (
-                    "gt",
-                    "gte",
-                    "lt",
-                    "lte",
-                    "in",
-                    "contains",
-                    "startswith",
-                    "endswith",
-                    "regex",
-                ):
-                    op = parts[-1]
-                    attr_path = parts[:-1]
-                else:
-                    op = "eq"
-                    attr_path = parts
-                expected_key = json.dumps(
-                    _normalize_dependency_identifier(expected), sort_keys=True
-                )
-                if matches(op, value_for_lookup(attr_path), expected_key):
-                    return False
-
-            return True
-
-        for action in ACTIONS:
-            action_section = cast(
-                dict[general_manager_name, manager_dependency_section],
-                idx[action],
+        for lookup, expected in excludes.items():
+            parts = lookup.split("__")
+            if parts[-1] in (
+                "gt",
+                "gte",
+                "lt",
+                "lte",
+                "in",
+                "contains",
+                "startswith",
+                "endswith",
+                "regex",
+            ):
+                op = parts[-1]
+                attr_path = parts[:-1]
+            else:
+                op = "eq"
+                attr_path = parts
+            expected_key = json.dumps(
+                _normalize_dependency_identifier(expected), sort_keys=True
             )
-            model_section = action_section.get(manager_name)
-            if not isinstance(model_section, dict):
-                continue
-            for lookup, lookup_map in model_section.items():
-                if lookup.startswith("__"):
-                    if lookup == ALL_RECORDS_LOOKUP:
-                        for cache_keys in cast(
-                            lookup_dependency_map, lookup_map
-                        ).values():
-                            for ck in list(cache_keys):
-                                logger.info(
-                                    "invalidating cache key",
-                                    context={
-                                        "manager": manager_name,
-                                        "key": ck,
-                                        "lookup": lookup,
-                                        "action": action,
-                                        "value": ALL_RECORDS_VALUE,
-                                    },
-                                )
-                                invalidate_cache_key(ck)
-                                remove_cache_key_from_index(ck)
-                    elif lookup.startswith("__sort__"):
-                        sort_lookup = lookup.removeprefix("__sort__")
-                        attr_path = sort_lookup.split("__")
-                        old_sort_value = old_relevant_values.get(sort_lookup)
-                        new_sort_value = current_value_for_path(attr_path)
-                        if old_sort_value == new_sort_value:
+            if matches(op, value_for_lookup(attr_path), expected_key):
+                return False
+
+        return True
+
+    for action in ACTIONS:
+        action_section = cast(
+            dict[general_manager_name, manager_dependency_section],
+            idx[action],
+        )
+        model_section = action_section.get(manager_name)
+        if not isinstance(model_section, dict):
+            continue
+        for lookup, lookup_map in model_section.items():
+            if lookup.startswith("__"):
+                if lookup == ALL_RECORDS_LOOKUP:
+                    for cache_keys in cast(lookup_dependency_map, lookup_map).values():
+                        for ck in list(cache_keys):
+                            logger.info(
+                                "invalidating cache key",
+                                context={
+                                    "manager": manager_name,
+                                    "key": ck,
+                                    "lookup": lookup,
+                                    "action": action,
+                                    "value": ALL_RECORDS_VALUE,
+                                },
+                            )
+                            invalidate_cache_key(ck)
+                            remove_cache_key_from_index(ck)
+                elif lookup.startswith("__sort__"):
+                    sort_lookup = lookup.removeprefix("__sort__")
+                    attr_path = sort_lookup.split("__")
+                    old_sort_value = old_relevant_values.get(sort_lookup)
+                    new_sort_value = current_value_for_path(attr_path)
+                    if old_sort_value == new_sort_value:
+                        continue
+                    for val_key, cache_keys in list(
+                        cast(lookup_dependency_map, lookup_map).items()
+                    ):
+                        payload = _json_loads_val_key(val_key)
+                        if not isinstance(payload, dict):
                             continue
-                        for val_key, cache_keys in list(
-                            cast(lookup_dependency_map, lookup_map).items()
-                        ):
-                            payload = _json_loads_val_key(val_key)
-                            if not isinstance(payload, dict):
-                                continue
-                            old_in_bucket = bucket_membership_matches(
-                                payload,
-                                use_old_values=True,
-                            )
-                            new_in_bucket = bucket_membership_matches(
-                                payload,
-                                use_old_values=False,
-                            )
-                            if not (old_in_bucket or new_in_bucket):
-                                continue
-                            for ck in list(cache_keys):
-                                logger.info(
-                                    "invalidating cache key",
-                                    context={
-                                        "manager": manager_name,
-                                        "key": ck,
-                                        "lookup": lookup,
-                                        "action": action,
-                                        "value": val_key,
-                                    },
-                                )
-                                invalidate_cache_key(ck)
-                                remove_cache_key_from_index(ck)
-                    continue
-                lookup_map = cast(lookup_dependency_map, lookup_map)
-                # 1) get operator and attribute path
-                parts = lookup.split("__")
-                if parts[-1] in (
-                    "gt",
-                    "gte",
-                    "lt",
-                    "lte",
-                    "in",
-                    "contains",
-                    "startswith",
-                    "endswith",
-                    "regex",
-                ):
-                    op = parts[-1]
-                    attr_path = parts[:-1]
-                else:
-                    op = "eq"
-                    attr_path = parts
-
-                # 2) get old & new value
-                old_val = old_relevant_values.get("__".join(attr_path))
-
-                current: object = instance
-                for attr in attr_path:
-                    current = getattr(current, attr, None)
-                    if current is None:
-                        break
-                new_val = current
-
-                # 3) check against all cache_keys
-                for val_key, cache_keys in list(lookup_map.items()):
-                    old_match = matches(op, old_val, val_key)
-                    new_match = matches(op, new_val, val_key)
-
-                    if action == "filter":
-                        # Filter: invalidate if new match or old match
+                        old_in_bucket = bucket_membership_matches(
+                            payload,
+                            use_old_values=True,
+                        )
+                        new_in_bucket = bucket_membership_matches(
+                            payload,
+                            use_old_values=False,
+                        )
+                        if not (old_in_bucket or new_in_bucket):
+                            continue
                         for ck in list(cache_keys):
-                            composite_decision = evaluate_composite(
-                                ck, lookup, action, model_section
+                            logger.info(
+                                "invalidating cache key",
+                                context={
+                                    "manager": manager_name,
+                                    "key": ck,
+                                    "lookup": lookup,
+                                    "action": action,
+                                    "value": val_key,
+                                },
                             )
-                            should_invalidate = (
-                                composite_decision
-                                if composite_decision is not None
-                                else (new_match or old_match)
-                            )
-                            if should_invalidate:
-                                logger.info(
-                                    "invalidating cache key",
-                                    context={
-                                        "manager": manager_name,
-                                        "key": ck,
-                                        "lookup": lookup,
-                                        "action": action,
-                                        "value": val_key,
-                                    },
-                                )
-                                invalidate_cache_key(ck)
-                                remove_cache_key_from_index(ck)
+                            invalidate_cache_key(ck)
+                            remove_cache_key_from_index(ck)
+                continue
+            lookup_map = cast(lookup_dependency_map, lookup_map)
+            # 1) get operator and attribute path
+            parts = lookup.split("__")
+            if parts[-1] in (
+                "gt",
+                "gte",
+                "lt",
+                "lte",
+                "in",
+                "contains",
+                "startswith",
+                "endswith",
+                "regex",
+            ):
+                op = parts[-1]
+                attr_path = parts[:-1]
+            else:
+                op = "eq"
+                attr_path = parts
 
-                    else:  # action == 'exclude'
-                        # Excludes: invalidate only if matches changed
-                        for ck in list(cache_keys):
-                            composite_decision = evaluate_composite(
-                                ck, lookup, action, model_section
+            # 2) get old & new value
+            old_val = old_relevant_values.get("__".join(attr_path))
+
+            current: object = instance
+            for attr in attr_path:
+                current = getattr(current, attr, None)
+                if current is None:
+                    break
+            new_val = current
+
+            # 3) check against all cache_keys
+            for val_key, cache_keys in list(lookup_map.items()):
+                old_match = matches(op, old_val, val_key)
+                new_match = matches(op, new_val, val_key)
+
+                if action == "filter":
+                    # Filter: invalidate if new match or old match
+                    for ck in list(cache_keys):
+                        composite_decision = evaluate_composite(
+                            ck, lookup, action, model_section
+                        )
+                        should_invalidate = (
+                            composite_decision
+                            if composite_decision is not None
+                            else (new_match or old_match)
+                        )
+                        if should_invalidate:
+                            logger.info(
+                                "invalidating cache key",
+                                context={
+                                    "manager": manager_name,
+                                    "key": ck,
+                                    "lookup": lookup,
+                                    "action": action,
+                                    "value": val_key,
+                                },
                             )
-                            should_invalidate = (
-                                composite_decision
-                                if composite_decision is not None
-                                else (old_match != new_match)
+                            invalidate_cache_key(ck)
+                            remove_cache_key_from_index(ck)
+
+                else:  # action == 'exclude'
+                    # Excludes: invalidate only if matches changed
+                    for ck in list(cache_keys):
+                        composite_decision = evaluate_composite(
+                            ck, lookup, action, model_section
+                        )
+                        should_invalidate = (
+                            composite_decision
+                            if composite_decision is not None
+                            else (old_match != new_match)
+                        )
+                        if should_invalidate:
+                            logger.info(
+                                "invalidating cache key",
+                                context={
+                                    "manager": manager_name,
+                                    "key": ck,
+                                    "lookup": lookup,
+                                    "action": action,
+                                    "value": val_key,
+                                },
                             )
-                            if should_invalidate:
-                                logger.info(
-                                    "invalidating cache key",
-                                    context={
-                                        "manager": manager_name,
-                                        "key": ck,
-                                        "lookup": lookup,
-                                        "action": action,
-                                        "value": val_key,
-                                    },
-                                )
-                                invalidate_cache_key(ck)
-                                remove_cache_key_from_index(ck)
-    finally:
-        end_dependency_data_change()
+                            invalidate_cache_key(ck)
+                            remove_cache_key_from_index(ck)

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -468,7 +468,8 @@ def _remove_cache_keys_from_index_locked(
     all_section = cast(dict[str, set[str]], idx.get("all", {}))
     for mname, key_set in list(all_section.items()):
         for cache_key in cache_keys:
-            key_set.discard(cache_key)
+            if cache_key in key_set:
+                key_set.remove(cache_key)
         if not key_set:
             del all_section[mname]
     for action in ACTIONS:
@@ -484,7 +485,8 @@ def _remove_cache_keys_from_index_locked(
                 lookup_map = cast(lookup_dependency_map, lookup_map)
                 for val_key, key_set in list(lookup_map.items()):
                     for cache_key in cache_keys:
-                        key_set.discard(cache_key)
+                        if cache_key in key_set:
+                            key_set.remove(cache_key)
                     if not key_set:
                         del lookup_map[val_key]
                 if not lookup_map:
@@ -503,7 +505,8 @@ def _remove_cache_keys_from_index_locked(
     for mname, query_section in list(request_query_section.items()):
         for identifier, key_set in list(query_section.items()):
             for cache_key in cache_keys:
-                key_set.discard(cache_key)
+                if cache_key in key_set:
+                    key_set.remove(cache_key)
             if not key_set:
                 del query_section[identifier]
         if not query_section:
@@ -531,6 +534,25 @@ def invalidate_and_remove_cache_keys(cache_keys: Iterable[str]) -> None:
         release_lock()
 
 
+def _invalidate_request_query_dependencies_locked(
+    idx: dependency_index,
+    manager_name: str,
+) -> tuple[str, ...]:
+    request_queries = cast(
+        request_query_manager_section,
+        idx.get("request_query", {}).get(manager_name, {}),
+    )
+    cache_keys = tuple(
+        dict.fromkeys(
+            cache_key for key_set in request_queries.values() for cache_key in key_set
+        )
+    )
+    for cache_key in cache_keys:
+        cache.delete(cache_key)
+    _remove_cache_keys_from_index_locked(idx, cache_keys)
+    return cache_keys
+
+
 def invalidate_request_query_dependencies(manager_name: str) -> tuple[str, ...]:
     """
     Invalidate all request-query cache keys tracked for a manager atomically.
@@ -541,24 +563,12 @@ def invalidate_request_query_dependencies(manager_name: str) -> tuple[str, ...]:
     acquire_lock_with_retry("invalidate_request_query_dependencies")
     try:
         idx = get_full_index()
-        request_queries = cast(
-            request_query_manager_section,
-            idx.get("request_query", {}).get(manager_name, {}),
+        invalidated_keys = _invalidate_request_query_dependencies_locked(
+            idx, manager_name
         )
-        cache_keys = tuple(
-            dict.fromkeys(
-                cache_key
-                for key_set in request_queries.values()
-                for cache_key in key_set
-            )
-        )
-        if not cache_keys:
-            return ()
-        for cache_key in cache_keys:
-            cache.delete(cache_key)
-        _remove_cache_keys_from_index_locked(idx, cache_keys)
-        set_full_index(idx)
-        return cache_keys
+        if invalidated_keys:
+            set_full_index(idx)
+        return invalidated_keys
     finally:
         release_lock()
 
@@ -610,25 +620,26 @@ def capture_old_values(
         instance._old_values = vals
 
 
-@receiver(post_data_change)
-def generic_cache_invalidation(
-    sender: type[GeneralManager],
+def _generic_cache_invalidation_locked(
+    idx: dependency_index,
+    manager_name: str,
     instance: GeneralManager,
     old_relevant_values: dict[str, Any],
-    **kwargs: object,
 ) -> None:
     """
-    Invalidate cache entries whose recorded dependencies are affected by changes to a GeneralManager instance.
+    Invalidate cache entries affected by a change while the dependency lock is held.
 
     Uses the dependency index to compare previously captured values against the instance's current values for tracked lookups, evaluates both simple and composite dependency conditions for "filter" and "exclude" actions, and for any dependency that warrants invalidation it deletes the corresponding cache entry and removes its references from the index.
 
     Parameters:
-        sender (type[GeneralManager]): Manager class that emitted the signal.
+        idx (dependency_index): Dependency index loaded by the public receiver.
+        manager_name (str): Name of the manager class that emitted the signal.
         instance (GeneralManager): The manager instance that was changed.
         old_relevant_values (dict[str, Any]): Mapping of lookup paths (joined by "__") to their values as captured before the change; used to compare old vs. new values for invalidation decisions.
     """
-    manager_name = sender.__name__
-    invalidated_request_query_keys = invalidate_request_query_dependencies(manager_name)
+    invalidated_request_query_keys = _invalidate_request_query_dependencies_locked(
+        idx, manager_name
+    )
     for cache_key in invalidated_request_query_keys:
         logger.info(
             "invalidating request query cache key",
@@ -638,7 +649,6 @@ def generic_cache_invalidation(
                 "action": REQUEST_QUERY_ACTION,
             },
         )
-    idx = get_full_index()
     all_cache_keys = tuple(
         cast(dict[str, set[str]], idx.get("all", {})).get(manager_name, set())
     )
@@ -651,8 +661,8 @@ def generic_cache_invalidation(
                 "action": "all",
             },
         )
-        invalidate_cache_key(cache_key)
-        remove_cache_key_from_index(cache_key)
+        cache.delete(cache_key)
+        _remove_cache_keys_from_index_locked(idx, (cache_key,))
 
     def _json_loads_val_key(val_key: Any) -> Any:
         if isinstance(val_key, str):
@@ -1016,10 +1026,12 @@ def generic_cache_invalidation(
         model_section = action_section.get(manager_name)
         if not isinstance(model_section, dict):
             continue
-        for lookup, lookup_map in model_section.items():
+        for lookup, lookup_map in list(model_section.items()):
             if lookup.startswith("__"):
                 if lookup == ALL_RECORDS_LOOKUP:
-                    for cache_keys in cast(lookup_dependency_map, lookup_map).values():
+                    for cache_keys in list(
+                        cast(lookup_dependency_map, lookup_map).values()
+                    ):
                         for ck in list(cache_keys):
                             logger.info(
                                 "invalidating cache key",
@@ -1031,8 +1043,8 @@ def generic_cache_invalidation(
                                     "value": ALL_RECORDS_VALUE,
                                 },
                             )
-                            invalidate_cache_key(ck)
-                            remove_cache_key_from_index(ck)
+                            cache.delete(ck)
+                            _remove_cache_keys_from_index_locked(idx, (ck,))
                 elif lookup.startswith("__sort__"):
                     sort_lookup = lookup.removeprefix("__sort__")
                     attr_path = sort_lookup.split("__")
@@ -1067,8 +1079,8 @@ def generic_cache_invalidation(
                                     "value": val_key,
                                 },
                             )
-                            invalidate_cache_key(ck)
-                            remove_cache_key_from_index(ck)
+                            cache.delete(ck)
+                            _remove_cache_keys_from_index_locked(idx, (ck,))
                 continue
             lookup_map = cast(lookup_dependency_map, lookup_map)
             # 1) get operator and attribute path
@@ -1127,8 +1139,8 @@ def generic_cache_invalidation(
                                     "value": val_key,
                                 },
                             )
-                            invalidate_cache_key(ck)
-                            remove_cache_key_from_index(ck)
+                            cache.delete(ck)
+                            _remove_cache_keys_from_index_locked(idx, (ck,))
 
                 else:  # action == 'exclude'
                     # Excludes: invalidate only if matches changed
@@ -1152,5 +1164,37 @@ def generic_cache_invalidation(
                                     "value": val_key,
                                 },
                             )
-                            invalidate_cache_key(ck)
-                            remove_cache_key_from_index(ck)
+                            cache.delete(ck)
+                            _remove_cache_keys_from_index_locked(idx, (ck,))
+
+
+@receiver(post_data_change)
+def generic_cache_invalidation(
+    sender: type[GeneralManager],
+    instance: GeneralManager,
+    old_relevant_values: dict[str, Any],
+    **kwargs: object,
+) -> None:
+    """
+    Invalidate cache entries whose recorded dependencies are affected by changes to a GeneralManager instance.
+
+    Uses the dependency index to compare previously captured values against the instance's current values for tracked lookups, evaluates both simple and composite dependency conditions for "filter" and "exclude" actions, and for any dependency that warrants invalidation it deletes the corresponding cache entry and removes its references from the index.
+
+    Parameters:
+        sender (type[GeneralManager]): Manager class that emitted the signal.
+        instance (GeneralManager): The manager instance that was changed.
+        old_relevant_values (dict[str, Any]): Mapping of lookup paths (joined by "__") to their values as captured before the change; used to compare old vs. new values for invalidation decisions.
+    """
+    manager_name = sender.__name__
+    acquire_lock_with_retry("generic_cache_invalidation")
+    try:
+        idx = get_full_index()
+        _generic_cache_invalidation_locked(
+            idx,
+            manager_name,
+            instance,
+            old_relevant_values,
+        )
+        set_full_index(idx)
+    finally:
+        release_lock()

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -64,6 +64,7 @@ INDEX_KEY = "dependency_index"  # Cache key storing the complete dependency inde
 LOCK_KEY = "dependency_index_lock"  # Cache key used for the dependency lock
 DEPENDENCY_GENERATION_KEY = "dependency_index_generation"
 DATA_CHANGE_LOCK_KEY = "dependency_index_data_change_lock"
+DATA_CHANGE_COUNT_KEY = "dependency_index_data_change_count"
 LOCK_TIMEOUT = 5  # Lock TTL in seconds
 UNDEFINED = object()  # Sentinel for undefined values
 ACTIONS: tuple[Literal["filter"], Literal["exclude"]] = ("filter", "exclude")
@@ -113,6 +114,16 @@ def _set_dependency_generation(generation: int) -> int:
     return generation
 
 
+def _get_dependency_data_change_count() -> int:
+    count = cache.get(DATA_CHANGE_COUNT_KEY, 0)
+    return max(int(count or 0), 0)
+
+
+def _set_dependency_data_change_count(count: int) -> int:
+    cache.set(DATA_CHANGE_COUNT_KEY, count, LOCK_TIMEOUT)
+    return count
+
+
 def begin_dependency_data_change() -> int:
     """
     Mark a data change as active and bump the dependency generation.
@@ -123,6 +134,7 @@ def begin_dependency_data_change() -> int:
     acquire_lock_with_retry("begin_dependency_data_change")
     try:
         generation = _set_dependency_generation(get_dependency_generation() + 1)
+        _set_dependency_data_change_count(_get_dependency_data_change_count() + 1)
         cache.set(DATA_CHANGE_LOCK_KEY, "1", LOCK_TIMEOUT)
         return generation
     finally:
@@ -131,7 +143,17 @@ def begin_dependency_data_change() -> int:
 
 def end_dependency_data_change() -> None:
     """Release the publish barrier for a completed data change."""
-    cache.delete(DATA_CHANGE_LOCK_KEY)
+    acquire_lock_with_retry("end_dependency_data_change")
+    try:
+        count = _set_dependency_data_change_count(
+            max(_get_dependency_data_change_count() - 1, 0)
+        )
+        if count == 0:
+            cache.delete(DATA_CHANGE_LOCK_KEY)
+        else:
+            cache.set(DATA_CHANGE_LOCK_KEY, "1", LOCK_TIMEOUT)
+    finally:
+        release_lock()
 
 
 def is_dependency_data_change_active() -> bool:

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -212,6 +212,62 @@ def parse_dependency_identifier(identifier: str) -> Any:
 # -----------------------------------------------------------------------------
 # DEPENDENCY RECORDING
 # -----------------------------------------------------------------------------
+def _record_dependencies_locked(
+    idx: dependency_index,
+    cache_key: str,
+    dependencies: Iterable[Dependency],
+) -> None:
+    """Mutate an already-loaded dependency index for one cache key."""
+    for model_name, action, identifier in set(dependencies):
+        if action in ("filter", "exclude"):
+            action_key = cast(Literal["filter", "exclude"], action)
+            params = parse_dependency_identifier(identifier)
+            if not isinstance(params, dict):
+                continue
+            action_section = cast(
+                dict[general_manager_name, manager_dependency_section],
+                idx[action_key],
+            )
+            section = action_section.setdefault(model_name, {})
+            if not params:
+                lookup_map = section.setdefault(ALL_RECORDS_LOOKUP, {})
+                lookup_map.setdefault(ALL_RECORDS_VALUE, set()).add(cache_key)
+                continue
+            if len(params) > 1:
+                cache_dependencies = section.setdefault("__cache_dependencies__", {})
+                cache_dependencies.setdefault(cache_key, set()).add(identifier)
+            for lookup, val in params.items():
+                lookup_map = section.setdefault(lookup, {})
+                val_key = json.dumps(
+                    _normalize_dependency_identifier(val), sort_keys=True
+                )
+                lookup_map.setdefault(val_key, set()).add(cache_key)
+
+        elif action == "request_query":
+            request_index = cast(
+                dict[str, dict[str, set[str]]],
+                idx.setdefault("request_query", {}),
+            )
+            request_section = request_index.setdefault(model_name, {})
+            request_section.setdefault(identifier, set()).add(cache_key)
+
+        elif action == "all":
+            all_index = cast(
+                dict[str, set[str]],
+                idx.setdefault("all", {}),
+            )
+            all_index.setdefault(model_name, set()).add(cache_key)
+
+        else:
+            filter_section = cast(
+                dict[general_manager_name, manager_dependency_section],
+                idx["filter"],
+            )
+            section = filter_section.setdefault(model_name, {})
+            lookup_map = section.setdefault("identification", {})
+            lookup_map.setdefault(identifier, set()).add(cache_key)
+
+
 def record_dependencies(
     cache_key: str,
     dependencies: Iterable[Dependency],
@@ -232,61 +288,32 @@ def record_dependencies(
     acquire_lock_with_retry("record_dependencies")
     try:
         idx = get_full_index()
-        for model_name, action, identifier in dependencies:
-            if action in ("filter", "exclude"):
-                action_key = cast(Literal["filter", "exclude"], action)
-                params = parse_dependency_identifier(identifier)
-                if not isinstance(params, dict):
-                    continue
-                action_section = cast(
-                    dict[general_manager_name, manager_dependency_section],
-                    idx[action_key],
-                )
-                section = action_section.setdefault(model_name, {})
-                if not params:
-                    lookup_map = section.setdefault(ALL_RECORDS_LOOKUP, {})
-                    lookup_map.setdefault(ALL_RECORDS_VALUE, set()).add(cache_key)
-                    continue
-                if len(params) > 1:
-                    cache_dependencies = section.setdefault(
-                        "__cache_dependencies__", {}
-                    )
-                    cache_dependencies.setdefault(cache_key, set()).add(identifier)
-                for lookup, val in params.items():
-                    lookup_map = section.setdefault(lookup, {})
-                    val_key = json.dumps(
-                        _normalize_dependency_identifier(val), sort_keys=True
-                    )
-                    lookup_map.setdefault(val_key, set()).add(cache_key)
-
-            elif action == "request_query":
-                request_index = cast(
-                    dict[str, dict[str, set[str]]],
-                    idx.setdefault("request_query", {}),
-                )
-                request_section = request_index.setdefault(model_name, {})
-                request_section.setdefault(identifier, set()).add(cache_key)
-
-            elif action == "all":
-                all_index = cast(
-                    dict[str, set[str]],
-                    idx.setdefault("all", {}),
-                )
-                all_index.setdefault(model_name, set()).add(cache_key)
-
-            else:
-                # Treat identification lookups as a simple filter on `id`
-                filter_section = cast(
-                    dict[general_manager_name, manager_dependency_section],
-                    idx["filter"],
-                )
-                section = filter_section.setdefault(model_name, {})
-                lookup_map = section.setdefault("identification", {})
-                val_key = identifier
-                lookup_map.setdefault(val_key, set()).add(cache_key)
-
+        _record_dependencies_locked(idx, cache_key, dependencies)
         set_full_index(idx)
+    finally:
+        release_lock()
 
+
+def record_many_dependencies(
+    entries: Iterable[tuple[str, Iterable[Dependency]]],
+) -> None:
+    """
+    Register dependency metadata for many cache keys while holding one index lock.
+    """
+    normalized: dict[str, set[Dependency]] = {}
+    for cache_key, dependencies in entries:
+        dep_set = set(dependencies)
+        if dep_set:
+            normalized.setdefault(cache_key, set()).update(dep_set)
+    if not normalized:
+        return
+
+    acquire_lock_with_retry("record_many_dependencies")
+    try:
+        idx = get_full_index()
+        for cache_key, dependencies in normalized.items():
+            _record_dependencies_locked(idx, cache_key, dependencies)
+        set_full_index(idx)
     finally:
         release_lock()
 

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -62,6 +62,8 @@ class DependencyLockTimeoutError(TimeoutError):
 # -----------------------------------------------------------------------------
 INDEX_KEY = "dependency_index"  # Cache key storing the complete dependency index
 LOCK_KEY = "dependency_index_lock"  # Cache key used for the dependency lock
+DEPENDENCY_GENERATION_KEY = "dependency_index_generation"
+DATA_CHANGE_LOCK_KEY = "dependency_index_data_change_lock"
 LOCK_TIMEOUT = 5  # Lock TTL in seconds
 UNDEFINED = object()  # Sentinel for undefined values
 ACTIONS: tuple[Literal["filter"], Literal["exclude"]] = ("filter", "exclude")
@@ -98,6 +100,43 @@ def release_lock() -> None:
         None
     """
     cache.delete(LOCK_KEY)
+
+
+def get_dependency_generation() -> int:
+    """Return the current dependency-cache mutation generation."""
+    generation = cache.get(DEPENDENCY_GENERATION_KEY, 0)
+    return int(generation or 0)
+
+
+def _set_dependency_generation(generation: int) -> int:
+    cache.set(DEPENDENCY_GENERATION_KEY, generation, None)
+    return generation
+
+
+def begin_dependency_data_change() -> int:
+    """
+    Mark a data change as active and bump the dependency generation.
+
+    The generation bump happens before the underlying mutation, so computations
+    that started before the mutation cannot publish dependency-scoped values.
+    """
+    acquire_lock_with_retry("begin_dependency_data_change")
+    try:
+        generation = _set_dependency_generation(get_dependency_generation() + 1)
+        cache.set(DATA_CHANGE_LOCK_KEY, "1", LOCK_TIMEOUT)
+        return generation
+    finally:
+        release_lock()
+
+
+def end_dependency_data_change() -> None:
+    """Release the publish barrier for a completed data change."""
+    cache.delete(DATA_CHANGE_LOCK_KEY)
+
+
+def is_dependency_data_change_active() -> bool:
+    """Return whether dependency-scoped cache publishing should pause."""
+    return cache.get(DATA_CHANGE_LOCK_KEY) is not None
 
 
 def acquire_lock_with_retry(operation: str) -> None:
@@ -514,6 +553,7 @@ def capture_old_values(
     Parameters:
         instance (GeneralManager | None): Manager instance about to change; if provided, this function sets instance._old_values to a mapping of lookup keys to their current values for use by post-change invalidation logic.
     """
+    begin_dependency_data_change()
     if instance is None:
         return
     manager_name = sender.__name__
@@ -566,285 +606,345 @@ def generic_cache_invalidation(
         instance (GeneralManager): The manager instance that was changed.
         old_relevant_values (dict[str, Any]): Mapping of lookup paths (joined by "__") to their values as captured before the change; used to compare old vs. new values for invalidation decisions.
     """
-    manager_name = sender.__name__
-    invalidated_request_query_keys = invalidate_request_query_dependencies(manager_name)
-    for cache_key in invalidated_request_query_keys:
-        logger.info(
-            "invalidating request query cache key",
-            context={
-                "manager": manager_name,
-                "key": cache_key,
-                "action": REQUEST_QUERY_ACTION,
-            },
+    try:
+        manager_name = sender.__name__
+        invalidated_request_query_keys = invalidate_request_query_dependencies(
+            manager_name
         )
-    idx = get_full_index()
-    all_cache_keys = tuple(
-        cast(dict[str, set[str]], idx.get("all", {})).get(manager_name, set())
-    )
-    for cache_key in all_cache_keys:
-        logger.info(
-            "invalidating cache key",
-            context={
-                "manager": manager_name,
-                "key": cache_key,
-                "action": "all",
-            },
+        for cache_key in invalidated_request_query_keys:
+            logger.info(
+                "invalidating request query cache key",
+                context={
+                    "manager": manager_name,
+                    "key": cache_key,
+                    "action": REQUEST_QUERY_ACTION,
+                },
+            )
+        idx = get_full_index()
+        all_cache_keys = tuple(
+            cast(dict[str, set[str]], idx.get("all", {})).get(manager_name, set())
         )
-        invalidate_cache_key(cache_key)
-        remove_cache_key_from_index(cache_key)
+        for cache_key in all_cache_keys:
+            logger.info(
+                "invalidating cache key",
+                context={
+                    "manager": manager_name,
+                    "key": cache_key,
+                    "action": "all",
+                },
+            )
+            invalidate_cache_key(cache_key)
+            remove_cache_key_from_index(cache_key)
 
-    def _json_loads_val_key(val_key: Any) -> Any:
-        if isinstance(val_key, str):
-            try:
-                return json.loads(val_key)
-            except (json.JSONDecodeError, ValueError):
-                return val_key  # treat as opaque string
-        return val_key
+        def _json_loads_val_key(val_key: Any) -> Any:
+            if isinstance(val_key, str):
+                try:
+                    return json.loads(val_key)
+                except (json.JSONDecodeError, ValueError):
+                    return val_key  # treat as opaque string
+            return val_key
 
-    def _repr_marker(raw: Any) -> str | None:
-        if isinstance(raw, dict) and set(raw.keys()) == {"__repr__"}:
-            marker = raw.get("__repr__")
-            return marker if isinstance(marker, str) else None
-        return None
-
-    def _coerce_to_type(sample: Any, raw: Any) -> Any | None:
-        """
-        Coerces a raw value to match the type and semantics of a sample value.
-
-        Attempts to convert `raw` into the same type as `sample`. Handles:
-        - datetimes: parses ISO-like strings, preserves or aligns timezone info with `sample`,
-        - dates: parses ISO date strings,
-        - booleans: recognizes common textual and numeric boolean representations,
-        - other types: attempts to call the sample's type on `raw`.
-
-        Parameters:
-            sample: A value whose type and semantics should be used as the target.
-            raw: The input value to coerce.
-
-        Returns:
-            The coerced value of the same type as `sample`, or `None` if `raw` cannot be sensibly converted.
-        """
-        if sample is None:
+        def _repr_marker(raw: Any) -> str | None:
+            if isinstance(raw, dict) and set(raw.keys()) == {"__repr__"}:
+                marker = raw.get("__repr__")
+                return marker if isinstance(marker, str) else None
             return None
 
-        if isinstance(sample, datetime):
-            if isinstance(raw, datetime):
-                parsed = raw
-            elif isinstance(raw, str):
-                candidate = raw.replace("Z", "+00:00")
-                candidate = candidate.replace(" ", "T", 1)
-                try:
-                    parsed = datetime.fromisoformat(candidate)
-                except ValueError:
-                    return None
-            else:
+        def _coerce_to_type(sample: Any, raw: Any) -> Any | None:
+            """
+            Coerces a raw value to match the type and semantics of a sample value.
+
+            Attempts to convert `raw` into the same type as `sample`. Handles:
+            - datetimes: parses ISO-like strings, preserves or aligns timezone info with `sample`,
+            - dates: parses ISO date strings,
+            - booleans: recognizes common textual and numeric boolean representations,
+            - other types: attempts to call the sample's type on `raw`.
+
+            Parameters:
+                sample: A value whose type and semantics should be used as the target.
+                raw: The input value to coerce.
+
+            Returns:
+                The coerced value of the same type as `sample`, or `None` if `raw` cannot be sensibly converted.
+            """
+            if sample is None:
                 return None
 
-            if sample.tzinfo and parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=sample.tzinfo)
-            elif not sample.tzinfo and parsed.tzinfo is not None:
-                parsed = parsed.replace(tzinfo=None)
-            return parsed
-
-        if isinstance(sample, date) and not isinstance(sample, datetime):
-            if isinstance(raw, date) and not isinstance(raw, datetime):
-                return raw
-            if isinstance(raw, str):
-                try:
-                    return date.fromisoformat(raw)
-                except ValueError:
+            if isinstance(sample, datetime):
+                if isinstance(raw, datetime):
+                    parsed = raw
+                elif isinstance(raw, str):
+                    candidate = raw.replace("Z", "+00:00")
+                    candidate = candidate.replace(" ", "T", 1)
+                    try:
+                        parsed = datetime.fromisoformat(candidate)
+                    except ValueError:
+                        return None
+                else:
                     return None
-            return None
 
-        # Booleans: avoid bool("False") == True
-        if isinstance(sample, bool):
-            if isinstance(raw, bool):
-                return raw
-            if isinstance(raw, (int,)):
-                return bool(raw)
-            if isinstance(raw, str):
-                s = raw.strip().lower()
-                if s in {"true", "1", "yes", "y", "t"}:
-                    return True
-                if s in {"false", "0", "no", "n", "f"}:
-                    return False
-            return None
-        try:
-            return type(sample)(raw)  # type: ignore
-        except (TypeError, ValueError):
-            if isinstance(raw, type(sample)):
-                return raw
-            return None
+                if sample.tzinfo and parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=sample.tzinfo)
+                elif not sample.tzinfo and parsed.tzinfo is not None:
+                    parsed = parsed.replace(tzinfo=None)
+                return parsed
 
-    def matches(op: str, value: Any, val_key: Any) -> bool:
-        """
-        Evaluate whether a given value satisfies a lookup operation described by `op` and `val_key`.
+            if isinstance(sample, date) and not isinstance(sample, datetime):
+                if isinstance(raw, date) and not isinstance(raw, datetime):
+                    return raw
+                if isinstance(raw, str):
+                    try:
+                        return date.fromisoformat(raw)
+                    except ValueError:
+                        return None
+                return None
 
-        Supports operators:
-        - "eq": equality; attempts to interpret `val_key` as a literal and coerce it to `value`'s type before comparing.
-        - "in": membership; expects `val_key` to be a literal iterable and checks if any coerced element equals `value`.
-        - "gt", "gte", "lt", "lte": numeric/date comparisons; `val_key` is interpreted as a literal and coerced to `value`'s type.
-        - "contains", "startswith", "endswith": string containment/prefix/suffix checks; both sides are compared as strings.
-        - "regex": treats `val_key` as a regular expression pattern and tests it against the string form of `value`.
-
-        Behavior notes:
-        - If `value` is None the function only matches explicit null equality
-          or membership checks.
-        - ``val_key`` is a JSON-serialised string produced by
-          :func:`json.dumps`.  Parsing is done with :func:`json.loads`; if
-          JSON parsing or type coercion fails, the function falls back to
-          conservative comparisons or returns ``False`` where appropriate.
-        - Regex patterns that fail to compile are treated as non-matching.
-
-        Parameters:
-            op (str): The lookup operator name (one of the supported operators above).
-            value (Any): The runtime value to test.
-            val_key (Any): The stored comparison key (often a string representation) to interpret for the comparison.
-
-        Returns:
-            bool: `True` if the comparison defined by `op` and `val_key` matches `value`, `False` otherwise.
-        """
-        # eq
-        if op == "eq":
-            literal_val = _json_loads_val_key(val_key)
-            if literal_val is None:
-                return value is None
-            repr_marker = _repr_marker(literal_val)
-            if repr_marker is not None:
-                return repr(value) == repr_marker
-            comparable = _coerce_to_type(value, literal_val)
-            if comparable is None:
-                return repr(value) == val_key
-            return value == comparable
-
-        # in
-        if op == "in":
+            # Booleans: avoid bool("False") == True
+            if isinstance(sample, bool):
+                if isinstance(raw, bool):
+                    return raw
+                if isinstance(raw, (int,)):
+                    return bool(raw)
+                if isinstance(raw, str):
+                    s = raw.strip().lower()
+                    if s in {"true", "1", "yes", "y", "t"}:
+                        return True
+                    if s in {"false", "0", "no", "n", "f"}:
+                        return False
+                return None
             try:
-                seq = json.loads(val_key)
-            except (json.JSONDecodeError, ValueError):
-                return False
-            for item in seq:
-                if item is None:
-                    if value is None:
-                        return True
-                    continue
-                repr_marker = _repr_marker(item)
+                return type(sample)(raw)  # type: ignore
+            except (TypeError, ValueError):
+                if isinstance(raw, type(sample)):
+                    return raw
+                return None
+
+        def matches(op: str, value: Any, val_key: Any) -> bool:
+            """
+            Evaluate whether a given value satisfies a lookup operation described by `op` and `val_key`.
+
+            Supports operators:
+            - "eq": equality; attempts to interpret `val_key` as a literal and coerce it to `value`'s type before comparing.
+            - "in": membership; expects `val_key` to be a literal iterable and checks if any coerced element equals `value`.
+            - "gt", "gte", "lt", "lte": numeric/date comparisons; `val_key` is interpreted as a literal and coerced to `value`'s type.
+            - "contains", "startswith", "endswith": string containment/prefix/suffix checks; both sides are compared as strings.
+            - "regex": treats `val_key` as a regular expression pattern and tests it against the string form of `value`.
+
+            Behavior notes:
+            - If `value` is None the function only matches explicit null equality
+              or membership checks.
+            - ``val_key`` is a JSON-serialised string produced by
+              :func:`json.dumps`.  Parsing is done with :func:`json.loads`; if
+              JSON parsing or type coercion fails, the function falls back to
+              conservative comparisons or returns ``False`` where appropriate.
+            - Regex patterns that fail to compile are treated as non-matching.
+
+            Parameters:
+                op (str): The lookup operator name (one of the supported operators above).
+                value (Any): The runtime value to test.
+                val_key (Any): The stored comparison key (often a string representation) to interpret for the comparison.
+
+            Returns:
+                bool: `True` if the comparison defined by `op` and `val_key` matches `value`, `False` otherwise.
+            """
+            # eq
+            if op == "eq":
+                literal_val = _json_loads_val_key(val_key)
+                if literal_val is None:
+                    return value is None
+                repr_marker = _repr_marker(literal_val)
                 if repr_marker is not None:
-                    if repr(value) == repr_marker:
+                    return repr(value) == repr_marker
+                comparable = _coerce_to_type(value, literal_val)
+                if comparable is None:
+                    return repr(value) == val_key
+                return value == comparable
+
+            # in
+            if op == "in":
+                try:
+                    seq = json.loads(val_key)
+                except (json.JSONDecodeError, ValueError):
+                    return False
+                for item in seq:
+                    if item is None:
+                        if value is None:
+                            return True
+                        continue
+                    repr_marker = _repr_marker(item)
+                    if repr_marker is not None:
+                        if repr(value) == repr_marker:
+                            return True
+                        continue
+                    comparable = _coerce_to_type(value, item)
+                    if comparable is not None:
+                        if value == comparable:
+                            return True
+                    elif repr(value) == repr(item):
                         return True
-                    continue
-                comparable = _coerce_to_type(value, item)
-                if comparable is not None:
-                    if value == comparable:
-                        return True
-                elif repr(value) == repr(item):
-                    return True
+                return False
+
+            # range comparisons
+            if op in ("gt", "gte", "lt", "lte"):
+                if value is None:
+                    return False
+                literal_val = _json_loads_val_key(val_key)
+                thr = _coerce_to_type(value, literal_val)
+                if thr is None:
+                    return False
+                if op == "gt":
+                    return value > thr
+                if op == "gte":
+                    return value >= thr
+                if op == "lt":
+                    return value < thr
+                if op == "lte":
+                    return value <= thr
+
+            # wildcard / regex comparisons
+            if op in ("contains", "startswith", "endswith", "regex"):
+                if value is None:
+                    return False
+                try:
+                    literal = json.loads(val_key)
+                except (json.JSONDecodeError, ValueError):
+                    literal = val_key
+
+                # ensure we always work with strings to avoid TypeErrors
+                text = "" if value is None else str(value)
+                if op == "contains":
+                    return literal in text
+                if op == "startswith":
+                    return text.startswith(literal)
+                if op == "endswith":
+                    return text.endswith(literal)
+                # regex: treat the stored key as the regex pattern
+                if op == "regex":
+                    try:
+                        pattern_source = (
+                            literal if isinstance(literal, str) else str(literal)
+                        )
+                        pattern = re.compile(pattern_source)
+                    except re.error:
+                        return False
+                    return bool(pattern.search(text))
+
             return False
 
-        # range comparisons
-        if op in ("gt", "gte", "lt", "lte"):
-            if value is None:
-                return False
-            literal_val = _json_loads_val_key(val_key)
-            thr = _coerce_to_type(value, literal_val)
-            if thr is None:
-                return False
-            if op == "gt":
-                return value > thr
-            if op == "gte":
-                return value >= thr
-            if op == "lt":
-                return value < thr
-            if op == "lte":
-                return value <= thr
+        def current_value_for_path(path: list[str]) -> Any:
+            """
+            Fetches the current value from the captured `instance` by following a sequence of attribute names.
 
-        # wildcard / regex comparisons
-        if op in ("contains", "startswith", "endswith", "regex"):
-            if value is None:
-                return False
-            try:
-                literal = json.loads(val_key)
-            except (json.JSONDecodeError, ValueError):
-                literal = val_key
+            Parameters:
+                path (list[str]): Ordered attribute names to traverse on the instance (e.g., ["user", "profile", "email"]).
 
-            # ensure we always work with strings to avoid TypeErrors
-            text = "" if value is None else str(value)
-            if op == "contains":
-                return literal in text
-            if op == "startswith":
-                return text.startswith(literal)
-            if op == "endswith":
-                return text.endswith(literal)
-            # regex: treat the stored key as the regex pattern
-            if op == "regex":
-                try:
-                    pattern_source = (
-                        literal if isinstance(literal, str) else str(literal)
-                    )
-                    pattern = re.compile(pattern_source)
-                except re.error:
-                    return False
-                return bool(pattern.search(text))
+            Returns:
+                The value found at the end of the attribute path, or `None` if any attribute along the path is missing.
+            """
+            current: object = instance
+            for attr in path:
+                current = getattr(current, attr, UNDEFINED)
+                if current is UNDEFINED:
+                    return None
+            return current
 
-        return False
+        def evaluate_composite(
+            cache_key: str,
+            lookup_key: str,
+            action: Literal["filter", "exclude"],
+            model_section: dict[str, dict[str, set[str]]],
+        ) -> bool | None:
+            """
+            Determine whether a composite dependency (multiple lookup params grouped under a single identifier)
+            for a given cache key and lookup should cause cache invalidation.
 
-    def current_value_for_path(path: list[str]) -> Any:
-        """
-        Fetches the current value from the captured `instance` by following a sequence of attribute names.
+            Parameters:
+                cache_key (str): The cache key being evaluated.
+                lookup_key (str): The specific lookup (operator and attribute path joined by `"__"`) that prompted evaluation.
+                action (Literal["filter", "exclude"]): The dependency action context; "filter" treats a match as cause for invalidation,
+                    "exclude" treats a change in match membership as cause for invalidation.
+                model_section (dict[str, dict[str, set[str]]]): The index section for the model containing lookup maps and an
+                    optional "__cache_dependencies__" mapping from cache keys to sets of identifier strings (each identifier
+                    encodes multiple lookup parameters).
 
-        Parameters:
-            path (list[str]): Ordered attribute names to traverse on the instance (e.g., ["user", "profile", "email"]).
-
-        Returns:
-            The value found at the end of the attribute path, or `None` if any attribute along the path is missing.
-        """
-        current: object = instance
-        for attr in path:
-            current = getattr(current, attr, UNDEFINED)
-            if current is UNDEFINED:
+            Returns:
+                bool | None: `True` if the composite dependency indicates the cache entry should be invalidated,
+                `False` if it indicates no invalidation is required, or `None` if there are no composite identifiers
+                registered for `cache_key`.
+            """
+            cache_dependencies = model_section.get("__cache_dependencies__", {})
+            identifiers = (
+                cache_dependencies.get(cache_key) if cache_dependencies else None
+            )
+            if not identifiers:
                 return None
-        return current
 
-    def evaluate_composite(
-        cache_key: str,
-        lookup_key: str,
-        action: Literal["filter", "exclude"],
-        model_section: dict[str, dict[str, set[str]]],
-    ) -> bool | None:
-        """
-        Determine whether a composite dependency (multiple lookup params grouped under a single identifier)
-        for a given cache key and lookup should cause cache invalidation.
+            for identifier in identifiers:
+                params = parse_dependency_identifier(identifier)
+                if not isinstance(params, dict):
+                    continue
+                if lookup_key not in params:
+                    continue
+                old_all = True
+                new_all = True
+                for param_lookup, expected in params.items():
+                    parts_param = param_lookup.split("__")
+                    if parts_param[-1] in (
+                        "gt",
+                        "gte",
+                        "lt",
+                        "lte",
+                        "in",
+                        "contains",
+                        "startswith",
+                        "endswith",
+                        "regex",
+                    ):
+                        op_param = parts_param[-1]
+                        attr_path_param = parts_param[:-1]
+                    else:
+                        op_param = "eq"
+                        attr_path_param = parts_param
+                    expected_key = json.dumps(
+                        _normalize_dependency_identifier(expected), sort_keys=True
+                    )
+                    old_val_param = old_relevant_values.get("__".join(attr_path_param))
+                    new_val_param = current_value_for_path(attr_path_param)
+                    if not matches(op_param, old_val_param, expected_key):
+                        old_all = False
+                    if not matches(op_param, new_val_param, expected_key):
+                        new_all = False
+                    if not old_all and not new_all and action == "filter":
+                        break
+                if action == "filter":
+                    if old_all or new_all:
+                        return True
+                else:  # exclude
+                    if old_all != new_all:
+                        return True
+            return False
 
-        Parameters:
-            cache_key (str): The cache key being evaluated.
-            lookup_key (str): The specific lookup (operator and attribute path joined by `"__"`) that prompted evaluation.
-            action (Literal["filter", "exclude"]): The dependency action context; "filter" treats a match as cause for invalidation,
-                "exclude" treats a change in match membership as cause for invalidation.
-            model_section (dict[str, dict[str, set[str]]]): The index section for the model containing lookup maps and an
-                optional "__cache_dependencies__" mapping from cache keys to sets of identifier strings (each identifier
-                encodes multiple lookup parameters).
+        def bucket_membership_matches(
+            params: dict[str, Any],
+            *,
+            use_old_values: bool,
+        ) -> bool:
+            """
+            Check whether the changed row belongs to a bucket described by filters/excludes.
+            """
+            filters = params.get("filters", {})
+            excludes = params.get("excludes", {})
+            if not isinstance(filters, dict) or not isinstance(excludes, dict):
+                return False
 
-        Returns:
-            bool | None: `True` if the composite dependency indicates the cache entry should be invalidated,
-            `False` if it indicates no invalidation is required, or `None` if there are no composite identifiers
-            registered for `cache_key`.
-        """
-        cache_dependencies = model_section.get("__cache_dependencies__", {})
-        identifiers = cache_dependencies.get(cache_key) if cache_dependencies else None
-        if not identifiers:
-            return None
+            def value_for_lookup(attr_path: list[str]) -> Any:
+                if use_old_values:
+                    return old_relevant_values.get("__".join(attr_path))
+                return current_value_for_path(attr_path)
 
-        for identifier in identifiers:
-            params = parse_dependency_identifier(identifier)
-            if not isinstance(params, dict):
-                continue
-            if lookup_key not in params:
-                continue
-            old_all = True
-            new_all = True
-            for param_lookup, expected in params.items():
-                parts_param = param_lookup.split("__")
-                if parts_param[-1] in (
+            for lookup, expected in filters.items():
+                parts = lookup.split("__")
+                if parts[-1] in (
                     "gt",
                     "gte",
                     "lt",
@@ -855,241 +955,190 @@ def generic_cache_invalidation(
                     "endswith",
                     "regex",
                 ):
-                    op_param = parts_param[-1]
-                    attr_path_param = parts_param[:-1]
+                    op = parts[-1]
+                    attr_path = parts[:-1]
                 else:
-                    op_param = "eq"
-                    attr_path_param = parts_param
+                    op = "eq"
+                    attr_path = parts
                 expected_key = json.dumps(
                     _normalize_dependency_identifier(expected), sort_keys=True
                 )
-                old_val_param = old_relevant_values.get("__".join(attr_path_param))
-                new_val_param = current_value_for_path(attr_path_param)
-                if not matches(op_param, old_val_param, expected_key):
-                    old_all = False
-                if not matches(op_param, new_val_param, expected_key):
-                    new_all = False
-                if not old_all and not new_all and action == "filter":
-                    break
-            if action == "filter":
-                if old_all or new_all:
-                    return True
-            else:  # exclude
-                if old_all != new_all:
-                    return True
-        return False
+                if not matches(op, value_for_lookup(attr_path), expected_key):
+                    return False
 
-    def bucket_membership_matches(
-        params: dict[str, Any],
-        *,
-        use_old_values: bool,
-    ) -> bool:
-        """
-        Check whether the changed row belongs to a bucket described by filters/excludes.
-        """
-        filters = params.get("filters", {})
-        excludes = params.get("excludes", {})
-        if not isinstance(filters, dict) or not isinstance(excludes, dict):
-            return False
+            for lookup, expected in excludes.items():
+                parts = lookup.split("__")
+                if parts[-1] in (
+                    "gt",
+                    "gte",
+                    "lt",
+                    "lte",
+                    "in",
+                    "contains",
+                    "startswith",
+                    "endswith",
+                    "regex",
+                ):
+                    op = parts[-1]
+                    attr_path = parts[:-1]
+                else:
+                    op = "eq"
+                    attr_path = parts
+                expected_key = json.dumps(
+                    _normalize_dependency_identifier(expected), sort_keys=True
+                )
+                if matches(op, value_for_lookup(attr_path), expected_key):
+                    return False
 
-        def value_for_lookup(attr_path: list[str]) -> Any:
-            if use_old_values:
-                return old_relevant_values.get("__".join(attr_path))
-            return current_value_for_path(attr_path)
+            return True
 
-        for lookup, expected in filters.items():
-            parts = lookup.split("__")
-            if parts[-1] in (
-                "gt",
-                "gte",
-                "lt",
-                "lte",
-                "in",
-                "contains",
-                "startswith",
-                "endswith",
-                "regex",
-            ):
-                op = parts[-1]
-                attr_path = parts[:-1]
-            else:
-                op = "eq"
-                attr_path = parts
-            expected_key = json.dumps(
-                _normalize_dependency_identifier(expected), sort_keys=True
+        for action in ACTIONS:
+            action_section = cast(
+                dict[general_manager_name, manager_dependency_section],
+                idx[action],
             )
-            if not matches(op, value_for_lookup(attr_path), expected_key):
-                return False
-
-        for lookup, expected in excludes.items():
-            parts = lookup.split("__")
-            if parts[-1] in (
-                "gt",
-                "gte",
-                "lt",
-                "lte",
-                "in",
-                "contains",
-                "startswith",
-                "endswith",
-                "regex",
-            ):
-                op = parts[-1]
-                attr_path = parts[:-1]
-            else:
-                op = "eq"
-                attr_path = parts
-            expected_key = json.dumps(
-                _normalize_dependency_identifier(expected), sort_keys=True
-            )
-            if matches(op, value_for_lookup(attr_path), expected_key):
-                return False
-
-        return True
-
-    for action in ACTIONS:
-        action_section = cast(
-            dict[general_manager_name, manager_dependency_section],
-            idx[action],
-        )
-        model_section = action_section.get(manager_name)
-        if not isinstance(model_section, dict):
-            continue
-        for lookup, lookup_map in model_section.items():
-            if lookup.startswith("__"):
-                if lookup == ALL_RECORDS_LOOKUP:
-                    for cache_keys in cast(lookup_dependency_map, lookup_map).values():
-                        for ck in list(cache_keys):
-                            logger.info(
-                                "invalidating cache key",
-                                context={
-                                    "manager": manager_name,
-                                    "key": ck,
-                                    "lookup": lookup,
-                                    "action": action,
-                                    "value": ALL_RECORDS_VALUE,
-                                },
-                            )
-                            invalidate_cache_key(ck)
-                            remove_cache_key_from_index(ck)
-                elif lookup.startswith("__sort__"):
-                    sort_lookup = lookup.removeprefix("__sort__")
-                    attr_path = sort_lookup.split("__")
-                    old_sort_value = old_relevant_values.get(sort_lookup)
-                    new_sort_value = current_value_for_path(attr_path)
-                    if old_sort_value == new_sort_value:
-                        continue
-                    for val_key, cache_keys in list(
-                        cast(lookup_dependency_map, lookup_map).items()
-                    ):
-                        payload = _json_loads_val_key(val_key)
-                        if not isinstance(payload, dict):
-                            continue
-                        old_in_bucket = bucket_membership_matches(
-                            payload,
-                            use_old_values=True,
-                        )
-                        new_in_bucket = bucket_membership_matches(
-                            payload,
-                            use_old_values=False,
-                        )
-                        if not (old_in_bucket or new_in_bucket):
-                            continue
-                        for ck in list(cache_keys):
-                            logger.info(
-                                "invalidating cache key",
-                                context={
-                                    "manager": manager_name,
-                                    "key": ck,
-                                    "lookup": lookup,
-                                    "action": action,
-                                    "value": val_key,
-                                },
-                            )
-                            invalidate_cache_key(ck)
-                            remove_cache_key_from_index(ck)
+            model_section = action_section.get(manager_name)
+            if not isinstance(model_section, dict):
                 continue
-            lookup_map = cast(lookup_dependency_map, lookup_map)
-            # 1) get operator and attribute path
-            parts = lookup.split("__")
-            if parts[-1] in (
-                "gt",
-                "gte",
-                "lt",
-                "lte",
-                "in",
-                "contains",
-                "startswith",
-                "endswith",
-                "regex",
-            ):
-                op = parts[-1]
-                attr_path = parts[:-1]
-            else:
-                op = "eq"
-                attr_path = parts
-
-            # 2) get old & new value
-            old_val = old_relevant_values.get("__".join(attr_path))
-
-            current: object = instance
-            for attr in attr_path:
-                current = getattr(current, attr, None)
-                if current is None:
-                    break
-            new_val = current
-
-            # 3) check against all cache_keys
-            for val_key, cache_keys in list(lookup_map.items()):
-                old_match = matches(op, old_val, val_key)
-                new_match = matches(op, new_val, val_key)
-
-                if action == "filter":
-                    # Filter: invalidate if new match or old match
-                    for ck in list(cache_keys):
-                        composite_decision = evaluate_composite(
-                            ck, lookup, action, model_section
-                        )
-                        should_invalidate = (
-                            composite_decision
-                            if composite_decision is not None
-                            else (new_match or old_match)
-                        )
-                        if should_invalidate:
-                            logger.info(
-                                "invalidating cache key",
-                                context={
-                                    "manager": manager_name,
-                                    "key": ck,
-                                    "lookup": lookup,
-                                    "action": action,
-                                    "value": val_key,
-                                },
+            for lookup, lookup_map in model_section.items():
+                if lookup.startswith("__"):
+                    if lookup == ALL_RECORDS_LOOKUP:
+                        for cache_keys in cast(
+                            lookup_dependency_map, lookup_map
+                        ).values():
+                            for ck in list(cache_keys):
+                                logger.info(
+                                    "invalidating cache key",
+                                    context={
+                                        "manager": manager_name,
+                                        "key": ck,
+                                        "lookup": lookup,
+                                        "action": action,
+                                        "value": ALL_RECORDS_VALUE,
+                                    },
+                                )
+                                invalidate_cache_key(ck)
+                                remove_cache_key_from_index(ck)
+                    elif lookup.startswith("__sort__"):
+                        sort_lookup = lookup.removeprefix("__sort__")
+                        attr_path = sort_lookup.split("__")
+                        old_sort_value = old_relevant_values.get(sort_lookup)
+                        new_sort_value = current_value_for_path(attr_path)
+                        if old_sort_value == new_sort_value:
+                            continue
+                        for val_key, cache_keys in list(
+                            cast(lookup_dependency_map, lookup_map).items()
+                        ):
+                            payload = _json_loads_val_key(val_key)
+                            if not isinstance(payload, dict):
+                                continue
+                            old_in_bucket = bucket_membership_matches(
+                                payload,
+                                use_old_values=True,
                             )
-                            invalidate_cache_key(ck)
-                            remove_cache_key_from_index(ck)
-
-                else:  # action == 'exclude'
-                    # Excludes: invalidate only if matches changed
-                    for ck in list(cache_keys):
-                        composite_decision = evaluate_composite(
-                            ck, lookup, action, model_section
-                        )
-                        should_invalidate = (
-                            composite_decision
-                            if composite_decision is not None
-                            else (old_match != new_match)
-                        )
-                        if should_invalidate:
-                            logger.info(
-                                "invalidating cache key",
-                                context={
-                                    "manager": manager_name,
-                                    "key": ck,
-                                    "lookup": lookup,
-                                    "action": action,
-                                    "value": val_key,
-                                },
+                            new_in_bucket = bucket_membership_matches(
+                                payload,
+                                use_old_values=False,
                             )
-                            invalidate_cache_key(ck)
-                            remove_cache_key_from_index(ck)
+                            if not (old_in_bucket or new_in_bucket):
+                                continue
+                            for ck in list(cache_keys):
+                                logger.info(
+                                    "invalidating cache key",
+                                    context={
+                                        "manager": manager_name,
+                                        "key": ck,
+                                        "lookup": lookup,
+                                        "action": action,
+                                        "value": val_key,
+                                    },
+                                )
+                                invalidate_cache_key(ck)
+                                remove_cache_key_from_index(ck)
+                    continue
+                lookup_map = cast(lookup_dependency_map, lookup_map)
+                # 1) get operator and attribute path
+                parts = lookup.split("__")
+                if parts[-1] in (
+                    "gt",
+                    "gte",
+                    "lt",
+                    "lte",
+                    "in",
+                    "contains",
+                    "startswith",
+                    "endswith",
+                    "regex",
+                ):
+                    op = parts[-1]
+                    attr_path = parts[:-1]
+                else:
+                    op = "eq"
+                    attr_path = parts
+
+                # 2) get old & new value
+                old_val = old_relevant_values.get("__".join(attr_path))
+
+                current: object = instance
+                for attr in attr_path:
+                    current = getattr(current, attr, None)
+                    if current is None:
+                        break
+                new_val = current
+
+                # 3) check against all cache_keys
+                for val_key, cache_keys in list(lookup_map.items()):
+                    old_match = matches(op, old_val, val_key)
+                    new_match = matches(op, new_val, val_key)
+
+                    if action == "filter":
+                        # Filter: invalidate if new match or old match
+                        for ck in list(cache_keys):
+                            composite_decision = evaluate_composite(
+                                ck, lookup, action, model_section
+                            )
+                            should_invalidate = (
+                                composite_decision
+                                if composite_decision is not None
+                                else (new_match or old_match)
+                            )
+                            if should_invalidate:
+                                logger.info(
+                                    "invalidating cache key",
+                                    context={
+                                        "manager": manager_name,
+                                        "key": ck,
+                                        "lookup": lookup,
+                                        "action": action,
+                                        "value": val_key,
+                                    },
+                                )
+                                invalidate_cache_key(ck)
+                                remove_cache_key_from_index(ck)
+
+                    else:  # action == 'exclude'
+                        # Excludes: invalidate only if matches changed
+                        for ck in list(cache_keys):
+                            composite_decision = evaluate_composite(
+                                ck, lookup, action, model_section
+                            )
+                            should_invalidate = (
+                                composite_decision
+                                if composite_decision is not None
+                                else (old_match != new_match)
+                            )
+                            if should_invalidate:
+                                logger.info(
+                                    "invalidating cache key",
+                                    context={
+                                        "manager": manager_name,
+                                        "key": ck,
+                                        "lookup": lookup,
+                                        "action": action,
+                                        "value": val_key,
+                                    },
+                                )
+                                invalidate_cache_key(ck)
+                                remove_cache_key_from_index(ck)
+    finally:
+        end_dependency_data_change()

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -1,0 +1,117 @@
+"""Coordination helpers for dependency-scoped cache publishing."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Protocol
+
+from django.core.cache import cache as coordination_cache
+
+from general_manager.cache.dependency_index import (
+    LOCK_TIMEOUT,
+    Dependency,
+    get_dependency_generation,
+    is_dependency_data_change_active,
+    record_many_dependencies,
+)
+
+
+class CachePublishAborted(RuntimeError):
+    """Raised when dependency-cache publishing is no longer safe."""
+
+
+@dataclass(frozen=True)
+class CacheComputeLease:
+    """Token proving ownership of a dependency-cache computation."""
+
+    key: str
+    token: str
+
+
+class DependencyCacheBackend(Protocol):
+    def get(self, key: str, default: Any = None) -> Any:
+        raise NotImplementedError
+
+    def set(self, key: str, value: Any, timeout: int | None = None) -> None:
+        raise NotImplementedError
+
+
+RecordManyDependenciesFn = Callable[[Iterable[tuple[str, Iterable[Dependency]]]], None]
+
+COMPUTE_LOCK_PREFIX = "dependency_cache_compute_lock"
+COMPUTE_LOCK_TIMEOUT = LOCK_TIMEOUT
+WAIT_INITIAL_DELAY = 0.01
+WAIT_MAX_DELAY = 0.2
+
+
+def _compute_lock_key(cache_key: str) -> str:
+    return f"{COMPUTE_LOCK_PREFIX}:{cache_key}"
+
+
+def acquire_compute_lease(
+    cache_key: str,
+    *,
+    timeout: int = COMPUTE_LOCK_TIMEOUT,
+) -> CacheComputeLease | None:
+    """Acquire a per-cache-key compute lease if no worker currently owns it."""
+    lock_key = _compute_lock_key(cache_key)
+    token = uuid.uuid4().hex
+    if not coordination_cache.add(lock_key, token, timeout):
+        return None
+    return CacheComputeLease(key=lock_key, token=token)
+
+
+def release_compute_lease(lease: CacheComputeLease) -> None:
+    """Release a compute lease only when its token still owns the lock key."""
+    if coordination_cache.get(lease.key) == lease.token:
+        coordination_cache.delete(lease.key)
+
+
+def wait_for_cached_dependency_value(
+    cache_backend: DependencyCacheBackend,
+    cache_key: str,
+    timeout_seconds: float = LOCK_TIMEOUT,
+    sentinel: Any = None,
+) -> Any:
+    """Poll for a cached dependency value until it appears or the wait expires."""
+    deadline = time.monotonic() + timeout_seconds
+    delay = WAIT_INITIAL_DELAY
+
+    while True:
+        cached_value = cache_backend.get(cache_key, sentinel)
+        if cached_value is not sentinel:
+            return cached_value
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return sentinel
+
+        time.sleep(min(delay, remaining))
+        delay = min(delay * 2, WAIT_MAX_DELAY)
+
+
+def publish_dependency_cache_entry(
+    *,
+    cache_key: str,
+    deps_key: str,
+    result: Any,
+    dependencies: Iterable[Dependency],
+    cache_backend: DependencyCacheBackend,
+    timeout: int | None,
+    started_generation: int,
+    record_many_fn: RecordManyDependenciesFn = record_many_dependencies,
+) -> None:
+    """Publish dependency metadata and value only if the computation is current."""
+    if is_dependency_data_change_active():
+        raise CachePublishAborted()
+    if get_dependency_generation() != started_generation:
+        raise CachePublishAborted()
+
+    dependency_set = set(dependencies)
+    if dependency_set:
+        record_many_fn([(cache_key, dependency_set)])
+
+    cache_backend.set(deps_key, dependency_set, timeout)
+    cache_backend.set(cache_key, result, timeout)

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -119,7 +119,14 @@ def publish_dependency_cache_entry(
     started_generation: int,
     record_many_fn: RecordManyDependenciesFn | None = None,
 ) -> None:
-    """Publish dependency metadata and value only if the computation is current."""
+    """Publish dependency metadata and value only if the computation is current.
+
+    When supplied, ``record_many_fn`` is called while the dependency-index lock
+    acquired by ``acquire_lock_with_retry`` is still held. Custom callbacks must
+    not acquire that lock again or call helpers that do so. The cache decorator
+    passes ``None`` for the default ``record_dependencies`` implementation so
+    this function can use the non-reentrant locked helper directly.
+    """
     dependency_set = set(dependencies)
 
     acquire_lock_with_retry("publish_dependency_cache_entry")

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -12,9 +12,13 @@ from django.core.cache import cache as coordination_cache
 from general_manager.cache.dependency_index import (
     LOCK_TIMEOUT,
     Dependency,
+    _record_dependencies_locked,
+    acquire_lock_with_retry,
     get_dependency_generation,
+    get_full_index,
     is_dependency_data_change_active,
-    record_many_dependencies,
+    release_lock,
+    set_full_index,
 )
 
 
@@ -44,6 +48,7 @@ COMPUTE_LOCK_PREFIX = "dependency_cache_compute_lock"
 COMPUTE_LOCK_TIMEOUT = LOCK_TIMEOUT
 WAIT_INITIAL_DELAY = 0.01
 WAIT_MAX_DELAY = 0.2
+_WAIT_MISS = object()
 
 
 def _compute_lock_key(cache_key: str) -> str:
@@ -64,16 +69,20 @@ def acquire_compute_lease(
 
 
 def release_compute_lease(lease: CacheComputeLease) -> None:
-    """Release a compute lease only when its token still owns the lock key."""
-    if coordination_cache.get(lease.key) == lease.token:
-        coordination_cache.delete(lease.key)
+    """Release a compute lease without risking deletion of a newer owner.
+
+    Django's cache API does not provide an atomic compare-and-delete operation.
+    Leaving the lease to expire avoids a check-then-delete race where an expired
+    lease could delete another worker's freshly acquired token.
+    """
+    return None
 
 
 def wait_for_cached_dependency_value(
     cache_backend: DependencyCacheBackend,
     cache_key: str,
     timeout_seconds: float = LOCK_TIMEOUT,
-    sentinel: Any = None,
+    sentinel: Any = _WAIT_MISS,
 ) -> Any:
     """Poll for a cached dependency value until it appears or the wait expires."""
     deadline = time.monotonic() + timeout_seconds
@@ -92,6 +101,13 @@ def wait_for_cached_dependency_value(
         delay = min(delay * 2, WAIT_MAX_DELAY)
 
 
+def _ensure_publish_current(started_generation: int) -> None:
+    if is_dependency_data_change_active():
+        raise CachePublishAborted()
+    if get_dependency_generation() != started_generation:
+        raise CachePublishAborted()
+
+
 def publish_dependency_cache_entry(
     *,
     cache_key: str,
@@ -101,17 +117,30 @@ def publish_dependency_cache_entry(
     cache_backend: DependencyCacheBackend,
     timeout: int | None,
     started_generation: int,
-    record_many_fn: RecordManyDependenciesFn = record_many_dependencies,
+    record_many_fn: RecordManyDependenciesFn | None = None,
 ) -> None:
     """Publish dependency metadata and value only if the computation is current."""
-    if is_dependency_data_change_active():
-        raise CachePublishAborted()
-    if get_dependency_generation() != started_generation:
-        raise CachePublishAborted()
-
     dependency_set = set(dependencies)
-    if dependency_set:
-        record_many_fn([(cache_key, dependency_set)])
 
-    cache_backend.set(deps_key, dependency_set, timeout)
-    cache_backend.set(cache_key, result, timeout)
+    acquire_lock_with_retry("publish_dependency_cache_entry")
+    try:
+        _ensure_publish_current(started_generation)
+
+        if record_many_fn is not None:
+            if dependency_set:
+                record_many_fn([(cache_key, dependency_set)])
+            _ensure_publish_current(started_generation)
+        else:
+            idx = get_full_index()
+            if dependency_set:
+                _record_dependencies_locked(idx, cache_key, dependency_set)
+            _ensure_publish_current(started_generation)
+            cache_backend.set(deps_key, dependency_set, timeout)
+            set_full_index(idx)
+            cache_backend.set(cache_key, result, timeout)
+            return
+
+        cache_backend.set(deps_key, dependency_set, timeout)
+        cache_backend.set(cache_key, result, timeout)
+    finally:
+        release_lock()

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -55,11 +55,19 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
         )
         old_relevant_values = getattr(instance_before, "_old_values", {})
         pre_identification = deepcopy(getattr(instance_before, "identification", None))
-        if isinstance(func, classmethod):
-            inner = cast(Callable[P, R], func.__func__)
-            result = inner(*args, **kwargs)
-        else:
-            result = func(*args, **kwargs)
+        try:
+            if isinstance(func, classmethod):
+                inner = cast(Callable[P, R], func.__func__)
+                result = inner(*args, **kwargs)
+            else:
+                result = func(*args, **kwargs)
+        except Exception:
+            from general_manager.cache.dependency_index import (
+                end_dependency_data_change,
+            )
+
+            end_dependency_data_change()
+            raise
 
         instance = result
         identification = getattr(instance, "identification", None)

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -39,55 +39,58 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
         Returns:
             R: The result returned by the wrapped function.
         """
-        action = func.__name__
-        if func.__name__ == "create":
-            sender = args[0]
-            instance_before = None
-        else:
-            instance = args[0]
-            sender = instance.__class__
-            instance_before = instance
-        pre_data_change.send(
-            sender=sender,
-            instance=instance_before,
-            action=action,
-            **kwargs,
+        from general_manager.cache.dependency_index import (
+            begin_dependency_data_change,
+            end_dependency_data_change,
         )
-        old_relevant_values = getattr(instance_before, "_old_values", {})
-        pre_identification = deepcopy(getattr(instance_before, "identification", None))
+
+        begin_dependency_data_change()
         try:
+            action = func.__name__
+            if func.__name__ == "create":
+                sender = args[0]
+                instance_before = None
+            else:
+                instance = args[0]
+                sender = instance.__class__
+                instance_before = instance
+            pre_data_change.send(
+                sender=sender,
+                instance=instance_before,
+                action=action,
+                **kwargs,
+            )
+            old_relevant_values = getattr(instance_before, "_old_values", {})
+            pre_identification = deepcopy(
+                getattr(instance_before, "identification", None)
+            )
             if isinstance(func, classmethod):
                 inner = cast(Callable[P, R], func.__func__)
                 result = inner(*args, **kwargs)
             else:
                 result = func(*args, **kwargs)
-        except Exception:
-            from general_manager.cache.dependency_index import (
-                end_dependency_data_change,
+
+            instance = result
+            identification = getattr(instance, "identification", None)
+            if identification is None:
+                identification = pre_identification
+
+            post_data_change.send(
+                sender=sender,
+                instance=instance,
+                previous_instance=instance_before,
+                identification=identification,
+                action=action,
+                old_relevant_values=old_relevant_values,
+                **kwargs,
             )
-
+            if instance_before is not None:
+                try:
+                    delattr(instance_before, "_old_values")
+                except AttributeError:
+                    pass
+            return result
+        finally:
             end_dependency_data_change()
-            raise
-
-        instance = result
-        identification = getattr(instance, "identification", None)
-        if identification is None:
-            identification = pre_identification
-
-        post_data_change.send(
-            sender=sender,
-            instance=instance,
-            previous_instance=instance_before,
-            identification=identification,
-            action=action,
-            old_relevant_values=old_relevant_values,
-            **kwargs,
-        )
-        if instance_before is not None:
-            try:
-                delattr(instance_before, "_old_values")
-            except AttributeError:
-                pass
-        return result
 
     return wrapper

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -6,12 +6,16 @@ from typing import Callable, TypeVar, ParamSpec, cast
 
 from functools import wraps
 
+from general_manager.logging import get_logger
+
 post_data_change = Signal()
 
 pre_data_change = Signal()
 
 P = ParamSpec("P")
 R = TypeVar("R")
+
+logger = get_logger("cache.signals")
 
 
 def data_change(func: Callable[P, R]) -> Callable[P, R]:
@@ -44,6 +48,7 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
             end_dependency_data_change,
         )
 
+        primary_exc: BaseException | None = None
         begin_dependency_data_change()
         try:
             action = func.__name__
@@ -89,8 +94,21 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
                     delattr(instance_before, "_old_values")
                 except AttributeError:
                     pass
+        except BaseException as error:
+            primary_exc = error
+            raise
+        else:
             return result
         finally:
-            end_dependency_data_change()
+            try:
+                end_dependency_data_change()
+            except Exception:
+                if primary_exc is not None:
+                    logger.exception(
+                        "Dependency data-change cleanup failed while handling "
+                        "another exception."
+                    )
+                else:
+                    raise
 
     return wrapper

--- a/src/general_manager/utils/testing.py
+++ b/src/general_manager/utils/testing.py
@@ -20,6 +20,13 @@ from general_manager.api.remote_api import clear_remote_api_urls
 from general_manager.api.remote_invalidation import clear_remote_invalidation_routes
 from general_manager.apps import GeneralmanagerConfig
 from general_manager.cache.cache_decorator import _SENTINEL
+from general_manager.cache.dependency_index import (
+    DATA_CHANGE_COUNT_KEY,
+    DATA_CHANGE_LOCK_KEY,
+    DEPENDENCY_GENERATION_KEY,
+    INDEX_KEY,
+    LOCK_KEY,
+)
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.interface.base_interface import InterfaceBase
@@ -32,6 +39,13 @@ from general_manager.interface.infrastructure.startup_hooks import (
 _original_get_app: Callable[[str], AppConfig | None] = (
     global_apps.get_containing_app_config
 )
+_DEPENDENCY_COORDINATION_KEYS = {
+    DATA_CHANGE_COUNT_KEY,
+    DATA_CHANGE_LOCK_KEY,
+    DEPENDENCY_GENERATION_KEY,
+    INDEX_KEY,
+    LOCK_KEY,
+}
 
 
 def create_fallback_get_app(fallback_app: str) -> Callable[[str], AppConfig | None]:
@@ -533,10 +547,15 @@ class GeneralManagerTransactionTestCase(
             "Cache.get should have been called and found something",
         )
 
-        self.assertNotIn(
-            ("set", ANY),
-            ops,
-            "Cache.set should not have stored anything",
+        value_sets = [
+            op
+            for op in ops
+            if op[0] == "set" and op[1] not in _DEPENDENCY_COORDINATION_KEYS
+        ]
+        self.assertEqual(
+            value_sets,
+            [],
+            "Cache.set should not have stored a cached value",
         )
         self.__reset_cache_counter()
 

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -2,6 +2,11 @@ from django.test import SimpleTestCase
 from django.core.cache import cache
 from unittest import mock
 from general_manager.cache.cache_decorator import cached, DependencyTracker
+from general_manager.cache.dependency_index import (
+    begin_dependency_data_change,
+    end_dependency_data_change,
+)
+from general_manager.cache.dependency_publish import CachePublishAborted
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.utils.make_cache_key import make_cache_key
 import pickle
@@ -66,6 +71,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         Initializes a fake cache backend and a call recording list, and resets thread-local dependency tracking state to ensure test isolation.
         """
         DependencyTracker.reset_thread_local_storage()
+        cache.clear()
 
         self.fake_cache = FakeCacheBackend()
         self.record_calls = []
@@ -90,6 +96,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         """
         with DependencyTracker():
             pass
+        cache.clear()
 
     def test_real_tracker_records_manual_tracks(self):
         """
@@ -252,6 +259,111 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         res2 = fn(2, 3)
         self.assertEqual(res2, 5)
         self.assertEqual(self.record_calls, [])
+
+    def test_dependency_scope_waits_for_published_value_when_lease_is_owned(self):
+        calls = 0
+
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
+        def fn(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        key = make_cache_key(fn, (3,), {})
+        deps_key = f"{key}:deps"
+        self.fake_cache.set(deps_key, {("User", "identification", "3")}, None)
+        original_get = self.fake_cache.get
+        key_reads = 0
+
+        def publish_after_initial_miss(cache_key, default=None):
+            nonlocal key_reads
+            if cache_key == key:
+                key_reads += 1
+                if key_reads == 2:
+                    self.fake_cache.set(key, 6, None)
+            return original_get(cache_key, default)
+
+        self.fake_cache.get = publish_after_initial_miss
+
+        with mock.patch(
+            "general_manager.cache.cache_decorator.acquire_compute_lease",
+            return_value=None,
+        ):
+            with DependencyTracker() as dependencies:
+                self.assertEqual(fn(3), 6)
+
+        self.assertEqual(calls, 0)
+        self.assertEqual(dependencies, {("User", "identification", "3")})
+
+    def test_dependency_scope_returns_result_without_caching_when_publish_aborts(self):
+        calls = 0
+
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
+        def fn(value):
+            nonlocal calls
+            calls += 1
+            DependencyTracker.track("User", "identification", str(value))
+            return value * 2
+
+        with mock.patch(
+            "general_manager.cache.cache_decorator.publish_dependency_cache_entry",
+            side_effect=CachePublishAborted,
+        ):
+            self.assertEqual(fn(3), 6)
+
+        key = make_cache_key(fn, (3,), {})
+        self.assertEqual(calls, 1)
+        self.assertNotIn(key, self.fake_cache.store)
+        self.assertNotIn(f"{key}:deps", self.fake_cache.store)
+        self.assertEqual(self.record_calls, [])
+
+    def test_dependency_scope_does_not_cache_when_generation_changes_during_compute(
+        self,
+    ):
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+        )
+        def fn(value):
+            DependencyTracker.track("User", "identification", str(value))
+            begin_dependency_data_change()
+            end_dependency_data_change()
+            return value * 2
+
+        self.assertEqual(fn(3), 6)
+
+        key = make_cache_key(fn, (3,), {})
+        self.assertNotIn(key, self.fake_cache.store)
+        self.assertNotIn(f"{key}:deps", self.fake_cache.store)
+
+    def test_dependency_scope_does_not_cache_when_barrier_is_active_at_publish(
+        self,
+    ):
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+        )
+        def fn(value):
+            DependencyTracker.track("User", "identification", str(value))
+            begin_dependency_data_change()
+            return value * 2
+
+        try:
+            self.assertEqual(fn(3), 6)
+        finally:
+            end_dependency_data_change()
+
+        key = make_cache_key(fn, (3,), {})
+        self.assertNotIn(key, self.fake_cache.store)
+        self.assertNotIn(f"{key}:deps", self.fake_cache.store)
 
     def test_cache_decorator_with_timeout_and_record_fn(self):
         """

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -10,6 +10,7 @@ from general_manager.cache.dependency_publish import CachePublishAborted
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.utils.make_cache_key import make_cache_key
 import pickle
+import threading
 import time
 
 
@@ -31,6 +32,7 @@ class FakeCacheBackend:
         """
         self.store = {}
         self.timeouts = {}
+        self.lock = threading.RLock()
 
     def get(self, key, default=None):
         """
@@ -43,7 +45,8 @@ class FakeCacheBackend:
         Returns:
             The unpickled value associated with the key, or the default if not found.
         """
-        cached_value = self.store.get(key, default)
+        with self.lock:
+            cached_value = self.store.get(key, default)
         if cached_value is not default:
             return _trusted_pickle_loads(cached_value)  # type: ignore
         return default
@@ -57,8 +60,9 @@ class FakeCacheBackend:
             value: The Python object to cache; it is serialized with pickle prior to storage.
             timeout: Optional expiration time for the cache entry. This backend does not enforce expiration.
         """
-        self.store[key] = pickle.dumps(value)
-        self.timeouts[key] = timeout
+        with self.lock:
+            self.store[key] = pickle.dumps(value)
+            self.timeouts[key] = timeout
 
 
 class TestCacheDecoratorBackend(SimpleTestCase):
@@ -364,6 +368,57 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         key = make_cache_key(fn, (3,), {})
         self.assertNotIn(key, self.fake_cache.store)
         self.assertNotIn(f"{key}:deps", self.fake_cache.store)
+
+    def test_dependency_scope_concurrent_miss_computes_once(self):
+        calls = 0
+        calls_lock = threading.Lock()
+        compute_started = threading.Event()
+        release_compute = threading.Event()
+        start_together = threading.Barrier(2)
+        results = []
+        errors = []
+
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
+        def fn(value):
+            nonlocal calls
+            with calls_lock:
+                calls += 1
+            DependencyTracker.track("User", "identification", str(value))
+            compute_started.set()
+            self.assertTrue(release_compute.wait(timeout=2))
+            return value * 2
+
+        def call_cached_function():
+            try:
+                start_together.wait(timeout=2)
+                results.append(fn(3))
+            except (AssertionError, RuntimeError) as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=call_cached_function),
+            threading.Thread(target=call_cached_function),
+        ]
+        for thread in threads:
+            thread.start()
+
+        self.assertTrue(compute_started.wait(timeout=2))
+        release_compute.set()
+
+        for thread in threads:
+            thread.join(timeout=5)
+
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        if errors:
+            raise AssertionError(errors)
+
+        self.assertEqual(sorted(results), [6, 6])
+        self.assertEqual(calls, 1)
+        self.assertEqual(len(self.record_calls), 1)
 
     def test_cache_decorator_with_timeout_and_record_fn(self):
         """

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -155,11 +155,19 @@ class TestDependencyGenerationAndBarrier(TestCase):
         self.assertFalse(is_dependency_data_change_active())
         self.assertEqual(get_dependency_generation(), 1)
 
-    def test_capture_old_values_begins_data_change_for_create(self):
-        capture_old_values(sender=SimpleNamespace, instance=None)
+    def test_create_data_change_owns_generation_and_barrier_lifecycle(self):
+        class Example:
+            @classmethod
+            @data_change
+            def create(cls):
+                return SimpleNamespace(identification=None)
 
+        result = Example.create()
+
+        self.assertIsNotNone(result)
         self.assertEqual(get_dependency_generation(), 1)
-        self.assertTrue(is_dependency_data_change_active())
+        self.assertFalse(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 0)
 
     def test_overlapping_data_changes_keep_barrier_until_last_end(self):
         begin_dependency_data_change()
@@ -197,25 +205,64 @@ class TestDependencyGenerationAndBarrier(TestCase):
 
         self.assertEqual(calls, [])
         self.assertFalse(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 0)
 
-    def test_generic_cache_invalidation_releases_barrier_when_invalidation_raises(self):
-        begin_dependency_data_change()
+    def test_pre_data_change_exception_releases_dependency_barrier(self):
+        class Example:
+            @data_change
+            def update(self):
+                return self
 
-        with (
-            patch(
-                "general_manager.cache.dependency_index."
-                "invalidate_request_query_dependencies",
-                side_effect=RuntimeError("boom"),
-            ),
-            self.assertRaisesRegex(RuntimeError, "boom"),
-        ):
-            generic_cache_invalidation(
-                sender=SimpleNamespace,
-                instance=SimpleNamespace(),
-                old_relevant_values={},
+        def receiver(**kwargs):
+            raise RuntimeError
+
+        pre_data_change.connect(
+            receiver,
+            weak=False,
+            dispatch_uid="test_pre_failure_releases_barrier",
+        )
+        try:
+            with self.assertRaises(RuntimeError):
+                Example().update()
+        finally:
+            pre_data_change.disconnect(
+                dispatch_uid="test_pre_failure_releases_barrier",
             )
 
         self.assertFalse(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 0)
+
+    def test_post_data_change_exception_releases_dependency_barrier(self):
+        class Example:
+            @data_change
+            def mutate(self):
+                return self
+
+        def receiver(**kwargs):
+            raise RuntimeError
+
+        post_data_change.connect(
+            receiver,
+            weak=False,
+            dispatch_uid="test_post_failure_releases_barrier",
+        )
+        try:
+            with self.assertRaises(RuntimeError):
+                Example().mutate()
+        finally:
+            post_data_change.disconnect(
+                dispatch_uid="test_post_failure_releases_barrier",
+            )
+
+        self.assertFalse(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 0)
+
+    def test_begin_data_change_stores_barrier_and_count_without_timeout(self):
+        with patch.object(cache, "set", wraps=cache.set) as set_spy:
+            begin_dependency_data_change()
+
+        set_spy.assert_any_call(DATA_CHANGE_COUNT_KEY, 1, None)
+        set_spy.assert_any_call(DATA_CHANGE_LOCK_KEY, "1", None)
 
 
 @override_settings(CACHES=TEST_CACHES)

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -207,6 +207,40 @@ class TestDependencyGenerationAndBarrier(TestCase):
         self.assertFalse(is_dependency_data_change_active())
         self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 0)
 
+    @patch(
+        "general_manager.cache.dependency_index.end_dependency_data_change",
+        side_effect=RuntimeError("cleanup"),
+    )
+    def test_data_change_preserves_mutation_exception_when_cleanup_fails(
+        self, mock_end_dependency_data_change
+    ):
+        class Example:
+            @data_change
+            def update(self):
+                raise RuntimeError("boom")
+
+        with self.assertRaisesRegex(RuntimeError, "^boom$"):
+            Example().update()
+
+        mock_end_dependency_data_change.assert_called_once_with()
+
+    @patch(
+        "general_manager.cache.dependency_index.end_dependency_data_change",
+        side_effect=RuntimeError("cleanup"),
+    )
+    def test_data_change_propagates_cleanup_exception_after_success(
+        self, mock_end_dependency_data_change
+    ):
+        class Example:
+            @data_change
+            def mutate(self):
+                return self
+
+        with self.assertRaisesRegex(RuntimeError, "^cleanup$"):
+            Example().mutate()
+
+        mock_end_dependency_data_change.assert_called_once_with()
+
     def test_pre_data_change_exception_releases_dependency_barrier(self):
         class Example:
             @data_change

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -1,8 +1,14 @@
 from django.test import TestCase, override_settings
 from general_manager.cache.dependency_index import (
+    DATA_CHANGE_LOCK_KEY,
+    DEPENDENCY_GENERATION_KEY,
     acquire_lock,
-    release_lock,
+    begin_dependency_data_change,
+    end_dependency_data_change,
     get_full_index,
+    get_dependency_generation,
+    is_dependency_data_change_active,
+    release_lock,
     set_full_index,
     record_dependencies,
     record_many_dependencies,
@@ -122,6 +128,37 @@ class TestFullIndex(TestCase):
                 "all": {},
             },
         )
+
+
+@override_settings(CACHES=TEST_CACHES)
+class TestDependencyGenerationAndBarrier(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def test_generation_defaults_to_zero(self):
+        self.assertEqual(get_dependency_generation(), 0)
+
+    def test_begin_data_change_bumps_generation_and_sets_barrier(self):
+        generation = begin_dependency_data_change()
+
+        self.assertEqual(generation, 1)
+        self.assertEqual(cache.get(DEPENDENCY_GENERATION_KEY), 1)
+        self.assertTrue(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_LOCK_KEY), "1")
+
+    def test_end_data_change_releases_barrier_without_changing_generation(self):
+        begin_dependency_data_change()
+
+        end_dependency_data_change()
+
+        self.assertFalse(is_dependency_data_change_active())
+        self.assertEqual(get_dependency_generation(), 1)
+
+    def test_capture_old_values_begins_data_change_for_create(self):
+        capture_old_values(sender=SimpleNamespace, instance=None)
+
+        self.assertEqual(get_dependency_generation(), 1)
+        self.assertTrue(is_dependency_data_change_active())
 
 
 @override_settings(CACHES=TEST_CACHES)

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -28,7 +28,7 @@ import time
 import json
 from datetime import datetime, timezone, date
 from unittest.mock import patch, call
-from general_manager.cache.signals import data_change, pre_data_change
+from general_manager.cache.signals import data_change, post_data_change, pre_data_change
 from types import SimpleNamespace
 
 
@@ -179,9 +179,23 @@ class TestDependencyGenerationAndBarrier(TestCase):
             def update(self):
                 raise RuntimeError("boom")
 
-        with self.assertRaisesRegex(RuntimeError, "boom"):
-            Example().update()
+        calls = []
 
+        def receiver(**kwargs):
+            calls.append(kwargs)
+
+        post_data_change.connect(
+            receiver,
+            weak=False,
+            dispatch_uid="test_failed_mutation_no_post",
+        )
+        try:
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                Example().update()
+        finally:
+            post_data_change.disconnect(dispatch_uid="test_failed_mutation_no_post")
+
+        self.assertEqual(calls, [])
         self.assertFalse(is_dependency_data_change_active())
 
     def test_generic_cache_invalidation_releases_barrier_when_invalidation_raises(self):

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -1262,6 +1262,9 @@ class GenericCacheInvalidationTests(TestCase):
         mock_get_index,
     ):
         mock_invalidate_request_queries.return_value = ()
+        invalidated_keys = ("ROOT-1", "ALL-1", "ALL-2")
+        for cache_key in invalidated_keys:
+            cache.set(cache_key, f"value-{cache_key}", None)
         mock_get_index.return_value = {
             "filter": {"DummyManager2": {"__all__": {"__all__": {"ALL-1", "ALL-2"}}}},
             "exclude": {},
@@ -1278,11 +1281,11 @@ class GenericCacheInvalidationTests(TestCase):
         mock_invalidate_request_queries.assert_not_called()
         mock_invalidate.assert_not_called()
         mock_remove.assert_not_called()
+        for cache_key in invalidated_keys:
+            self.assertIsNone(cache.get(cache_key))
         self.assert_cache_keys_removed_from_index(
             mock_get_index.return_value,
-            "ROOT-1",
-            "ALL-1",
-            "ALL-2",
+            *invalidated_keys,
         )
 
     @patch("general_manager.cache.dependency_index.get_full_index")
@@ -1418,6 +1421,7 @@ class GenericCacheInvalidationTests(TestCase):
 
         Sets up an index containing an exclude rule for DummyManager2 (count__gt 5) and simulates a transition from an old value that matched the exclude (count = 10) to a new instance value that no longer matches (count = 3); asserts that the affected cache key is invalidated and removed.
         """
+        cache.set("X", "value-X", None)
         mock_get_index.return_value = {
             "filter": {},
             "exclude": {"DummyManager2": {"count__gt": {"5": ["X"]}}},
@@ -1433,6 +1437,7 @@ class GenericCacheInvalidationTests(TestCase):
 
         mock_invalidate.assert_not_called()
         mock_remove.assert_not_called()
+        self.assertIsNone(cache.get("X"))
         self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
@@ -1515,6 +1520,7 @@ class GenericCacheInvalidationTests(TestCase):
         mock_invalidate,
         mock_get_index,
     ):
+        cache.set("X", "value-X", None)
         mock_get_index.return_value = {
             "filter": {"DummyManager": {"title__contains": {'"hallo"': ["X"]}}},
             "exclude": {},
@@ -1530,6 +1536,7 @@ class GenericCacheInvalidationTests(TestCase):
         )
         mock_invalidate.assert_not_called()
         mock_remove.assert_not_called()
+        self.assertIsNone(cache.get("X"))
         self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
@@ -2074,6 +2081,7 @@ class GenericCacheInvalidationTests(TestCase):
         mock_get_index,
     ):
         identifier = json.dumps({"status": "blocked", "count__gte": 5})
+        cache.set("EXC", "value-EXC", None)
         mock_get_index.return_value = {
             "filter": {},
             "exclude": {
@@ -2095,6 +2103,7 @@ class GenericCacheInvalidationTests(TestCase):
 
         mock_invalidate.assert_not_called()
         mock_remove.assert_not_called()
+        self.assertIsNone(cache.get("EXC"))
         self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "EXC")
 
     @patch("general_manager.cache.dependency_index.get_full_index")

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -27,7 +27,7 @@ from general_manager.cache.dependency_index import (
 import time
 import json
 from datetime import datetime, timezone, date
-from unittest.mock import patch, call
+from unittest.mock import patch
 from general_manager.cache.signals import data_change, post_data_change, pre_data_change
 from types import SimpleNamespace
 
@@ -1137,6 +1137,59 @@ class MissingAttrManager:
 
 
 class GenericCacheInvalidationTests(TestCase):
+    def assert_cache_keys_removed_from_index(
+        self,
+        idx: dict[object, object],
+        *cache_keys: str,
+    ) -> None:
+        remaining_keys = set(cache_keys)
+
+        def assert_absent(value: object) -> None:
+            if isinstance(value, dict):
+                for key, nested in value.items():
+                    self.assertNotIn(key, remaining_keys)
+                    assert_absent(nested)
+            elif isinstance(value, (list, set, tuple)):
+                for nested in value:
+                    self.assertNotIn(nested, remaining_keys)
+
+        assert_absent(idx)
+
+    @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
+    @patch(
+        "general_manager.cache.dependency_index.invalidate_request_query_dependencies",
+        return_value=(),
+    )
+    def test_filter_invalidation_uses_locked_internals_without_public_helper_reentry(
+        self,
+        mock_invalidate_request_queries,
+        mock_remove,
+    ):
+        cache.set("FILTER-1", "value", None)
+        set_full_index(
+            {
+                "filter": {"DummyManager2": {"status": {'"active"': {"FILTER-1"}}}},
+                "exclude": {},
+                "request_query": {},
+                "all": {},
+            }
+        )
+        inst = DummyManager2(status="active", count=1)
+
+        generic_cache_invalidation(
+            sender=DummyManager2,
+            instance=inst,
+            old_relevant_values={"status": "inactive"},
+        )
+
+        mock_invalidate_request_queries.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assertIsNone(cache.get("FILTER-1"))
+        self.assertEqual(
+            get_full_index(),
+            {"filter": {}, "exclude": {}, "request_query": {}, "all": {}},
+        )
+
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1164,13 +1217,14 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values={},
         )
 
-        self.assertCountEqual(
-            mock_invalidate.call_args_list,
-            [call("ROOT-1"), call("ALL-1"), call("ALL-2")],
-        )
-        self.assertCountEqual(
-            mock_remove.call_args_list,
-            [call("ROOT-1"), call("ALL-1"), call("ALL-2")],
+        mock_invalidate_request_queries.assert_not_called()
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(
+            mock_get_index.return_value,
+            "ROOT-1",
+            "ALL-1",
+            "ALL-2",
         )
 
     @patch("general_manager.cache.dependency_index.get_full_index")
@@ -1186,8 +1240,12 @@ class GenericCacheInvalidationTests(TestCase):
         mock_remove,
         mock_get_index,
     ):
-        mock_invalidate_request_queries.return_value = ("rq-1", "rq-2")
-        mock_get_index.return_value = {"filter": {}, "exclude": {}}
+        mock_get_index.return_value = {
+            "filter": {},
+            "exclude": {},
+            "request_query": {"DummyManager2": {"query": {"rq-1", "rq-2"}}},
+            "all": {},
+        }
         inst = DummyManager2(status="active", count=1)
 
         generic_cache_invalidation(
@@ -1196,9 +1254,14 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values={"status": "inactive"},
         )
 
-        mock_invalidate_request_queries.assert_called_once_with("DummyManager2")
+        mock_invalidate_request_queries.assert_not_called()
         mock_invalidate.assert_not_called()
         mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(
+            mock_get_index.return_value,
+            "rq-1",
+            "rq-2",
+        )
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1223,10 +1286,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        # Assert: filter => new_match=True ⇒ invalidate & remove per key
-        expected_calls = [call("A"), call("B")]
-        self.assertEqual(mock_invalidate.call_args_list, expected_calls)
-        self.assertEqual(mock_remove.call_args_list, expected_calls)
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "A", "B")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1250,8 +1312,11 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("MISSING")
-        mock_remove.assert_called_once_with("MISSING")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(
+            mock_get_index.return_value, "MISSING"
+        )
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1275,8 +1340,11 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("MISSING")
-        mock_remove.assert_called_once_with("MISSING")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(
+            mock_get_index.return_value, "MISSING"
+        )
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1305,8 +1373,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1351,8 +1420,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values={},
         )
 
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1400,8 +1470,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1450,8 +1521,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1475,8 +1547,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1505,9 +1578,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        expected_calls = [call("X"), call("Y")]
-        self.assertEqual(mock_invalidate.call_args_list, expected_calls)
-        self.assertEqual(mock_remove.call_args_list, expected_calls)
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X", "Y")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1531,8 +1604,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1581,8 +1655,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1606,8 +1681,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1631,8 +1707,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1656,8 +1733,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1681,8 +1759,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1731,8 +1810,9 @@ class GenericCacheInvalidationTests(TestCase):
             instance=inst,
             old_relevant_values={"count": 3},
         )
-        mock_invalidate.assert_called_once_with("X")
-        mock_remove.assert_called_once_with("X")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "X")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1796,8 +1876,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("DATE")
-        mock_remove.assert_called_once_with("DATE")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "DATE")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1827,8 +1908,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("OBJ")
-        mock_remove.assert_called_once_with("OBJ")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "OBJ")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1888,8 +1970,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("DATEZ")
-        mock_remove.assert_called_once_with("DATEZ")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "DATEZ")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1919,8 +2002,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("DAY")
-        mock_remove.assert_called_once_with("DAY")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "DAY")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1951,9 +2035,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        expected_calls = [call("EXC"), call("EXC")]
-        self.assertEqual(mock_invalidate.call_args_list, expected_calls)
-        self.assertEqual(mock_remove.call_args_list, expected_calls)
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "EXC")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1982,8 +2066,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("OBJ")
-        mock_remove.assert_called_once_with("OBJ")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "OBJ")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -2012,8 +2097,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("OBJ")
-        mock_remove.assert_called_once_with("OBJ")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "OBJ")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -2069,8 +2155,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values={},
         )
 
-        mock_invalidate.assert_called_once_with("REP")
-        mock_remove.assert_called_once_with("REP")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "REP")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -2130,8 +2217,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("NAIVE")
-        mock_remove.assert_called_once_with("NAIVE")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "NAIVE")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -2190,8 +2278,9 @@ class GenericCacheInvalidationTests(TestCase):
             old_relevant_values=old_vals,
         )
 
-        mock_invalidate.assert_called_once_with("DAYOBJ")
-        mock_remove.assert_called_once_with("DAYOBJ")
+        mock_invalidate.assert_not_called()
+        mock_remove.assert_not_called()
+        self.assert_cache_keys_removed_from_index(mock_get_index.return_value, "DAYOBJ")
 
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -275,11 +275,13 @@ class TestDependencyGenerationAndBarrier(TestCase):
         with patch.object(cache, "set", side_effect=set_spy):
             begin_dependency_data_change()
             begin_dependency_data_change()
+            set_calls.clear()
             end_dependency_data_change()
 
         self.assertTrue(is_dependency_data_change_active())
         self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 1)
         self.assertIn((DATA_CHANGE_COUNT_KEY, 1, None), set_calls)
+        self.assertIn((DATA_CHANGE_LOCK_KEY, "1", None), set_calls)
 
 
 @override_settings(CACHES=TEST_CACHES)

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -264,6 +264,23 @@ class TestDependencyGenerationAndBarrier(TestCase):
         set_spy.assert_any_call(DATA_CHANGE_COUNT_KEY, 1, None)
         set_spy.assert_any_call(DATA_CHANGE_LOCK_KEY, "1", None)
 
+    def test_end_data_change_preserves_positive_count_without_timeout(self):
+        original_set = cache.set
+        set_calls = []
+
+        def set_spy(key, value, timeout=None):
+            set_calls.append((key, value, timeout))
+            return original_set(key, value, timeout)
+
+        with patch.object(cache, "set", side_effect=set_spy):
+            begin_dependency_data_change()
+            begin_dependency_data_change()
+            end_dependency_data_change()
+
+        self.assertTrue(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 1)
+        self.assertIn((DATA_CHANGE_COUNT_KEY, 1, None), set_calls)
+
 
 @override_settings(CACHES=TEST_CACHES)
 class TestRecordDependencies(TestCase):

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -1190,6 +1190,64 @@ class GenericCacheInvalidationTests(TestCase):
             {"filter": {}, "exclude": {}, "request_query": {}, "all": {}},
         )
 
+    def test_generic_invalidation_serializes_multiple_mutations_under_one_lock(self):
+        invalidated_keys = ("rq-key", "all-key", "filter-key")
+        for cache_key in invalidated_keys:
+            cache.set(cache_key, f"value-{cache_key}", None)
+        cache.set("unaffected-key", "still-cached", None)
+        set_full_index(
+            {
+                "filter": {
+                    "DummyManager2": {
+                        "status": {
+                            '"active"': {"filter-key"},
+                            '"archived"': {"unaffected-key"},
+                        }
+                    }
+                },
+                "exclude": {},
+                "request_query": {
+                    "DummyManager2": {"query": {"rq-key"}},
+                    "OtherManager": {"query": {"unaffected-key"}},
+                },
+                "all": {"DummyManager2": {"all-key"}},
+            }
+        )
+        inst = DummyManager2(status="active", count=1)
+
+        with (
+            patch(
+                "general_manager.cache.dependency_index.acquire_lock_with_retry"
+            ) as mock_acquire,
+            patch(
+                "general_manager.cache.dependency_index.release_lock"
+            ) as mock_release,
+            patch("general_manager.cache.dependency_index.set_full_index") as mock_set,
+        ):
+            generic_cache_invalidation(
+                sender=DummyManager2,
+                instance=inst,
+                old_relevant_values={"status": "inactive"},
+            )
+
+        mock_acquire.assert_called_once_with("generic_cache_invalidation")
+        mock_release.assert_called_once()
+        mock_set.assert_called_once()
+        for cache_key in invalidated_keys:
+            self.assertIsNone(cache.get(cache_key))
+        self.assertEqual(cache.get("unaffected-key"), "still-cached")
+
+        persisted_idx = mock_set.call_args.args[0]
+        self.assert_cache_keys_removed_from_index(persisted_idx, *invalidated_keys)
+        self.assertEqual(
+            persisted_idx["filter"],
+            {"DummyManager2": {"status": {'"archived"': {"unaffected-key"}}}},
+        )
+        self.assertEqual(
+            persisted_idx["request_query"],
+            {"OtherManager": {"query": {"unaffected-key"}}},
+        )
+
     @patch("general_manager.cache.dependency_index.get_full_index")
     @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
     @patch("general_manager.cache.dependency_index.invalidate_cache_key")
@@ -1233,7 +1291,7 @@ class GenericCacheInvalidationTests(TestCase):
     @patch(
         "general_manager.cache.dependency_index.invalidate_request_query_dependencies"
     )
-    def test_request_query_invalidation_uses_batch_helper(
+    def test_request_query_invalidation_uses_locked_helper(
         self,
         mock_invalidate_request_queries,
         mock_invalidate,

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -5,6 +5,7 @@ from general_manager.cache.dependency_index import (
     get_full_index,
     set_full_index,
     record_dependencies,
+    record_many_dependencies,
     remove_cache_key_from_index,
     invalidate_cache_key,
     invalidate_and_remove_cache_keys,
@@ -383,6 +384,81 @@ class TestRecordDependencies(TestCase):
                     ("project", "identification", json.dumps({"id": 1})),
                 ],
             )
+
+
+@override_settings(CACHES=TEST_CACHES)
+class TestRecordManyDependencies(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    @patch("general_manager.cache.dependency_index.acquire_lock")
+    def test_records_many_dependency_sets_under_one_lock(self, mock_acquire):
+        mock_acquire.return_value = True
+
+        record_many_dependencies(
+            [
+                (
+                    "cache-a",
+                    {
+                        ("project", "filter", json.dumps({"name": "A"})),
+                        ("project", "identification", "1"),
+                    },
+                ),
+                (
+                    "cache-b",
+                    {
+                        ("project", "filter", json.dumps({"name": "B"})),
+                        ("project", "identification", "2"),
+                    },
+                ),
+            ]
+        )
+
+        self.assertEqual(mock_acquire.call_count, 1)
+        self.assertEqual(
+            get_full_index(),
+            {
+                "filter": {
+                    "project": {
+                        "name": {
+                            '"A"': {"cache-a"},
+                            '"B"': {"cache-b"},
+                        },
+                        "identification": {
+                            "1": {"cache-a"},
+                            "2": {"cache-b"},
+                        },
+                    }
+                },
+                "exclude": {},
+                "request_query": {},
+                "all": {},
+            },
+        )
+
+    def test_record_many_deduplicates_exact_cache_dependency_pairs(self):
+        dependency = ("project", "filter", json.dumps({"name": "A"}))
+
+        record_many_dependencies(
+            [
+                ("cache-a", {dependency}),
+                ("cache-a", {dependency}),
+                ("cache-b", {dependency}),
+            ]
+        )
+
+        self.assertEqual(
+            get_full_index()["filter"]["project"]["name"],
+            {'"A"': {"cache-a", "cache-b"}},
+        )
+
+    def test_record_many_ignores_empty_dependency_sets(self):
+        record_many_dependencies([("cache-a", set()), ("cache-b", [])])
+
+        self.assertEqual(
+            get_full_index(),
+            {"filter": {}, "exclude": {}, "request_query": {}, "all": {}},
+        )
 
 
 @override_settings(CACHES=TEST_CACHES)

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, override_settings
 from general_manager.cache.dependency_index import (
+    DATA_CHANGE_COUNT_KEY,
     DATA_CHANGE_LOCK_KEY,
     DEPENDENCY_GENERATION_KEY,
     acquire_lock,
@@ -27,7 +28,7 @@ import time
 import json
 from datetime import datetime, timezone, date
 from unittest.mock import patch, call
-from general_manager.cache.signals import pre_data_change
+from general_manager.cache.signals import data_change, pre_data_change
 from types import SimpleNamespace
 
 
@@ -159,6 +160,48 @@ class TestDependencyGenerationAndBarrier(TestCase):
 
         self.assertEqual(get_dependency_generation(), 1)
         self.assertTrue(is_dependency_data_change_active())
+
+    def test_overlapping_data_changes_keep_barrier_until_last_end(self):
+        begin_dependency_data_change()
+        begin_dependency_data_change()
+
+        end_dependency_data_change()
+        self.assertTrue(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 1)
+
+        end_dependency_data_change()
+        self.assertFalse(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 0)
+
+    def test_data_change_exception_releases_dependency_barrier(self):
+        class Example:
+            @data_change
+            def update(self):
+                raise RuntimeError("boom")
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            Example().update()
+
+        self.assertFalse(is_dependency_data_change_active())
+
+    def test_generic_cache_invalidation_releases_barrier_when_invalidation_raises(self):
+        begin_dependency_data_change()
+
+        with (
+            patch(
+                "general_manager.cache.dependency_index."
+                "invalidate_request_query_dependencies",
+                side_effect=RuntimeError("boom"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "boom"),
+        ):
+            generic_cache_invalidation(
+                sender=SimpleNamespace,
+                instance=SimpleNamespace(),
+                old_relevant_values={},
+            )
+
+        self.assertFalse(is_dependency_data_change_active())
 
 
 @override_settings(CACHES=TEST_CACHES)

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any
+
+from django.test import SimpleTestCase, override_settings
+
+from general_manager.cache.dependency_index import (
+    begin_dependency_data_change,
+    end_dependency_data_change,
+    get_dependency_generation,
+)
+from general_manager.cache.dependency_publish import (
+    CacheComputeLease,
+    CachePublishAborted,
+    acquire_compute_lease,
+    coordination_cache,
+    publish_dependency_cache_entry,
+    release_compute_lease,
+    wait_for_cached_dependency_value,
+    _compute_lock_key,
+)
+
+
+TEST_CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-dependency-publish",
+    }
+}
+
+
+class FakeDependencyCacheBackend:
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.timeouts: dict[str, int | None] = {}
+        self.set_order: list[str] = []
+
+    def get(self, key: str, default: Any = None) -> Any:
+        cached_value = self.store.get(key, default)
+        if cached_value is not default:
+            return pickle.loads(cached_value)  # noqa: S301
+        return default
+
+    def set(self, key: str, value: Any, timeout: int | None = None) -> None:
+        self.store[key] = pickle.dumps(value)
+        self.timeouts[key] = timeout
+        self.set_order.append(key)
+
+
+@override_settings(CACHES=TEST_CACHES)
+class TestDependencyPublish(SimpleTestCase):
+    def setUp(self) -> None:
+        coordination_cache.clear()
+
+    def tearDown(self) -> None:
+        coordination_cache.clear()
+
+    def test_acquire_compute_lease_allows_one_active_lease_per_key(self) -> None:
+        lease = acquire_compute_lease("cache-a")
+
+        self.assertIsInstance(lease, CacheComputeLease)
+        assert lease is not None
+        self.assertEqual(lease.key, _compute_lock_key("cache-a"))
+        self.assertEqual(coordination_cache.get(lease.key), lease.token)
+        self.assertIsNone(acquire_compute_lease("cache-a"))
+
+    def test_release_compute_lease_only_releases_owned_token(self) -> None:
+        lease = acquire_compute_lease("cache-a")
+        assert lease is not None
+        coordination_cache.set(lease.key, "other-token", None)
+
+        release_compute_lease(lease)
+
+        self.assertEqual(coordination_cache.get(lease.key), "other-token")
+        self.assertIsNone(acquire_compute_lease("cache-a"))
+
+        release_compute_lease(CacheComputeLease(lease.key, "other-token"))
+
+        self.assertIsNone(coordination_cache.get(lease.key))
+        self.assertIsInstance(acquire_compute_lease("cache-a"), CacheComputeLease)
+
+    def test_publish_records_dependencies_before_deps_and_value(self) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        cache_key = "cache-a"
+        deps_key = f"{cache_key}:deps"
+        dependencies = {
+            ("Project", "filter", '{"name": "alpha"}'),
+            ("Project", "identification", "1"),
+        }
+        events: list[str] = []
+        recorded_entries: list[tuple[str, set[tuple[str, str, str]]]] = []
+
+        def record_many_fn(entries: Any) -> None:
+            for key, dependency_set in entries:
+                recorded_entries.append((key, set(dependency_set)))
+            events.append("record")
+
+        original_set = cache_backend.set
+
+        def record_set_order(key: str, value: Any, timeout: int | None = None) -> None:
+            events.append(f"set:{key}")
+            original_set(key, value, timeout)
+
+        cache_backend.set = record_set_order  # type: ignore[method-assign]
+
+        publish_dependency_cache_entry(
+            cache_key=cache_key,
+            deps_key=deps_key,
+            result={"status": "ready"},
+            dependencies=dependencies,
+            cache_backend=cache_backend,
+            timeout=30,
+            started_generation=get_dependency_generation(),
+            record_many_fn=record_many_fn,
+        )
+
+        self.assertEqual(
+            events,
+            ["record", f"set:{deps_key}", f"set:{cache_key}"],
+        )
+        self.assertEqual(recorded_entries, [(cache_key, dependencies)])
+        self.assertEqual(cache_backend.get(deps_key), dependencies)
+        self.assertEqual(cache_backend.get(cache_key), {"status": "ready"})
+        self.assertEqual(cache_backend.timeouts[deps_key], 30)
+        self.assertEqual(cache_backend.timeouts[cache_key], 30)
+
+    def test_publish_aborts_without_writes_when_generation_changed(self) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        started_generation = get_dependency_generation()
+        begin_dependency_data_change()
+        end_dependency_data_change()
+        recorded_entries: list[Any] = []
+
+        with self.assertRaises(CachePublishAborted):
+            publish_dependency_cache_entry(
+                cache_key="cache-a",
+                deps_key="cache-a:deps",
+                result="stale",
+                dependencies={("Project", "identification", "1")},
+                cache_backend=cache_backend,
+                timeout=None,
+                started_generation=started_generation,
+                record_many_fn=recorded_entries.extend,
+            )
+
+        self.assertEqual(recorded_entries, [])
+        self.assertEqual(cache_backend.store, {})
+
+    def test_publish_aborts_without_writes_when_data_change_active(self) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        recorded_entries: list[Any] = []
+        begin_dependency_data_change()
+        try:
+            with self.assertRaises(CachePublishAborted):
+                publish_dependency_cache_entry(
+                    cache_key="cache-a",
+                    deps_key="cache-a:deps",
+                    result="barrier-blocked",
+                    dependencies={("Project", "identification", "1")},
+                    cache_backend=cache_backend,
+                    timeout=None,
+                    started_generation=get_dependency_generation(),
+                    record_many_fn=recorded_entries.extend,
+                )
+        finally:
+            end_dependency_data_change()
+
+        self.assertEqual(recorded_entries, [])
+        self.assertEqual(cache_backend.store, {})
+
+    def test_wait_for_cached_dependency_value_returns_published_value(self) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        cache_key = "cache-a"
+        marker = object()
+
+        def ignore_record_many(_entries: Any) -> None:
+            return None
+
+        publish_dependency_cache_entry(
+            cache_key=cache_key,
+            deps_key=f"{cache_key}:deps",
+            result="ready",
+            dependencies={("Project", "identification", "1")},
+            cache_backend=cache_backend,
+            timeout=None,
+            started_generation=get_dependency_generation(),
+            record_many_fn=ignore_record_many,
+        )
+
+        self.assertEqual(
+            wait_for_cached_dependency_value(
+                cache_backend,
+                cache_key,
+                timeout_seconds=0.01,
+                sentinel=marker,
+            ),
+            "ready",
+        )

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pickle
 from typing import Any
+from unittest import mock
 
 from django.test import SimpleTestCase, override_settings
 
@@ -68,17 +69,21 @@ class TestDependencyPublish(SimpleTestCase):
     def test_release_compute_lease_only_releases_owned_token(self) -> None:
         lease = acquire_compute_lease("cache-a")
         assert lease is not None
+
+        release_compute_lease(lease)
+
+        self.assertEqual(coordination_cache.get(lease.key), lease.token)
+        self.assertIsNone(acquire_compute_lease("cache-a"))
+
+    def test_release_compute_lease_never_removes_new_owner_token(self) -> None:
+        lease = acquire_compute_lease("cache-a")
+        assert lease is not None
         coordination_cache.set(lease.key, "other-token", None)
 
         release_compute_lease(lease)
 
         self.assertEqual(coordination_cache.get(lease.key), "other-token")
         self.assertIsNone(acquire_compute_lease("cache-a"))
-
-        release_compute_lease(CacheComputeLease(lease.key, "other-token"))
-
-        self.assertIsNone(coordination_cache.get(lease.key))
-        self.assertIsInstance(acquire_compute_lease("cache-a"), CacheComputeLease)
 
     def test_publish_records_dependencies_before_deps_and_value(self) -> None:
         cache_backend = FakeDependencyCacheBackend()
@@ -168,6 +173,123 @@ class TestDependencyPublish(SimpleTestCase):
 
         self.assertEqual(recorded_entries, [])
         self.assertEqual(cache_backend.store, {})
+
+    def test_publish_aborts_without_writes_when_generation_changes_after_recording(
+        self,
+    ) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        started_generation = get_dependency_generation()
+        recorded_entries: list[Any] = []
+
+        with (
+            mock.patch(
+                "general_manager.cache.dependency_publish.get_dependency_generation",
+                side_effect=[started_generation, started_generation + 1],
+            ),
+            self.assertRaises(CachePublishAborted),
+        ):
+            publish_dependency_cache_entry(
+                cache_key="cache-a",
+                deps_key="cache-a:deps",
+                result="stale",
+                dependencies={("Project", "identification", "1")},
+                cache_backend=cache_backend,
+                timeout=None,
+                started_generation=started_generation,
+                record_many_fn=recorded_entries.extend,
+            )
+
+        self.assertEqual(
+            recorded_entries,
+            [("cache-a", {("Project", "identification", "1")})],
+        )
+        self.assertEqual(cache_backend.store, {})
+
+    def test_publish_aborts_without_writes_when_barrier_starts_after_recording(
+        self,
+    ) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        started_generation = get_dependency_generation()
+        recorded_entries: list[Any] = []
+
+        with (
+            mock.patch(
+                "general_manager.cache.dependency_publish.is_dependency_data_change_active",
+                side_effect=[False, True],
+            ),
+            self.assertRaises(CachePublishAborted),
+        ):
+            publish_dependency_cache_entry(
+                cache_key="cache-a",
+                deps_key="cache-a:deps",
+                result="stale",
+                dependencies={("Project", "identification", "1")},
+                cache_backend=cache_backend,
+                timeout=None,
+                started_generation=started_generation,
+                record_many_fn=recorded_entries.extend,
+            )
+
+        self.assertEqual(
+            recorded_entries,
+            [("cache-a", {("Project", "identification", "1")})],
+        )
+        self.assertEqual(cache_backend.store, {})
+
+    def test_wait_for_cached_dependency_value_returns_cached_none(self) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        cache_backend.set("cache-a", None, None)
+
+        self.assertIsNone(
+            wait_for_cached_dependency_value(
+                cache_backend,
+                "cache-a",
+                timeout_seconds=0.01,
+            )
+        )
+
+    def test_wait_for_cached_dependency_value_returns_sentinel_on_timeout(
+        self,
+    ) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        marker = object()
+
+        self.assertIs(
+            wait_for_cached_dependency_value(
+                cache_backend,
+                "cache-a",
+                timeout_seconds=0,
+                sentinel=marker,
+            ),
+            marker,
+        )
+
+    def test_wait_for_cached_dependency_value_polls_until_value_exists(self) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+        marker = object()
+        attempts = 0
+        original_get = cache_backend.get
+
+        def delayed_get(key: str, default: Any = None) -> Any:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 3:
+                cache_backend.set(key, "ready", None)
+            return original_get(key, default)
+
+        cache_backend.get = delayed_get  # type: ignore[method-assign]
+
+        with mock.patch("general_manager.cache.dependency_publish.time.sleep"):
+            self.assertEqual(
+                wait_for_cached_dependency_value(
+                    cache_backend,
+                    "cache-a",
+                    timeout_seconds=1,
+                    sentinel=marker,
+                ),
+                "ready",
+            )
+        self.assertEqual(attempts, 3)
 
     def test_wait_for_cached_dependency_value_returns_published_value(self) -> None:
         cache_backend = FakeDependencyCacheBackend()

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -66,7 +66,7 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertEqual(coordination_cache.get(lease.key), lease.token)
         self.assertIsNone(acquire_compute_lease("cache-a"))
 
-    def test_release_compute_lease_only_releases_owned_token(self) -> None:
+    def test_release_compute_lease_leaves_owned_token_until_timeout(self) -> None:
         lease = acquire_compute_lease("cache-a")
         assert lease is not None
 


### PR DESCRIPTION
## Summary
- add mutation generation and publish barriers for dependency-scoped cache entries
- coordinate dependency cache misses with per-key compute leases
- publish dependency metadata and values through a guarded dependency-index lock
- add regression coverage for stale publish races and duplicate concurrent work
- document dependency cache coherency behavior

Fixes #265.

## Validation
- python -m pytest tests/unit/test_dependency_index.py tests/unit/test_dependency_publish.py tests/unit/test_cache_decorator.py tests/integration/test_caching.py tests/integration/test_request_caching.py -q
- ruff check src tests
- ruff format --check on touched files
- mypy src
- mkdocs build --strict --site-dir /tmp/general_manager-docs-check
- git diff --check

Note: repo-wide ruff format --check src tests still reports three unrelated pre-existing files that would be reformatted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated caching concepts docs to explain safe dependency-scoped cache entry publication, including coordination and retry behavior.

* **New Features**
  * Improved dependency-scoped caching to coordinate concurrent computations, wait for published values when another worker is computing, and avoid caching when invalidation/gen changes occur during computation.

* **Bug Fixes**
  * Prevented incorrect cache writes when the dependency publish safety checks fail (e.g., generation changes or active invalidation barriers).

* **Tests**
  * Added/expanded unit tests covering leasing, publish abort conditions, generation tracking, and concurrent cache misses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->