### PR TITLE
feat: add run-scoped ORM bucket result reuse

### DIFF
--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -164,6 +164,16 @@ context continues to read from the database normally. Negative lookups are not
 cached, and ORM update/delete paths clear affected row entries in the active run
 context after successful mutations.
 
+ORM-backed `DatabaseBucket` terminal operations also reuse conservative
+run-scoped primary-key snapshots inside the active context. Equivalent bounded
+bucket evaluations can share the materialized result for iteration, length,
+`count()`, `first()`, `last()`, scalar indexing, primary-key `get()`, and
+membership checks after a snapshot exists. The cache is intentionally
+conservative: unsupported query shapes and large buckets bypass reuse, count-only
+paths do not force full materialization, dependencies are still tracked on every
+terminal operation, and any framework mutation clears bucket snapshots in the
+active run before the data changes.
+
 ## Manual dependency-index helpers
 
 Most application code should rely on CRUD signals and dependency-scoped

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -208,6 +208,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         search_date: datetime | date | None = None,
         sort_keys: tuple[str, ...] | None = None,
         sort_reverse: bool = False,
+        run_scoped_cacheable: bool = True,
     ) -> None:
         """
         Instantiate a database-backed bucket with optional filter state.
@@ -229,6 +230,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         self._search_date = search_date
         self._sort_keys = sort_keys
         self._sort_reverse = sort_reverse
+        self._run_scoped_cacheable = run_scoped_cacheable
 
     def __reduce__(self) -> str | tuple[Any, ...]:
         """
@@ -287,6 +289,8 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
 
     def _query_signature(self) -> tuple[Hashable, ...] | None:
         """Return a conservative run-cache signature for this queryset."""
+        if not self._run_scoped_cacheable:
+            return None
         query = self._data.query
         if not isinstance(query, Query):
             return None
@@ -443,6 +447,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             search_date=self._search_date,
             sort_keys=self._sort_keys,
             sort_reverse=self._sort_reverse,
+            run_scoped_cacheable=False,
         )
 
     def __merge_filter_definitions(
@@ -580,6 +585,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             search_date=search_date,
             sort_keys=self._sort_keys,
             sort_reverse=self._sort_reverse,
+            run_scoped_cacheable=self._run_scoped_cacheable,
         )
 
     def exclude(self, **kwargs: Any) -> DatabaseBucket[GeneralManagerType]:
@@ -627,6 +633,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             search_date=search_date,
             sort_keys=self._sort_keys,
             sort_reverse=self._sort_reverse,
+            run_scoped_cacheable=self._run_scoped_cacheable,
         )
 
     def first(self) -> GeneralManagerType | None:
@@ -693,6 +700,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             search_date=self._search_date,
             sort_keys=self._sort_keys,
             sort_reverse=self._sort_reverse,
+            run_scoped_cacheable=self._run_scoped_cacheable,
         )
 
     def get(self, **kwargs: Any) -> GeneralManagerType:
@@ -741,6 +749,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
                 search_date=self._search_date,
                 sort_keys=self._sort_keys,
                 sort_reverse=self._sort_reverse,
+                run_scoped_cacheable=self._run_scoped_cacheable,
             )
         self._track_effective_dependencies()
         primary_keys = self._peek_run_scoped_primary_keys()
@@ -886,6 +895,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             search_date=self._search_date,
             sort_keys=key,
             sort_reverse=reverse,
+            run_scoped_cacheable=self._run_scoped_cacheable,
         )
 
     def none(self) -> DatabaseBucket[GeneralManagerType]:

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -722,8 +722,11 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         if primary_keys is not None:
             requested_primary_key = self._snapshot_get_primary_key(kwargs)
             if requested_primary_key is not None:
-                if requested_primary_key in primary_keys:
+                match_count = primary_keys.count(requested_primary_key)
+                if match_count == 1:
                     return self._build_manager(requested_primary_key)
+                if match_count > 1:
+                    raise self._data.model.MultipleObjectsReturned
                 raise self._data.model.DoesNotExist
         element = self._data.get(**kwargs)
         return self._build_manager(element.pk)
@@ -754,6 +757,8 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         self._track_effective_dependencies()
         primary_keys = self._peek_run_scoped_primary_keys()
         if primary_keys is not None:
