### PR TITLE
feat: add run-scoped bucket indexes

### DIFF
--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -64,32 +64,52 @@ Enable Django cache logging or use Redis monitoring tools to ensure cache hits i
 
 ## Working-set reuse
 
-For bulk-style calculations, prefer loading related rows once and indexing them in the active run context:
+For bulk-style calculations, build a run-scoped index directly from the source
+bucket. The framework derives a stable run-local key from the bucket and key
+spec, so repeated lookups in the same `CalculationRunContext` reuse the same
+index without application-specific cache keys.
 
 ```python
-from general_manager.cache import current_calculation_run_context
-
 @graph_ql_property
 def volume(self) -> int:
-    ctx = current_calculation_run_context()
-    if ctx is None:
-        rows = DerivativeVolume.filter(
-            derivative=self.derivative,
-            revision=self.revision,
-            search_date=self.search_date,
-        )
-        return rows.get(volume_date=self.target_date).quantity
-
-    rows_by_date = ctx.index(
-        key=("volume_rows", self.derivative.id, self.revision.id, self.search_date),
-        loader=lambda: DerivativeVolume.filter(
-            derivative=self.derivative,
-            revision=self.revision,
-            search_date=self.search_date,
-        ),
-        index_by=lambda row: row.volume_date,
+    rows = DerivativeVolume.filter(
+        derivative=self.derivative,
+        revision=self.revision,
+        search_date=self.search_date,
     )
+    rows_by_date = rows.index_by("volume_date")
     return rows_by_date[self.target_date].quantity
 ```
 
-Use `ensure_calculation_run_context` around custom bulk jobs or background tasks that should share the same run cache but may already execute inside a GraphQL request context.
+Use `index_many("field_name")` when more than one row can share a key:
+
+```python
+@graph_ql_property
+def daily_quantities(self) -> dict[date, int]:
+    rows = DerivativeVolume.filter(
+        derivative=self.derivative,
+        revision=self.revision,
+        search_date=self.search_date,
+    )
+    rows_by_date = rows.index_many("volume_date")
+    return {
+        volume_date: sum(row.quantity for row in volume_rows)
+        for volume_date, volume_rows in rows_by_date.items()
+    }
+```
+
+`index_by(...)` raises `DuplicateBucketIndexKeyError` when duplicate keys are
+found. Composite keys use tuples of field names, for example
+`rows.index_by(("project", "date"))`. `None` is a valid key value; missing fields
+raise `MissingBucketIndexKeyError`, unsupported key specs raise
+`UnsupportedBucketIndexKeySpecError`, unhashable keys raise
+`UnhashableBucketIndexKeyError`, and indexes that exceed their row guardrail
+raise `BucketIndexTooLargeError`.
+
+Use `ensure_calculation_run_context` around custom bulk jobs or background tasks
+that should share the same run cache but may already execute inside a GraphQL
+request context.
+
+Most application code should use the bucket methods directly. Lower-level
+helpers can inspect `current_calculation_run_context` when they need to adapt
+to an already active run.

--- a/src/general_manager/_types/bucket.py
+++ b/src/general_manager/_types/bucket.py
@@ -4,14 +4,26 @@ from __future__ import annotations
 
 __all__ = [
     "Bucket",
+    "BucketIndexTooLargeError",
     "CalculationBucket",
     "DatabaseBucket",
+    "DuplicateBucketIndexKeyError",
     "GroupBucket",
+    "MissingBucketIndexKeyError",
     "RequestBucket",
+    "UnhashableBucketIndexKeyError",
+    "UnsupportedBucketIndexKeySpecError",
 ]
 
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.bucket.calculation_bucket import CalculationBucket
 from general_manager.bucket.database_bucket import DatabaseBucket
 from general_manager.bucket.group_bucket import GroupBucket
+from general_manager.bucket.indexing import (
+    BucketIndexTooLargeError,
+    DuplicateBucketIndexKeyError,
+    MissingBucketIndexKeyError,
+    UnhashableBucketIndexKeyError,
+    UnsupportedBucketIndexKeySpecError,
+)
 from general_manager.bucket.request_bucket import RequestBucket

--- a/src/general_manager/bucket/base_bucket.py
+++ b/src/general_manager/bucket/base_bucket.py
@@ -263,7 +263,11 @@ class Bucket(ABC, Generic[GeneralManagerType]):
         *,
         max_rows: int | None = 1000,
     ) -> dict[Hashable, GeneralManagerType]:
-        """Build or reuse a unique run-scoped index over this bucket."""
+        """Build or reuse a unique run-scoped index over this bucket.
+
+        Duplicate frozen keys raise an error because each key must identify one
+        row. The result is cached only for the active calculation run.
+        """
         normalized_key_spec = normalize_bucket_index_key_spec(key_spec)
         source_signature = self._bucket_index_source_signature()
         with ensure_calculation_run_context() as context:
@@ -298,7 +302,11 @@ class Bucket(ABC, Generic[GeneralManagerType]):
         *,
         max_rows: int | None = 1000,
     ) -> dict[Hashable, tuple[GeneralManagerType, ...]]:
-        """Build or reuse a multi-value run-scoped index over this bucket."""
+        """Build or reuse a run-scoped index that groups rows by key.
+
+        Values are tuples preserving source iteration order, and the cached
+        result is scoped to the active calculation run.
+        """
         normalized_key_spec = normalize_bucket_index_key_spec(key_spec)
         source_signature = self._bucket_index_source_signature()
         with ensure_calculation_run_context() as context:

--- a/src/general_manager/bucket/base_bucket.py
+++ b/src/general_manager/bucket/base_bucket.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from collections.abc import Hashable
 from typing import (
     Type,
     Generator,
@@ -10,6 +11,15 @@ from typing import (
     Generic,
     TypeVar,
 )
+
+from general_manager.bucket.indexing import (
+    BucketIndexKeySpec,
+    build_multi_bucket_index,
+    build_unique_bucket_index,
+    normalize_bucket_index_key_spec,
+)
+from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.run_context import ensure_calculation_run_context
 
 GeneralManagerType = TypeVar("GeneralManagerType", bound="GeneralManager")
 
@@ -238,6 +248,80 @@ class Bucket(ABC, Generic[GeneralManagerType]):
         from general_manager.bucket.group_bucket import GroupBucket
 
         return GroupBucket(self._manager_class, group_by_keys, self)
+
+    def _bucket_index_source_signature(self) -> Hashable:
+        """Return the conservative run-local source signature for bucket indexes."""
+        return (
+            self.__class__,
+            self._manager_class,
+            id(self),
+        )
+
+    def index_by(
+        self,
+        key_spec: BucketIndexKeySpec,
+        *,
+        max_rows: int | None = 1000,
+    ) -> dict[Hashable, GeneralManagerType]:
+        """Build or reuse a unique run-scoped index over this bucket."""
+        normalized_key_spec = normalize_bucket_index_key_spec(key_spec)
+        source_signature = self._bucket_index_source_signature()
+        with ensure_calculation_run_context() as context:
+            cached = context.get_bucket_index_result(
+                source_signature,
+                normalized_key_spec,
+                False,
+            )
+            if cached is not None:
+                return cached  # type: ignore[return-value]
+
+            with DependencyTracker() as dependencies:
+                index = build_unique_bucket_index(
+                    self,
+                    key_spec,
+                    max_rows=max_rows,
+                )
+            context.set_bucket_index_result(
+                source_signature,
+                normalized_key_spec,
+                False,
+                index,
+                dependencies,
+            )
+            return index
+
+    def index_many(
+        self,
+        key_spec: BucketIndexKeySpec,
+        *,
+        max_rows: int | None = 1000,
+    ) -> dict[Hashable, tuple[GeneralManagerType, ...]]:
+        """Build or reuse a multi-value run-scoped index over this bucket."""
+        normalized_key_spec = normalize_bucket_index_key_spec(key_spec)
+        source_signature = self._bucket_index_source_signature()
+        with ensure_calculation_run_context() as context:
+            cached = context.get_bucket_index_result(
+                source_signature,
+                normalized_key_spec,
+                True,
+            )
+            if cached is not None:
+                return cached  # type: ignore[return-value]
+
+            with DependencyTracker() as dependencies:
+                index = build_multi_bucket_index(
+                    self,
+                    key_spec,
+                    max_rows=max_rows,
+                )
+            context.set_bucket_index_result(
+                source_signature,
+                normalized_key_spec,
+                True,
+                index,
+                dependencies,
+            )
+            return index
 
     def none(self) -> Bucket[GeneralManagerType]:
         """

--- a/src/general_manager/bucket/base_bucket.py
+++ b/src/general_manager/bucket/base_bucket.py
@@ -271,6 +271,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
                 source_signature,
                 normalized_key_spec,
                 False,
+                max_rows,
             )
             if cached is not None:
                 return cached  # type: ignore[return-value]
@@ -287,6 +288,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
                 False,
                 index,
                 dependencies,
+                max_rows,
             )
             return index
 
@@ -304,6 +306,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
                 source_signature,
                 normalized_key_spec,
                 True,
+                max_rows,
             )
             if cached is not None:
                 return cached  # type: ignore[return-value]
@@ -320,6 +323,7 @@ class Bucket(ABC, Generic[GeneralManagerType]):
                 True,
                 index,
                 dependencies,
+                max_rows,
             )
             return index
 

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -1,7 +1,7 @@
 """Bucket implementation that enumerates calculation interface combinations."""
 
 from __future__ import annotations
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable
 from types import UnionType
 from typing import (
     Any,
@@ -22,6 +22,7 @@ from general_manager.interface.base_interface import (
     GeneralManagerType,
 )
 from general_manager.bucket.base_bucket import Bucket
+from general_manager.bucket.indexing import freeze_bucket_index_value
 from general_manager.manager.input import Input, InputDomain
 from general_manager.utils.filter_parser import parse_filters
 
@@ -460,6 +461,16 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         if isinstance(self.sort_key, str):
             return (self.sort_key,)
         return self.sort_key
+
+    def _bucket_index_source_signature(self) -> Hashable:
+        return (
+            "calculation",
+            self._manager_class,
+            freeze_bucket_index_value(self.filter_definitions),
+            freeze_bucket_index_value(self.exclude_definitions),
+            self._normalized_sort_key(),
+            self.reverse,
+        )
 
     def _sort_uses_only_inputs(self, sort_key: tuple[str, ...] | None) -> bool:
         """Return whether a sort can be applied to raw input dictionaries."""

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -463,6 +463,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         return self.sort_key
 
     def _bucket_index_source_signature(self) -> Hashable:
+        """Return a stable signature for equivalent calculation bucket plans."""
         return (
             "calculation",
             self._manager_class,

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -330,6 +330,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         )
 
     def _bucket_index_source_signature(self) -> Hashable:
+        """Return a queryset signature when safe, otherwise use object identity."""
         query_signature = self._query_signature()
         if query_signature is None:
             return super()._bucket_index_source_signature()

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -329,6 +329,12 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             self._sort_reverse,
         )
 
+    def _bucket_index_source_signature(self) -> Hashable:
+        query_signature = self._query_signature()
+        if query_signature is None:
+            return super()._bucket_index_source_signature()
+        return ("database", query_signature)
+
     def _get_run_scoped_primary_keys(self) -> tuple[Any, ...] | None:
         """
         Load or reuse a bounded primary-key snapshot for this bucket.

--- a/src/general_manager/bucket/indexing.py
+++ b/src/general_manager/bucket/indexing.py
@@ -12,6 +12,7 @@ NormalizedBucketIndexKeySpec = tuple[str, tuple[str, ...], bool]
 
 
 def _frozen_pair_sort_key(pair: tuple[Hashable, Hashable]) -> tuple[str, str]:
+    """Return a string-only sort key for frozen mapping pairs."""
     return (str(pair[0]), str(pair[1]))
 
 
@@ -19,6 +20,7 @@ class UnsupportedBucketIndexKeySpecError(TypeError):
     """Raised when a bucket index key spec cannot produce a stable run key."""
 
     def __init__(self, key_spec: object) -> None:
+        """Build an error that names the unsupported key specification."""
         super().__init__(
             "Bucket index key specs must be a field name or a non-empty tuple "
             f"of field names; got {key_spec!r}."
@@ -29,6 +31,7 @@ class MissingBucketIndexKeyError(AttributeError):
     """Raised when an indexed row does not expose a requested key field."""
 
     def __init__(self, field_name: str, row: object) -> None:
+        """Build an error that identifies the missing row field."""
         super().__init__(
             f"Cannot build bucket index: {row!r} is missing key field {field_name!r}."
         )
@@ -38,6 +41,7 @@ class DuplicateBucketIndexKeyError(ValueError):
     """Raised when a unique bucket index sees more than one row for a key."""
 
     def __init__(self, key: Hashable) -> None:
+        """Build an error that identifies the duplicated frozen index key."""
         super().__init__(f"Bucket index key {key!r} matched more than one row.")
 
 
@@ -45,6 +49,7 @@ class BucketIndexTooLargeError(ValueError):
     """Raised when index construction exceeds the configured row guardrail."""
 
     def __init__(self, max_rows: int) -> None:
+        """Build an error that reports the row guardrail that was exceeded."""
         super().__init__(
             f"Bucket index construction exceeded the configured limit of {max_rows} rows."
         )
@@ -54,6 +59,7 @@ class UnhashableBucketIndexKeyError(TypeError):
     """Raised when a key value cannot be converted to a hashable identity."""
 
     def __init__(self, key: object) -> None:
+        """Build an error that reports the unfreezable key value."""
         super().__init__(f"Bucket index key {key!r} is not hashable.")
 
 
@@ -73,7 +79,11 @@ def normalize_bucket_index_key_spec(
 
 
 def freeze_bucket_index_value(value: object) -> Hashable:
-    """Return a hashable identity for values used as bucket index keys."""
+    """Return a stable hashable identity for values used as index keys.
+
+    Manager instances are represented by their class and identification, and
+    containers are recursively frozen so equivalent values share a run-cache key.
+    """
     from general_manager.manager.general_manager import GeneralManager
 
     if isinstance(value, GeneralManager):
@@ -120,7 +130,7 @@ def resolve_bucket_index_key(
     row: object,
     key_spec: BucketIndexKeySpec,
 ) -> Hashable:
-    """Resolve and freeze the index key for one row."""
+    """Resolve the requested field value or composite key for one row."""
     _, field_names, composite = normalize_bucket_index_key_spec(key_spec)
     values: list[Hashable] = []
     for field_name in field_names:
@@ -138,6 +148,7 @@ def _iter_guarded_rows(
     rows: Iterable[T],
     max_rows: int | None,
 ) -> Iterable[T]:
+    """Yield rows until max_rows is exceeded, then raise a guardrail error."""
     for index, row in enumerate(rows):
         if max_rows is not None and index >= max_rows:
             raise BucketIndexTooLargeError(max_rows)
@@ -150,7 +161,7 @@ def build_unique_bucket_index(
     *,
     max_rows: int | None,
 ) -> dict[Hashable, T]:
-    """Build a unique index and fail when duplicate keys are found."""
+    """Build a unique index and fail when duplicate frozen keys are found."""
     indexed: dict[Hashable, T] = {}
     for row in _iter_guarded_rows(rows, max_rows):
         key = resolve_bucket_index_key(row, key_spec)
@@ -166,7 +177,7 @@ def build_multi_bucket_index(
     *,
     max_rows: int | None,
 ) -> dict[Hashable, tuple[T, ...]]:
-    """Build an index that preserves all rows for duplicate keys."""
+    """Build a grouped index that preserves row order for duplicate keys."""
     grouped: defaultdict[Hashable, list[T]] = defaultdict(list)
     for row in _iter_guarded_rows(rows, max_rows):
         grouped[resolve_bucket_index_key(row, key_spec)].append(row)

--- a/src/general_manager/bucket/indexing.py
+++ b/src/general_manager/bucket/indexing.py
@@ -11,6 +11,10 @@ BucketIndexKeySpec = str | tuple[str, ...]
 NormalizedBucketIndexKeySpec = tuple[str, tuple[str, ...], bool]
 
 
+def _frozen_pair_sort_key(pair: tuple[Hashable, Hashable]) -> tuple[str, str]:
+    return (str(pair[0]), str(pair[1]))
+
+
 class UnsupportedBucketIndexKeySpecError(TypeError):
     """Raised when a bucket index key spec cannot produce a stable run key."""
 
@@ -78,10 +82,13 @@ def freeze_bucket_index_value(value: object) -> Hashable:
             tuple(
                 sorted(
                     (
-                        cast(Hashable, freeze_bucket_index_value(key)),
-                        freeze_bucket_index_value(identifier),
-                    )
-                    for key, identifier in value.identification.items()
+                        (
+                            cast(Hashable, freeze_bucket_index_value(key)),
+                            freeze_bucket_index_value(identifier),
+                        )
+                        for key, identifier in value.identification.items()
+                    ),
+                    key=_frozen_pair_sort_key,
                 )
             ),
         )
@@ -89,10 +96,13 @@ def freeze_bucket_index_value(value: object) -> Hashable:
         return tuple(
             sorted(
                 (
-                    cast(Hashable, freeze_bucket_index_value(key)),
-                    freeze_bucket_index_value(item),
-                )
-                for key, item in value.items()
+                    (
+                        cast(Hashable, freeze_bucket_index_value(key)),
+                        freeze_bucket_index_value(item),
+                    )
+                    for key, item in value.items()
+                ),
+                key=_frozen_pair_sort_key,
             )
         )
     if isinstance(value, (list, tuple)):

