### PR TITLE
feat: prefetch dependency-cached GraphQL list fields

### DIFF
--- a/src/general_manager/api/graphql_prefetch.py
+++ b/src/general_manager/api/graphql_prefetch.py
@@ -1,0 +1,181 @@
+"""Internal GraphQL helpers for dependency-cache prefetch planning."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+import re
+from typing import Any
+
+from django.core.cache import cache as django_cache
+from graphql import GraphQLResolveInfo
+from graphql.language.ast import (
+    FieldNode,
+    FragmentSpreadNode,
+    InlineFragmentNode,
+    SelectionSetNode,
+)
+
+from general_manager.api.property import GraphQLProperty
+from general_manager.cache.dependency_cache import (
+    DependencyCacheBackend,
+    DependencyCacheHit,
+    read_many_dependency_cache_hits,
+)
+from general_manager.cache.run_context import current_calculation_run_context
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.utils.make_cache_key import make_cache_key
+
+
+def normalize_graphql_name(name: str) -> str:
+    """Convert a GraphQL field name to the Python attribute name."""
+    if "_" in name:
+        return name
+    snake = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    snake = re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake)
+    return snake.lower()
+
+
+def collect_selected_graphql_property_names(
+    info: GraphQLResolveInfo,
+    manager_class: type[Any],
+    *,
+    root_field: str,
+    normalize_name: Callable[[str], str] = normalize_graphql_name,
+) -> set[str]:
+    """Return GraphQLProperty names selected directly under root_field."""
+    interface_cls = getattr(manager_class, "Interface", None)
+    if interface_cls is None:
+        return set()
+    available_properties = set(interface_cls.get_graph_ql_properties().keys())
+    if not available_properties:
+        return set()
+
+    property_names: set[str] = set()
+
+    def collect_direct_fields(
+        selection_set: SelectionSetNode | None,
+        visited: frozenset[str],
+    ) -> None:
+        if selection_set is None:
+            return
+        for selection in selection_set.selections:
+            if isinstance(selection, FieldNode):
+                normalized = normalize_name(selection.name.value)
+                if normalized in available_properties:
+                    property_names.add(normalized)
+            elif isinstance(selection, InlineFragmentNode):
+                collect_direct_fields(selection.selection_set, visited)
+            elif isinstance(selection, FragmentSpreadNode):
+                fragment_name = selection.name.value
+                if fragment_name in visited:
+                    continue
+                fragment = info.fragments.get(fragment_name)
+                if fragment is not None:
+                    collect_direct_fields(
+                        fragment.selection_set,
+                        visited | frozenset((fragment_name,)),
+                    )
+
+    def inspect_for_root(
+        selection_set: SelectionSetNode | None,
+        visited: frozenset[str],
+    ) -> None:
+        if selection_set is None:
+            return
+        for selection in selection_set.selections:
+            if isinstance(selection, FieldNode):
+                if selection.name.value == root_field:
+                    collect_direct_fields(selection.selection_set, visited)
+                else:
+                    inspect_for_root(selection.selection_set, visited)
+            elif isinstance(selection, InlineFragmentNode):
+                inspect_for_root(selection.selection_set, visited)
+            elif isinstance(selection, FragmentSpreadNode):
+                fragment_name = selection.name.value
+                if fragment_name in visited:
+                    continue
+                fragment = info.fragments.get(fragment_name)
+                if fragment is not None:
+                    inspect_for_root(
+                        fragment.selection_set,
+                        visited | frozenset((fragment_name,)),
+                    )
+
+    for field_node in getattr(info, "field_nodes", ()):
+        inspect_for_root(field_node.selection_set, frozenset())
+    return property_names
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyCachePrefetchPlan:
+    """A dependency-cache key planned for one GraphQL list item field."""
+
+    cache_key: str
+    instance: GeneralManager
+    property_name: str
+
+
+def plan_dependency_cache_prefetches(
+    instances: Iterable[GeneralManager],
+    manager_class: type[Any],
+    property_names: Iterable[str],
+    *,
+    can_read_field: Callable[[GeneralManager, str], bool],
+) -> dict[str, DependencyCachePrefetchPlan]:
+    """Build dependency-cache key plans for selected readable properties."""
+    interface_cls = getattr(manager_class, "Interface", None)
+    if interface_cls is None:
+        return {}
+
+    available_properties = interface_cls.get_graph_ql_properties()
+    selected = set(property_names)
+    plans: dict[str, DependencyCachePrefetchPlan] = {}
+
+    for property_name in selected:
+        prop = available_properties.get(property_name)
+        if not isinstance(prop, GraphQLProperty):
+            continue
+        if prop.cache != "dependency":
+            continue
+
+        cached_getter = prop._get_cached_fget()
+        for instance in instances:
+            if not can_read_field(instance, property_name):
+                continue
+            cache_key = make_cache_key(cached_getter, (instance,), {})
+            plans.setdefault(
+                cache_key,
+                DependencyCachePrefetchPlan(
+                    cache_key=cache_key,
+                    instance=instance,
+                    property_name=property_name,
+                ),
+            )
+    return plans
+
+
+DependencyCacheBulkReader = Callable[
+    [DependencyCacheBackend, Iterable[str]],
+    dict[str, DependencyCacheHit],
+]
+
+
+def prefetch_dependency_cache_hits(
+    plans: Mapping[str, DependencyCachePrefetchPlan],
+    *,
+    cache_backend: DependencyCacheBackend = django_cache,
+    reader: DependencyCacheBulkReader | None = None,
+) -> dict[str, DependencyCacheHit]:
+    """Bulk-read planned dependency-cache hits into the active run context."""
+    context = current_calculation_run_context()
+    if context is None or not plans:
+        return {}
+
+    if reader is None:
+        reader = read_many_dependency_cache_hits
+    cache_keys = tuple(plans.keys())
+    hits = reader(cache_backend, cache_keys)
+    if hits:
+        context.set_dependency_cache_hits(hits)
+    return hits

--- a/src/general_manager/api/graphql_prefetch.py
+++ b/src/general_manager/api/graphql_prefetch.py
@@ -129,6 +129,7 @@ def plan_dependency_cache_prefetches(
         return {}
 
     available_properties = interface_cls.get_graph_ql_properties()
+    instance_list = list(instances)
     selected = set(property_names)
     plans: dict[str, DependencyCachePrefetchPlan] = {}
 
@@ -140,7 +141,7 @@ def plan_dependency_cache_prefetches(
             continue
 
         cached_getter = prop._get_cached_fget()
-        for instance in instances:
+        for instance in instance_list:
             if not can_read_field(instance, property_name):
                 continue
             cache_key = make_cache_key(cached_getter, (instance,), {})

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -21,6 +21,11 @@ from general_manager.bucket.base_bucket import Bucket
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
 from general_manager.api.graphql_errors import get_read_permission_filter
+from general_manager.api.graphql_prefetch import (
+    collect_selected_graphql_property_names,
+    plan_dependency_cache_prefetches,
+    prefetch_dependency_cache_hits,
+)
 from general_manager.permission.graphql_capabilities import (
     get_capability_context,
     get_graphql_capabilities,
@@ -543,6 +548,26 @@ def create_list_resolver(
         qs_paginated: Any = apply_pagination(qs_grouped, page, page_size)
         if not hasattr(qs_paginated, "groups"):
             qs_paginated = list(qs_paginated)
+        if isinstance(qs_paginated, list):
+            selected_property_names = collect_selected_graphql_property_names(
+                info,
+                manager_class,
+                root_field="items",
+            )
+            if selected_property_names:
+                prefetch_plans = plan_dependency_cache_prefetches(
+                    qs_paginated,
+                    manager_class,
+                    selected_property_names,
+                    can_read_field=lambda instance, property_name: (
+                        check_read_permission(
+                            instance,
+                            info,
+                            property_name,
+                        )
+                    ),
+                )
+                prefetch_dependency_cache_hits(prefetch_plans)
         if isinstance(qs_paginated, list) and selection_includes_path(
             info, ("items", "capabilities")
         ):

--- a/src/general_manager/api/graphql_subscriptions.py
+++ b/src/general_manager/api/graphql_subscriptions.py
@@ -16,18 +16,14 @@ from typing import Any, Callable, Iterable, TYPE_CHECKING, cast
 
 from channels.layers import BaseChannelLayer, get_channel_layer  # type: ignore[import]
 
-from graphql.language.ast import (
-    FieldNode,
-    FragmentSpreadNode,
-    InlineFragmentNode,
-    SelectionSetNode,
-)
-
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import (
     Dependency,
     parse_dependency_identifier,
     serialize_dependency_identifier,
+)
+from general_manager.api.graphql_prefetch import (
+    collect_selected_graphql_property_names,
 )
 from general_manager.logging import get_logger
 from general_manager.manager.general_manager import GeneralManager
@@ -334,50 +330,12 @@ def subscription_property_names(
     Returns:
         Set of selected ``GraphQLProperty`` names; empty set if none found.
     """