+            if item < 0:
+                raise ValueError
             return self._build_manager(primary_keys[item])
         return self._build_manager(self._data[item].pk)
 

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -332,6 +332,28 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         context.set_orm_bucket_result(signature, primary_keys)
         return primary_keys
 
+    def _peek_run_scoped_primary_keys(self) -> tuple[Any, ...] | None:
+        context = current_calculation_run_context()
+        if context is None:
+            return None
+        signature = self._query_signature()
+        if signature is None:
+            return None
+        cached = context.get_orm_bucket_result(signature)
+        if cached is None:
+            return None
+        return cached  # type: ignore[return-value]
+
+    @staticmethod
+    def _snapshot_get_primary_key(kwargs: dict[str, Any]) -> Any | None:
+        if len(kwargs) != 1:
+            return None
+        if "pk" in kwargs:
+            return kwargs["pk"]
+        if "id" in kwargs:
+            return kwargs["id"]
+        return None
+
     def _track_effective_dependencies(self) -> None:
         """Record the bucket's effective filter/exclude state when it is evaluated."""
         manager_name = self._manager_class.__name__
@@ -615,6 +637,11 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             GeneralManagerType | None: First manager instance if available.
         """
         self._track_effective_dependencies()
+        primary_keys = self._peek_run_scoped_primary_keys()
+        if primary_keys is not None:
+            if not primary_keys:
+                return None
+            return self._build_manager(primary_keys[0])
         first_element = self._data.first()
         if first_element is None:
             return None
@@ -628,6 +655,11 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             GeneralManagerType | None: Last manager instance if available.
         """
         self._track_effective_dependencies()
+        primary_keys = self._peek_run_scoped_primary_keys()
+        if primary_keys is not None:
+            if not primary_keys:
+                return None
+            return self._build_manager(primary_keys[-1])
         first_element = self._data.last()
         if first_element is None:
             return None
@@ -641,6 +673,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             int: Number of queryset rows.
         """
         self._track_effective_dependencies()
+        primary_keys = self._peek_run_scoped_primary_keys()
+        if primary_keys is not None:
+            return len(primary_keys)
         return self._data.count()
 
     def all(self) -> DatabaseBucket[GeneralManagerType]:
@@ -675,6 +710,13 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             models.MultipleObjectsReturned: Propagated when multiple rows satisfy the lookup.
         """
         self._track_effective_dependencies()
+        primary_keys = self._peek_run_scoped_primary_keys()
+        if primary_keys is not None:
+            requested_primary_key = self._snapshot_get_primary_key(kwargs)
+            if requested_primary_key is not None:
+                if requested_primary_key in primary_keys:
+                    return self._build_manager(requested_primary_key)
+                raise self._data.model.DoesNotExist
         element = self._data.get(**kwargs)
         return self._build_manager(element.pk)
 
@@ -701,6 +743,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
                 sort_reverse=self._sort_reverse,
             )
         self._track_effective_dependencies()
+        primary_keys = self._peek_run_scoped_primary_keys()
+        if primary_keys is not None:
+            return self._build_manager(primary_keys[item])
         return self._build_manager(self._data[item].pk)
 
     def __len__(self) -> int:
@@ -711,6 +756,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             int: Size of the queryset.
         """
         self._track_effective_dependencies()
+        primary_keys = self._peek_run_scoped_primary_keys()
+        if primary_keys is not None:
+            return len(primary_keys)
         return self._data.count()
 
     def __str__(self) -> str:
@@ -750,6 +798,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             pk = item.pk
         if pk is None:
             return False
+        primary_keys = self._peek_run_scoped_primary_keys()
+        if primary_keys is not None:
+            return pk in primary_keys
         return self._data.filter(pk=pk).exists()
 
     def sort(

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -1,20 +1,24 @@
 """Database-backed bucket implementation for GeneralManager collections."""
 
 from __future__ import annotations
+from collections.abc import Hashable
 from datetime import date, datetime
 from typing import Any, Generator, Type, TypeVar
 
-from django.core.exceptions import FieldError
+from django.core.exceptions import EmptyResultSet, FieldError
 from django.db import models
+from django.db.models.sql.query import Query
 
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import serialize_dependency_identifier
+from general_manager.cache.run_context import current_calculation_run_context
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.utils.filter_parser import create_filter_function
 
 modelsModel = TypeVar("modelsModel", bound=models.Model)
 GeneralManagerType = TypeVar("GeneralManagerType", bound=GeneralManager)
+MAX_RUN_SCOPED_BUCKET_RESULT_ROWS = 1000
 
 
 class DatabaseBucketTypeMismatchError(TypeError):
@@ -281,6 +285,53 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             for key, values in definitions.items()
         }
 
+    def _query_signature(self) -> tuple[Hashable, ...] | None:
+        """Return a conservative run-cache signature for this queryset."""
+        query = self._data.query
+        if not isinstance(query, Query):
+            return None
+        if query.select_for_update:
+            return None
+        if query.combinator:
+            return None
+        if query.distinct:
+            return None
+        try:
+            sql, params = self._data.query.sql_with_params()
+        except (EmptyResultSet, FieldError, TypeError, ValueError):
+            return None
+        return (
+            self._manager_class,
+            self._data.model,
+            self._data.db,
+            sql,
+            tuple(params),
+            self._search_date,
+            self._sort_keys,
+            self._sort_reverse,
+        )
+
+    def _get_run_scoped_primary_keys(self) -> tuple[Any, ...] | None:
+        context = current_calculation_run_context()
+        if context is None:
+            return None
+        signature = self._query_signature()
+        if signature is None:
+            return None
+        cached = context.get_orm_bucket_result(signature)
+        if cached is not None:
+            return cached  # type: ignore[return-value]
+
+        primary_keys = tuple(
+            self._data.values_list("pk", flat=True)[
+                : MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 1
+            ]
+        )
+        if len(primary_keys) > MAX_RUN_SCOPED_BUCKET_RESULT_ROWS:
+            return None
+        context.set_orm_bucket_result(signature, primary_keys)
+        return primary_keys
+
     def _track_effective_dependencies(self) -> None:
         """Record the bucket's effective filter/exclude state when it is evaluated."""
         manager_name = self._manager_class.__name__
