### PR TITLE
feat: combine dependency cache payloads

### DIFF
--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -110,8 +110,8 @@ Dependency-scoped cache entries are published through a guarded write path:
 
 - a mutation generation is read before computation starts
 - data-changing operations raise the generation and hold a publish barrier while invalidation runs
-- the dependency index, dependency metadata, and visible cached value are written under the dependency-index lock
-- dependency metadata is published before the cached value, so a visible value is already reachable by later invalidation
+- the dependency index and combined value/dependency payload are written under the dependency-index lock
+- dependency metadata is stored with the cached value, so a visible value is already reachable by later invalidation
 - if the generation changed or the publish barrier is active, the fresh function result is returned to the caller but is not stored
 
 This means a dependency-scoped value is only shared after GeneralManager can

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -16,6 +16,11 @@ from typing import (
 from django.core.cache import cache as django_cache
 
 from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.dependency_cache import (
+    DependencyCacheHit,
+    read_dependency_cache_hit,
+    replay_dependency_cache_hit,
+)
 from general_manager.cache.dependency_index import (
     Dependency,
     get_dependency_generation,
@@ -26,7 +31,7 @@ from general_manager.cache.dependency_publish import (
     acquire_compute_lease,
     publish_dependency_cache_entry,
     release_compute_lease,
-    wait_for_cached_dependency_value,
+    wait_for_cached_dependency_hit,
 )
 from general_manager.cache.run_context import ensure_calculation_run_context
 from general_manager.cache.model_dependency_collector import ModelDependencyCollector
@@ -179,52 +184,48 @@ def cached(
                 )
                 return result
 
-            deps_key = f"{key}:deps"
-
-            def track_cached_dependencies() -> None:
-                cached_deps = cache_backend.get(deps_key)
-                if cached_deps:
-                    for class_name, operation, identifier in cached_deps:
-                        DependencyTracker.track(class_name, operation, identifier)
-
-            cached_result = cache_backend.get(key, _SENTINEL)
-            if cached_result is not _SENTINEL:
-                track_cached_dependencies()
+            def return_cached_hit(hit: DependencyCacheHit, message: str) -> object:
+                replay_dependency_cache_hit(hit)
                 logger.debug(
-                    "cache hit",
+                    message,
                     context={
                         "function": func.__qualname__,
                         "key": key,
                         "scope": scope,
                     },
                 )
-                return cached_result
+                return hit.value
+
+            cached_hit = read_dependency_cache_hit(
+                cache_backend,
+                key,
+                sentinel=_SENTINEL,
+            )
+            if cached_hit is not _SENTINEL:
+                return return_cached_hit(cached_hit, "cache hit")
 
             lease = acquire_compute_lease(key)
             while lease is None:
-                cached_result = wait_for_cached_dependency_value(
+                cached_hit = wait_for_cached_dependency_hit(
                     cache_backend,
                     key,
                     sentinel=_SENTINEL,
                 )
-                if cached_result is not _SENTINEL:
-                    track_cached_dependencies()
-                    logger.debug(
+                if cached_hit is not _SENTINEL:
+                    return return_cached_hit(
+                        cached_hit,
                         "cache hit after waiting for dependency publish",
-                        context={
-                            "function": func.__qualname__,
-                            "key": key,
-                            "scope": scope,
-                        },
                     )
-                    return cached_result
                 lease = acquire_compute_lease(key)
 
             try:
-                cached_result = cache_backend.get(key, _SENTINEL)
-                if cached_result is not _SENTINEL:
-                    track_cached_dependencies()
-                    return cached_result
+                cached_hit = read_dependency_cache_hit(
+                    cache_backend,
+                    key,
+                    sentinel=_SENTINEL,
+                )
+                if cached_hit is not _SENTINEL:
+                    return return_cached_hit(cached_hit, "cache hit")
 
                 started_generation = get_dependency_generation()
                 with DependencyTracker() as dependencies:
@@ -240,7 +241,6 @@ def cached(
                 try:
                     publish_dependency_cache_entry(
                         cache_key=key,
-                        deps_key=deps_key,
                         result=result,
                         dependencies=dependencies,
                         cache_backend=cache_backend,

--- a/src/general_manager/cache/dependency_cache.py
+++ b/src/general_manager/cache/dependency_cache.py
@@ -1,0 +1,154 @@
+"""Internal helpers for dependency-scoped cache entry reads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Protocol, TypeGuard
+
+from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.dependency_index import Dependency
+
+DEPENDENCY_CACHE_ENTRY_VERSION = 1
+_MISSING = object()
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyCacheEntry:
+    """Persisted dependency-cache payload stored at the main cache key."""
+
+    version: int
+    value: Any
+    dependencies: frozenset[Dependency]
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyCacheHit:
+    """In-memory representation of a dependency-cache hit."""
+
+    value: Any
+    dependencies: frozenset[Dependency]
+
+
+class DependencyCacheBackend(Protocol):
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return a cached value or *default* when absent."""
+        ...
+
+    def set(self, key: str, value: Any, timeout: int | None = None) -> None:
+        """Store a cached value."""
+        ...
+
+
+class DependencyCacheGetManyBackend(DependencyCacheBackend, Protocol):
+    def get_many(self, keys: Iterable[str]) -> Mapping[str, Any]:
+        """Return cached values for all found keys."""
+        ...
+
+
+def make_dependency_cache_entry(
+    value: Any,
+    dependencies: Iterable[Dependency],
+) -> DependencyCacheEntry:
+    """Build the current persisted dependency-cache payload."""
+    return DependencyCacheEntry(
+        version=DEPENDENCY_CACHE_ENTRY_VERSION,
+        value=value,
+        dependencies=frozenset(dependencies),
+    )
+
+
+def read_dependency_cache_hit(
+    cache_backend: DependencyCacheBackend,
+    cache_key: str,
+    *,
+    sentinel: Any = _MISSING,
+) -> DependencyCacheHit | Any:
+    """Read one dependency-cache entry, including legacy split entries."""
+    payload = cache_backend.get(cache_key, sentinel)
+    if payload is sentinel:
+        return sentinel
+    combined_hit = _combined_payload_to_hit(payload)
+    if combined_hit is _MISSING:
+        return sentinel
+    if combined_hit is not None:
+        return combined_hit
+    dependency_payload = cache_backend.get(_legacy_deps_key(cache_key), ())
+    return DependencyCacheHit(
+        value=payload,
+        dependencies=frozenset(dependency_payload or ()),
+    )
+
+
+def read_many_dependency_cache_hits(
+    cache_backend: DependencyCacheBackend,
+    cache_keys: Iterable[str],
+) -> dict[str, DependencyCacheHit]:
+    """Bulk-read dependency-cache hits for known keys."""
+    keys = tuple(dict.fromkeys(cache_keys))
+    if not keys:
+        return {}
+    if not _supports_get_many(cache_backend):
+        return _read_many_without_get_many(cache_backend, keys)
+
+    payloads = cache_backend.get_many(keys)
+    hits: dict[str, DependencyCacheHit] = {}
+    legacy_keys: list[str] = []
+    for key in keys:
+        if key not in payloads:
+            continue
+        combined_hit = _combined_payload_to_hit(payloads[key])
+        if combined_hit is _MISSING:
+            continue
+        if isinstance(combined_hit, DependencyCacheHit):
+            hits[key] = combined_hit
+            continue
+        legacy_keys.append(key)
+
+    if legacy_keys:
+        deps_keys = {_legacy_deps_key(key): key for key in legacy_keys}
+        legacy_deps = cache_backend.get_many(deps_keys.keys())
+        for deps_key, key in deps_keys.items():
+            hits[key] = DependencyCacheHit(
+                value=payloads[key],
+                dependencies=frozenset(legacy_deps.get(deps_key, ()) or ()),
+            )
+    return hits
+
+
+def replay_dependency_cache_hit(hit: DependencyCacheHit) -> None:
+    """Replay cached dependencies into active dependency tracking scopes."""
+    for class_name, operation, identifier in hit.dependencies:
+        DependencyTracker.track(class_name, operation, identifier)
+
+
+def _legacy_deps_key(cache_key: str) -> str:
+    return f"{cache_key}:deps"
+
+
+def _combined_payload_to_hit(payload: Any) -> DependencyCacheHit | None | object:
+    if not isinstance(payload, DependencyCacheEntry):
+        return None
+    if payload.version != DEPENDENCY_CACHE_ENTRY_VERSION:
+        return _MISSING
+    return DependencyCacheHit(
+        value=payload.value,
+        dependencies=payload.dependencies,
+    )
+
+
+def _supports_get_many(
+    cache_backend: DependencyCacheBackend,
+) -> TypeGuard[DependencyCacheGetManyBackend]:
+    return callable(getattr(cache_backend, "get_many", None))
+
+
+def _read_many_without_get_many(
+    cache_backend: DependencyCacheBackend,
+    cache_keys: tuple[str, ...],
+) -> dict[str, DependencyCacheHit]:
+    hits: dict[str, DependencyCacheHit] = {}
+    for key in cache_keys:
+        hit = read_dependency_cache_hit(cache_backend, key, sentinel=_MISSING)
+        if hit is not _MISSING:
+            hits[key] = hit
+    return hits

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Protocol
+from typing import Any, Callable, Iterable
 
 from django.core.cache import cache as coordination_cache
 
+from general_manager.cache.dependency_cache import (
+    DependencyCacheBackend,
+    make_dependency_cache_entry,
+    read_dependency_cache_hit,
+)
 from general_manager.cache.dependency_index import (
     LOCK_TIMEOUT,
     Dependency,
@@ -32,14 +37,6 @@ class CacheComputeLease:
 
     key: str
     token: str
-
-
-class DependencyCacheBackend(Protocol):
-    def get(self, key: str, default: Any = None) -> Any:
-        raise NotImplementedError
-
-    def set(self, key: str, value: Any, timeout: int | None = None) -> None:
-        raise NotImplementedError
 
 
 RecordManyDependenciesFn = Callable[[Iterable[tuple[str, Iterable[Dependency]]]], None]
@@ -78,20 +75,24 @@ def release_compute_lease(lease: CacheComputeLease) -> None:
     return None
 
 
-def wait_for_cached_dependency_value(
+def wait_for_cached_dependency_hit(
     cache_backend: DependencyCacheBackend,
     cache_key: str,
     timeout_seconds: float = LOCK_TIMEOUT,
     sentinel: Any = _WAIT_MISS,
 ) -> Any:
-    """Poll for a cached dependency value until it appears or the wait expires."""
+    """Poll for a dependency-cache hit until it appears or the wait expires."""
     deadline = time.monotonic() + timeout_seconds
     delay = WAIT_INITIAL_DELAY
 
     while True:
-        cached_value = cache_backend.get(cache_key, sentinel)
-        if cached_value is not sentinel:
-            return cached_value
+        cached_hit = read_dependency_cache_hit(
+            cache_backend,
+            cache_key,
+            sentinel=sentinel,
+        )
+        if cached_hit is not sentinel:
+            return cached_hit
 
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -111,7 +112,6 @@ def _ensure_publish_current(started_generation: int) -> None:
 def publish_dependency_cache_entry(
     *,
     cache_key: str,
-    deps_key: str,
     result: Any,
     dependencies: Iterable[Dependency],
     cache_backend: DependencyCacheBackend,
@@ -142,12 +142,12 @@ def publish_dependency_cache_entry(
             if dependency_set:
                 _record_dependencies_locked(idx, cache_key, dependency_set)
             _ensure_publish_current(started_generation)
-            cache_backend.set(deps_key, dependency_set, timeout)
             set_full_index(idx)
-            cache_backend.set(cache_key, result, timeout)
-            return
 
-        cache_backend.set(deps_key, dependency_set, timeout)
-        cache_backend.set(cache_key, result, timeout)
+        cache_backend.set(
+            cache_key,
+            make_dependency_cache_entry(result, dependency_set),
+            timeout,
+        )
     finally:
         release_lock()

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -69,10 +69,12 @@ def release_compute_lease(lease: CacheComputeLease) -> None:
     """Release a compute lease without risking deletion of a newer owner.
 
     Django's cache API does not provide an atomic compare-and-delete operation.
-    Leaving the lease to expire avoids a check-then-delete race where an expired
-    lease could delete another worker's freshly acquired token.
+    Checking the owner token first keeps normal recomputes fast while avoiding
+    deletion when the lease has already been replaced by another worker.
     """
-    return None
+    if coordination_cache.get(lease.key) != lease.token:
+        return
+    coordination_cache.delete(lease.key)
 
 
 def wait_for_cached_dependency_hit(

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -2,6 +2,11 @@ from django.test import SimpleTestCase
 from django.core.cache import cache
 from unittest import mock
 from general_manager.cache.cache_decorator import cached, DependencyTracker
+from general_manager.cache.dependency_cache import (
+    DependencyCacheHit,
+    make_dependency_cache_entry,
+    read_dependency_cache_hit,
+)
 from general_manager.cache.dependency_index import (
     begin_dependency_data_change,
     end_dependency_data_change,
@@ -101,6 +106,14 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         with DependencyTracker():
             pass
         cache.clear()
+
+    def assert_dependency_cache_hit(self, key, value, dependencies=None):
+        hit = read_dependency_cache_hit(self.fake_cache, key)
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+        self.assertEqual(hit.value, value)
+        if dependencies is not None:
+            self.assertEqual(hit.dependencies, frozenset(dependencies))
 
     def test_real_tracker_records_manual_tracks(self):
         """
@@ -248,7 +261,11 @@ class TestCacheDecoratorBackend(SimpleTestCase):
 
         # Result should be in the fake cache
         self.assertIn(key, self.fake_cache.store)
-        self.assertEqual(_trusted_pickle_loads(self.fake_cache.store[key]), 5)
+        self.assert_dependency_cache_hit(
+            key,
+            5,
+            {("User", "identification", "2"), ("Profile", "identification", "3")},
+        )
 
         # record_fn should have been called once
         self.assertEqual(len(self.record_calls), 1)
@@ -264,7 +281,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self.assertEqual(res2, 5)
         self.assertEqual(self.record_calls, [])
 
-    def test_dependency_scope_waits_for_published_value_when_lease_is_owned(self):
+    def test_dependency_scope_replays_dependencies_from_combined_cache_hit(self):
         calls = 0
 
         @cached(
@@ -278,8 +295,37 @@ class TestCacheDecoratorBackend(SimpleTestCase):
             return value * 2
 
         key = make_cache_key(fn, (3,), {})
-        deps_key = f"{key}:deps"
-        self.fake_cache.set(deps_key, {("User", "identification", "3")}, None)
+        dependencies = {("User", "identification", "3")}
+        self.fake_cache.set(
+            key,
+            make_dependency_cache_entry(6, dependencies),
+            None,
+        )
+
+        with DependencyTracker() as tracked_dependencies:
+            self.assertEqual(fn(3), 6)
+
+        self.assertEqual(calls, 0)
+        self.assertEqual(tracked_dependencies, dependencies)
+        self.assertEqual(self.record_calls, [])
+
+    def test_dependency_scope_waits_for_published_combined_entry_when_lease_is_owned(
+        self,
+    ):
+        calls = 0
+
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
+        def fn(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        key = make_cache_key(fn, (3,), {})
+        expected_dependencies = {("User", "identification", "3")}
         original_get = self.fake_cache.get
         key_reads = 0
 
@@ -288,7 +334,11 @@ class TestCacheDecoratorBackend(SimpleTestCase):
             if cache_key == key:
                 key_reads += 1
                 if key_reads == 2:
-                    self.fake_cache.set(key, 6, None)
+                    self.fake_cache.set(
+                        key,
+                        make_dependency_cache_entry(6, expected_dependencies),
+                        None,
+                    )
             return original_get(cache_key, default)
 
         self.fake_cache.get = publish_after_initial_miss
@@ -301,7 +351,31 @@ class TestCacheDecoratorBackend(SimpleTestCase):
                 self.assertEqual(fn(3), 6)
 
         self.assertEqual(calls, 0)
-        self.assertEqual(dependencies, {("User", "identification", "3")})
+        self.assertEqual(dependencies, expected_dependencies)
+
+    def test_dependency_scope_reads_legacy_split_cache_entry(self):
+        calls = 0
+
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
+        def fn(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        key = make_cache_key(fn, (3,), {})
+        dependencies = {("User", "identification", "3")}
+        self.fake_cache.set(key, 6, None)
+        self.fake_cache.set(f"{key}:deps", dependencies, None)
+
+        with DependencyTracker() as tracked_dependencies:
+            self.assertEqual(fn(3), 6)
+
+        self.assertEqual(calls, 0)
+        self.assertEqual(tracked_dependencies, dependencies)
 
     def test_dependency_scope_returns_result_without_caching_when_publish_aborts(self):
         calls = 0
@@ -504,8 +578,16 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         # Result should be in the fake cache
         self.assertIn(key_outer, self.fake_cache.store)
         self.assertIn(key_inner, self.fake_cache.store)
-        self.assertEqual(_trusted_pickle_loads(self.fake_cache.store[key_outer]), 5)
-        self.assertEqual(_trusted_pickle_loads(self.fake_cache.store[key_inner]), 5)
+        self.assert_dependency_cache_hit(
+            key_outer,
+            5,
+            {("User", "identification", "2"), ("Profile", "identification", "3")},
+        )
+        self.assert_dependency_cache_hit(
+            key_inner,
+            5,
+            {("Profile", "identification", "3")},
+        )
 
         # record_fn should have been called twice
         # once for the outer function and once for the inner function
@@ -569,7 +651,11 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         # now the inner function should be in the cache
         key_inner = make_cache_key(inner_function, (2, 3), {})
         self.assertIn(key_inner, self.fake_cache.store)
-        self.assertEqual(_trusted_pickle_loads(self.fake_cache.store[key_inner]), 5)
+        self.assert_dependency_cache_hit(
+            key_inner,
+            5,
+            {("Profile", "identification", "3")},
+        )
 
         # second call: outer function: Cache miss
         res = outer_function(2, 3)
@@ -578,7 +664,11 @@ class TestCacheDecoratorBackend(SimpleTestCase):
 
         # Result should be in the fake cache
         self.assertIn(key_outer, self.fake_cache.store)
-        self.assertEqual(_trusted_pickle_loads(self.fake_cache.store[key_outer]), 5)
+        self.assert_dependency_cache_hit(
+            key_outer,
+            5,
+            {("User", "identification", "2"), ("Profile", "identification", "3")},
+        )
 
         # record_fn should have been called twice
         # once for the outer function and once for the inner function

--- a/tests/unit/test_dependency_cache.py
+++ b/tests/unit/test_dependency_cache.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable, Mapping
+
+from django.test import SimpleTestCase
+
+from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.dependency_cache import (
+    DEPENDENCY_CACHE_ENTRY_VERSION,
+    DependencyCacheEntry,
+    DependencyCacheHit,
+    make_dependency_cache_entry,
+    read_dependency_cache_hit,
+    read_many_dependency_cache_hits,
+    replay_dependency_cache_hit,
+)
+from general_manager.cache.dependency_index import Dependency
+
+
+def _trusted_pickle_loads(data: bytes) -> object:
+    return pickle.loads(data)  # noqa: S301 - test cache uses controlled data
+
+
+class PickleCache:
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.get_calls: list[str] = []
+        self.get_many_calls: list[tuple[str, ...]] = []
+
+    def get(self, key: str, default: Any = None) -> Any:
+        self.get_calls.append(key)
+        cached_value = self.store.get(key, default)
+        if cached_value is not default:
+            return _trusted_pickle_loads(cached_value)
+        return default
+
+    def set(self, key: str, value: Any, timeout: int | None = None) -> None:
+        del timeout
+        self.store[key] = pickle.dumps(value)
+
+    def get_many(self, keys: Iterable[str]) -> Mapping[str, Any]:
+        key_tuple = tuple(keys)
+        self.get_many_calls.append(key_tuple)
+        return {
+            key: _trusted_pickle_loads(self.store[key])
+            for key in key_tuple
+            if key in self.store
+        }
+
+
+class PickleCacheWithoutGetMany:
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.get_calls: list[str] = []
+
+    def get(self, key: str, default: Any = None) -> Any:
+        self.get_calls.append(key)
+        cached_value = self.store.get(key, default)
+        if cached_value is not default:
+            return _trusted_pickle_loads(cached_value)
+        return default
+
+    def set(self, key: str, value: Any, timeout: int | None = None) -> None:
+        del timeout
+        self.store[key] = pickle.dumps(value)
+
+
+class DependencyCacheEntryTests(SimpleTestCase):
+    def setUp(self) -> None:
+        DependencyTracker.reset_thread_local_storage()
+
+    def tearDown(self) -> None:
+        DependencyTracker.reset_thread_local_storage()
+
+    def test_make_dependency_cache_entry_tags_payload_version(self) -> None:
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+
+        entry = make_dependency_cache_entry({"status": "ready"}, dependencies)
+
+        self.assertEqual(entry.version, DEPENDENCY_CACHE_ENTRY_VERSION)
+        self.assertEqual(entry.value, {"status": "ready"})
+        self.assertEqual(entry.dependencies, frozenset(dependencies))
+
+    def test_reads_falsey_combined_values_as_hits(self) -> None:
+        values = [None, False, 0, [], {}]
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+
+        for index, value in enumerate(values):
+            with self.subTest(value=value):
+                cache_backend = PickleCache()
+                cache_key = f"cache-{index}"
+                cache_backend.set(
+                    cache_key,
+                    make_dependency_cache_entry(value, dependencies),
+                    None,
+                )
+
+                marker = object()
+                hit = read_dependency_cache_hit(
+                    cache_backend,
+                    cache_key,
+                    sentinel=marker,
+                )
+
+                self.assertIsInstance(hit, DependencyCacheHit)
+                assert isinstance(hit, DependencyCacheHit)
+                self.assertEqual(hit.value, value)
+                self.assertEqual(hit.dependencies, frozenset(dependencies))
+
+    def test_missing_key_returns_sentinel(self) -> None:
+        cache_backend = PickleCache()
+        marker = object()
+
+        self.assertIs(
+            read_dependency_cache_hit(cache_backend, "missing", sentinel=marker),
+            marker,
+        )
+
+    def test_legacy_split_value_and_dependencies_read_correctly(self) -> None:
+        cache_backend = PickleCache()
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 7}')}
+        cache_backend.set("cache-a", False, None)
+        cache_backend.set("cache-a:deps", dependencies, None)
+
+        hit = read_dependency_cache_hit(cache_backend, "cache-a")
+
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+        self.assertIs(hit.value, False)
+        self.assertEqual(hit.dependencies, frozenset(dependencies))
+
+    def test_legacy_value_without_deps_is_still_a_hit_with_empty_dependencies(
+        self,
+    ) -> None:
+        cache_backend = PickleCache()
+        cache_backend.set("cache-a", 0, None)
+
+        hit = read_dependency_cache_hit(cache_backend, "cache-a")
+
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+        self.assertEqual(hit.value, 0)
+        self.assertEqual(hit.dependencies, frozenset())
+
+    def test_plain_dict_value_is_not_misclassified_as_combined_payload(self) -> None:
+        cache_backend = PickleCache()
+        value = {
+            "version": DEPENDENCY_CACHE_ENTRY_VERSION,
+            "value": "not framework metadata",
+            "dependencies": [],
+        }
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 3}')}
+        cache_backend.set("cache-a", value, None)
+        cache_backend.set("cache-a:deps", dependencies, None)
+
+        hit = read_dependency_cache_hit(cache_backend, "cache-a")
+
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+        self.assertEqual(hit.value, value)
+        self.assertEqual(hit.dependencies, frozenset(dependencies))
+
+    def test_unknown_combined_payload_version_is_treated_as_miss(self) -> None:
+        cache_backend = PickleCache()
+        cache_backend.set(
+            "cache-a",
+            DependencyCacheEntry(version=999, value="future", dependencies=frozenset()),
+            None,
+        )
+        marker = object()
+
+        self.assertIs(
+            read_dependency_cache_hit(cache_backend, "cache-a", sentinel=marker),
+            marker,
+        )
+
+    def test_bulk_read_uses_one_get_many_for_combined_entries(self) -> None:
+        cache_backend = PickleCache()
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+        for index in range(5):
+            cache_backend.set(
+                f"cache-{index}",
+                make_dependency_cache_entry(index, dependencies),
+                None,
+            )
+
+        hits = read_many_dependency_cache_hits(
+            cache_backend,
+            [f"cache-{index}" for index in range(5)],
+        )
+
+        self.assertEqual(set(hits), {f"cache-{index}" for index in range(5)})
+        self.assertEqual([hit.value for hit in hits.values()], [0, 1, 2, 3, 4])
+        self.assertEqual(
+            cache_backend.get_many_calls,
+            [("cache-0", "cache-1", "cache-2", "cache-3", "cache-4")],
+        )
+        self.assertEqual(cache_backend.get_calls, [])
+
+    def test_bulk_read_fetches_legacy_dependencies_in_one_extra_get_many(self) -> None:
+        cache_backend = PickleCache()
+        for index in range(3):
+            cache_backend.set(f"cache-{index}", index, None)
+            cache_backend.set(
+                f"cache-{index}:deps",
+                {("Project", "identification", f'{{"id": {index}}}')},
+                None,
+            )
+
+        hits = read_many_dependency_cache_hits(
+            cache_backend,
+            ["cache-0", "cache-1", "cache-2"],
+        )
+
+        self.assertEqual(
+            [hits[f"cache-{index}"].value for index in range(3)], [0, 1, 2]
+        )
+        self.assertEqual(
+            cache_backend.get_many_calls,
+            [
+                ("cache-0", "cache-1", "cache-2"),
+                ("cache-0:deps", "cache-1:deps", "cache-2:deps"),
+            ],
+        )
+        self.assertEqual(cache_backend.get_calls, [])
+
+    def test_bulk_read_falls_back_to_single_reads_without_get_many(self) -> None:
+        cache_backend = PickleCacheWithoutGetMany()
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+        for index in range(2):
+            cache_backend.set(
+                f"cache-{index}",
+                make_dependency_cache_entry(index, dependencies),
+                None,
+            )
+
+        hits = read_many_dependency_cache_hits(cache_backend, ["cache-0", "cache-1"])
+
+        self.assertEqual([hits["cache-0"].value, hits["cache-1"].value], [0, 1])
+        self.assertEqual(cache_backend.get_calls, ["cache-0", "cache-1"])
+
+    def test_replay_dependency_cache_hit_tracks_dependencies(self) -> None:
+        hit = DependencyCacheHit(
+            value="ready",
+            dependencies=frozenset(
+                {
+                    ("Project", "identification", '{"id": 1}'),
+                    ("User", "all", ""),
+                }
+            ),
+        )
+
+        with DependencyTracker() as dependencies:
+            replay_dependency_cache_hit(hit)
+
+        self.assertEqual(dependencies, set(hit.dependencies))

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -6,6 +6,10 @@ from unittest import mock
 
 from django.test import SimpleTestCase, override_settings
 
+from general_manager.cache.dependency_cache import (
+    DependencyCacheEntry,
+    DependencyCacheHit,
+)
 from general_manager.cache.dependency_index import (
     begin_dependency_data_change,
     end_dependency_data_change,
@@ -18,7 +22,7 @@ from general_manager.cache.dependency_publish import (
     coordination_cache,
     publish_dependency_cache_entry,
     release_compute_lease,
-    wait_for_cached_dependency_value,
+    wait_for_cached_dependency_hit,
     _compute_lock_key,
 )
 
@@ -85,10 +89,9 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertEqual(coordination_cache.get(lease.key), "other-token")
         self.assertIsNone(acquire_compute_lease("cache-a"))
 
-    def test_publish_records_dependencies_before_deps_and_value(self) -> None:
+    def test_publish_records_dependencies_before_combined_entry(self) -> None:
         cache_backend = FakeDependencyCacheBackend()
         cache_key = "cache-a"
-        deps_key = f"{cache_key}:deps"
         dependencies = {
             ("Project", "filter", '{"name": "alpha"}'),
             ("Project", "identification", "1"),
@@ -111,7 +114,6 @@ class TestDependencyPublish(SimpleTestCase):
 
         publish_dependency_cache_entry(
             cache_key=cache_key,
-            deps_key=deps_key,
             result={"status": "ready"},
             dependencies=dependencies,
             cache_backend=cache_backend,
@@ -120,15 +122,15 @@ class TestDependencyPublish(SimpleTestCase):
             record_many_fn=record_many_fn,
         )
 
-        self.assertEqual(
-            events,
-            ["record", f"set:{deps_key}", f"set:{cache_key}"],
-        )
+        self.assertEqual(events, ["record", f"set:{cache_key}"])
         self.assertEqual(recorded_entries, [(cache_key, dependencies)])
-        self.assertEqual(cache_backend.get(deps_key), dependencies)
-        self.assertEqual(cache_backend.get(cache_key), {"status": "ready"})
-        self.assertEqual(cache_backend.timeouts[deps_key], 30)
+        payload = cache_backend.get(cache_key)
+        self.assertIsInstance(payload, DependencyCacheEntry)
+        assert isinstance(payload, DependencyCacheEntry)
+        self.assertEqual(payload.value, {"status": "ready"})
+        self.assertEqual(payload.dependencies, frozenset(dependencies))
         self.assertEqual(cache_backend.timeouts[cache_key], 30)
+        self.assertNotIn(f"{cache_key}:deps", cache_backend.store)
 
     def test_publish_aborts_without_writes_when_generation_changed(self) -> None:
         cache_backend = FakeDependencyCacheBackend()
@@ -140,7 +142,6 @@ class TestDependencyPublish(SimpleTestCase):
         with self.assertRaises(CachePublishAborted):
             publish_dependency_cache_entry(
                 cache_key="cache-a",
-                deps_key="cache-a:deps",
                 result="stale",
                 dependencies={("Project", "identification", "1")},
                 cache_backend=cache_backend,
@@ -160,7 +161,6 @@ class TestDependencyPublish(SimpleTestCase):
             with self.assertRaises(CachePublishAborted):
                 publish_dependency_cache_entry(
                     cache_key="cache-a",
-                    deps_key="cache-a:deps",
                     result="barrier-blocked",
                     dependencies={("Project", "identification", "1")},
                     cache_backend=cache_backend,
@@ -190,7 +190,6 @@ class TestDependencyPublish(SimpleTestCase):
         ):
             publish_dependency_cache_entry(
                 cache_key="cache-a",
-                deps_key="cache-a:deps",
                 result="stale",
                 dependencies={("Project", "identification", "1")},
                 cache_backend=cache_backend,
@@ -221,7 +220,6 @@ class TestDependencyPublish(SimpleTestCase):
         ):
             publish_dependency_cache_entry(
                 cache_key="cache-a",
-                deps_key="cache-a:deps",
                 result="stale",
                 dependencies={("Project", "identification", "1")},
                 cache_backend=cache_backend,
@@ -236,26 +234,40 @@ class TestDependencyPublish(SimpleTestCase):
         )
         self.assertEqual(cache_backend.store, {})
 
-    def test_wait_for_cached_dependency_value_returns_cached_none(self) -> None:
+    def test_wait_for_cached_dependency_hit_returns_cached_none(self) -> None:
         cache_backend = FakeDependencyCacheBackend()
-        cache_backend.set("cache-a", None, None)
-
-        self.assertIsNone(
-            wait_for_cached_dependency_value(
-                cache_backend,
-                "cache-a",
-                timeout_seconds=0.01,
-            )
+        publish_dependency_cache_entry(
+            cache_key="cache-a",
+            result=None,
+            dependencies={("Project", "identification", "1")},
+            cache_backend=cache_backend,
+            timeout=None,
+            started_generation=get_dependency_generation(),
+            record_many_fn=lambda _entries: None,
         )
 
-    def test_wait_for_cached_dependency_value_returns_sentinel_on_timeout(
+        hit = wait_for_cached_dependency_hit(
+            cache_backend,
+            "cache-a",
+            timeout_seconds=0.01,
+        )
+
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+        self.assertIsNone(hit.value)
+        self.assertEqual(
+            hit.dependencies,
+            frozenset({("Project", "identification", "1")}),
+        )
+
+    def test_wait_for_cached_dependency_hit_returns_sentinel_on_timeout(
         self,
     ) -> None:
         cache_backend = FakeDependencyCacheBackend()
         marker = object()
 
         self.assertIs(
-            wait_for_cached_dependency_value(
+            wait_for_cached_dependency_hit(
                 cache_backend,
                 "cache-a",
                 timeout_seconds=0,
@@ -264,7 +276,7 @@ class TestDependencyPublish(SimpleTestCase):
             marker,
         )
 
-    def test_wait_for_cached_dependency_value_polls_until_value_exists(self) -> None:
+    def test_wait_for_cached_dependency_hit_polls_until_value_exists(self) -> None:
         cache_backend = FakeDependencyCacheBackend()
         marker = object()
         attempts = 0
@@ -274,48 +286,54 @@ class TestDependencyPublish(SimpleTestCase):
             nonlocal attempts
             attempts += 1
             if attempts == 3:
-                cache_backend.set(key, "ready", None)
+                publish_dependency_cache_entry(
+                    cache_key="cache-a",
+                    result="ready",
+                    dependencies={("Project", "identification", "1")},
+                    cache_backend=cache_backend,
+                    timeout=None,
+                    started_generation=get_dependency_generation(),
+                    record_many_fn=lambda _entries: None,
+                )
             return original_get(key, default)
 
         cache_backend.get = delayed_get  # type: ignore[method-assign]
 
         with mock.patch("general_manager.cache.dependency_publish.time.sleep"):
-            self.assertEqual(
-                wait_for_cached_dependency_value(
-                    cache_backend,
-                    "cache-a",
-                    timeout_seconds=1,
-                    sentinel=marker,
-                ),
-                "ready",
+            hit = wait_for_cached_dependency_hit(
+                cache_backend,
+                "cache-a",
+                timeout_seconds=1,
+                sentinel=marker,
             )
+
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+        self.assertEqual(hit.value, "ready")
         self.assertEqual(attempts, 3)
 
-    def test_wait_for_cached_dependency_value_returns_published_value(self) -> None:
+    def test_wait_for_cached_dependency_hit_returns_published_value(self) -> None:
         cache_backend = FakeDependencyCacheBackend()
         cache_key = "cache-a"
         marker = object()
 
-        def ignore_record_many(_entries: Any) -> None:
-            return None
-
         publish_dependency_cache_entry(
             cache_key=cache_key,
-            deps_key=f"{cache_key}:deps",
             result="ready",
             dependencies={("Project", "identification", "1")},
             cache_backend=cache_backend,
             timeout=None,
             started_generation=get_dependency_generation(),
-            record_many_fn=ignore_record_many,
+            record_many_fn=lambda _entries: None,
         )
 
-        self.assertEqual(
-            wait_for_cached_dependency_value(
-                cache_backend,
-                cache_key,
-                timeout_seconds=0.01,
-                sentinel=marker,
-            ),
-            "ready",
+        hit = wait_for_cached_dependency_hit(
+            cache_backend,
+            cache_key,
+            timeout_seconds=0.01,
+            sentinel=marker,
         )
+
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+        self.assertEqual(hit.value, "ready")

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -70,14 +70,19 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertEqual(coordination_cache.get(lease.key), lease.token)
         self.assertIsNone(acquire_compute_lease("cache-a"))
 
-    def test_release_compute_lease_leaves_owned_token_until_timeout(self) -> None:
+    def test_release_compute_lease_removes_owned_token_for_immediate_reuse(
+        self,
+    ) -> None:
         lease = acquire_compute_lease("cache-a")
         assert lease is not None
 
         release_compute_lease(lease)
 
-        self.assertEqual(coordination_cache.get(lease.key), lease.token)
-        self.assertIsNone(acquire_compute_lease("cache-a"))
+        self.assertIsNone(coordination_cache.get(lease.key))
+        next_lease = acquire_compute_lease("cache-a")
+        self.assertIsInstance(next_lease, CacheComputeLease)
+        assert next_lease is not None
+        self.assertNotEqual(next_lease.token, lease.token)
 
     def test_release_compute_lease_never_removes_new_owner_token(self) -> None:
         lease = acquire_compute_lease("cache-a")


### PR DESCRIPTION
## Summary
- Add an internal tagged dependency-cache payload that stores values with dependency metadata.
- Read combined entries and legacy split value/deps entries through a private helper, including bulk get_many support.
- Wire dependency publishing, lease waiting, and cached decorator hits to replay dependencies from combined cache hits.

## Test Plan
- python -m pytest -q
- ruff check src/general_manager/cache/dependency_cache.py src/general_manager/cache/cache_decorator.py src/general_manager/cache/dependency_publish.py tests/unit/test_dependency_cache.py tests/unit/test_cache_decorator.py tests/unit/test_dependency_publish.py
- ruff format --check src/general_manager/cache/dependency_cache.py src/general_manager/cache/cache_decorator.py src/general_manager/cache/dependency_publish.py tests/unit/test_dependency_cache.py tests/unit/test_cache_decorator.py tests/unit/test_dependency_publish.py
- mypy src/general_manager/cache/dependency_cache.py src/general_manager/cache/cache_decorator.py src/general_manager/cache/dependency_publish.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated dependency-scoped cache entry writing to improve cache invalidation accuracy and reliability.

* **Documentation**
  * Updated caching documentation with clarified dependency-scoped cache entry publishing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->