-    interface_cls = getattr(manager_class, "Interface", None)
-    if interface_cls is None:
-        return set()
-    available_properties = set(interface_cls.get_graph_ql_properties().keys())
-    if not available_properties:
-        return set()
-
-    property_names: set[str] = set()
-
-    def collect_from_selection(selection_set: SelectionSetNode | None) -> None:
-        if selection_set is None:
-            return
-        for selection in selection_set.selections:
-            if isinstance(selection, FieldNode):
-                name = selection.name.value
-                normalized = normalize_graphql_name(name)
-                if normalized in available_properties:
-                    property_names.add(normalized)
-            elif isinstance(selection, FragmentSpreadNode):
-                fragment = info.fragments.get(selection.name.value)
-                if fragment is not None:
-                    collect_from_selection(fragment.selection_set)
-            elif isinstance(selection, InlineFragmentNode):
-                collect_from_selection(selection.selection_set)
-
-    def inspect_selection_set(selection_set: SelectionSetNode | None) -> None:
-        if selection_set is None:
-            return
-        for selection in selection_set.selections:
-            if isinstance(selection, FieldNode):
-                if selection.name.value == "item":
-                    collect_from_selection(selection.selection_set)
-                else:
-                    inspect_selection_set(selection.selection_set)
-            elif isinstance(selection, FragmentSpreadNode):
-                fragment = info.fragments.get(selection.name.value)
-                if fragment is not None:
-                    inspect_selection_set(fragment.selection_set)
-            elif isinstance(selection, InlineFragmentNode):
-                inspect_selection_set(selection.selection_set)
-
-    for node in info.field_nodes:
-        inspect_selection_set(node.selection_set)
-    return property_names
+    return collect_selected_graphql_property_names(
+        info,
+        manager_class,
+        root_field="item",
+        normalize_name=normalize_graphql_name,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -33,7 +33,10 @@ from general_manager.cache.dependency_publish import (
     release_compute_lease,
     wait_for_cached_dependency_hit,
 )
-from general_manager.cache.run_context import ensure_calculation_run_context
+from general_manager.cache.run_context import (
+    current_calculation_run_context,
+    ensure_calculation_run_context,
+)
 from general_manager.cache.model_dependency_collector import ModelDependencyCollector
 from general_manager.logging import get_logger
 from general_manager.utils.make_cache_key import make_cache_key
@@ -195,6 +198,17 @@ def cached(
                     },
                 )
                 return hit.value