@@ -321,6 +372,11 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             GeneralManagerType: Manager instance for each primary key in the queryset.
         """
         self._track_effective_dependencies()
+        primary_keys = self._get_run_scoped_primary_keys()
+        if primary_keys is not None:
+            for primary_key in primary_keys:
+                yield self._build_manager(primary_key)
+            return
         for item in self._data:
             yield self._build_manager(item.pk)
 

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -219,6 +219,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             filter_definitions (dict[str, list[Any]] | None): Pre-existing filter expressions captured from parent buckets.
             exclude_definitions (dict[str, list[Any]] | None): Pre-existing exclusion expressions captured from parent buckets.
             search_date (datetime | date | None): Optional timestamp applied when instantiating manager instances.
+            sort_keys (tuple[str, ...] | None): Property names used by a previous bucket sort operation.
+            sort_reverse (bool): Whether sorted keys should be interpreted in descending order for dependency tracking.
+            run_scoped_cacheable (bool): Whether terminal results from this bucket are safe to reuse inside the active calculation run.
 
         Returns:
             None
@@ -288,7 +291,18 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         }
 
     def _query_signature(self) -> tuple[Hashable, ...] | None:
-        """Return a conservative run-cache signature for this queryset."""
+        """
+        Return a conservative run-scoped cache signature for this queryset.
+
+        The signature is only produced for queryset shapes whose SQL, database
+        alias, manager class, model, search date, and sort state can safely
+        distinguish equivalent terminal results. Unsupported or risky query
+        forms return ``None`` so callers fall back to normal ORM evaluation.
+
+        Returns:
+            tuple[Hashable, ...] | None: Cache key components for equivalent
+            queryset results, or ``None`` when reuse should be bypassed.
+        """
         if not self._run_scoped_cacheable:
             return None
         query = self._data.query
@@ -316,6 +330,19 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         )
 
     def _get_run_scoped_primary_keys(self) -> tuple[Any, ...] | None:
+        """
+        Load or reuse a bounded primary-key snapshot for this bucket.
+
+        The method materializes at most ``MAX_RUN_SCOPED_BUCKET_RESULT_ROWS``
+        primary keys and stores them in the active
+        :class:`CalculationRunContext`. Buckets without an active context,
+        without a safe signature, or above the materialization guardrail return
+        ``None`` so terminal operations continue through the database.
+
+        Returns:
+            tuple[Any, ...] | None: Cached or newly materialized primary keys,
+            or ``None`` when run-scoped reuse is unavailable.
+        """
         context = current_calculation_run_context()
         if context is None:
             return None
@@ -337,6 +364,17 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         return primary_keys
 
     def _peek_run_scoped_primary_keys(self) -> tuple[Any, ...] | None:
+        """
+        Return an already cached primary-key snapshot without evaluating the ORM.
+
+        Terminal operations such as ``count()`` and membership checks call this
+        helper so they can reuse a snapshot created by iteration without forcing
+        materialization on their own.
+
+        Returns:
+            tuple[Any, ...] | None: Cached primary keys for this bucket, or
+            ``None`` when no snapshot exists.
+        """
         context = current_calculation_run_context()
         if context is None:
             return None
@@ -350,6 +388,21 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
 
     @staticmethod
     def _snapshot_get_primary_key(kwargs: dict[str, Any]) -> Any | None:
+        """
+        Extract the primary key from a snapshot-safe ``get()`` lookup.
+
+        Only single-key ``pk`` and ``id`` lookups can be answered from the
+        cached primary-key tuple while preserving Django's ``QuerySet.get()``
+        semantics. All other lookup shapes return ``None`` and use the normal
+        ORM path.
+
+        Parameters:
+            kwargs (dict[str, Any]): Lookup arguments passed to ``get()``.
+
+        Returns:
+            Any | None: Requested primary key when the lookup is snapshot-safe,
+            otherwise ``None``.
+        """
         if len(kwargs) != 1:
             return None
         if "pk" in kwargs:

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -18,6 +18,7 @@ _active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
     "general_manager_calculation_run_context",
     default=None,
 )
+ORM_BUCKET_RESULT_PREFIX = "orm_bucket_result"
 
 
 class CalculationRunContext:
@@ -78,6 +79,18 @@ class CalculationRunContext:
         for key in list(self._values):
             if isinstance(key, tuple) and key[: len(prefix)] == prefix:
                 del self._values[key]
+
+    def get_orm_bucket_result(self, key: Hashable) -> object:
+        """Return a cached ORM bucket result for key, or None when absent."""
+        return self.get((ORM_BUCKET_RESULT_PREFIX, key))
+
+    def set_orm_bucket_result(self, key: Hashable, value: object) -> None:
+        """Store an ORM bucket result for the active run."""
+        self.set((ORM_BUCKET_RESULT_PREFIX, key), value)
+
+    def clear_orm_bucket_results(self) -> None:
+        """Discard all run-scoped ORM bucket result entries."""
+        self.discard_prefix((ORM_BUCKET_RESULT_PREFIX,))
 
     def has(self, key: Hashable) -> bool:
         """Return whether key has a value in the active run."""

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -47,9 +47,13 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
             begin_dependency_data_change,
             end_dependency_data_change,
         )
+        from general_manager.cache.run_context import current_calculation_run_context
 
         primary_exc: BaseException | None = None
         begin_dependency_data_change()
+        context = current_calculation_run_context()
+        if context is not None:
+            context.clear_orm_bucket_results()
         try:
             action = func.__name__
             if func.__name__ == "create":

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 from unittest.mock import patch
 from django.utils import timezone
 from general_manager.cache.dependency_index import get_full_index
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.utils.testing import GeneralManagerTransactionTestCase
 from general_manager.manager import GeneralManager, Input
 from django.db.models.fields import CharField, IntegerField, DateField, DateTimeField
@@ -1491,6 +1492,22 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
             refreshed_commercials1.chained_first_project_name, "Third Project"
         )
         self.assert_cache_hit()
+
+    def test_run_scoped_bucket_results_clear_after_mutation_inside_run(self):
+        with CalculationRunContext():
+            bucket = self.TestProject.filter(name="Another Project")
+            self.assertEqual(
+                [project.identification["id"] for project in bucket],
+                [self.project2.identification["id"]],
+            )
+
+            self.project2 = self.project2.update(
+                name="Renamed Project",
+                ignore_permission=True,
+            )
+
+            refreshed_bucket = self.TestProject.filter(name="Another Project")
+            self.assertEqual(list(refreshed_bucket), [])
 
     def test_grouped_filtered_bucket_count_invalidates_on_create(self):
         """

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -82,6 +82,27 @@ def test_discard_prefix_removes_matching_tuple_keys_only() -> None:
         assert ctx.get("plain") == "value"
 
 
