### PR TITLE
Batch dependency-cache publication across calculation runs

### DIFF
--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -111,6 +111,7 @@ Dependency-scoped cache entries are published through a guarded write path:
 - a mutation generation is read before computation starts
 - data-changing operations raise the generation and hold a publish barrier while invalidation runs
 - inside a `CalculationRunContext`, computed misses are buffered and exposed to later calls in the same run
+- custom dependency `record_fn` callbacks preserve immediate publication instead of using the run buffer
 - buffered entries publish at run exit or at a controlled guardrail flush point
 - the dependency index and combined value/dependency payloads are written under the dependency-index lock
 - dependency metadata is stored before cached values become visible, so a visible value is already reachable by later invalidation

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -119,7 +119,7 @@ Dependency-scoped cache entries are published through a guarded write path:
 This means a dependency-scoped value is only shared after GeneralManager can
 prove that no data mutation overlapped the computation and publish step. Values
 computed during the current run remain available to that run even when guarded
-publication is skipped.
+publication is skipped, until a data change begins in that run.
 
 Concurrent workers for the same dependency-scoped cache key coordinate with a
 short-lived compute lease. The worker that acquires the lease performs the

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -110,12 +110,16 @@ Dependency-scoped cache entries are published through a guarded write path:
 
 - a mutation generation is read before computation starts
 - data-changing operations raise the generation and hold a publish barrier while invalidation runs
-- the dependency index and combined value/dependency payload are written under the dependency-index lock
-- dependency metadata is stored with the cached value, so a visible value is already reachable by later invalidation
+- inside a `CalculationRunContext`, computed misses are buffered and exposed to later calls in the same run
+- buffered entries publish at run exit or at a controlled guardrail flush point
+- the dependency index and combined value/dependency payloads are written under the dependency-index lock
+- dependency metadata is stored before cached values become visible, so a visible value is already reachable by later invalidation
 - if the generation changed or the publish barrier is active, the fresh function result is returned to the caller but is not stored
 
 This means a dependency-scoped value is only shared after GeneralManager can