+
+            prefetch_context = current_calculation_run_context()
+            if prefetch_context is not None:
+                prefetched_hit = prefetch_context.get_dependency_cache_hit(
+                    key, _SENTINEL
+                )
+                if isinstance(prefetched_hit, DependencyCacheHit):
+                    return return_cached_hit(
+                        prefetched_hit,
+                        "cache hit from dependency prefetch",
+                    )
 
             cached_hit = read_dependency_cache_hit(
                 cache_backend,

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Hashable, Iterable
+from collections.abc import Callable, Hashable, Iterable, Mapping
 from contextvars import ContextVar, Token
 from types import TracebackType
-from typing import Optional, TypeVar
+from typing import TYPE_CHECKING, Optional, TypeVar
+
+if TYPE_CHECKING:
+    from general_manager.cache.dependency_cache import DependencyCacheHit
 
 K = TypeVar("K", bound=Hashable)
 T = TypeVar("T")
@@ -22,6 +25,7 @@ class CalculationRunContext:
 
     def __init__(self) -> None:
         self._values: dict[Hashable, object] = {}
+        self._dependency_cache_hits: dict[str, DependencyCacheHit] = {}
         self._token: Token[CalculationRunContext | None] | None = None
 
     def __enter__(self) -> "CalculationRunContext":
@@ -38,6 +42,7 @@ class CalculationRunContext:
             _active_context.reset(self._token)
             self._token = None
         self._values.clear()
+        self._dependency_cache_hits.clear()
 
     def get_or_set(self, key: Hashable, loader: Callable[[], T]) -> T:
         """Return a cached value for key, loading it once per active context."""
@@ -52,6 +57,21 @@ class CalculationRunContext:
     def set(self, key: Hashable, value: object) -> None:
         """Store a value for the active run."""
         self._values[key] = value
+
+    def set_dependency_cache_hits(
+        self,
+        hits: Mapping[str, DependencyCacheHit],
+    ) -> None:
+        """Store dependency-cache hits prefetched for the active run."""
+        self._dependency_cache_hits.update(hits)
+
+    def get_dependency_cache_hit(
+        self,
+        key: str,
+        default: object = None,
+    ) -> DependencyCacheHit | object:
+        """Return a prefetched dependency-cache hit, or default when absent."""
+        return self._dependency_cache_hits.get(key, default)
 
     def discard_prefix(self, prefix: tuple[Hashable, ...]) -> None:
         """Discard tuple keys that start with the supplied prefix."""

--- a/src/general_manager/utils/testing.py
+++ b/src/general_manager/utils/testing.py
@@ -2,7 +2,7 @@
 
 from contextlib import suppress
 from importlib import import_module
-from typing import Any, Callable, ClassVar, Sequence, cast
+from typing import Any, Callable, ClassVar, Iterable, Sequence, cast
 
 from django.apps import AppConfig, apps as global_apps
 from django.conf import settings
@@ -294,7 +294,11 @@ class LoggingCache(LocMemCache):
     def __init__(self, location: str, params: dict[str, Any]) -> None:
         """Initialise the cache backend and the operation log store."""
         super().__init__(location, params)
-        self.ops: list[tuple[str, object, bool] | tuple[str, object]] = []
+        self.ops: list[
+            tuple[str, object, bool]
+            | tuple[str, object]
+            | tuple[str, tuple[str, ...], tuple[str, ...]]
+        ] = []
 
     def get(
         self,
@@ -316,6 +320,17 @@ class LoggingCache(LocMemCache):
         val = super().get(key, default)
         self.ops.append(("get", key, val is not _SENTINEL))
         return val
+
+    def get_many(
+        self,
+        keys: Iterable[str],
+        version: int | None = None,
+    ) -> dict[str, Any]:
+        """Retrieve multiple keys and record the bulk lookup."""
+        key_tuple = tuple(keys)
+        values: dict[str, Any] = super().get_many(key_tuple, version=version)
+        self.ops.append(("get_many", key_tuple, tuple(values.keys())))
+        return values
 
     def set(
         self,
@@ -557,6 +572,14 @@ class GeneralManagerTransactionTestCase(
             [],
             "Cache.set should not have stored a cached value",
         )
+        self.__reset_cache_counter()
+
+    def cache_ops(self) -> list[tuple[Any, ...]]:
+        """Return recorded cache operations for assertions."""
+        return list(cast(Any, caches["default"]).ops)
+
+    def reset_cache_ops(self) -> None:
+        """Clear recorded cache operations for assertions."""
         self.__reset_cache_counter()
 
     def __reset_cache_counter(self) -> None:

--- a/tests/integration/test_graphql_dependency_cache_prefetch.py
+++ b/tests/integration/test_graphql_dependency_cache_prefetch.py
@@ -1,5 +1,3 @@
-# type: ignore
-
 from typing import ClassVar
 from unittest.mock import patch
 

--- a/tests/integration/test_graphql_dependency_cache_prefetch.py
+++ b/tests/integration/test_graphql_dependency_cache_prefetch.py
@@ -1,0 +1,299 @@
+# type: ignore
+
+from typing import ClassVar
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.db.models import CharField
+from django.utils.crypto import get_random_string
+
+from general_manager.api.property import graph_ql_property
+from general_manager.cache.dependency_cache import DependencyCacheHit
+from general_manager.interface import CalculationInterface, DatabaseInterface
+from general_manager.manager import GeneralManager, Input
+from general_manager.measurement import Measurement, MeasurementField
+from general_manager.permission.base_permission import ReadPermissionPlan
+from general_manager.permission.manager_based_permission import ManagerBasedPermission
+from general_manager.permission.permission_checks import register_permission
+from general_manager.utils.make_cache_key import make_cache_key
+from general_manager.utils.testing import GeneralManagerTransactionTestCase
+
+
+@register_permission("denyCalculatedTax")
+def _deny_calculated_tax(_instance, _user, _config):
+    return False
+
+
+class TestGraphQLDependencyCachePrefetch(GeneralManagerTransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        class PrefetchEmployee(GeneralManager):
+            name: str
+            salary: Measurement
+
+            class Interface(DatabaseInterface):
+                name = CharField(max_length=100)
+                salary = MeasurementField(base_unit="EUR")
+
+        class PrefetchCalculation(GeneralManager):
+            employee: PrefetchEmployee
+            dependency_calls: ClassVar[int] = 0
+            run_calls: ClassVar[int] = 0
+
+            class Interface(CalculationInterface):
+                employee = Input(
+                    PrefetchEmployee,
+                    possible_values=lambda: PrefetchEmployee.all(),
+                )
+
+            @graph_ql_property(cache="dependency")
+            def calculated_tax(self) -> Measurement:
+                type(self).dependency_calls += 1
+                return self.employee.salary * 0.2
+
+            @graph_ql_property(cache="run")
+            def run_scoped_value(self) -> int:
+                type(self).run_calls += 1
+                return int(self.employee.salary.quantity.magnitude)
+
+        cls.Employee = PrefetchEmployee
+        cls.Calculation = PrefetchCalculation
+        cls.general_manager_classes = [PrefetchEmployee, PrefetchCalculation]
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+        password = get_random_string(12)
+        self.user = get_user_model().objects.create_superuser(
+            username="prefetcher",
+            password=password,
+        )
+        self.client.login(username="prefetcher", password=password)
+        self.alice = self.Employee.create(
+            name="Alice",
+            salary=Measurement(3000, "EUR"),
+            ignore_permission=True,
+        )
+        self.bob = self.Employee.create(
+            name="Bob",
+            salary=Measurement(4000, "EUR"),
+            ignore_permission=True,
+        )
+        self.Calculation.dependency_calls = 0
+        self.Calculation.run_calls = 0
+
+    def _list_query(self, extra_fields: str = "") -> str:
+        return f"""
+        query {{
+            prefetchCalculationList(page: 1, pageSize: 1) {{
+                items {{
+                    employee {{ name }}
+                    calculatedTax {{ value unit }}
+                    {extra_fields}
+                }}
+                pageInfo {{ totalCount currentPage totalPages }}
+            }}
+        }}
+        """
+
+    def _single_query(self) -> str:
+        return """
+        query($employeeId: ID!) {
+            prefetchCalculation(employeeId: $employeeId) {
+                employee { name }
+                calculatedTax { value unit }
+            }
+        }
+        """
+
+    def test_single_and_list_queries_return_same_dependency_cached_value(self):
+        single_response = self.query(
+            self._single_query(),
+            variables={"employeeId": self.alice.id},
+        )
+        list_response = self.query(self._list_query())
+
+        self.assertResponseNoErrors(single_response)
+        self.assertResponseNoErrors(list_response)
+        single_item = single_response.json()["data"]["prefetchCalculation"]
+        list_item = response_item(list_response)
+
+        self.assertEqual(single_item["employee"]["name"], list_item["employee"]["name"])
+        self.assertEqual(single_item["calculatedTax"], list_item["calculatedTax"])
+
+    def test_only_selected_dependency_cached_fields_are_planned(self):
+        query = self._list_query(extra_fields="runScopedValue")
+
+        with patch(
+            "general_manager.api.graphql_resolvers.prefetch_dependency_cache_hits",
+            return_value={},
+        ) as prefetch:
+            response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        plans = prefetch.call_args.args[0]
+        planned_names = {plan.property_name for plan in plans.values()}
+        self.assertEqual(planned_names, {"calculated_tax"})
+
+    def test_prefetch_plans_only_paginated_items(self):
+        with patch(
+            "general_manager.api.graphql_resolvers.prefetch_dependency_cache_hits",
+            return_value={},
+        ) as prefetch:
+            response = self.query(self._list_query())
+
+        self.assertResponseNoErrors(response)
+        plans = prefetch.call_args.args[0]
+        self.assertEqual(len(plans), 1)
+        planned_instance = next(iter(plans.values())).instance
+        self.assertEqual(planned_instance.employee.name, "Alice")
+
+    def test_cache_miss_computes_through_existing_property_path(self):
+        response = self.query(self._list_query())
+
+        self.assertResponseNoErrors(response)
+        item = response_item(response)
+        self.assertEqual(item["calculatedTax"]["value"], 600)
+        self.assertEqual(self.Calculation.dependency_calls, 1)
+
+    def test_hot_prefetch_uses_bulk_hit_without_per_field_cache_read(self):
+        instance = self.Calculation(employee=self.alice)
+        prop = self.Calculation.Interface.get_graph_ql_properties()["calculated_tax"]
+        cache_key = make_cache_key(prop._get_cached_fget(), (instance,), {})
+        hit = DependencyCacheHit(
+            value=Measurement(600, "EUR"),
+            dependencies=frozenset(
+                {
+                    (
+                        "PrefetchEmployee",
+                        "identification",
+                        f'{{"id": {self.alice.id}}}',
+                    )
+                }
+            ),
+        )
+
+        def fake_reader(_cache_backend, cache_keys):
+            self.assertEqual(tuple(cache_keys), (cache_key,))
+            return {cache_key: hit}
+
+        with (
+            patch(
+                "general_manager.api.graphql_prefetch.read_many_dependency_cache_hits",
+                side_effect=fake_reader,
+            ) as bulk_read,
+            patch(
+                "general_manager.cache.cache_decorator.read_dependency_cache_hit",
+                side_effect=AssertionError("single-key dependency cache read used"),
+            ),
+        ):
+            response = self.query(self._list_query())
+
+        self.assertResponseNoErrors(response)
+        item = response_item(response)
+        self.assertEqual(item["calculatedTax"]["value"], 600)
+        self.assertEqual(item["calculatedTax"]["unit"], "EUR")
+        self.assertEqual(self.Calculation.dependency_calls, 0)
+        bulk_read.assert_called_once()
+
+    def test_hot_list_uses_get_many_for_selected_dependency_cached_fields(self):
+        first = self.query(self._list_query())
+        self.assertResponseNoErrors(first)
+        self.assertEqual(self.Calculation.dependency_calls, 1)
+
+        self.reset_cache_ops()
+        self.Calculation.dependency_calls = 0
+
+        second = self.query(self._list_query())
+
+        self.assertResponseNoErrors(second)
+        self.assertEqual(self.Calculation.dependency_calls, 0)
+        ops = self.cache_ops()
+        get_many_ops = [op for op in ops if op[0] == "get_many"]
+        self.assertTrue(get_many_ops)
+
+
+class TestGraphQLDependencyCachePrefetchPermissions(GeneralManagerTransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        class SecureEmployee(GeneralManager):
+            name: str
+            salary: Measurement
+
+            class Interface(DatabaseInterface):
+                name = CharField(max_length=100)
+                salary = MeasurementField(base_unit="EUR")
+
+        class SecureCalculation(GeneralManager):
+            employee: SecureEmployee
+            calls: ClassVar[int] = 0
+
+            class Interface(CalculationInterface):
+                employee = Input(
+                    SecureEmployee,
+                    possible_values=lambda: SecureEmployee.all(),
+                )
+
+            class Permission(ManagerBasedPermission):
+                __read__: ClassVar[list[str]] = ["public"]
+                calculated_tax: ClassVar[dict[str, list[str]]] = {
+                    "read": ["denyCalculatedTax"]
+                }
+
+                def get_read_permission_plan(self) -> ReadPermissionPlan:
+                    return ReadPermissionPlan(
+                        filters=[{"filter": {}, "exclude": {}}],
+                        requires_instance_check=False,
+                    )
+
+            @graph_ql_property(cache="dependency")
+            def calculated_tax(self) -> Measurement:
+                type(self).calls += 1
+                return self.employee.salary * 0.2
+
+        cls.Employee = SecureEmployee
+        cls.Calculation = SecureCalculation
+        cls.general_manager_classes = [SecureEmployee, SecureCalculation]
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+        password = get_random_string(12)
+        self.user = get_user_model().objects.create_user(
+            username="limited",
+            password=password,
+        )
+        self.client.login(username="limited", password=password)
+        self.employee = self.Employee.create(
+            name="Denied",
+            salary=Measurement(5000, "EUR"),
+            ignore_permission=True,
+        )
+        self.Calculation.calls = 0
+
+    def test_denied_field_is_not_prefetched_or_computed(self):
+        query = """
+        query {
+            secureCalculationList {
+                items {
+                    calculatedTax { value unit }
+                }
+            }
+        }
+        """
+
+        with patch(
+            "general_manager.api.graphql_resolvers.prefetch_dependency_cache_hits",
+            return_value={},
+        ) as prefetch:
+            response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        payload = response.json()["data"]["secureCalculationList"]["items"][0]
+        self.assertIsNone(payload["calculatedTax"])
+        self.assertEqual(prefetch.call_args.args[0], {})
+        self.assertEqual(self.Calculation.calls, 0)
+
+
+def response_item(response):
+    return response.json()["data"]["prefetchCalculationList"]["items"][0]

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -37,6 +37,7 @@ class FakeCacheBackend:
         """
         self.store = {}
         self.timeouts = {}
+        self.get_calls = []
         self.lock = threading.RLock()
 
     def get(self, key, default=None):
@@ -50,6 +51,7 @@ class FakeCacheBackend:
         Returns:
             The unpickled value associated with the key, or the default if not found.
         """
+        self.get_calls.append(key)
         with self.lock:
             cached_value = self.store.get(key, default)
         if cached_value is not default:
@@ -689,6 +691,32 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self.record_calls.clear()
         res2 = outer_function(2, 3)
         self.assertEqual(res2, 5)
+        self.assertEqual(self.record_calls, [])
+
+    def test_dependency_scope_uses_prefetched_hit_before_backend_read(self):
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
+        def sample(value):
+            del value
+            self.fail("prefetched hit should avoid calculation")
+
+        key = make_cache_key(sample, (7,), {})
+        hit = DependencyCacheHit(
+            value=21,
+            dependencies=frozenset({("Project", "identification", '{"id": 7}')}),
+        )
+
+        with CalculationRunContext() as context:
+            context.set_dependency_cache_hits({key: hit})
+            with DependencyTracker() as dependencies:
+                result = sample(7)
+
+        self.assertEqual(result, 21)
+        self.assertEqual(dependencies, set(hit.dependencies))
+        self.assertEqual(self.fake_cache.get_calls, [])
         self.assertEqual(self.record_calls, [])
 
 

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -1,3 +1,4 @@
+from general_manager.cache.dependency_cache import DependencyCacheHit
 from general_manager.cache.run_context import (
     CalculationRunContext,
     current_calculation_run_context,
@@ -40,6 +41,30 @@ def test_public_storage_helpers_store_and_check_values() -> None:
         assert ctx.get("answer") == 42
         assert ctx.has("answer")
         assert "answer" in ctx
+
+
+def test_dependency_cache_prefetch_hits_are_available_inside_context() -> None:
+    hit = DependencyCacheHit(
+        value="ready",
+        dependencies=frozenset({("Project", "identification", '{"id": 1}')}),
+    )
+
+    with CalculationRunContext() as context:
+        context.set_dependency_cache_hits({"cache-key": hit})
+
+        assert context.get_dependency_cache_hit("cache-key") == hit
+        assert context.get_dependency_cache_hit("missing", "fallback") == "fallback"
+
+
+def test_dependency_cache_prefetch_hits_are_cleared_on_exit() -> None:
+    hit = DependencyCacheHit(value=10, dependencies=frozenset())
+    context = CalculationRunContext()
+
+    with context:
+        context.set_dependency_cache_hits({"cache-key": hit})
+        assert context.get_dependency_cache_hit("cache-key") == hit
+
+    assert context.get_dependency_cache_hit("cache-key", None) is None
 
 
 def test_discard_prefix_removes_matching_tuple_keys_only() -> None:

--- a/tests/unit/test_graphql_prefetch.py
+++ b/tests/unit/test_graphql_prefetch.py
@@ -1,0 +1,216 @@
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+from django.test import SimpleTestCase
+from graphql import parse
+
+from general_manager.api.graphql_prefetch import (
+    DependencyCachePrefetchPlan,
+    collect_selected_graphql_property_names,
+    plan_dependency_cache_prefetches,
+    prefetch_dependency_cache_hits,
+)
+from general_manager.cache.dependency_cache import DependencyCacheHit
+from general_manager.cache.run_context import CalculationRunContext
+from general_manager.api.property import GraphQLProperty, graph_ql_property
+from general_manager.utils.make_cache_key import make_cache_key
+
+
+def _prop() -> GraphQLProperty:
+    def getter(_self: object) -> int:
+        return 1
+
+    return GraphQLProperty(getter)
+
+
+class FakeInterface:
+    @staticmethod
+    def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+        return {
+            "calculated_tax": _prop(),
+            "budget_used": _prop(),
+            "hidden_cost": _prop(),
+        }
+
+
+class FakeManager:
+    Interface = FakeInterface
+
+
+def _info(query: str) -> Any:
+    document = parse(query)
+    operation = next(
+        definition
+        for definition in document.definitions
+        if definition.kind == "operation_definition"
+    )
+    fragments = {
+        definition.name.value: definition
+        for definition in document.definitions
+        if definition.kind == "fragment_definition"
+    }
+    return SimpleNamespace(
+        field_nodes=list(operation.selection_set.selections),
+        fragments=fragments,
+    )
+
+
+class GraphQLPrefetchSelectionTests(SimpleTestCase):
+    def test_collects_selected_properties_under_items(self) -> None:
+        info = _info(
+            """
+            query {
+                taxCalculationList {
+                    items {
+                        id
+                        calculatedTax { value unit }
+                        ...TaxFields
+                    }
+                }
+            }
+            fragment TaxFields on TaxCalculationType {
+                budgetUsed { value unit }
+            }
+            """
+        )
+
+        selected = collect_selected_graphql_property_names(
+            info,
+            FakeManager,
+            root_field="items",
+        )
+
+        self.assertEqual(selected, {"calculated_tax", "budget_used"})
+
+    def test_does_not_collect_nested_relation_properties(self) -> None:
+        info = _info(
+            """
+            query {
+                taxCalculationList {
+                    items {
+                        employee {
+                            hiddenCost
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        selected = collect_selected_graphql_property_names(
+            info,
+            FakeManager,
+            root_field="items",
+        )
+
+        self.assertEqual(selected, set())
+
+
+class PlannedObject:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    @graph_ql_property(cache="dependency")
+    def computed_value(self) -> int:
+        return self.value * 2
+
+    @graph_ql_property(cache="run")
+    def run_value(self) -> int:
+        return self.value * 3
+
+    class Interface:
+        @staticmethod
+        def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+            return {
+                "computed_value": PlannedObject.computed_value,
+                "run_value": PlannedObject.run_value,
+            }
+
+
+class GraphQLPrefetchPlanningTests(SimpleTestCase):
+    def test_plans_dependency_cached_selected_properties_with_real_keys(self) -> None:
+        instance = PlannedObject(4)
+
+        plans = plan_dependency_cache_prefetches(
+            [instance],
+            PlannedObject,
+            {"computed_value", "run_value"},
+            can_read_field=lambda _instance, _field_name: True,
+        )
+
+        prop = PlannedObject.Interface.get_graph_ql_properties()["computed_value"]
+        expected_key = make_cache_key(prop._get_cached_fget(), (instance,), {})
+        self.assertEqual(set(plans), {expected_key})
+        self.assertEqual(plans[expected_key].property_name, "computed_value")
+        self.assertIs(plans[expected_key].instance, instance)
+
+    def test_skips_permission_denied_property_instances(self) -> None:
+        first = PlannedObject(1)
+        second = PlannedObject(2)
+
+        plans = plan_dependency_cache_prefetches(
+            [first, second],
+            PlannedObject,
+            {"computed_value"},
+            can_read_field=lambda instance, _field_name: instance is first,
+        )
+
+        self.assertEqual(len(plans), 1)
+        self.assertIs(next(iter(plans.values())).instance, first)
+
+
+class GraphQLPrefetchExecutionTests(SimpleTestCase):
+    def test_prefetch_reads_many_and_stores_hits_in_current_context(self) -> None:
+        hit = DependencyCacheHit(
+            value=42,
+            dependencies=frozenset({("Project", "identification", '{"id": 1}')}),
+        )
+        reader = Mock(return_value={"cache-key": hit})
+        cache_backend = object()
+        plan = DependencyCachePrefetchPlan(
+            cache_key="cache-key",
+            instance=PlannedObject(1),
+            property_name="computed_value",
+        )
+
+        with CalculationRunContext() as context:
+            hits = prefetch_dependency_cache_hits(
+                {"cache-key": plan},
+                cache_backend=cache_backend,
+                reader=reader,
+            )
+
+            self.assertEqual(hits, {"cache-key": hit})
+            self.assertEqual(context.get_dependency_cache_hit("cache-key"), hit)
+
+        reader.assert_called_once_with(cache_backend, ("cache-key",))
+
+    def test_prefetch_without_context_skips_reader(self) -> None:
+        reader = Mock(return_value={})
+        plan = DependencyCachePrefetchPlan(
+            cache_key="cache-key",
+            instance=PlannedObject(1),
+            property_name="computed_value",
+        )
+
+        hits = prefetch_dependency_cache_hits(
+            {"cache-key": plan},
+            cache_backend=object(),
+            reader=reader,
+        )
+
+        self.assertEqual(hits, {})
+        reader.assert_not_called()
+
+
+class GraphQLPrefetchGroupedSkipTests(SimpleTestCase):
+    def test_planner_can_be_called_with_empty_materialized_items(self) -> None:
+        plans = plan_dependency_cache_prefetches(
+            [],
+            PlannedObject,
+            {"computed_value"},
+            can_read_field=lambda _instance, _field_name: True,
+        )
+
+        self.assertEqual(plans, {})

--- a/tests/unit/test_graphql_prefetch.py
+++ b/tests/unit/test_graphql_prefetch.py
@@ -115,6 +115,10 @@ class PlannedObject:
     def computed_value(self) -> int:
         return self.value * 2
 
+    @graph_ql_property(cache="dependency")
+    def other_computed_value(self) -> int:
+        return self.value * 4
+
     @graph_ql_property(cache="run")
     def run_value(self) -> int:
         return self.value * 3
@@ -124,6 +128,7 @@ class PlannedObject:
         def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
             return {
                 "computed_value": PlannedObject.computed_value,
+                "other_computed_value": PlannedObject.other_computed_value,
                 "run_value": PlannedObject.run_value,
             }
 
@@ -158,6 +163,24 @@ class GraphQLPrefetchPlanningTests(SimpleTestCase):
 
         self.assertEqual(len(plans), 1)
         self.assertIs(next(iter(plans.values())).instance, first)
+
+    def test_reiterates_one_shot_instance_iterables_for_each_property(self) -> None:
+        first = PlannedObject(1)
+        second = PlannedObject(2)
+        instances = (instance for instance in (first, second))
+
+        plans = plan_dependency_cache_prefetches(
+            instances,
+            PlannedObject,
+            {"computed_value", "other_computed_value"},
+            can_read_field=lambda _instance, _field_name: True,
+        )
+
+        self.assertEqual(len(plans), 4)
+        self.assertEqual(
+            {plan.property_name for plan in plans.values()},
+            {"computed_value", "other_computed_value"},
+        )
 
 
 class GraphQLPrefetchExecutionTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
- Add internal GraphQL dependency-cache prefetch planning for selected `GraphQLProperty(cache="dependency")` list fields.
- Store #270 bulk-read hits in the active calculation run context so normal property resolution consumes them.
- Preserve fallback behavior for misses, field-level permissions, grouped results, and existing subscription selection handling.

## Test Plan
- `python -m pytest tests/unit/test_graphql_prefetch.py tests/unit/test_calculation_run_context.py tests/unit/test_cache_decorator.py tests/unit/test_graphql_subscriptions.py -q`
- `python -m pytest tests/integration/test_graphql_dependency_cache_prefetch.py tests/integration/test_graphql_query.py tests/integration/test_calculation_manager.py -q`
- `ruff check .`
- `ruff format --check src/general_manager/cache/run_context.py src/general_manager/cache/cache_decorator.py src/general_manager/api/graphql_prefetch.py src/general_manager/api/graphql_resolvers.py src/general_manager/api/graphql_subscriptions.py src/general_manager/utils/testing.py tests/unit/test_calculation_run_context.py tests/unit/test_cache_decorator.py tests/unit/test_graphql_prefetch.py tests/integration/test_graphql_dependency_cache_prefetch.py`
- `mypy`
- `python -m pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GraphQL list query performance through optimized caching strategies.
  * Enhanced permission-controlled access to cached fields in GraphQL responses.

* **Tests**
  * Added comprehensive integration and unit test coverage for caching behavior.
  * New cache testing utilities for validating bulk operations and multi-item scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->