+def test_orm_bucket_result_helpers_store_and_clear_entries() -> None:
+    with CalculationRunContext() as ctx:
+        ctx.set_orm_bucket_result(("query", "a"), ("pk1", "pk2"))
+        ctx.set(("other", "query", "a"), "keep")
+
+        assert ctx.get_orm_bucket_result(("query", "a")) == ("pk1", "pk2")
+
+        ctx.clear_orm_bucket_results()
+
+        assert ctx.get_orm_bucket_result(("query", "a")) is None
+        assert ctx.get(("other", "query", "a")) == "keep"
+
+
+def test_orm_bucket_result_helpers_distinguish_empty_tuple_from_missing() -> None:
+    with CalculationRunContext() as ctx:
+        ctx.set_orm_bucket_result(("query", "empty"), ())
+
+        assert ctx.get_orm_bucket_result(("query", "empty")) == ()
+        assert ctx.get_orm_bucket_result(("query", "missing")) is None
+
+
 def test_index_loads_once_and_groups_by_key() -> None:
     calls = 0
 

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -3,10 +3,11 @@
 from datetime import datetime
 from unittest.mock import patch
 
-from django.test import TestCase
 from django.contrib.auth.models import User
+from django.contrib.auth.models import Group
 from django.db.models import functions
 from django.db.models.query import QuerySet