--- a/src/general_manager/bucket/indexing.py
+++ b/src/general_manager/bucket/indexing.py
@@ -1,0 +1,163 @@
+"""Run-scoped bucket index helpers."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Hashable, Iterable
+from typing import TypeVar, cast
+
+T = TypeVar("T")
+BucketIndexKeySpec = str | tuple[str, ...]
+NormalizedBucketIndexKeySpec = tuple[str, tuple[str, ...], bool]
+
+
+class UnsupportedBucketIndexKeySpecError(TypeError):
+    """Raised when a bucket index key spec cannot produce a stable run key."""
+
+    def __init__(self, key_spec: object) -> None:
+        super().__init__(
+            "Bucket index key specs must be a field name or a non-empty tuple "
+            f"of field names; got {key_spec!r}."
+        )
+
+
+class MissingBucketIndexKeyError(AttributeError):
+    """Raised when an indexed row does not expose a requested key field."""
+
+    def __init__(self, field_name: str, row: object) -> None:
+        super().__init__(
+            f"Cannot build bucket index: {row!r} is missing key field {field_name!r}."
+        )
+
+
+class DuplicateBucketIndexKeyError(ValueError):
+    """Raised when a unique bucket index sees more than one row for a key."""
+
+    def __init__(self, key: Hashable) -> None:
+        super().__init__(f"Bucket index key {key!r} matched more than one row.")
+
+
+class BucketIndexTooLargeError(ValueError):
+    """Raised when index construction exceeds the configured row guardrail."""
+
+    def __init__(self, max_rows: int) -> None:
+        super().__init__(
+            f"Bucket index construction exceeded the configured limit of {max_rows} rows."
+        )
+
+
+class UnhashableBucketIndexKeyError(TypeError):
+    """Raised when a key value cannot be converted to a hashable identity."""
+
+    def __init__(self, key: object) -> None:
+        super().__init__(f"Bucket index key {key!r} is not hashable.")
+
+
+def normalize_bucket_index_key_spec(
+    key_spec: object,
+) -> NormalizedBucketIndexKeySpec:
+    """Return a stable normalized representation for a supported key spec."""
+    if isinstance(key_spec, str):
+        return ("field", (key_spec,), False)
+    if (
+        isinstance(key_spec, tuple)
+        and len(key_spec) > 0
+        and all(isinstance(part, str) for part in key_spec)
+    ):
+        return ("field", key_spec, True)
+    raise UnsupportedBucketIndexKeySpecError(key_spec)
+
+
+def freeze_bucket_index_value(value: object) -> Hashable:
+    """Return a hashable identity for values used as bucket index keys."""
+    from general_manager.manager.general_manager import GeneralManager
+
+    if isinstance(value, GeneralManager):
+        return (
+            value.__class__,
+            tuple(
+                sorted(
+                    (
+                        cast(Hashable, freeze_bucket_index_value(key)),
+                        freeze_bucket_index_value(identifier),
+                    )
+                    for key, identifier in value.identification.items()
+                )
+            ),
+        )
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (
+                    cast(Hashable, freeze_bucket_index_value(key)),
+                    freeze_bucket_index_value(item),
+                )
+                for key, item in value.items()
+            )
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(freeze_bucket_index_value(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(freeze_bucket_index_value(item) for item in value)
+    try:
+        hash(value)
+    except TypeError as error:
+        raise UnhashableBucketIndexKeyError(value) from error
+    return cast(Hashable, value)
+
+
+def resolve_bucket_index_key(
+    row: object,
+    key_spec: BucketIndexKeySpec,
+) -> Hashable:
+    """Resolve and freeze the index key for one row."""
+    _, field_names, composite = normalize_bucket_index_key_spec(key_spec)
+    values: list[Hashable] = []
+    for field_name in field_names:
+        try:
+            value = getattr(row, field_name)
+        except AttributeError as error:
+            raise MissingBucketIndexKeyError(field_name, row) from error
+        values.append(freeze_bucket_index_value(value))
+    if composite:
+        return tuple(values)
+    return values[0]
+
+
+def _iter_guarded_rows(
+    rows: Iterable[T],
+    max_rows: int | None,
+) -> Iterable[T]:
+    for index, row in enumerate(rows):
+        if max_rows is not None and index >= max_rows:
+            raise BucketIndexTooLargeError(max_rows)
+        yield row
+
+
+def build_unique_bucket_index(
+    rows: Iterable[T],
+    key_spec: BucketIndexKeySpec,
+    *,
+    max_rows: int | None,
+) -> dict[Hashable, T]:
+    """Build a unique index and fail when duplicate keys are found."""
+    indexed: dict[Hashable, T] = {}
+    for row in _iter_guarded_rows(rows, max_rows):
+        key = resolve_bucket_index_key(row, key_spec)
+        if key in indexed:
+            raise DuplicateBucketIndexKeyError(key)
+        indexed[key] = row
+    return indexed
+
+
+def build_multi_bucket_index(
+    rows: Iterable[T],
+    key_spec: BucketIndexKeySpec,
+    *,
+    max_rows: int | None,
+) -> dict[Hashable, tuple[T, ...]]:
+    """Build an index that preserves all rows for duplicate keys."""
+    grouped: defaultdict[Hashable, list[T]] = defaultdict(list)
+    for row in _iter_guarded_rows(rows, max_rows):
+        grouped[resolve_bucket_index_key(row, key_spec)].append(row)
+    return {key: tuple(values) for key, values in grouped.items()}

--- a/src/general_manager/bucket/request_bucket.py
+++ b/src/general_manager/bucket/request_bucket.py
@@ -186,14 +186,7 @@ class RequestBucket(Bucket[GeneralManagerType]):
                 freeze_bucket_index_value(self.filters),
                 freeze_bucket_index_value(self.excludes),
             )
-        return (
-            "request-items",
-            self._manager_class,
-            tuple(
-                freeze_bucket_index_value(item.identification)
-                for item in self._ensure_items()
-            ),
-        )
+        return super()._bucket_index_source_signature()
 
     def __iter__(self) -> Generator[GeneralManagerType, None, None]:
         yield from self._ensure_items()

--- a/src/general_manager/bucket/request_bucket.py
+++ b/src/general_manager/bucket/request_bucket.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator, Mapping
+from collections.abc import Generator, Hashable, Mapping
 from typing import TYPE_CHECKING, Any, cast
 
 from general_manager.bucket.base_bucket import Bucket, GeneralManagerType
+from general_manager.bucket.indexing import freeze_bucket_index_value
 from general_manager.interface.requests import (
     RequestLocalPredicate,
     RequestLocalPaginationUnsupportedError,
@@ -170,6 +171,28 @@ class RequestBucket(Bucket[GeneralManagerType]):
             )
         return tuple(item.identification for item in self._ensure_items()) == tuple(
             item.identification for item in other._ensure_items()
+        )
+
+    def _bucket_index_source_signature(self) -> Hashable:
+        if self.request_plan is not None:
+            restore_func, restore_args = self.request_plan.__reduce__()
+            return (
+                "request",
+                self._manager_class,
+                self._interface_cls,
+                self._operation_name,
+                restore_func,
+                freeze_bucket_index_value(restore_args),
+                freeze_bucket_index_value(self.filters),
+                freeze_bucket_index_value(self.excludes),
+            )
+        return (
+            "request-items",
+            self._manager_class,
+            tuple(
+                freeze_bucket_index_value(item.identification)
+                for item in self._ensure_items()
+            ),
         )
 
     def __iter__(self) -> Generator[GeneralManagerType, None, None]:

--- a/src/general_manager/bucket/request_bucket.py
+++ b/src/general_manager/bucket/request_bucket.py
@@ -174,6 +174,7 @@ class RequestBucket(Bucket[GeneralManagerType]):
         )
 
     def _bucket_index_source_signature(self) -> Hashable:
+        """Return a stable request signature, or object identity for materialized data."""
         if self.request_plan is not None:
             restore_func, restore_args = self.request_plan.__reduce__()
             return (

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -33,6 +33,8 @@ logger = get_logger("cache.run_context")
 
 @dataclass(frozen=True)
 class BucketIndexRunCacheEntry:
+    """Run-cache payload for a bucket index plus dependencies to replay on hits."""
+
     value: object
     dependencies: frozenset["Dependency"]
 
@@ -200,6 +202,7 @@ class CalculationRunContext:
         many: bool,
         max_rows: int | None,
     ) -> tuple[Hashable, ...]:
+        """Return the full run-cache key for one bucket index variant."""
         return (BUCKET_INDEX_PREFIX, source_signature, key_spec, many, max_rows)
 
     def get_bucket_index_result(

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable, Hashable, Iterable, Mapping
 from contextvars import ContextVar, Token
+from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, Optional, TypeVar
 
@@ -12,6 +13,7 @@ from general_manager.logging import get_logger
 
 if TYPE_CHECKING:
     from general_manager.cache.dependency_cache import DependencyCacheHit
+    from general_manager.cache.dependency_index import Dependency
     from general_manager.cache.dependency_publish import (
         PendingDependencyCachePublication,
     )
@@ -24,8 +26,15 @@ _active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
     default=None,
 )
 ORM_BUCKET_RESULT_PREFIX = "orm_bucket_result"
+BUCKET_INDEX_PREFIX = "bucket_index"
 DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE = 1000
 logger = get_logger("cache.run_context")
+
+
+@dataclass(frozen=True)
+class BucketIndexRunCacheEntry:
+    value: object
+    dependencies: frozenset["Dependency"]
 
 
 class CalculationRunContext:
@@ -183,6 +192,52 @@ class CalculationRunContext:
     def clear_orm_bucket_results(self) -> None:
         """Discard all run-scoped ORM bucket result entries."""
         self.discard_prefix((ORM_BUCKET_RESULT_PREFIX,))
+
+    def _bucket_index_cache_key(
+        self,
+        source_signature: Hashable,
+        key_spec: Hashable,
+        many: bool,
+    ) -> tuple[Hashable, ...]:
+        return (BUCKET_INDEX_PREFIX, source_signature, key_spec, many)
+
+    def get_bucket_index_result(
+        self,
+        source_signature: Hashable,
+        key_spec: Hashable,
+        many: bool,
+    ) -> object:
+        """Return a cached bucket index and replay its source dependencies."""
+        entry = self.get(self._bucket_index_cache_key(source_signature, key_spec, many))
+        if not isinstance(entry, BucketIndexRunCacheEntry):
+            return None
+
+        from general_manager.cache.cache_tracker import DependencyTracker
+
+        for class_name, operation, identifier in entry.dependencies:
+            DependencyTracker.track(class_name, operation, identifier)
+        return entry.value
+
+    def set_bucket_index_result(
+        self,
+        source_signature: Hashable,
+        key_spec: Hashable,
+        many: bool,
+        value: object,
+        dependencies: Iterable["Dependency"],
+    ) -> None:
+        """Store a bucket index and the dependencies touched while building it."""
+        self.set(
+            self._bucket_index_cache_key(source_signature, key_spec, many),
+            BucketIndexRunCacheEntry(
+                value=value,
+                dependencies=frozenset(dependencies),
+            ),
+        )
+
+    def clear_bucket_indexes(self) -> None:
+        """Discard all run-scoped bucket index entries."""
+        self.discard_prefix((BUCKET_INDEX_PREFIX,))
 
     def has(self, key: Hashable) -> bool:
         """Return whether key has a value in the active run."""

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -198,17 +198,21 @@ class CalculationRunContext:
         source_signature: Hashable,
         key_spec: Hashable,
         many: bool,
+        max_rows: int | None,
     ) -> tuple[Hashable, ...]:
-        return (BUCKET_INDEX_PREFIX, source_signature, key_spec, many)
+        return (BUCKET_INDEX_PREFIX, source_signature, key_spec, many, max_rows)
 
     def get_bucket_index_result(
         self,
         source_signature: Hashable,
         key_spec: Hashable,
         many: bool,
+        max_rows: int | None,
     ) -> object:
         """Return a cached bucket index and replay its source dependencies."""
-        entry = self.get(self._bucket_index_cache_key(source_signature, key_spec, many))
+        entry = self.get(
+            self._bucket_index_cache_key(source_signature, key_spec, many, max_rows)
+        )
         if not isinstance(entry, BucketIndexRunCacheEntry):
             return None
 
@@ -225,10 +229,11 @@ class CalculationRunContext:
         many: bool,
         value: object,
         dependencies: Iterable["Dependency"],
+        max_rows: int | None,
     ) -> None:
         """Store a bucket index and the dependencies touched while building it."""
         self.set(
-            self._bucket_index_cache_key(source_signature, key_spec, many),
+            self._bucket_index_cache_key(source_signature, key_spec, many, max_rows),
             BucketIndexRunCacheEntry(
                 value=value,
                 dependencies=frozenset(dependencies),

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -54,6 +54,7 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
         context = current_calculation_run_context()
         if context is not None:
             context.clear_orm_bucket_results()
+            context.clear_bucket_indexes()
         try:
             action = func.__name__
             if func.__name__ == "create":

--- a/src/general_manager/public_api_registry.py
+++ b/src/general_manager/public_api_registry.py
@@ -388,13 +388,33 @@ CACHE_EXPORTS: LazyExportMap = {
 
 BUCKET_EXPORTS: LazyExportMap = {
     "Bucket": ("general_manager.bucket.base_bucket", "Bucket"),
-    "DatabaseBucket": ("general_manager.bucket.database_bucket", "DatabaseBucket"),
+    "BucketIndexTooLargeError": (
+        "general_manager.bucket.indexing",
+        "BucketIndexTooLargeError",
+    ),
     "CalculationBucket": (
         "general_manager.bucket.calculation_bucket",
         "CalculationBucket",
     ),
+    "DatabaseBucket": ("general_manager.bucket.database_bucket", "DatabaseBucket"),
+    "DuplicateBucketIndexKeyError": (
+        "general_manager.bucket.indexing",
+        "DuplicateBucketIndexKeyError",
+    ),
     "GroupBucket": ("general_manager.bucket.group_bucket", "GroupBucket"),
+    "MissingBucketIndexKeyError": (
+        "general_manager.bucket.indexing",
+        "MissingBucketIndexKeyError",
+    ),
     "RequestBucket": ("general_manager.bucket.request_bucket", "RequestBucket"),
+    "UnhashableBucketIndexKeyError": (
+        "general_manager.bucket.indexing",
+        "UnhashableBucketIndexKeyError",
+    ),
+    "UnsupportedBucketIndexKeySpecError": (
+        "general_manager.bucket.indexing",
+        "UnsupportedBucketIndexKeySpecError",
+    ),
 }
 
 

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -1510,6 +1510,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
             self.assertEqual(list(refreshed_bucket), [])
 
     def test_run_scoped_bucket_indexes_clear_after_mutation_inside_run(self):
+        """Clear cached bucket indexes after a mutation inside the same run."""
         with CalculationRunContext():
             bucket = self.TestProject.filter(name="Another Project")
             index = bucket.index_by("identification")

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -1509,6 +1509,23 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
             refreshed_bucket = self.TestProject.filter(name="Another Project")
             self.assertEqual(list(refreshed_bucket), [])
 
+    def test_run_scoped_bucket_indexes_clear_after_mutation_inside_run(self):
+        with CalculationRunContext():
+            bucket = self.TestProject.filter(name="Another Project")
+            index = bucket.index_by("identification")
+            self.assertEqual(
+                sorted(project.identification["id"] for project in index.values()),
+                [self.project2.identification["id"]],
+            )
+
+            self.project2 = self.project2.update(
+                name="Renamed Project",
+                ignore_permission=True,
+            )
+
+            refreshed_bucket = self.TestProject.filter(name="Another Project")
+            self.assertEqual(refreshed_bucket.index_by("identification"), {})
+
     def test_grouped_filtered_bucket_count_invalidates_on_create(self):
         """
         Ensure grouped calculations built from chained buckets invalidate on matching creates.

