### PR TITLE
feat: align cached decorator cache option

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -32,9 +32,9 @@ Every data-changing operation emits signals captured by the dependency tracker (
 
 To take advantage of the tracker:
 
-- Wrap expensive resolvers with `@cached(scope="dependency")` or `@graph_ql_property(cache="dependency")` when they should persist across runs and invalidate through the dependency index.
-- Use `@cached(scope="timeout", timeout=seconds)` when time-based expiry is enough and dependency tracking would add unnecessary overhead.
-- Use the default `@cached()` or `@graph_ql_property` run scope for helpers that only need reuse within one request, calculation graph, bulk operation, or background run.
+- Wrap expensive resolvers with `@cached(cache="dependency")` or `@graph_ql_property(cache="dependency")` when they should persist across runs and invalidate through the dependency index.
+- Use `@cached(cache="timeout", timeout=seconds)` when time-based expiry is enough and dependency tracking would add unnecessary overhead.
+- Use the default `@cached` or `@graph_ql_property` run cache for helpers that only need reuse within one request, calculation graph, bulk operation, or background run.
 - Mark inputs and outputs clearly so dependencies can be resolved.
 - Configure a shared cache backend when you run multiple worker processes.
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -81,7 +81,7 @@ background run:
 ```python
 from general_manager.cache.cache_decorator import cached
 
-@cached()
+@cached
 def project_forecast(project_id: int) -> dict[str, float]:
     project = Project(id=project_id)
     return {
@@ -90,14 +90,14 @@ def project_forecast(project_id: int) -> dict[str, float]:
     }
 ```
 
-The default `scope="run"` stores values in `CalculationRunContext`. Values are
+The default `cache="run"` stores values in `CalculationRunContext`. Values are
 discarded when the run ends and do not participate in dependency invalidation.
 
-Use dependency scope when a value should be reused across runs and invalidated
+Use dependency caching when a value should be reused across runs and invalidated
 when tracked managers change:
 
 ```python
-@cached(scope="dependency")
+@cached(cache="dependency")
 def project_forecast(project_id: int) -> dict[str, float]:
     ...
 ```
@@ -129,17 +129,17 @@ appear and then reuse it instead of repeating the same CPU work. If the
 computing worker fails before publishing, the lease expires and a later worker
 can retry the computation.
 
-Use timeout scope when a value should be cached in the configured cache backend
+Use timeout caching when a value should be cached in the configured cache backend
 for a fixed duration without dependency tracking:
 
 ```python
-@cached(scope="timeout", timeout=300)  # Cache for 5 minutes
+@cached(cache="timeout", timeout=300)  # Cache for 5 minutes
 def project_forecast(project_id: int) -> dict[str, float]:
     ...
 ```
 
-`timeout` is required for `scope="timeout"` and is not accepted on the other
-scopes. The cache entry expires after the given duration and is not invalidated
+`timeout` is required for `cache="timeout"` and is not accepted on the other
+cache modes. The cache entry expires after the given duration and is not invalidated
 through the dependency index.
 
 ## Run context storage

--- a/docs/concepts/interfaces/dependency_graph.md
+++ b/docs/concepts/interfaces/dependency_graph.md
@@ -8,9 +8,9 @@ CRUD operations on `GeneralManager` instances emit the `data_change` signal defi
 
 ## Recording dependencies
 
-When an interface resolves related data (for example, fetching a bucket of child managers), it calls `DependencyTracker.track()`. Cached functions using `@cached(scope="dependency")` persist these dependencies so that mutations can invalidate the correct cache entries.
+When an interface resolves related data (for example, fetching a bucket of child managers), it calls `DependencyTracker.track()`. Cached functions using `@cached(cache="dependency")` persist these dependencies so that mutations can invalidate the correct cache entries.
 
-Run-scoped `@cached()` and `@graph_ql_property` caching is separate from the dependency index. Values stored in `CalculationRunContext` are discarded at the end of the request or run, so they do not need invalidation and do not appear in the dependency index. Dependency-aware properties opt in with `@graph_ql_property(cache="dependency")`.
+Run-cached `@cached` and `@graph_ql_property` caching is separate from the dependency index. Values stored in `CalculationRunContext` are discarded at the end of the request or run, so they do not need invalidation and do not appear in the dependency index. Dependency-aware properties opt in with `@graph_ql_property(cache="dependency")`.
 
 ## Graph traversal
 

--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -95,7 +95,7 @@ class GraphQLProperty(property):
         selected_cache = self.cache
         if selected_cache == "none":
             return self._raw_fget
-        return cached(scope=cast(Literal["dependency", "run"], selected_cache))(
+        return cached(cache=cast(Literal["dependency", "run"], selected_cache))(
             self._raw_fget
         )
 

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -11,6 +11,7 @@ from typing import (
     Set,
     TypeVar,
     cast,
+    overload,
 )
 
 from django.core.cache import cache as django_cache
@@ -88,102 +89,122 @@ class UnsupportedCacheScopeError(ValueError):
 
 
 class CacheTimeoutConfigurationError(ValueError):
-    """Raised when timeout is used with an incompatible cache scope."""
+    """Raised when timeout is used with an incompatible cache setting."""
 
     @classmethod
     def missing_timeout(cls) -> "CacheTimeoutConfigurationError":
-        return cls('scope="timeout" requires timeout')
+        return cls('cache="timeout" requires timeout')
 
     @classmethod
     def unexpected_timeout(cls) -> "CacheTimeoutConfigurationError":
-        return cls('timeout is only supported with scope="timeout"')
+        return cls('timeout is only supported with cache="timeout"')
 
 
+@overload
+def cached(func: FuncT) -> FuncT: ...
+@overload
 def cached(
+    func: None = None,
     timeout: Optional[int] = None,
     cache_backend: CacheBackend = django_cache,
     record_fn: RecordFn = record_dependencies,
     *,
-    scope: CacheScope = "run",
-) -> Callable[[FuncT], FuncT]:
+    cache: CacheScope = "run",
+) -> Callable[[FuncT], FuncT]: ...
+
+
+def cached(
+    func: FuncT | None = None,
+    timeout: Optional[int] = None,
+    cache_backend: CacheBackend = django_cache,
+    record_fn: RecordFn = record_dependencies,
+    *,
+    cache: CacheScope = "run",
+) -> FuncT | Callable[[FuncT], FuncT]:
     """
-    Decorator factory for caching a function call.
+    Decorator for caching a function call.
 
     By default, cached values are scoped to the active
     :class:`~general_manager.cache.run_context.CalculationRunContext` and are
-    discarded when that run ends. Use ``scope="dependency"`` to persist values
+    discarded when that run ends. Use ``cache="dependency"`` to persist values
     in ``cache_backend`` and use ``record_fn`` to persist dependency metadata
-    for invalidation. Use ``scope="timeout"`` with ``timeout`` set for
+    for invalidation. Use ``cache="timeout"`` with ``timeout`` set for
     cache-backend storage with time-based expiry; dependency recording is
-    ignored for timeout-scoped values.
+    ignored for timeout-cached values.
 
     Parameters:
-        timeout (int | None): Expiration in seconds for timeout-scoped cached values.
-            Required when ``scope`` is ``"timeout"`` and invalid with any other
+        func (Callable[..., object] | None): Function being decorated when used
+            as ``@cached``. Leave unset when using ``@cached(...)``.
+        timeout (int | None): Expiration in seconds for timeout-cached values.
+            Required when ``cache`` is ``"timeout"`` and invalid with any other
             ``CacheScope``.
         cache_backend (CacheBackend): Backend used to read and write cached results.
         record_fn (RecordFn): Callback invoked to persist dependency metadata when
-            ``scope`` is ``"dependency"``. Defaults to
+            ``cache`` is ``"dependency"``. Defaults to
             :func:`~general_manager.cache.dependency_index.record_dependencies`.
-        scope (CacheScope): Cache storage strategy. ``"run"`` memoizes for the active run,
+        cache (CacheScope): Cache storage strategy. ``"run"`` memoizes for the active run,
             ``"dependency"`` stores in ``cache_backend`` with dependency tracking,
             ``"timeout"`` stores in ``cache_backend`` with time-based expiry, and
             ``"none"`` disables caching.
 
     Returns:
-        Callable: Decorator that wraps the target function with caching behaviour.
+        Callable: Decorated function or decorator that wraps the target function
+            with caching behaviour.
 
     Raises:
-        ValueError: Raised for invalid ``scope``/``timeout`` combinations, including
+        ValueError: Raised for invalid ``cache``/``timeout`` combinations, including
             unsupported ``CacheScope`` values, missing ``timeout`` for
-            ``scope="timeout"``, and ``timeout`` supplied for non-timeout scopes.
+            ``cache="timeout"``, and ``timeout`` supplied for non-timeout cache modes.
         DependencyLockTimeoutError: Propagated from ``record_fn`` (i.e.
             :func:`~general_manager.cache.dependency_index.record_dependencies`) when the
-            dependency-index lock cannot be acquired within the configured timeout.  The cached
+            dependency-index lock cannot be acquired within the configured timeout. The cached
             value has already been stored at that point; only the dependency metadata is lost.
     """
-    if scope not in {"dependency", "run", "timeout", "none"}:
-        raise UnsupportedCacheScopeError(scope)
-    if scope == "timeout" and timeout is None:
+    if cache not in {"dependency", "run", "timeout", "none"}:
+        raise UnsupportedCacheScopeError(cache)
+    if cache == "timeout" and timeout is None:
         raise CacheTimeoutConfigurationError.missing_timeout()
-    if timeout is not None and scope != "timeout":
+    if timeout is not None and cache != "timeout":
         raise CacheTimeoutConfigurationError.unexpected_timeout()
 
-    def decorator(func: FuncT) -> FuncT:
-        @wraps(func)
+    def decorator(decorated_func: FuncT) -> FuncT:
+        @wraps(decorated_func)
         def wrapper(*args: object, **kwargs: object) -> object:
-            if scope == "none":
-                return func(*args, **kwargs)
+            if cache == "none":
+                return decorated_func(*args, **kwargs)
 
-            if scope == "run":
-                key = make_cache_key(func, args, kwargs)
+            if cache == "run":
+                key = make_cache_key(decorated_func, args, kwargs)
                 with ensure_calculation_run_context() as context:
-                    return context.get_or_set(key, lambda: func(*args, **kwargs))
+                    return context.get_or_set(
+                        key,
+                        lambda: decorated_func(*args, **kwargs),
+                    )
 
-            key = make_cache_key(func, args, kwargs)
+            key = make_cache_key(decorated_func, args, kwargs)
 
-            if scope == "timeout":
+            if cache == "timeout":
                 cached_result = cache_backend.get(key, _SENTINEL)
                 if cached_result is not _SENTINEL:
                     logger.debug(
                         "cache hit",
                         context={
-                            "function": func.__qualname__,
+                            "function": decorated_func.__qualname__,
                             "key": key,
-                            "scope": scope,
+                            "cache": cache,
                         },
                     )
                     return cached_result
 
-                result = func(*args, **kwargs)
+                result = decorated_func(*args, **kwargs)
                 cache_backend.set(key, result, timeout)
                 logger.debug(
                     "cache miss stored",
                     context={
-                        "function": func.__qualname__,
+                        "function": decorated_func.__qualname__,
                         "key": key,
                         "timeout": timeout,
-                        "scope": scope,
+                        "cache": cache,
                     },
                 )
                 return result
@@ -193,9 +214,9 @@ def cached(
                 logger.debug(
                     message,
                     context={
-                        "function": func.__qualname__,
+                        "function": decorated_func.__qualname__,
                         "key": key,
-                        "scope": scope,
+                        "cache": cache,
                     },
                 )
                 return hit.value
@@ -245,7 +266,7 @@ def cached(
 
                 started_generation = get_dependency_generation()
                 with DependencyTracker() as dependencies:
-                    result = func(*args, **kwargs)
+                    result = decorated_func(*args, **kwargs)
                     ModelDependencyCollector.add_args(dependencies, args, kwargs)
 
                 def record_many(
@@ -287,9 +308,9 @@ def cached(
                         logger.debug(
                             "dependency cache publish aborted",
                             context={
-                                "function": func.__qualname__,
+                                "function": decorated_func.__qualname__,
                                 "key": key,
-                                "scope": scope,
+                                "cache": cache,
                             },
                         )
             finally:
@@ -299,7 +320,7 @@ def cached(
             logger.debug(
                 "cache miss recorded",
                 context={
-                    "function": func.__qualname__,
+                    "function": decorated_func.__qualname__,
                     "key": key,
                     "dependency_count": len(dependencies),
                     "timeout": timeout,
@@ -308,8 +329,10 @@ def cached(
             return result
 
         # fix for python 3.14:
-        wrapper.__annotations__ = func.__annotations__
+        wrapper.__annotations__ = decorated_func.__annotations__
 
         return cast(FuncT, wrapper)
 
-    return decorator
+    if func is None:
+        return decorator
+    return decorator(func)

--- a/tests/integration/test_remote_manager_interface.py
+++ b/tests/integration/test_remote_manager_interface.py
@@ -388,7 +388,7 @@ class RemoteManagerInterfaceIntegrationTests(GeneralManagerTransactionTestCase):
         self.assertEqual(cause.request_id, "gm-detail-999")
 
     def test_websocket_event_can_invalidate_cached_remote_queries(self) -> None:
-        @cached(scope="dependency")
+        @cached(cache="dependency")
         def active_count() -> int:
             return self.RemoteProject.filter(status="active").count()
 
@@ -476,7 +476,7 @@ class RemoteManagerInterfaceIntegrationTests(GeneralManagerTransactionTestCase):
     def test_remote_invalidation_client_can_invalidate_cached_remote_queries(
         self,
     ) -> None:
-        @cached(scope="dependency")
+        @cached(cache="dependency")
         def active_count() -> int:
             return self.RemoteProject.filter(status="active").count()
 

--- a/tests/integration/test_request_caching.py
+++ b/tests/integration/test_request_caching.py
@@ -131,11 +131,11 @@ class RequestCachingIntegrationTest(GeneralManagerTransactionTestCase):
         ]
 
     def test_request_query_dependencies_are_recorded_per_operation(self) -> None:
-        @cached(scope="dependency")
+        @cached(cache="dependency")
         def active_count() -> int:
             return self.RemoteProject.filter(status="active").count()
 
-        @cached(scope="dependency")
+        @cached(cache="dependency")
         def search_count() -> int:
             return self.RemoteProject.Interface.query_operation(
                 "search",
@@ -170,7 +170,7 @@ class RequestCachingIntegrationTest(GeneralManagerTransactionTestCase):
     def test_request_query_invalidation_is_safe_and_does_not_trigger_detail_reads(
         self,
     ) -> None:
-        @cached(scope="dependency")
+        @cached(cache="dependency")
         def active_count() -> int:
             return self.RemoteProject.filter(status="active").count()
 

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -156,7 +156,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         Verifies that on the first call, the function result is cached and both cache.get and cache.set are called. On a subsequent call with the same arguments before expiration, only cache.get is called, confirming a cache hit.
         """
 
-        @cached(scope="timeout", timeout=5)
+        @cached(cache="timeout", timeout=5)
         def sample_function(x, y):
             return x + y
 
@@ -188,7 +188,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         `cache.get` and `cache.set` to be called again.
         """
 
-        @cached(scope="timeout", timeout=1)
+        @cached(cache="timeout", timeout=1)
         def sample_function(x, y):
             return x + y
 
@@ -219,7 +219,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         """
         custom_cache = FakeCacheBackend()
 
-        @cached(scope="timeout", timeout=5, cache_backend=custom_cache)
+        @cached(cache="timeout", timeout=5, cache_backend=custom_cache)
         def sample_function(x, y):
             """
             Returns the sum of two values.
@@ -246,7 +246,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         """
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -287,7 +287,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         calls = 0
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -317,7 +317,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         calls = 0
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -359,7 +359,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         calls = 0
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -383,7 +383,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         calls = 0
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -408,7 +408,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
     def test_dependency_scope_reuses_buffered_miss_inside_run_context(self):
         calls = 0
 
-        @cached(scope="dependency", cache_backend=self.fake_cache)
+        @cached(cache="dependency", cache_backend=self.fake_cache)
         def fn(value):
             nonlocal calls
             calls += 1
@@ -430,7 +430,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
     def test_dependency_scope_batch_abort_returns_result_without_cache_write(self):
         calls = 0
 
-        @cached(scope="dependency", cache_backend=self.fake_cache)
+        @cached(cache="dependency", cache_backend=self.fake_cache)
         def fn(value):
             nonlocal calls
             calls += 1
@@ -454,7 +454,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         calls = 0
         state = {"value": 3}
 
-        @cached(scope="dependency", cache_backend=self.fake_cache)
+        @cached(cache="dependency", cache_backend=self.fake_cache)
         def fn():
             nonlocal calls
             calls += 1
@@ -483,7 +483,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         calls = 0
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -506,7 +506,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
     def test_dependency_scope_batches_multiple_run_misses_under_one_index_write(self):
         calls = 0
 
-        @cached(scope="dependency", cache_backend=self.fake_cache)
+        @cached(cache="dependency", cache_backend=self.fake_cache)
         def fn(value):
             nonlocal calls
             calls += 1
@@ -536,7 +536,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self,
     ):
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
         )
         def fn(value):
@@ -555,7 +555,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self,
     ):
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
         )
         def fn(value):
@@ -582,7 +582,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         errors = []
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -630,7 +630,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         """
 
         @cached(
-            scope="timeout",
+            cache="timeout",
             timeout=5,
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
@@ -671,7 +671,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         """
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -680,7 +680,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
             return inner_function(x, y)
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -747,7 +747,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         """
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -756,7 +756,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
             return inner_function(x, y)
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -822,7 +822,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
 
     def test_dependency_scope_uses_prefetched_hit_before_backend_read(self):
         @cached(
-            scope="dependency",
+            cache="dependency",
             cache_backend=self.fake_cache,
             record_fn=self.record_fn,
         )
@@ -848,20 +848,41 @@ class TestCacheDecoratorBackend(SimpleTestCase):
 
 
 class TestCacheDecoratorScopes(SimpleTestCase):
-    def test_timeout_scope_requires_timeout(self):
-        with self.assertRaisesRegex(ValueError, 'scope="timeout" requires timeout'):
-            cached(scope="timeout")
+    def test_bare_cached_decorator_reuses_value_inside_context_only(self):
+        calls = 0
 
-    def test_set_timeout_is_only_valid_for_timeout_scope(self):
-        for scope in ("run", "dependency", "none"):
+        @cached
+        def sample(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        with CalculationRunContext():
+            self.assertEqual(sample(3), 6)
+            self.assertEqual(sample(3), 6)
+
+        self.assertEqual(sample(3), 6)
+        self.assertEqual(calls, 2)
+
+    def test_timeout_cache_requires_timeout(self):
+        with self.assertRaisesRegex(ValueError, 'cache="timeout" requires timeout'):
+            cached(cache="timeout")
+
+    def test_set_timeout_is_only_valid_for_timeout_cache(self):
+        for cache_scope in ("run", "dependency", "none"):
             with (
-                self.subTest(scope=scope),
+                self.subTest(cache=cache_scope),
                 self.assertRaisesRegex(
                     ValueError,
-                    'timeout is only supported with scope="timeout"',
+                    'timeout is only supported with cache="timeout"',
                 ),
             ):
-                cached(scope=scope, timeout=5)
+                cached(cache=cache_scope, timeout=5)
+
+    def test_scope_keyword_is_not_supported(self):
+        unsupported_kwargs = {"scope": "run"}
+        with self.assertRaises(TypeError):
+            cached(**unsupported_kwargs)
 
     def test_timeout_scope_uses_backend_without_dependency_recording(self):
         fake_cache = FakeCacheBackend()
@@ -872,7 +893,7 @@ class TestCacheDecoratorScopes(SimpleTestCase):
             record_calls.append((key, set(deps)))
 
         @cached(
-            scope="timeout", timeout=5, cache_backend=fake_cache, record_fn=record_fn
+            cache="timeout", timeout=5, cache_backend=fake_cache, record_fn=record_fn
         )
         def sample(value):
             nonlocal calls
@@ -917,7 +938,7 @@ class TestCacheDecoratorScopes(SimpleTestCase):
     def test_run_scope_reuses_value_inside_context_only(self):
         calls = 0
 
-        @cached(scope="run")
+        @cached(cache="run")
         def sample(value):
             nonlocal calls
             calls += 1
@@ -933,7 +954,7 @@ class TestCacheDecoratorScopes(SimpleTestCase):
     def test_run_scope_creates_context_when_missing_for_single_call(self):
         calls = 0
 
-        @cached(scope="run")
+        @cached(cache="run")
         def sample(value):
             nonlocal calls
             calls += 1
@@ -947,7 +968,7 @@ class TestCacheDecoratorScopes(SimpleTestCase):
         fake_cache = FakeCacheBackend()
         calls = 0
 
-        @cached(scope="none", cache_backend=fake_cache)
+        @cached(cache="none", cache_backend=fake_cache)
         def sample(value):
             nonlocal calls
             calls += 1

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -197,7 +197,7 @@ def test_cached_decorator_logs_cache_hit_and_miss() -> None:
     with patch("general_manager.cache.cache_decorator.logger") as mock_logger:
 
         @cached(
-            scope="dependency",
+            cache="dependency",
             timeout=None,
             cache_backend=fake_cache,
             record_fn=lambda _k, _d: None,


### PR DESCRIPTION
## Summary
- add bare @cached support while preserving existing cache behavior
- rename cached decorator configuration from scope= to cache= and update GraphQL integration
- update tests and docs for the new public decorator API

## Test Plan
- ruff format src/general_manager/cache/cache_decorator.py src/general_manager/api/property.py tests/unit/test_cache_decorator.py tests/unit/test_logging.py tests/integration/test_request_caching.py tests/integration/test_remote_manager_interface.py
- ruff check src/general_manager/cache/cache_decorator.py src/general_manager/api/property.py tests/unit/test_cache_decorator.py tests/unit/test_logging.py tests/integration/test_request_caching.py tests/integration/test_remote_manager_interface.py
- mypy src/general_manager/cache/cache_decorator.py src/general_manager/api/property.py
- python -m pytest tests/unit/test_cache_decorator.py tests/unit/test_logging.py tests/unit/test_graph_ql.py -q
- python -m pytest tests/integration/test_request_caching.py tests/integration/test_remote_manager_interface.py -q
- python -m pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated caching guidance to reflect simplified API usage.

* **Refactor**
  * Renamed caching decorator parameter from `scope` to `cache` for improved clarity.
  * Added support for bare `@cached` decorator syntax without parentheses.
  * Updated all caching configurations across tests and implementation to use the new `cache` parameter with consistent mode naming (`"run"`, `"dependency"`, `"timeout"`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->