+from django.test import TestCase
 
 from general_manager.bucket.database_bucket import (
     DatabaseBucket,
@@ -473,6 +474,26 @@ class DatabaseBucketTestCase(TestCase):
             with self.assertNumQueries(0), self.assertRaises(User.DoesNotExist):
                 bucket.get(pk=999)
 
+    def test_snapshot_get_duplicate_primary_key_raises_without_query(self):
+        first_group = Group.objects.create(name="first-group")
+        second_group = Group.objects.create(name="second-group")
+        self.u1.groups.add(first_group, second_group)
+        bucket = DatabaseBucket(
+            User.objects.filter(groups__name__in=[first_group.name, second_group.name]),
+            UserManager,
+        )
+
+        with CalculationRunContext():
+            self.assertEqual(
+                [manager.identification["id"] for manager in bucket],
+                [self.u1.id, self.u1.id],
+            )
+            with (
+                self.assertNumQueries(0),
+                self.assertRaises(User.MultipleObjectsReturned),
+            ):
+                bucket.get(pk=self.u1.pk)
+
     def test_snapshot_get_falls_back_for_non_primary_key_lookup(self):
         bucket = DatabaseBucket(User.objects.filter(username="alice"), UserManager)
 
@@ -762,6 +783,14 @@ class DatabaseBucketTestCase(TestCase):
 
         with self.assertRaises(ValueError):
             _ = self.bucket[-10]
+
+    def test_getitem_cached_negative_index_matches_queryset_behavior(self):
+        bucket = DatabaseBucket(User.objects.order_by("username"), UserManager)
+
+        with CalculationRunContext():
+            list(bucket)
+            with self.assertRaises(ValueError):
+                _ = bucket[-1]
 
     def test_slice_with_step_and_negative_slice(self):
         """

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -11,6 +11,7 @@ from django.db.models.query import QuerySet
 from general_manager.bucket.database_bucket import (
     DatabaseBucket,
     DuplicateDatabaseBucketSnapshotError,
+    MAX_RUN_SCOPED_BUCKET_RESULT_ROWS,
     _restore_database_bucket_from_primary_keys,
 )
 from general_manager.cache.cache_tracker import DependencyTracker
@@ -318,6 +319,36 @@ class DatabaseBucketTestCase(TestCase):
             ),
             dependencies,
         )
+
+    def test_large_bucket_result_bypasses_run_scoped_materialization(self):
+        users = [
+            User(username=f"user-{index:04d}")
+            for index in range(MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 1)
+        ]
+        User.objects.bulk_create(users)
+        bucket = DatabaseBucket(User.objects.order_by("username"), UserManager)
+
+        with CalculationRunContext(), self.assertNumQueries(2):
+            self.assertEqual(bucket.count(), MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 4)
+            self.assertEqual(bucket.count(), MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 4)
+
+    def test_union_bucket_bypasses_run_scoped_result_reuse(self):
+        first = DatabaseBucket(User.objects.filter(username="alice"), UserManager)
+        second = DatabaseBucket(User.objects.filter(username="bob"), UserManager)
+        first_union = first | second
+        second_union = DatabaseBucket(
+            User.objects.filter(username="alice"), UserManager
+        ) | DatabaseBucket(User.objects.filter(username="bob"), UserManager)
+
+        with CalculationRunContext(), self.assertNumQueries(2):
+            self.assertEqual(
+                sorted(manager.identification["id"] for manager in first_union),
+                sorted([self.u1.id, self.u2.id]),
+            )
+            self.assertEqual(
+                sorted(manager.identification["id"] for manager in second_union),
+                sorted([self.u1.id, self.u2.id]),
+            )
 
     def test_first_and_last(self):
         # first() returns the first manager

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -13,6 +13,7 @@ from general_manager.bucket.database_bucket import (
     DuplicateDatabaseBucketSnapshotError,
     _restore_database_bucket_from_primary_keys,
 )
+from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface.base_interface import InterfaceBase
@@ -296,6 +297,27 @@ class DatabaseBucketTestCase(TestCase):
 
         with CalculationRunContext(), self.assertNumQueries(1):
             self.assertIn(self.u1, bucket)
+
+    def test_bucket_result_cache_hit_still_tracks_dependencies(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username="alice"),
+            UserManager,
+            {"username": ["alice"]},
+        )
+
+        with CalculationRunContext():
+            list(bucket)
+            with DependencyTracker() as dependencies:
+                list(bucket)
+
+        self.assertIn(
+            (
+                "UserManager",
+                "filter",
+                '{"username": "alice"}',
+            ),
+            dependencies,
+        )
 
     def test_first_and_last(self):
         # first() returns the first manager

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -13,6 +13,7 @@ from general_manager.bucket.database_bucket import (
     DuplicateDatabaseBucketSnapshotError,
     _restore_database_bucket_from_primary_keys,
 )
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.api.property import graph_ql_property
@@ -221,6 +222,54 @@ class DatabaseBucketTestCase(TestCase):
         # __len__ and count()
         self.assertEqual(len(self.bucket), 3)
         self.assertEqual(self.bucket.count(), 3)
+
+    def test_equivalent_bucket_queries_share_iter_sql_inside_run_context(self):
+        first_bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+        )
+        second_bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            self.assertEqual(
+                [manager.identification["id"] for manager in first_bucket],
+                [self.u1.id, self.u2.id],
+            )
+            self.assertEqual(
+                [manager.identification["id"] for manager in second_bucket],
+                [self.u1.id, self.u2.id],
+            )
+
+    def test_different_ordering_does_not_share_iter_sql_inside_run_context(self):
+        ascending = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+            sort_keys=("username",),
+            sort_reverse=False,
+        )
+        descending = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("-username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+            sort_keys=("username",),
+            sort_reverse=True,
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(2):
+            self.assertEqual(
+                [manager.identification["id"] for manager in ascending],
+                [self.u1.id, self.u2.id],
+            )
+            self.assertEqual(
+                [manager.identification["id"] for manager in descending],
+                [self.u2.id, self.u1.id],
+            )
 
     def test_first_and_last(self):
         # first() returns the first manager

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -271,6 +271,32 @@ class DatabaseBucketTestCase(TestCase):
                 [self.u2.id, self.u1.id],
             )
 
+    def test_mixed_terminal_operations_reuse_materialized_bucket_snapshot(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            self.assertEqual(
+                [manager.identification["id"] for manager in bucket],
+                [self.u1.id, self.u2.id],
+            )
+            self.assertEqual(bucket.count(), 2)
+            self.assertEqual(len(bucket), 2)
+            self.assertEqual(bucket.first().identification["id"], self.u1.id)
+            self.assertEqual(bucket.last().identification["id"], self.u2.id)
+            self.assertEqual(bucket.get(pk=self.u1.pk).identification["id"], self.u1.id)
+            self.assertEqual(bucket[1].identification["id"], self.u2.id)
+            self.assertIn(self.u1, bucket)
+
+    def test_contains_does_not_materialize_uncached_bucket(self):
+        bucket = DatabaseBucket(User.objects.all(), UserManager)
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            self.assertIn(self.u1, bucket)
+
     def test_first_and_last(self):
         # first() returns the first manager
         """

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -299,6 +299,12 @@ class DatabaseBucketTestCase(TestCase):
         with CalculationRunContext(), self.assertNumQueries(1):
             self.assertIn(self.u1, bucket)
 
+    def test_contains_returns_false_for_unsaved_model_without_query(self):
+        unsaved = User(username="unsaved")
+
+        with self.assertNumQueries(0):
+            self.assertNotIn(unsaved, self.bucket)
+
     def test_bucket_result_cache_hit_still_tracks_dependencies(self):
         bucket = DatabaseBucket(
             User.objects.filter(username="alice"),
@@ -332,6 +338,93 @@ class DatabaseBucketTestCase(TestCase):
             self.assertEqual(bucket.count(), MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 4)
             self.assertEqual(bucket.count(), MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 4)
 
+    def test_over_limit_iteration_bypasses_run_scoped_materialization(self):
+        first_bucket = DatabaseBucket(User.objects.order_by("username"), UserManager)
+        second_bucket = DatabaseBucket(User.objects.order_by("username"), UserManager)
+
+        with (
+            patch(
+                "general_manager.bucket.database_bucket.MAX_RUN_SCOPED_BUCKET_RESULT_ROWS",
+                1,
+            ),
+            CalculationRunContext(),
+            self.assertNumQueries(4),
+        ):
+            self.assertEqual(
+                [manager.identification["id"] for manager in first_bucket],
+                [self.u1.id, self.u2.id, self.u3.id],
+            )
+            self.assertEqual(
+                [manager.identification["id"] for manager in second_bucket],
+                [self.u1.id, self.u2.id, self.u3.id],
+            )
+
+    def test_uncacheable_queryset_shapes_bypass_run_scoped_iteration_reuse(self):
+        cases = [
+            (
+                DatabaseBucket(User.objects.select_for_update(), UserManager),
+                DatabaseBucket(User.objects.select_for_update(), UserManager),
+            ),
+            (
+                DatabaseBucket(User.objects.distinct(), UserManager),
+                DatabaseBucket(User.objects.distinct(), UserManager),
+            ),
+            (
+                DatabaseBucket(
+                    User.objects.filter(username="alice").union(
+                        User.objects.filter(username="bob")
+                    ),
+                    UserManager,
+                ),
+                DatabaseBucket(
+                    User.objects.filter(username="alice").union(
+                        User.objects.filter(username="bob")
+                    ),
+                    UserManager,
+                ),
+            ),
+        ]
+
+        for first_bucket, second_bucket in cases:
+            with self.subTest(query=first_bucket._data.query):
+                with CalculationRunContext(), self.assertNumQueries(2):
+                    first_count = sum(1 for _manager in first_bucket)
+                    second_count = sum(1 for _manager in second_bucket)
+                    self.assertEqual(first_count, second_count)
+
+    def test_non_query_queryset_shape_bypasses_run_scoped_iteration_reuse(self):
+        first_bucket = DatabaseBucket(User.objects.all(), UserManager)
+        second_bucket = DatabaseBucket(User.objects.all(), UserManager)
+
+        with (
+            patch("general_manager.bucket.database_bucket.Query", str),
+            CalculationRunContext(),
+            self.assertNumQueries(2),
+        ):
+            first_count = sum(1 for _manager in first_bucket)
+            second_count = sum(1 for _manager in second_bucket)
+            self.assertEqual(first_count, second_count)
+
+    def test_sql_signature_errors_bypass_run_scoped_iteration_reuse(self):
+        bucket = DatabaseBucket(User.objects.filter(username="alice"), UserManager)
+
+        with patch.object(
+            bucket._data.query, "sql_with_params", side_effect=ValueError
+        ):
+            with CalculationRunContext(), self.assertNumQueries(1):
+                self.assertEqual(
+                    [manager.identification["id"] for manager in bucket],
+                    [self.u1.id],
+                )
+
+    def test_uncacheable_bucket_count_uses_database_path(self):
+        bucket = DatabaseBucket(
+            User.objects.all(), UserManager, run_scoped_cacheable=False
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            self.assertEqual(bucket.count(), 3)
+
     def test_union_bucket_bypasses_run_scoped_result_reuse(self):
         first = DatabaseBucket(User.objects.filter(username="alice"), UserManager)
         second = DatabaseBucket(User.objects.filter(username="bob"), UserManager)
@@ -349,6 +442,60 @@ class DatabaseBucketTestCase(TestCase):
                 sorted(manager.identification["id"] for manager in second_union),
                 sorted([self.u1.id, self.u2.id]),
             )
+
+    def test_empty_snapshot_first_and_last_return_none_without_queries(self):
+        bucket = DatabaseBucket(User.objects.filter(username="nobody"), UserManager)
+
+        with CalculationRunContext():
+            self.assertEqual(list(bucket), [])
+            with self.assertNumQueries(0):
+                self.assertIsNone(bucket.first())
+                self.assertIsNone(bucket.last())
+
+    def test_snapshot_get_uses_id_lookup_without_query(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+        )
+
+        with CalculationRunContext():
+            list(bucket)
+            with self.assertNumQueries(0):
+                manager = bucket.get(id=self.u2.id)
+
+        self.assertEqual(manager.identification["id"], self.u2.id)
+
+    def test_snapshot_get_missing_primary_key_raises_without_query(self):
+        bucket = DatabaseBucket(User.objects.filter(username="alice"), UserManager)
+
+        with CalculationRunContext():
+            list(bucket)
+            with self.assertNumQueries(0), self.assertRaises(User.DoesNotExist):
+                bucket.get(pk=999)
+
+    def test_snapshot_get_falls_back_for_non_primary_key_lookup(self):
+        bucket = DatabaseBucket(User.objects.filter(username="alice"), UserManager)
+
+        with CalculationRunContext():
+            list(bucket)
+            with self.assertNumQueries(1):
+                manager = bucket.get(username="alice")
+
+        self.assertEqual(manager.identification["id"], self.u1.id)
+
+    def test_snapshot_get_falls_back_for_ambiguous_lookup_shape(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]),
+            UserManager,
+        )
+
+        with CalculationRunContext():
+            list(bucket)
+            with (
+                self.assertNumQueries(1),
+                self.assertRaises(User.MultipleObjectsReturned),
+            ):
+                bucket.get()
 
     def test_first_and_last(self):
         # first() returns the first manager