-prove that no data mutation overlapped the computation and publish step.
+prove that no data mutation overlapped the computation and publish step. Values
+computed during the current run remain available to that run even when guarded
+publication is skipped.
 
 Concurrent workers for the same dependency-scoped cache key coordinate with a
 short-lived compute lease. The worker that acquires the lease performs the

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -28,6 +28,7 @@ from general_manager.cache.dependency_index import (
 )
 from general_manager.cache.dependency_publish import (
     CachePublishAborted,
+    PendingDependencyCachePublication,
     acquire_compute_lease,
     publish_dependency_cache_entry,
     release_compute_lease,
@@ -232,6 +233,7 @@ def cached(
                     )
                 lease = acquire_compute_lease(key)
 
+            lease_transferred_to_context = False
             try:
                 cached_hit = read_dependency_cache_hit(
                     cache_backend,
@@ -252,29 +254,47 @@ def cached(
                     for entry_key, entry_dependencies in entries:
                         record_fn(entry_key, set(entry_dependencies))
 
-                try:
-                    publish_dependency_cache_entry(
-                        cache_key=key,
-                        result=result,
-                        dependencies=dependencies,
-                        cache_backend=cache_backend,
-                        timeout=timeout,
-                        started_generation=started_generation,
-                        record_many_fn=(
-                            None if record_fn is record_dependencies else record_many
-                        ),
+                publish_context = current_calculation_run_context()
+                if publish_context is not None and record_fn is record_dependencies:
+                    publish_context.buffer_dependency_cache_publication(
+                        PendingDependencyCachePublication(
+                            cache_key=key,
+                            result=result,
+                            dependencies=frozenset(dependencies),
+                            cache_backend=cache_backend,
+                            timeout=timeout,
+                            started_generation=started_generation,
+                            lease=lease,
+                        )
                     )
-                except CachePublishAborted:
-                    logger.debug(
-                        "dependency cache publish aborted",
-                        context={
-                            "function": func.__qualname__,
-                            "key": key,
-                            "scope": scope,
-                        },
-                    )
+                    lease_transferred_to_context = True
+                else:
+                    try:
+                        publish_dependency_cache_entry(
+                            cache_key=key,
+                            result=result,
+                            dependencies=dependencies,
+                            cache_backend=cache_backend,
+                            timeout=timeout,
+                            started_generation=started_generation,
+                            record_many_fn=(
+                                None
+                                if record_fn is record_dependencies
+                                else record_many
+                            ),
+                        )
+                    except CachePublishAborted:
+                        logger.debug(
+                            "dependency cache publish aborted",
+                            context={
+                                "function": func.__qualname__,
+                                "key": key,
+                                "scope": scope,
+                            },
+                        )
             finally:
-                release_compute_lease(lease)
+                if not lease_transferred_to_context:
+                    release_compute_lease(lease)
 
             logger.debug(
                 "cache miss recorded",

--- a/src/general_manager/cache/dependency_cache.py
+++ b/src/general_manager/cache/dependency_cache.py
@@ -45,6 +45,16 @@ class DependencyCacheGetManyBackend(DependencyCacheBackend, Protocol):
         ...
 
 
+class DependencyCacheSetManyBackend(DependencyCacheBackend, Protocol):
+    def set_many(
+        self,
+        data: Mapping[str, Any],
+        timeout: int | None = None,
+    ) -> Any:
+        """Store cached values for many keys."""
+        ...
+
+
 def make_dependency_cache_entry(
     value: Any,
     dependencies: Iterable[Dependency],

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -124,6 +124,14 @@ def _set_dependency_data_change_count(count: int) -> int:
     return count
 
 
+def _discard_active_context_dependency_cache_state() -> None:
+    from general_manager.cache.run_context import current_calculation_run_context
+
+    context = current_calculation_run_context()
+    if context is not None:
+        context.discard_dependency_cache_state()
+
+
 def begin_dependency_data_change() -> int:
     """
     Mark a data change as active and bump the dependency generation.
@@ -136,9 +144,10 @@ def begin_dependency_data_change() -> int:
         generation = _set_dependency_generation(get_dependency_generation() + 1)
         _set_dependency_data_change_count(_get_dependency_data_change_count() + 1)
         cache.set(DATA_CHANGE_LOCK_KEY, "1", None)
-        return generation
     finally:
         release_lock()
+    _discard_active_context_dependency_cache_state()
+    return generation
 
 
 def end_dependency_data_change() -> None:

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -146,7 +146,14 @@ def begin_dependency_data_change() -> int:
         cache.set(DATA_CHANGE_LOCK_KEY, "1", None)
     finally:
         release_lock()
-    _discard_active_context_dependency_cache_state()
+    try:
+        _discard_active_context_dependency_cache_state()
+    except Exception:
+        try:
+            end_dependency_data_change()
+        except Exception:
+            logger.exception("dependency data-change cleanup rollback failed")
+        raise
     return generation
 
 

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -153,7 +153,10 @@ def _set_dependency_cache_entries(
             for entry in group_entries
         }
         if _supports_set_many(cache_backend):
-            cache_backend.set_many(payloads, timeout)
+            failed_keys = cache_backend.set_many(payloads, timeout) or ()
+            for key in failed_keys:
+                if key in payloads:
+                    cache_backend.set(key, payloads[key], timeout)
             continue
         for key, payload in payloads.items():
             cache_backend.set(key, payload, timeout)

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import time
 import uuid
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, TypeGuard
 
 from django.core.cache import cache as coordination_cache
 
 from general_manager.cache.dependency_cache import (
     DependencyCacheBackend,
+    DependencyCacheSetManyBackend,
     make_dependency_cache_entry,
     read_dependency_cache_hit,
 )
@@ -37,6 +39,19 @@ class CacheComputeLease:
 
     key: str
     token: str
+
+
+@dataclass(frozen=True)
+class PendingDependencyCachePublication:
+    """A dependency-cache miss waiting for guarded publication."""
+
+    cache_key: str
+    result: Any
+    dependencies: frozenset[Dependency]
+    cache_backend: DependencyCacheBackend
+    timeout: int | None
+    started_generation: int
+    lease: CacheComputeLease
 
 
 RecordManyDependenciesFn = Callable[[Iterable[tuple[str, Iterable[Dependency]]]], None]
@@ -109,6 +124,78 @@ def _ensure_publish_current(started_generation: int) -> None:
         raise CachePublishAborted()
     if get_dependency_generation() != started_generation:
         raise CachePublishAborted()
+
+
+def _supports_set_many(
+    cache_backend: DependencyCacheBackend,
+) -> TypeGuard[DependencyCacheSetManyBackend]:
+    return callable(getattr(cache_backend, "set_many", None))
+
+
+def _set_dependency_cache_entries(
+    entries: Iterable[PendingDependencyCachePublication],
+) -> None:
+    grouped: dict[
+        tuple[int, int | None],
+        list[PendingDependencyCachePublication],
+    ] = defaultdict(list)
+    for entry in entries:
+        grouped[(id(entry.cache_backend), entry.timeout)].append(entry)
+
+    for group_entries in grouped.values():
+        cache_backend = group_entries[0].cache_backend
+        timeout = group_entries[0].timeout
+        payloads = {
+            entry.cache_key: make_dependency_cache_entry(
+                entry.result,
+                entry.dependencies,
+            )
+            for entry in group_entries
+        }
+        if _supports_set_many(cache_backend):
+            cache_backend.set_many(payloads, timeout)
+            continue
+        for key, payload in payloads.items():
+            cache_backend.set(key, payload, timeout)
+
+
+def publish_dependency_cache_entries(
+    entries: Iterable[PendingDependencyCachePublication],
+) -> None:
+    """Publish dependency metadata and values for current entries in one batch."""
+    pending_entries = tuple(entries)
+    if not pending_entries:
+        return
+
+    acquire_lock_with_retry("publish_dependency_cache_entries")
+    try:
+        if is_dependency_data_change_active():
+            raise CachePublishAborted()
+
+        current_generation = get_dependency_generation()
+        publishable_entries = tuple(
+            entry
+            for entry in pending_entries
+            if entry.started_generation == current_generation
+        )
+        if not publishable_entries:
+            return
+
+        idx = get_full_index()
+        for entry in publishable_entries:
+            if entry.dependencies:
+                _record_dependencies_locked(
+                    idx,
+                    entry.cache_key,
+                    entry.dependencies,
+                )
+
+        _ensure_publish_current(current_generation)
+        set_full_index(idx)
+        _ensure_publish_current(current_generation)
+        _set_dependency_cache_entries(publishable_entries)
+    finally:
+        release_lock()
 
 
 def publish_dependency_cache_entry(

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -153,6 +153,13 @@ class CalculationRunContext:
         for entry in entries:
             release_compute_lease(entry.lease)
 
+    def discard_dependency_cache_state(self) -> None:
+        """Drop dependency-cache hits and buffered publications for this run."""
+        try:
+            self.discard_dependency_cache_publications()
+        finally:
+            self._dependency_cache_hits.clear()
+
     def discard_prefix(self, prefix: tuple[Hashable, ...]) -> None:
         """Discard tuple keys that start with the supplied prefix."""
         for key in list(self._values):

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -105,7 +105,13 @@ class CalculationRunContext:
     ) -> None:
         """Buffer a dependency-cache miss for guarded batch publication."""
         from general_manager.cache.dependency_cache import DependencyCacheHit
+        from general_manager.cache.dependency_publish import release_compute_lease
 
+        previous_entry = self._dependency_cache_pending_publications.get(
+            entry.cache_key
+        )
+        if previous_entry is not None and previous_entry.lease != entry.lease:
+            release_compute_lease(previous_entry.lease)
         self._dependency_cache_pending_publications[entry.cache_key] = entry
         self._dependency_cache_hits[entry.cache_key] = DependencyCacheHit(
             value=entry.result,

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -8,8 +8,13 @@ from contextvars import ContextVar, Token
 from types import TracebackType
 from typing import TYPE_CHECKING, Optional, TypeVar
 
+from general_manager.logging import get_logger
+
 if TYPE_CHECKING:
     from general_manager.cache.dependency_cache import DependencyCacheHit
+    from general_manager.cache.dependency_publish import (
+        PendingDependencyCachePublication,
+    )
 
 K = TypeVar("K", bound=Hashable)
 T = TypeVar("T")
@@ -19,14 +24,27 @@ _active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
     default=None,
 )
 ORM_BUCKET_RESULT_PREFIX = "orm_bucket_result"
+DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE = 1000
+logger = get_logger("cache.run_context")
 
 
 class CalculationRunContext:
     """Cache calculation work for one request, graph, bulk operation, or task."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        dependency_cache_publish_batch_size: int = (
+            DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE
+        ),
+    ) -> None:
         self._values: dict[Hashable, object] = {}
         self._dependency_cache_hits: dict[str, DependencyCacheHit] = {}
+        self._dependency_cache_pending_publications: dict[
+            str,
+            PendingDependencyCachePublication,
+        ] = {}
+        self._dependency_cache_publish_batch_size = dependency_cache_publish_batch_size
         self._token: Token[CalculationRunContext | None] | None = None
 
     def __enter__(self) -> "CalculationRunContext":
@@ -39,11 +57,18 @@ class CalculationRunContext:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        if self._token is not None:
-            _active_context.reset(self._token)
-            self._token = None
-        self._values.clear()
-        self._dependency_cache_hits.clear()
+        try:
+            if exc_type is None:
+                self.flush_dependency_cache_publications()
+            else:
+                self.discard_dependency_cache_publications()
+        finally:
+            if self._token is not None:
+                _active_context.reset(self._token)
+                self._token = None
+            self._values.clear()
+            self._dependency_cache_hits.clear()
+            self._dependency_cache_pending_publications.clear()
 
     def get_or_set(self, key: Hashable, loader: Callable[[], T]) -> T:
         """Return a cached value for key, loading it once per active context."""
@@ -73,6 +98,60 @@ class CalculationRunContext:
     ) -> DependencyCacheHit | object:
         """Return a prefetched dependency-cache hit, or default when absent."""
         return self._dependency_cache_hits.get(key, default)
+
+    def buffer_dependency_cache_publication(
+        self,
+        entry: PendingDependencyCachePublication,
+    ) -> None:
+        """Buffer a dependency-cache miss for guarded batch publication."""
+        from general_manager.cache.dependency_cache import DependencyCacheHit
+
+        self._dependency_cache_pending_publications[entry.cache_key] = entry
+        self._dependency_cache_hits[entry.cache_key] = DependencyCacheHit(
+            value=entry.result,
+            dependencies=entry.dependencies,
+        )
+        if (
+            len(self._dependency_cache_pending_publications)
+            >= self._dependency_cache_publish_batch_size
+        ):
+            self.flush_dependency_cache_publications()
+
+    def flush_dependency_cache_publications(self) -> None:
+        """Publish buffered dependency-cache misses and release their leases."""
+        entries = tuple(self._dependency_cache_pending_publications.values())
+        if not entries:
+            return
+        self._dependency_cache_pending_publications.clear()
+
+        from general_manager.cache.dependency_publish import (
+            CachePublishAborted,
+            publish_dependency_cache_entries,
+            release_compute_lease,
+        )
+
+        try:
+            publish_dependency_cache_entries(entries)
+        except CachePublishAborted:
+            logger.debug(
+                "dependency cache batch publish aborted",
+                context={"entry_count": len(entries)},
+            )
+        finally:
+            for entry in entries:
+                release_compute_lease(entry.lease)
+
+    def discard_dependency_cache_publications(self) -> None:
+        """Drop buffered dependency-cache misses and release their leases."""
+        entries = tuple(self._dependency_cache_pending_publications.values())
+        if not entries:
+            return
+        self._dependency_cache_pending_publications.clear()
+
+        from general_manager.cache.dependency_publish import release_compute_lease
+
+        for entry in entries:
+            release_compute_lease(entry.lease)
 
     def discard_prefix(self, prefix: tuple[Hashable, ...]) -> None:
         """Discard tuple keys that start with the supplied prefix."""

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -450,6 +450,35 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self.assertNotIn(key, self.fake_cache.store)
         self.assertNotIn(f"{key}:deps", self.fake_cache.store)
 
+    def test_dependency_scope_discards_buffered_run_hit_after_data_change(self):
+        calls = 0
+        state = {"value": 3}
+
+        @cached(scope="dependency", cache_backend=self.fake_cache)
+        def fn():
+            nonlocal calls
+            calls += 1
+            DependencyTracker.track("User", "identification", str(state["value"]))
+            return state["value"] * 2
+
+        key = make_cache_key(fn, (), {})
+
+        with CalculationRunContext():
+            self.assertEqual(fn(), 6)
+            begin_dependency_data_change()
+            try:
+                state["value"] = 4
+            finally:
+                end_dependency_data_change()
+
+            with DependencyTracker() as tracked_dependencies:
+                self.assertEqual(fn(), 8)
+
+        expected_dependencies = {("User", "identification", "4")}
+        self.assertEqual(calls, 2)
+        self.assertEqual(tracked_dependencies, expected_dependencies)
+        self.assert_dependency_cache_hit(key, 8, expected_dependencies)
+
     def test_dependency_scope_custom_record_fn_uses_immediate_publication(self):
         calls = 0
 

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -474,6 +474,35 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self.assertEqual(calls, 1)
         self.assertEqual(self.record_calls, [(key, expected_dependencies)])
 
+    def test_dependency_scope_batches_multiple_run_misses_under_one_index_write(self):
+        calls = 0
+
+        @cached(scope="dependency", cache_backend=self.fake_cache)
+        def fn(value):
+            nonlocal calls
+            calls += 1
+            DependencyTracker.track("User", "identification", str(value))
+            return value * 2
+
+        with mock.patch(
+            "general_manager.cache.dependency_index.acquire_lock",
+            return_value=True,
+        ) as acquire_lock:
+            with CalculationRunContext():
+                self.assertEqual(fn(1), 2)
+                self.assertEqual(fn(2), 4)
+                self.assertEqual(fn(3), 6)
+
+        self.assertEqual(calls, 3)
+        self.assertEqual(acquire_lock.call_count, 1)
+        for value in (1, 2, 3):
+            key = make_cache_key(fn, (value,), {})
+            self.assert_dependency_cache_hit(
+                key,
+                value * 2,
+                {("User", "identification", str(value))},
+            )
+
     def test_dependency_scope_does_not_cache_when_generation_changes_during_compute(
         self,
     ):

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -405,6 +405,75 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self.assertNotIn(f"{key}:deps", self.fake_cache.store)
         self.assertEqual(self.record_calls, [])
 
+    def test_dependency_scope_reuses_buffered_miss_inside_run_context(self):
+        calls = 0
+
+        @cached(scope="dependency", cache_backend=self.fake_cache)
+        def fn(value):
+            nonlocal calls
+            calls += 1
+            DependencyTracker.track("User", "identification", str(value))
+            return value * 2
+
+        key = make_cache_key(fn, (3,), {})
+        expected_dependencies = {("User", "identification", "3")}
+
+        with CalculationRunContext():
+            self.assertEqual(fn(3), 6)
+            with DependencyTracker() as tracked_dependencies:
+                self.assertEqual(fn(3), 6)
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(tracked_dependencies, expected_dependencies)
+        self.assert_dependency_cache_hit(key, 6, expected_dependencies)
+
+    def test_dependency_scope_batch_abort_returns_result_without_cache_write(self):
+        calls = 0
+
+        @cached(scope="dependency", cache_backend=self.fake_cache)
+        def fn(value):
+            nonlocal calls
+            calls += 1
+            DependencyTracker.track("User", "identification", str(value))
+            return value * 2
+
+        key = make_cache_key(fn, (3,), {})
+
+        try:
+            with CalculationRunContext():
+                self.assertEqual(fn(3), 6)
+                begin_dependency_data_change()
+        finally:
+            end_dependency_data_change()
+
+        self.assertEqual(calls, 1)
+        self.assertNotIn(key, self.fake_cache.store)
+        self.assertNotIn(f"{key}:deps", self.fake_cache.store)
+
+    def test_dependency_scope_custom_record_fn_uses_immediate_publication(self):
+        calls = 0
+
+        @cached(
+            scope="dependency",
+            cache_backend=self.fake_cache,
+            record_fn=self.record_fn,
+        )
+        def fn(value):
+            nonlocal calls
+            calls += 1
+            DependencyTracker.track("User", "identification", str(value))
+            return value * 2
+
+        key = make_cache_key(fn, (3,), {})
+        expected_dependencies = {("User", "identification", "3")}
+
+        with CalculationRunContext():
+            self.assertEqual(fn(3), 6)
+            self.assert_dependency_cache_hit(key, 6, expected_dependencies)
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(self.record_calls, [(key, expected_dependencies)])
+
     def test_dependency_scope_does_not_cache_when_generation_changes_during_compute(
         self,
     ):

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -1,8 +1,51 @@
+from unittest import mock
+
+import pytest
+
 from general_manager.cache.dependency_cache import DependencyCacheHit
+from general_manager.cache.dependency_publish import (
+    CacheComputeLease,
+    PendingDependencyCachePublication,
+)
 from general_manager.cache.run_context import (
     CalculationRunContext,
     current_calculation_run_context,
 )
+
+
+class DummyDependencyCacheBackend:
+    def get(self, key: str, default: object = None) -> object:
+        return default
+
+    def set(self, key: str, value: object, timeout: int | None = None) -> None:
+        return None
+
+
+def make_pending_publication(cache_key: str) -> PendingDependencyCachePublication:
+    return PendingDependencyCachePublication(
+        cache_key=cache_key,
+        result=f"value:{cache_key}",
+        dependencies=frozenset({("Project", "identification", cache_key)}),
+        cache_backend=DummyDependencyCacheBackend(),
+        timeout=None,
+        started_generation=0,
+        lease=CacheComputeLease(
+            key=f"dependency_cache_compute_lock:{cache_key}",
+            token=f"token:{cache_key}",
+        ),
+    )
+
+
+class CalculationFailed(RuntimeError):
+    """Test exception used to exercise context cleanup."""
+
+
+def raise_after_buffering(
+    context: CalculationRunContext,
+    entry: PendingDependencyCachePublication,
+) -> None:
+    context.buffer_dependency_cache_publication(entry)
+    raise CalculationFailed
 
 
 def test_context_is_active_only_inside_with_block() -> None:
@@ -65,6 +108,89 @@ def test_dependency_cache_prefetch_hits_are_cleared_on_exit() -> None:
         assert context.get_dependency_cache_hit("cache-key") == hit
 
     assert context.get_dependency_cache_hit("cache-key", None) is None
+
+
+def test_buffered_dependency_cache_publication_is_visible_as_run_hit() -> None:
+    entry = make_pending_publication("cache-a")
+
+    with (
+        mock.patch(
+            "general_manager.cache.dependency_publish.publish_dependency_cache_entries"
+        ),
+        mock.patch("general_manager.cache.dependency_publish.release_compute_lease"),
+        CalculationRunContext() as context,
+    ):
+        context.buffer_dependency_cache_publication(entry)
+
+        hit = context.get_dependency_cache_hit("cache-a")
+
+    assert isinstance(hit, DependencyCacheHit)
+    assert hit.value == "value:cache-a"
+    assert hit.dependencies == frozenset({("Project", "identification", "cache-a")})
+
+
+def test_dependency_cache_publications_flush_on_clean_exit() -> None:
+    entry = make_pending_publication("cache-a")
+
+    with (
+        mock.patch(
+            "general_manager.cache.dependency_publish.publish_dependency_cache_entries"
+        ) as publish_batch,
+        mock.patch(
+            "general_manager.cache.dependency_publish.release_compute_lease"
+        ) as release_lease,
+    ):
+        with CalculationRunContext() as context:
+            context.buffer_dependency_cache_publication(entry)
+
+    publish_batch.assert_called_once_with((entry,))
+    release_lease.assert_called_once_with(entry.lease)
+
+
+def test_dependency_cache_publications_discard_on_exception_and_release_leases() -> (
+    None
+):
+    entry = make_pending_publication("cache-a")
+
+    with (
+        mock.patch(
+            "general_manager.cache.dependency_publish.publish_dependency_cache_entries"
+        ) as publish_batch,
+        mock.patch(
+            "general_manager.cache.dependency_publish.release_compute_lease"
+        ) as release_lease,
+    ):
+        with pytest.raises(CalculationFailed):
+            with CalculationRunContext() as context:
+                raise_after_buffering(context, entry)
+
+    publish_batch.assert_not_called()
+    release_lease.assert_called_once_with(entry.lease)
+
+
+def test_dependency_cache_publication_guardrail_flushes_when_limit_is_reached() -> None:
+    first = make_pending_publication("cache-a")
+    second = make_pending_publication("cache-b")
+
+    with (
+        mock.patch(
+            "general_manager.cache.dependency_publish.publish_dependency_cache_entries"
+        ) as publish_batch,
+        mock.patch(
+            "general_manager.cache.dependency_publish.release_compute_lease"
+        ) as release_lease,
+    ):
+        with CalculationRunContext(dependency_cache_publish_batch_size=2) as context:
+            context.buffer_dependency_cache_publication(first)
+            publish_batch.assert_not_called()
+
+            context.buffer_dependency_cache_publication(second)
+
+            publish_batch.assert_called_once_with((first, second))
+            assert release_lease.call_args_list == [
+                mock.call(first.lease),
+                mock.call(second.lease),
+            ]
 
 
 def test_discard_prefix_removes_matching_tuple_keys_only() -> None:

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -168,6 +168,41 @@ def test_dependency_cache_publications_discard_on_exception_and_release_leases()
     release_lease.assert_called_once_with(entry.lease)
 
 
+def test_replacing_buffered_dependency_cache_publication_releases_prior_lease() -> None:
+    first = make_pending_publication("cache-a")
+    second = PendingDependencyCachePublication(
+        cache_key=first.cache_key,
+        result="value:cache-a:second",
+        dependencies=first.dependencies,
+        cache_backend=first.cache_backend,
+        timeout=first.timeout,
+        started_generation=first.started_generation,
+        lease=CacheComputeLease(
+            key=first.lease.key,
+            token=f"lease:{first.cache_key}:second",
+        ),
+    )
+
+    with (
+        mock.patch(
+            "general_manager.cache.dependency_publish.publish_dependency_cache_entries"
+        ),
+        mock.patch(
+            "general_manager.cache.dependency_publish.release_compute_lease"
+        ) as release_lease,
+    ):
+        with CalculationRunContext() as context:
+            context.buffer_dependency_cache_publication(first)
+            context.buffer_dependency_cache_publication(second)
+
+            release_lease.assert_called_once_with(first.lease)
+
+    assert release_lease.call_args_list == [
+        mock.call(first.lease),
+        mock.call(second.lease),
+    ]
+
+
 def test_dependency_cache_publication_guardrail_flushes_when_limit_is_reached() -> None:
     first = make_pending_publication("cache-a")
     second = make_pending_publication("cache-b")

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -147,6 +147,20 @@ class TestDependencyGenerationAndBarrier(TestCase):
         self.assertTrue(is_dependency_data_change_active())
         self.assertEqual(cache.get(DATA_CHANGE_LOCK_KEY), "1")
 
+    @patch(
+        "general_manager.cache.dependency_index._discard_active_context_dependency_cache_state",
+        side_effect=RuntimeError("run-context cleanup"),
+    )
+    def test_begin_data_change_releases_barrier_when_context_cleanup_fails(
+        self, mock_discard_active_context_state
+    ):
+        with self.assertRaisesRegex(RuntimeError, "^run-context cleanup$"):
+            begin_dependency_data_change()
+
+        mock_discard_active_context_state.assert_called_once_with()
+        self.assertFalse(is_dependency_data_change_active())
+        self.assertEqual(cache.get(DATA_CHANGE_COUNT_KEY), 0)
+
     def test_end_data_change_releases_barrier_without_changing_generation(self):
         begin_dependency_data_change()
 

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 import pickle
 from typing import Any
 from unittest import mock
 
 from django.test import SimpleTestCase, override_settings
 
+from general_manager.cache import dependency_publish
 from general_manager.cache.dependency_cache import (
     DependencyCacheEntry,
     DependencyCacheHit,
@@ -18,8 +20,10 @@ from general_manager.cache.dependency_index import (
 from general_manager.cache.dependency_publish import (
     CacheComputeLease,
     CachePublishAborted,
+    PendingDependencyCachePublication,
     acquire_compute_lease,
     coordination_cache,
+    publish_dependency_cache_entries,
     publish_dependency_cache_entry,
     release_compute_lease,
     wait_for_cached_dependency_hit,
@@ -53,6 +57,22 @@ class FakeDependencyCacheBackend:
         self.set_order.append(key)
 
 
+class FakeDependencyCacheSetManyBackend(FakeDependencyCacheBackend):
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_many_calls: list[tuple[dict[str, Any], int | None]] = []
+
+    def set_many(
+        self,
+        data: Mapping[str, Any],
+        timeout: int | None = None,
+    ) -> None:
+        payloads = dict(data)
+        self.set_many_calls.append((payloads, timeout))
+        for key, value in payloads.items():
+            self.set(key, value, timeout)
+
+
 @override_settings(CACHES=TEST_CACHES)
 class TestDependencyPublish(SimpleTestCase):
     def setUp(self) -> None:
@@ -60,6 +80,32 @@ class TestDependencyPublish(SimpleTestCase):
 
     def tearDown(self) -> None:
         coordination_cache.clear()
+
+    def make_pending_publication(
+        self,
+        *,
+        cache_key: str,
+        result: Any,
+        dependencies: set[tuple[str, str, str]],
+        cache_backend: FakeDependencyCacheBackend,
+        started_generation: int | None = None,
+    ) -> PendingDependencyCachePublication:
+        return PendingDependencyCachePublication(
+            cache_key=cache_key,
+            result=result,
+            dependencies=frozenset(dependencies),
+            cache_backend=cache_backend,
+            timeout=None,
+            started_generation=(
+                get_dependency_generation()
+                if started_generation is None
+                else started_generation
+            ),
+            lease=CacheComputeLease(
+                key=_compute_lock_key(cache_key),
+                token=f"lease-{cache_key}",
+            ),
+        )
 
     def test_acquire_compute_lease_allows_one_active_lease_per_key(self) -> None:
         lease = acquire_compute_lease("cache-a")
@@ -136,6 +182,135 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertEqual(payload.dependencies, frozenset(dependencies))
         self.assertEqual(cache_backend.timeouts[cache_key], 30)
         self.assertNotIn(f"{cache_key}:deps", cache_backend.store)
+
+    def test_batch_publish_records_index_once_before_bulk_value_write(self) -> None:
+        cache_backend = FakeDependencyCacheSetManyBackend()
+        events: list[str] = []
+        original_set_full_index = dependency_publish.set_full_index
+
+        def record_set_full_index(idx: Any) -> None:
+            events.append("index")
+            original_set_full_index(idx)
+
+        original_set_many = cache_backend.set_many
+
+        def record_set_many(
+            data: Mapping[str, Any],
+            timeout: int | None = None,
+        ) -> None:
+            events.append("set_many")
+            original_set_many(data, timeout)
+
+        cache_backend.set_many = record_set_many  # type: ignore[method-assign]
+
+        with mock.patch(
+            "general_manager.cache.dependency_publish.set_full_index",
+            side_effect=record_set_full_index,
+        ):
+            publish_dependency_cache_entries(
+                [
+                    self.make_pending_publication(
+                        cache_key="cache-a",
+                        result="alpha",
+                        dependencies={("Project", "identification", "1")},
+                        cache_backend=cache_backend,
+                    ),
+                    self.make_pending_publication(
+                        cache_key="cache-b",
+                        result="bravo",
+                        dependencies={("Project", "identification", "2")},
+                        cache_backend=cache_backend,
+                    ),
+                ]
+            )
+
+        self.assertEqual(events, ["index", "set_many"])
+        self.assertEqual(len(cache_backend.set_many_calls), 1)
+        self.assertEqual(
+            set(cache_backend.set_many_calls[0][0]), {"cache-a", "cache-b"}
+        )
+        self.assertEqual(
+            cache_backend.get("cache-a").value,
+            "alpha",
+        )
+        self.assertEqual(
+            cache_backend.get("cache-b").dependencies,
+            frozenset({("Project", "identification", "2")}),
+        )
+
+    def test_batch_publish_falls_back_to_per_key_set_without_set_many(self) -> None:
+        cache_backend = FakeDependencyCacheBackend()
+
+        publish_dependency_cache_entries(
+            [
+                self.make_pending_publication(
+                    cache_key="cache-a",
+                    result="alpha",
+                    dependencies={("Project", "identification", "1")},
+                    cache_backend=cache_backend,
+                ),
+                self.make_pending_publication(
+                    cache_key="cache-b",
+                    result="bravo",
+                    dependencies={("Project", "identification", "2")},
+                    cache_backend=cache_backend,
+                ),
+            ]
+        )
+
+        self.assertEqual(cache_backend.set_order, ["cache-a", "cache-b"])
+        self.assertEqual(cache_backend.get("cache-a").value, "alpha")
+        self.assertEqual(cache_backend.get("cache-b").value, "bravo")
+
+    def test_batch_publish_skips_entries_from_stale_generations(self) -> None:
+        cache_backend = FakeDependencyCacheSetManyBackend()
+        stale_generation = get_dependency_generation()
+        begin_dependency_data_change()
+        end_dependency_data_change()
+        current_generation = get_dependency_generation()
+
+        publish_dependency_cache_entries(
+            [
+                self.make_pending_publication(
+                    cache_key="cache-stale",
+                    result="old",
+                    dependencies={("Project", "identification", "1")},
+                    cache_backend=cache_backend,
+                    started_generation=stale_generation,
+                ),
+                self.make_pending_publication(
+                    cache_key="cache-current",
+                    result="new",
+                    dependencies={("Project", "identification", "2")},
+                    cache_backend=cache_backend,
+                    started_generation=current_generation,
+                ),
+            ]
+        )
+
+        self.assertIsNone(cache_backend.get("cache-stale"))
+        self.assertEqual(cache_backend.get("cache-current").value, "new")
+
+    def test_batch_publish_aborts_without_writes_when_data_change_active(self) -> None:
+        cache_backend = FakeDependencyCacheSetManyBackend()
+        begin_dependency_data_change()
+        try:
+            with self.assertRaises(CachePublishAborted):
+                publish_dependency_cache_entries(
+                    [
+                        self.make_pending_publication(
+                            cache_key="cache-a",
+                            result="blocked",
+                            dependencies={("Project", "identification", "1")},
+                            cache_backend=cache_backend,
+                        )
+                    ]
+                )
+        finally:
+            end_dependency_data_change()
+
+        self.assertEqual(cache_backend.store, {})
+        self.assertEqual(cache_backend.set_many_calls, [])
 
     def test_publish_aborts_without_writes_when_generation_changed(self) -> None:
         cache_backend = FakeDependencyCacheBackend()

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -73,6 +73,25 @@ class FakeDependencyCacheSetManyBackend(FakeDependencyCacheBackend):
             self.set(key, value, timeout)
 
 
+class FakeDependencyCachePartialSetManyBackend(FakeDependencyCacheBackend):
+    def __init__(self, failed_keys: set[str]) -> None:
+        super().__init__()
+        self.failed_keys = failed_keys
+        self.set_many_calls: list[tuple[dict[str, Any], int | None]] = []
+
+    def set_many(
+        self,
+        data: Mapping[str, Any],
+        timeout: int | None = None,
+    ) -> list[str]:
+        payloads = dict(data)
+        self.set_many_calls.append((payloads, timeout))
+        for key, value in payloads.items():
+            if key not in self.failed_keys:
+                self.set(key, value, timeout)
+        return sorted(self.failed_keys & payloads.keys())
+
+
 @override_settings(CACHES=TEST_CACHES)
 class TestDependencyPublish(SimpleTestCase):
     def setUp(self) -> None:
@@ -258,6 +277,31 @@ class TestDependencyPublish(SimpleTestCase):
             ]
         )
 
+        self.assertEqual(cache_backend.set_order, ["cache-a", "cache-b"])
+        self.assertEqual(cache_backend.get("cache-a").value, "alpha")
+        self.assertEqual(cache_backend.get("cache-b").value, "bravo")
+
+    def test_batch_publish_retries_set_many_failures_individually(self) -> None:
+        cache_backend = FakeDependencyCachePartialSetManyBackend({"cache-b"})
+
+        publish_dependency_cache_entries(
+            [
+                self.make_pending_publication(
+                    cache_key="cache-a",
+                    result="alpha",
+                    dependencies={("Project", "identification", "1")},
+                    cache_backend=cache_backend,
+                ),
+                self.make_pending_publication(
+                    cache_key="cache-b",
+                    result="bravo",
+                    dependencies={("Project", "identification", "2")},
+                    cache_backend=cache_backend,
+                ),
+            ]
+        )
+
+        self.assertEqual(len(cache_backend.set_many_calls), 1)
         self.assertEqual(cache_backend.set_order, ["cache-a", "cache-b"])
         self.assertEqual(cache_backend.get("cache-a").value, "alpha")
         self.assertEqual(cache_backend.get("cache-b").value, "bravo")


### PR DESCRIPTION
## Summary
- add guarded batch dependency-cache publication with `set_many` support and safe fallback writes
- buffer dependency-cache misses in `CalculationRunContext`, expose them as same-run hits, and release compute leases on flush/discard
- defer default dependency-cache publication inside active calculation runs while preserving immediate custom `record_fn` behavior
- document batched dependency-cache publication semantics

Fixes #276.

## Test Plan
- `python -m pytest tests/unit/test_dependency_publish.py tests/unit/test_calculation_run_context.py tests/unit/test_cache_decorator.py tests/unit/test_dependency_cache.py tests/unit/test_dependency_index.py -q`
- `python -m pytest tests/integration/test_caching.py tests/integration/test_request_caching.py tests/integration/test_graphql_dependency_cache_prefetch.py -q`
- `ruff check src tests`
- `ruff format --check src/general_manager/cache tests/unit/test_dependency_publish.py tests/unit/test_calculation_run_context.py tests/unit/test_cache_decorator.py`
- `mypy src`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added buffered, dependency-scoped cache publishing within calculation runs, including batch flush/guardrails for more efficient cache misses.
  * Introduced bulk dependency-cache writes (when supported by the backend) to reduce per-entry publish overhead.
* **Bug Fixes**
  * Improved correctness of lease handling and cache publication behavior during flush, discard, and dependency-data-change aborts.
* **Tests**
  * Added unit tests covering buffering visibility, batch flush/discard behavior, replacement, and bulk publish fallback/partial failures.
* **Documentation**
  * Expanded caching documentation with clearer guarded publication and visibility timing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->