--- a/tests/snapshots/public_api_exports.json
+++ b/tests/snapshots/public_api_exports.json
@@ -148,6 +148,10 @@
       "general_manager.bucket.base_bucket",
       "Bucket"
     ],
+    "BucketIndexTooLargeError": [
+      "general_manager.bucket.indexing",
+      "BucketIndexTooLargeError"
+    ],
     "CalculationBucket": [
       "general_manager.bucket.calculation_bucket",
       "CalculationBucket"
@@ -156,13 +160,29 @@
       "general_manager.bucket.database_bucket",
       "DatabaseBucket"
     ],
+    "DuplicateBucketIndexKeyError": [
+      "general_manager.bucket.indexing",
+      "DuplicateBucketIndexKeyError"
+    ],
     "GroupBucket": [
       "general_manager.bucket.group_bucket",
       "GroupBucket"
     ],
+    "MissingBucketIndexKeyError": [
+      "general_manager.bucket.indexing",
+      "MissingBucketIndexKeyError"
+    ],
     "RequestBucket": [
       "general_manager.bucket.request_bucket",
       "RequestBucket"
+    ],
+    "UnhashableBucketIndexKeyError": [
+      "general_manager.bucket.indexing",
+      "UnhashableBucketIndexKeyError"
+    ],
+    "UnsupportedBucketIndexKeySpecError": [
+      "general_manager.bucket.indexing",
+      "UnsupportedBucketIndexKeySpecError"
     ]
   },
   "general_manager.cache": {

--- a/tests/unit/test_base_bucket.py
+++ b/tests/unit/test_base_bucket.py
@@ -3,6 +3,7 @@ from django.test import SimpleTestCase
 
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.bucket.group_bucket import GroupBucket
+from general_manager.cache.run_context import CalculationRunContext
 
 
 # DummyBucket concrete implementation for testing
@@ -17,6 +18,13 @@ class DummyManager:
                 attributes (dict): A dictionary with keys 'a', 'b', and 'c', each mapped to None.
             """
             return {"a": None, "b": None, "c": None}
+
+
+class DummyRow:
+    def __init__(self, code: str | None, group: str, value: int) -> None:
+        self.code = code
+        self.group = group
+        self.value = value
 
 
 # DummyBucket concrete implementation for testing
@@ -386,3 +394,46 @@ class BucketTests(SimpleTestCase):
             bucket.group_by("x")(self)
         with self.assertRaises(ValueError):
             self.bucket.group_by("x")
+
+    def test_index_by_builds_unique_index_by_field_name(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow("A", "x", 1),
+                DummyRow("B", "x", 2),
+            ],
+        )
+
+        index = bucket.index_by("code")
+
+        self.assertEqual(index["A"].value, 1)
+        self.assertEqual(index["B"].value, 2)
+
+    def test_index_many_preserves_duplicate_key_order(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow("A", "x", 1),
+                DummyRow("A", "x", 2),
+                DummyRow("B", "y", 3),
+            ],
+        )
+
+        index = bucket.index_many("code")
+
+        self.assertEqual([row.value for row in index["A"]], [1, 2])
+        self.assertEqual([row.value for row in index["B"]], [3])
+
+    def test_index_by_reuses_same_bucket_object_inside_run_context(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow("A", "x", 1),
+            ],
+        )
+
+        with CalculationRunContext():
+            first = bucket.index_by("code")
+            second = bucket.index_by("code")
+
+        self.assertIs(first, second)

--- a/tests/unit/test_base_bucket.py
+++ b/tests/unit/test_base_bucket.py
@@ -3,6 +3,12 @@ from django.test import SimpleTestCase
 
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.bucket.group_bucket import GroupBucket
+from general_manager.bucket.indexing import (
+    BucketIndexTooLargeError,
+    DuplicateBucketIndexKeyError,
+    MissingBucketIndexKeyError,
+    UnsupportedBucketIndexKeySpecError,
+)
 from general_manager.cache.run_context import CalculationRunContext
 
 
@@ -437,3 +443,78 @@ class BucketTests(SimpleTestCase):
             second = bucket.index_by("code")
 
         self.assertIs(first, second)
+
+    def test_index_by_raises_for_duplicate_keys(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow("A", "x", 1),
+                DummyRow("A", "y", 2),
+            ],
+        )
+
+        with self.assertRaises(DuplicateBucketIndexKeyError):
+            bucket.index_by("code")
+
+    def test_index_by_supports_composite_keys(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow("A", "x", 1),
+                DummyRow("A", "y", 2),
+            ],
+        )
+
+        index = bucket.index_by(("code", "group"))
+
+        self.assertEqual(index[("A", "x")].value, 1)
+        self.assertEqual(index[("A", "y")].value, 2)
+
+    def test_index_by_allows_null_key(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow(None, "x", 1),
+            ],
+        )
+
+        index = bucket.index_by("code")
+
+        self.assertEqual(index[None].value, 1)
+
+    def test_index_by_raises_for_missing_key_field(self):
+        bucket = DummyBucket(self.manager_class, [DummyRow("A", "x", 1)])
+
+        with self.assertRaises(MissingBucketIndexKeyError):
+            bucket.index_by("missing")
+
+    def test_index_by_raises_for_unsupported_key_spec(self):
+        bucket = DummyBucket(self.manager_class, [DummyRow("A", "x", 1)])
+
+        with self.assertRaises(UnsupportedBucketIndexKeySpecError):
+            bucket.index_by(["code"])  # type: ignore[arg-type]
+
+    def test_index_by_respects_max_rows_guardrail(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow("A", "x", 1),
+                DummyRow("B", "x", 2),
+            ],
+        )
+
+        with self.assertRaises(BucketIndexTooLargeError):
+            bucket.index_by("code", max_rows=1)
+
+    def test_index_by_allows_explicit_unbounded_index(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow("A", "x", 1),
+                DummyRow("B", "x", 2),
+            ],
+        )
+
+        index = bucket.index_by("code", max_rows=None)
+
+        self.assertEqual(sorted(index), ["A", "B"])

--- a/tests/unit/test_base_bucket.py
+++ b/tests/unit/test_base_bucket.py
@@ -28,6 +28,7 @@ class DummyManager:
 
 class DummyRow:
     def __init__(self, code: str | None, group: str, value: int) -> None:
+        """Create a simple row carrying fields used by bucket index tests."""
         self.code = code
         self.group = group
         self.value = value
@@ -402,6 +403,7 @@ class BucketTests(SimpleTestCase):
             self.bucket.group_by("x")
 
     def test_index_by_builds_unique_index_by_field_name(self):
+        """Index rows by one field name and expose each matching row by key."""
         bucket = DummyBucket(
             self.manager_class,
             [
@@ -416,6 +418,7 @@ class BucketTests(SimpleTestCase):
         self.assertEqual(index["B"].value, 2)
 
     def test_index_many_preserves_duplicate_key_order(self):
+        """Group duplicate keys while preserving each row's source order."""
         bucket = DummyBucket(
             self.manager_class,
             [
@@ -431,6 +434,7 @@ class BucketTests(SimpleTestCase):
         self.assertEqual([row.value for row in index["B"]], [3])
 
     def test_index_by_reuses_same_bucket_object_inside_run_context(self):
+        """Reuse an index for the same bucket object within one run context."""
         bucket = DummyBucket(
             self.manager_class,
             [
@@ -445,6 +449,7 @@ class BucketTests(SimpleTestCase):
         self.assertIs(first, second)
 
     def test_index_by_raises_for_duplicate_keys(self):
+        """Raise when a unique index key matches more than one row."""
         bucket = DummyBucket(
             self.manager_class,
             [
@@ -457,6 +462,7 @@ class BucketTests(SimpleTestCase):
             bucket.index_by("code")
 
     def test_index_by_supports_composite_keys(self):
+        """Index rows by an ordered tuple of field values."""
         bucket = DummyBucket(
             self.manager_class,
             [
@@ -471,6 +477,7 @@ class BucketTests(SimpleTestCase):
         self.assertEqual(index[("A", "y")].value, 2)
 
     def test_index_by_allows_null_key(self):
+        """Allow None to be used as a unique bucket index key."""
         bucket = DummyBucket(
             self.manager_class,
             [
@@ -483,18 +490,21 @@ class BucketTests(SimpleTestCase):
         self.assertEqual(index[None].value, 1)
 
     def test_index_by_raises_for_missing_key_field(self):
+        """Raise a clear error when the requested key field is absent."""
         bucket = DummyBucket(self.manager_class, [DummyRow("A", "x", 1)])
 
         with self.assertRaises(MissingBucketIndexKeyError):
             bucket.index_by("missing")
 
     def test_index_by_raises_for_unsupported_key_spec(self):
+        """Reject key specs outside the supported string and tuple forms."""
         bucket = DummyBucket(self.manager_class, [DummyRow("A", "x", 1)])
 
         with self.assertRaises(UnsupportedBucketIndexKeySpecError):
             bucket.index_by(["code"])  # type: ignore[arg-type]
 
     def test_index_by_respects_max_rows_guardrail(self):
+        """Stop building an index when the configured row limit is exceeded."""
         bucket = DummyBucket(
             self.manager_class,
             [
@@ -507,6 +517,7 @@ class BucketTests(SimpleTestCase):
             bucket.index_by("code", max_rows=1)
 
     def test_index_by_allows_explicit_unbounded_index(self):
+        """Build an index with no row guardrail when max_rows is None."""
         bucket = DummyBucket(
             self.manager_class,
             [
@@ -520,6 +531,7 @@ class BucketTests(SimpleTestCase):
         self.assertEqual(sorted(index), ["A", "B"])
 
     def test_index_by_rechecks_max_rows_after_unbounded_cache_hit(self):
+        """Keep bounded and unbounded index lookups separated in the run cache."""
         bucket = DummyBucket(
             self.manager_class,
             [

--- a/tests/unit/test_base_bucket.py
+++ b/tests/unit/test_base_bucket.py
@@ -518,3 +518,18 @@ class BucketTests(SimpleTestCase):
         index = bucket.index_by("code", max_rows=None)
 
         self.assertEqual(sorted(index), ["A", "B"])
+
+    def test_index_by_rechecks_max_rows_after_unbounded_cache_hit(self):
+        bucket = DummyBucket(
+            self.manager_class,
+            [
+                DummyRow("A", "x", 1),
+                DummyRow("B", "x", 2),
+            ],
+        )
+
+        with CalculationRunContext():
+            bucket.index_by("code", max_rows=None)
+
+            with self.assertRaises(BucketIndexTooLargeError):
+                bucket.index_by("code", max_rows=1)

--- a/tests/unit/test_bucket_indexing.py
+++ b/tests/unit/test_bucket_indexing.py
@@ -14,6 +14,7 @@ from general_manager.manager.general_manager import GeneralManager
 
 class RelatedManager(GeneralManager):
     def __init__(self, pk: int) -> None:
+        """Create a manager with a simple integer identification value."""
         self._interface = object()
         self._GeneralManager__id = {"id": pk}
         self._manager_state_valid = True
@@ -22,6 +23,7 @@ class RelatedManager(GeneralManager):
 
 class MixedIdentificationManager(GeneralManager):
     def __init__(self) -> None:
+        """Create a manager whose identification keys use mixed hashable types."""
         self._interface = object()
         self._GeneralManager__id = {"id": 10, 2: "external"}
         self._manager_state_valid = True
@@ -30,15 +32,18 @@ class MixedIdentificationManager(GeneralManager):
 
 class Row:
     def __init__(self, day: str | None, related: object = None) -> None:
+        """Create a row object exposing fields used by index-key resolution."""
         self.day = day
         self.related = related
 
 
 def test_normalize_bucket_index_key_spec_accepts_field_name() -> None:
+    """Normalize a single field name into a non-composite field key spec."""
     assert normalize_bucket_index_key_spec("day") == ("field", ("day",), False)
 
 
 def test_normalize_bucket_index_key_spec_accepts_composite_tuple() -> None:
+    """Normalize a tuple of field names into a composite field key spec."""
     assert normalize_bucket_index_key_spec(("day", "related")) == (
         "field",
         ("day", "related"),
@@ -50,20 +55,24 @@ def test_normalize_bucket_index_key_spec_accepts_composite_tuple() -> None:
 def test_normalize_bucket_index_key_spec_rejects_unsupported_specs(
     key_spec: object,
 ) -> None:
+    """Reject key specs that cannot be represented as stable field lookups."""
     with pytest.raises(UnsupportedBucketIndexKeySpecError):
         normalize_bucket_index_key_spec(key_spec)
 
 
 def test_resolve_bucket_index_key_allows_none_key_values() -> None:
+    """Allow None as a valid resolved key value."""
     assert resolve_bucket_index_key(Row(None), "day") is None
 
 
 def test_resolve_bucket_index_key_raises_clear_error_for_missing_field() -> None:
+    """Raise a bucket-index-specific error when a row field is missing."""
     with pytest.raises(MissingBucketIndexKeyError, match="missing"):
         resolve_bucket_index_key(Row("2026-06-15"), "missing")
 
 
 def test_resolve_bucket_index_key_builds_composite_key() -> None:
+    """Resolve composite key specs into ordered tuples of field values."""
     row = Row("2026-06-15", related="component")
 
     assert resolve_bucket_index_key(row, ("day", "related")) == (
@@ -73,6 +82,7 @@ def test_resolve_bucket_index_key_builds_composite_key() -> None:
 
 
 def test_freeze_bucket_index_value_normalizes_manager_values() -> None:
+    """Represent manager values by class and frozen identification."""
     related = RelatedManager(10)
 
     assert freeze_bucket_index_value(related) == (
@@ -82,6 +92,7 @@ def test_freeze_bucket_index_value_normalizes_manager_values() -> None:
 
 
 def test_freeze_bucket_index_value_normalizes_nested_containers() -> None:
+    """Recursively freeze nested containers into stable hashable values."""
     value = {"ids": [2, 1], "flags": {True, False}}
 
     assert freeze_bucket_index_value(value) == (
@@ -91,6 +102,7 @@ def test_freeze_bucket_index_value_normalizes_nested_containers() -> None:
 
 
 def test_freeze_bucket_index_value_normalizes_mixed_type_dict_keys() -> None:
+    """Sort frozen dictionary pairs even when original keys have mixed types."""
     value = {"ids": [2, 1], 2: "external"}
 
     assert freeze_bucket_index_value(value) == (
@@ -102,6 +114,7 @@ def test_freeze_bucket_index_value_normalizes_mixed_type_dict_keys() -> None:
 def test_freeze_bucket_index_value_normalizes_mixed_type_manager_identity_keys() -> (
     None
 ):
+    """Sort frozen manager identity pairs when identity keys have mixed types."""
     related = MixedIdentificationManager()
 
     assert freeze_bucket_index_value(related) == (

--- a/tests/unit/test_bucket_indexing.py
+++ b/tests/unit/test_bucket_indexing.py
@@ -20,6 +20,14 @@ class RelatedManager(GeneralManager):
         self._manager_state_reason = None
 
 
+class MixedIdentificationManager(GeneralManager):
+    def __init__(self) -> None:
+        self._interface = object()
+        self._GeneralManager__id = {"id": 10, 2: "external"}
+        self._manager_state_valid = True
+        self._manager_state_reason = None
+
+
 class Row:
     def __init__(self, day: str | None, related: object = None) -> None:
         self.day = day
@@ -79,4 +87,27 @@ def test_freeze_bucket_index_value_normalizes_nested_containers() -> None:
     assert freeze_bucket_index_value(value) == (
         ("flags", frozenset({False, True})),
         ("ids", (2, 1)),
+    )
+
+
+def test_freeze_bucket_index_value_normalizes_mixed_type_dict_keys() -> None:
+    value = {"ids": [2, 1], 2: "external"}
+
+    assert freeze_bucket_index_value(value) == (
+        (2, "external"),
+        ("ids", (2, 1)),
+    )
+
+
+def test_freeze_bucket_index_value_normalizes_mixed_type_manager_identity_keys() -> (
+    None
+):
+    related = MixedIdentificationManager()
+
+    assert freeze_bucket_index_value(related) == (
+        MixedIdentificationManager,
+        (
+            (2, "external"),
+            ("id", 10),
+        ),
     )

--- a/tests/unit/test_bucket_indexing.py
+++ b/tests/unit/test_bucket_indexing.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from general_manager.bucket.indexing import (
+    MissingBucketIndexKeyError,
+    UnsupportedBucketIndexKeySpecError,
+    freeze_bucket_index_value,
+    normalize_bucket_index_key_spec,
+    resolve_bucket_index_key,
+)
+from general_manager.manager.general_manager import GeneralManager
+
+
+class RelatedManager(GeneralManager):
+    def __init__(self, pk: int) -> None:
+        self._interface = object()
+        self._GeneralManager__id = {"id": pk}
+        self._manager_state_valid = True
+        self._manager_state_reason = None
+
+
+class Row:
+    def __init__(self, day: str | None, related: object = None) -> None:
+        self.day = day
+        self.related = related
+
+
+def test_normalize_bucket_index_key_spec_accepts_field_name() -> None:
+    assert normalize_bucket_index_key_spec("day") == ("field", ("day",), False)
+
+
+def test_normalize_bucket_index_key_spec_accepts_composite_tuple() -> None:
+    assert normalize_bucket_index_key_spec(("day", "related")) == (
+        "field",
+        ("day", "related"),
+        True,
+    )
+
+
+@pytest.mark.parametrize("key_spec", [(), ("day", 1), ["day"], object()])
+def test_normalize_bucket_index_key_spec_rejects_unsupported_specs(
+    key_spec: object,
+) -> None:
+    with pytest.raises(UnsupportedBucketIndexKeySpecError):
+        normalize_bucket_index_key_spec(key_spec)
+
+
+def test_resolve_bucket_index_key_allows_none_key_values() -> None:
+    assert resolve_bucket_index_key(Row(None), "day") is None
+
+
+def test_resolve_bucket_index_key_raises_clear_error_for_missing_field() -> None:
+    with pytest.raises(MissingBucketIndexKeyError, match="missing"):
+        resolve_bucket_index_key(Row("2026-06-15"), "missing")
+
+
+def test_resolve_bucket_index_key_builds_composite_key() -> None:
+    row = Row("2026-06-15", related="component")
+
+    assert resolve_bucket_index_key(row, ("day", "related")) == (
+        "2026-06-15",
+        "component",
+    )
+
+
+def test_freeze_bucket_index_value_normalizes_manager_values() -> None:
+    related = RelatedManager(10)
+
+    assert freeze_bucket_index_value(related) == (
+        RelatedManager,
+        (("id", 10),),
+    )
+
+
+def test_freeze_bucket_index_value_normalizes_nested_containers() -> None:
+    value = {"ids": [2, 1], "flags": {True, False}}
+
+    assert freeze_bucket_index_value(value) == (
+        ("flags", frozenset({False, True})),
+        ("ids", (2, 1)),
+    )

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -267,6 +267,7 @@ def test_orm_bucket_result_helpers_distinguish_empty_tuple_from_missing() -> Non
 
 
 def test_bucket_index_helpers_store_replay_and_clear_dependencies() -> None:
+    """Store a bucket index, replay its dependencies on hit, then clear it."""
     dependencies: set[Dependency] = {
         ("Project", "filter", '{"status": "active"}'),
     }
@@ -306,6 +307,7 @@ def test_bucket_index_helpers_store_replay_and_clear_dependencies() -> None:
 
 
 def test_bucket_index_helpers_distinguish_unique_and_many_indexes() -> None:
+    """Keep unique and multi-value bucket indexes in separate cache entries."""
     key_spec = ("field", ("code",), False)
 
     with CalculationRunContext() as ctx:

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -2,7 +2,9 @@ from unittest import mock
 
 import pytest
 
+from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_cache import DependencyCacheHit
+from general_manager.cache.dependency_index import Dependency
 from general_manager.cache.dependency_publish import (
     CacheComputeLease,
     PendingDependencyCachePublication,
@@ -262,6 +264,73 @@ def test_orm_bucket_result_helpers_distinguish_empty_tuple_from_missing() -> Non
 
         assert ctx.get_orm_bucket_result(("query", "empty")) == ()
         assert ctx.get_orm_bucket_result(("query", "missing")) is None
+
+
+def test_bucket_index_helpers_store_replay_and_clear_dependencies() -> None:
+    dependencies: set[Dependency] = {
+        ("Project", "filter", '{"status": "active"}'),
+    }
+
+    with CalculationRunContext() as ctx:
+        ctx.set_bucket_index_result(
+            ("source", "projects"),
+            ("field", ("code",), False),
+            False,
+            {"A": "project-a"},
+            dependencies,
+        )
+
+        with DependencyTracker() as tracked_dependencies:
+            result = ctx.get_bucket_index_result(
+                ("source", "projects"),
+                ("field", ("code",), False),
+                False,
+            )
+
+        assert result == {"A": "project-a"}
+        assert dependencies <= tracked_dependencies
+
+        ctx.clear_bucket_indexes()
+
+        assert (
+            ctx.get_bucket_index_result(
+                ("source", "projects"),
+                ("field", ("code",), False),
+                False,
+            )
+            is None
+        )
+
+
+def test_bucket_index_helpers_distinguish_unique_and_many_indexes() -> None:
+    key_spec = ("field", ("code",), False)
+
+    with CalculationRunContext() as ctx:
+        ctx.set_bucket_index_result(
+            ("source", "projects"),
+            key_spec,
+            False,
+            {"A": "project-a"},
+            set(),
+        )
+        ctx.set_bucket_index_result(
+            ("source", "projects"),
+            key_spec,
+            True,
+            {"A": ("project-a", "project-b")},
+            set(),
+        )
+
+        assert ctx.get_bucket_index_result(
+            ("source", "projects"),
+            key_spec,
+            False,
+        ) == {"A": "project-a"}
+        assert ctx.get_bucket_index_result(
+            ("source", "projects"),
+            key_spec,
+            True,
+        ) == {"A": ("project-a", "project-b")}
 
 
 def test_index_loads_once_and_groups_by_key() -> None:

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -278,6 +278,7 @@ def test_bucket_index_helpers_store_replay_and_clear_dependencies() -> None:
             False,
             {"A": "project-a"},
             dependencies,
+            1000,
         )
 
         with DependencyTracker() as tracked_dependencies:
@@ -285,6 +286,7 @@ def test_bucket_index_helpers_store_replay_and_clear_dependencies() -> None:
                 ("source", "projects"),
                 ("field", ("code",), False),
                 False,
+                1000,
             )
 
         assert result == {"A": "project-a"}
@@ -297,6 +299,7 @@ def test_bucket_index_helpers_store_replay_and_clear_dependencies() -> None:
                 ("source", "projects"),
                 ("field", ("code",), False),
                 False,
+                1000,
             )
             is None
         )
@@ -312,6 +315,7 @@ def test_bucket_index_helpers_distinguish_unique_and_many_indexes() -> None:
             False,
             {"A": "project-a"},
             set(),
+            1000,
         )
         ctx.set_bucket_index_result(
             ("source", "projects"),
@@ -319,17 +323,20 @@ def test_bucket_index_helpers_distinguish_unique_and_many_indexes() -> None:
             True,
             {"A": ("project-a", "project-b")},
             set(),
+            1000,
         )
 
         assert ctx.get_bucket_index_result(
             ("source", "projects"),
             key_spec,
             False,
+            1000,
         ) == {"A": "project-a"}
         assert ctx.get_bucket_index_result(
             ("source", "projects"),
             key_spec,
             True,
+            1000,
         ) == {"A": ("project-a", "project-b")}
 
 

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -249,6 +249,7 @@ class DatabaseBucketTestCase(TestCase):
             )
 
     def test_equivalent_database_buckets_share_index_inside_run_context(self):
+        """Share a bucket index for equivalent querysets in one run context."""
         first_bucket = DatabaseBucket(
             User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
             UserManager,
@@ -271,6 +272,7 @@ class DatabaseBucketTestCase(TestCase):
         )
 
     def test_repeated_equivalent_index_lookups_reduce_sql_work(self):
+        """Avoid a second SQL query for equivalent index lookups in one run."""
         first_bucket = DatabaseBucket(
             User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
             UserManager,
@@ -345,6 +347,7 @@ class DatabaseBucketTestCase(TestCase):
             self.assertNotIn(unsaved, self.bucket)
 
     def test_bucket_result_cache_hit_still_tracks_dependencies(self):
+        """Replay queryset dependencies when a database bucket result is cached."""
         bucket = DatabaseBucket(
             User.objects.filter(username="alice"),
             UserManager,
@@ -366,6 +369,7 @@ class DatabaseBucketTestCase(TestCase):
         )
 
     def test_database_bucket_index_hit_replays_source_dependencies(self):
+        """Replay queryset dependencies when a database bucket index is cached."""
         bucket = DatabaseBucket(
             User.objects.filter(username="alice"),
             UserManager,

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -270,6 +270,22 @@ class DatabaseBucketTestCase(TestCase):
             [self.u1.id, self.u2.id],
         )
 
+    def test_repeated_equivalent_index_lookups_reduce_sql_work(self):
+        first_bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+        )
+        second_bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            self.assertEqual(len(first_bucket.index_by("identification")), 2)
+            self.assertEqual(len(second_bucket.index_by("identification")), 2)
+
     def test_different_ordering_does_not_share_iter_sql_inside_run_context(self):
         ascending = DatabaseBucket(
             User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
@@ -339,6 +355,27 @@ class DatabaseBucketTestCase(TestCase):
             list(bucket)
             with DependencyTracker() as dependencies:
                 list(bucket)
+
+        self.assertIn(
+            (
+                "UserManager",
+                "filter",
+                '{"username": "alice"}',
+            ),
+            dependencies,
+        )
+
+    def test_database_bucket_index_hit_replays_source_dependencies(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username="alice"),
+            UserManager,
+            {"username": ["alice"]},
+        )
+
+        with CalculationRunContext():
+            bucket.index_by("identification")
+            with DependencyTracker() as dependencies:
+                bucket.index_by("identification")
 
         self.assertIn(
             (

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -248,6 +248,28 @@ class DatabaseBucketTestCase(TestCase):
                 [self.u1.id, self.u2.id],
             )
 
+    def test_equivalent_database_buckets_share_index_inside_run_context(self):
+        first_bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+        )
+        second_bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            first_index = first_bucket.index_by("identification")
+            second_index = second_bucket.index_by("identification")
+
+        self.assertIs(first_index, second_index)
+        self.assertEqual(
+            sorted(manager.identification["id"] for manager in first_index.values()),
+            [self.u1.id, self.u2.id],
+        )
+
     def test_different_ordering_does_not_share_iter_sql_inside_run_context(self):
         ascending = DatabaseBucket(
             User.objects.filter(username__in=["alice", "bob"]).order_by("username"),

--- a/tests/unit/test_request_interface.py
+++ b/tests/unit/test_request_interface.py
@@ -539,6 +539,7 @@ class TestRequestInterface(SimpleTestCase):
         self.assertTrue(bucket._materialized)
 
     def test_materialized_request_bucket_indexes_keep_distinct_payloads(self) -> None:
+        """Keep indexes for separately materialized request buckets isolated."""
         alpha_payload = {
             "id": 1,
             "name": "Alpha",

--- a/tests/unit/test_request_interface.py
+++ b/tests/unit/test_request_interface.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 from django.test import SimpleTestCase
 
 from general_manager.bucket.request_bucket import RequestBucket
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.interface.bundles import REQUEST_CAPABILITIES
 from general_manager.interface import RequestInterface
 from general_manager.interface.requests import (
@@ -536,6 +537,40 @@ class TestRequestInterface(SimpleTestCase):
         assert item is not None
         self.assertEqual(item.name, "Alpha")
         self.assertTrue(bucket._materialized)
+
+    def test_materialized_request_bucket_indexes_keep_distinct_payloads(self) -> None:
+        alpha_payload = {
+            "id": 1,
+            "name": "Alpha",
+            "status": "active",
+            "updated_at": datetime(2026, 3, 11, 9, 0, 0),
+            "local_name": "Alpha Local",
+        }
+        beta_payload = {
+            "id": 1,
+            "name": "Beta",
+            "status": "active",
+            "updated_at": datetime(2026, 3, 11, 9, 0, 0),
+            "local_name": "Beta Local",
+        }
+        alpha_bucket = RequestBucket(
+            RemoteProject,
+            RemoteProject.Interface,
+            raw_items=(alpha_payload,),
+        )
+        beta_bucket = RequestBucket(
+            RemoteProject,
+            RemoteProject.Interface,
+            raw_items=(beta_payload,),
+        )
+
+        with CalculationRunContext():
+            alpha_index = alpha_bucket.index_by("name")
+            beta_index = beta_bucket.index_by("name")
+
+        self.assertEqual(sorted(alpha_index), ["Alpha"])
+        self.assertEqual(sorted(beta_index), ["Beta"])
+        self.assertIsNot(alpha_index, beta_index)
 
     def test_all_preserves_existing_request_filters(self) -> None:
         bucket = RemoteProject.filter(status="active")


### PR DESCRIPTION
## Summary
- Add bucket-aware run-scoped indexing via Bucket.index_by(...) and Bucket.index_many(...)
- Cache indexes in CalculationRunContext with source dependency replay and same-run mutation clearing
- Document the new API and export supported bucket index exceptions

## Test Plan
- python -m pytest tests/unit/test_bucket_indexing.py tests/unit/test_base_bucket.py tests/unit/test_calculation_run_context.py tests/unit/test_database_bucket.py tests/integration/test_caching.py -v
- ruff check src/general_manager/bucket/indexing.py src/general_manager/bucket/base_bucket.py src/general_manager/bucket/database_bucket.py src/general_manager/bucket/calculation_bucket.py src/general_manager/bucket/request_bucket.py src/general_manager/cache/run_context.py src/general_manager/cache/signals.py tests/unit/test_bucket_indexing.py tests/unit/test_base_bucket.py tests/unit/test_calculation_run_context.py tests/unit/test_database_bucket.py tests/integration/test_caching.py
- ruff format --check src/general_manager/bucket/indexing.py src/general_manager/bucket/base_bucket.py src/general_manager/bucket/database_bucket.py src/general_manager/bucket/calculation_bucket.py src/general_manager/bucket/request_bucket.py src/general_manager/cache/run_context.py src/general_manager/cache/signals.py tests/unit/test_bucket_indexing.py tests/unit/test_base_bucket.py tests/unit/test_calculation_run_context.py tests/unit/test_database_bucket.py tests/integration/test_caching.py
- mypy
- python -m pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `index_by()` and `index_many()` to buckets for fast, keyed lookups built from row attributes
  * Bucket indexes are cached and reused within the same calculation run for better repeated access
  * Exposed additional bucket index validation errors (e.g., duplicate keys, missing fields, unsupported key specs, unhashable keys, index too large)
* **Bug Fixes**
  * Ensured cached bucket indexes are cleared after data changes within a run
* **Documentation**
  * Updated the “Working-set reuse” guide with the new indexing approach and error cases
* **Tests**
  * Added integration and unit coverage for caching, clearing, and key/index behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->