### PR DESCRIPTION
## Summary
- Add run-scoped ORM bucket result storage to CalculationRunContext.
- Reuse conservative DatabaseBucket primary-key snapshots for equivalent bounded terminal operations.
- Clear run-scoped bucket results on mutations and cover dependency replay, mutation freshness, and guardrails.

Refs #274

## Test Plan
- python -m pytest tests/unit/test_calculation_run_context.py tests/unit/test_database_bucket.py -q
- python -m pytest tests/integration/test_caching.py -k "terminal_operations_track_without_iteration or mixed_terminal_operations_on_shared_bucket_invalidate_once or repeated_terminal_use_does_not_over_record_dependency_index or run_scoped_bucket_results_clear_after_mutation_inside_run" -q
- ruff check src/general_manager/cache/run_context.py src/general_manager/cache/signals.py src/general_manager/bucket/database_bucket.py tests/unit/test_calculation_run_context.py tests/unit/test_database_bucket.py tests/integration/test_caching.py
- mypy src/general_manager/cache/run_context.py src/general_manager/cache/signals.py src/general_manager/bucket/database_bucket.py
- python -m pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled run-scoped caching for ORM database bucket operations, with a per-bucket option to control reuse and improved performance for common terminal actions.
  * Combined bucket operations now default to conservative caching behavior.
* **Documentation**
  * Updated the caching guide to explain run-scoped primary-key reuse, conservative bypass conditions, and how in-run data changes invalidate cached results.
* **Tests**
  * Added integration and unit tests covering cache reuse, snapshot behavior, dependency tracking, and post-mutation cache clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->