### PR TITLE
feat: shard dependency cache index

### DIFF
--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import random
-import re
 import time
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Tuple, Type, cast
@@ -12,6 +11,26 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, Tuple, Type, cast
 from django.core.cache import cache
 from django.dispatch import receiver
 
+from general_manager.cache.dependency_matching import (
+    current_value_for_path as resolve_current_value_for_path,
+    lookup_spec_from_key,
+    matches_lookup_value,
+    normalize_dependency_value,
+    parse_dependency_identifier,
+    serialize_normalized_value,
+)
+from general_manager.cache.dependency_shards import (
+    ReverseDependencyMembership,
+    all_records_cache_keys,
+    candidate_cache_keys_for_lookup,
+    record_cache_dependencies,
+    record_many_cache_dependencies,
+    remove_cache_key_from_shards,
+    request_query_cache_keys,
+    reverse_membership_key,
+    reverse_memberships,
+    tracked_lookup_names,
+)
 from general_manager.cache.signals import post_data_change, pre_data_change
 from general_manager.logging import get_logger
 
@@ -222,7 +241,10 @@ def get_full_index() -> dependency_index:
             "request_query": {},
             "all": {},
         }
-        cache.set(INDEX_KEY, idx, None)
+        for reverse in reverse_memberships():
+            dependencies: set[Dependency] = set(reverse.simple_dependencies)
+            dependencies.update(reverse.composite_dependencies)
+            _record_dependencies_locked(idx, reverse.cache_key, dependencies)
         return idx
     idx = cast(dependency_index, cached_index)
     changed = False
@@ -253,37 +275,12 @@ def set_full_index(idx: dependency_index) -> None:
 
 def _normalize_dependency_identifier(value: Any) -> Any:
     """Return a JSON-serializable representation for dependency tracking."""
-    if isinstance(value, dict):
-        return {
-            str(key): _normalize_dependency_identifier(val)
-            for key, val in value.items()
-        }
-    if isinstance(value, (list, tuple)):
-        return [_normalize_dependency_identifier(item) for item in value]
-    if isinstance(value, set):
-        return [
-            _normalize_dependency_identifier(item) for item in sorted(value, key=str)
-        ]
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, date):
-        return value.isoformat()
-    if isinstance(value, (str, int, float, bool)) or value is None:
-        return value
-    return {"__repr__": repr(value)}
+    return normalize_dependency_value(value)
 
 
 def serialize_dependency_identifier(value: Any) -> str:
     """Serialize dependency payloads using a deterministic literal-safe format."""
-    return json.dumps(_normalize_dependency_identifier(value), sort_keys=True)
-
-
-def parse_dependency_identifier(identifier: str) -> Any:
-    """Parse a JSON-serialized dependency identifier, returning None on failure."""
-    try:
-        return json.loads(identifier)
-    except (json.JSONDecodeError, ValueError):
-        return None
+    return serialize_normalized_value(value)
 
 
 # -----------------------------------------------------------------------------
@@ -364,9 +361,7 @@ def record_dependencies(
     """
     acquire_lock_with_retry("record_dependencies")
     try:
-        idx = get_full_index()
-        _record_dependencies_locked(idx, cache_key, dependencies)
-        set_full_index(idx)
+        record_cache_dependencies(cache_key, dependencies)
     finally:
         release_lock()
 
@@ -387,10 +382,7 @@ def record_many_dependencies(
 
     acquire_lock_with_retry("record_many_dependencies")
     try:
-        idx = get_full_index()
-        for cache_key, dependencies in normalized.items():
-            _record_dependencies_locked(idx, cache_key, dependencies)
-        set_full_index(idx)
+        record_many_cache_dependencies(normalized.items())
     finally:
         release_lock()
 
@@ -412,50 +404,12 @@ def remove_cache_key_from_index(cache_key: str) -> None:
     """
     acquire_lock_with_retry("remove_cache_key_from_index")
     try:
-        idx = get_full_index()
-        all_section = cast(dict[str, set[str]], idx.get("all", {}))
-        for mname, key_set in list(all_section.items()):
-            if cache_key in key_set:
-                key_set.remove(cache_key)
-                if not key_set:
-                    del all_section[mname]
-        for action in ACTIONS:
-            action_section = cast(
-                dict[general_manager_name, manager_dependency_section],
-                idx[action],
-            )
-            for mname, model_section in list(action_section.items()):
-                cache_dependencies = model_section.get("__cache_dependencies__", {})
-                for lookup, lookup_map in list(model_section.items()):
-                    if lookup == "__cache_dependencies__":
-                        continue
-                    lookup_map = cast(lookup_dependency_map, lookup_map)
-                    for val_key, key_set in list(lookup_map.items()):
-                        if cache_key in key_set:
-                            key_set.remove(cache_key)
-                            if not key_set:
-                                del lookup_map[val_key]
-                    if not lookup_map:
-                        del model_section[lookup]
-                if cache_dependencies:
-                    cache_dependencies.pop(cache_key, None)
-                    if not cache_dependencies:
-                        model_section.pop("__cache_dependencies__", None)
-                if not model_section:
-                    del action_section[mname]
-        request_query_section = cast(
-            dict[str, dict[str, set[str]]],
-            idx.get("request_query", {}),
-        )
-        for mname, query_section in list(request_query_section.items()):
-            for identifier, key_set in list(query_section.items()):
-                if cache_key in key_set:
-                    key_set.remove(cache_key)
-                    if not key_set:
-                        del query_section[identifier]
-            if not query_section:
-                del request_query_section[mname]
-        set_full_index(idx)
+        if cache.get(INDEX_KEY, None) is not None and not reverse_memberships():
+            idx = get_full_index()
+            _remove_cache_keys_from_index_locked(idx, (cache_key,))
+            set_full_index(idx)
+            return
+        remove_cache_key_from_shards(cache_key)
     finally:
         release_lock()
 
@@ -541,11 +495,16 @@ def invalidate_and_remove_cache_keys(cache_keys: Iterable[str]) -> None:
         return
     acquire_lock_with_retry("invalidate_and_remove_cache_keys")
     try:
-        idx = get_full_index()
+        if cache.get(INDEX_KEY, None) is not None and not reverse_memberships():
+            idx = get_full_index()
+            for cache_key in keys:
+                cache.delete(cache_key)
+            _remove_cache_keys_from_index_locked(idx, keys)
+            set_full_index(idx)
+            return
         for cache_key in keys:
             cache.delete(cache_key)
-        _remove_cache_keys_from_index_locked(idx, keys)
-        set_full_index(idx)
+            remove_cache_key_from_shards(cache_key)
     finally:
         release_lock()
 
@@ -578,12 +537,19 @@ def invalidate_request_query_dependencies(manager_name: str) -> tuple[str, ...]:
     """
     acquire_lock_with_retry("invalidate_request_query_dependencies")
     try:
-        idx = get_full_index()
-        invalidated_keys = _invalidate_request_query_dependencies_locked(
-            idx, manager_name
-        )
-        if invalidated_keys:
-            set_full_index(idx)
+        if cache.get(INDEX_KEY, None) is not None and not reverse_memberships():
+            idx = get_full_index()
+            invalidated_keys = _invalidate_request_query_dependencies_locked(
+                idx,
+                manager_name,
+            )
+            if invalidated_keys:
+                set_full_index(idx)
+            return invalidated_keys
+        invalidated_keys = tuple(dict.fromkeys(request_query_cache_keys(manager_name)))
+        for cache_key in invalidated_keys:
+            cache.delete(cache_key)
+            remove_cache_key_from_shards(cache_key)
         return invalidated_keys
     finally:
         release_lock()
@@ -604,23 +570,23 @@ def capture_old_values(
     if instance is None:
         return
     manager_name = sender.__name__
-    idx = get_full_index()
-    # get all lookups for this model
-    lookups = set()
-    for action in ACTIONS:
-        model_section = idx[action].get(manager_name)
-        if isinstance(model_section, dict):
-            for lookup in model_section.keys():
-                if not isinstance(lookup, str):
-                    continue
-                if lookup.startswith("__sort__"):
-                    lookups.add(lookup.removeprefix("__sort__"))
-                    continue
-                if lookup.startswith("__"):
-                    continue
-                lookups.add(lookup)
-        elif isinstance(model_section, list):
-            lookups |= set(model_section)
+    lookups = tracked_lookup_names(manager_name)
+    if not lookups and not reverse_memberships():
+        idx = get_full_index()
+        for action in ACTIONS:
+            model_section = idx[action].get(manager_name)
+            if isinstance(model_section, dict):
+                for lookup in model_section.keys():
+                    if not isinstance(lookup, str):
+                        continue
+                    if lookup.startswith("__sort__"):
+                        lookups.add(lookup.removeprefix("__sort__"))
+                        continue
+                    if lookup.startswith("__"):
+                        continue
+                    lookups.add(lookup)
+            elif isinstance(model_section, list):
+                lookups |= set(model_section)
     if lookups and instance.identification:
         # save old values for later comparison
         vals: dict[str, object] = {}
@@ -764,116 +730,8 @@ def _generic_cache_invalidation_locked(
             return None
 
     def matches(op: str, value: Any, val_key: Any) -> bool:
-        """
-        Evaluate whether a given value satisfies a lookup operation described by `op` and `val_key`.
-
-        Supports operators:
-        - "eq": equality; attempts to interpret `val_key` as a literal and coerce it to `value`'s type before comparing.
-        - "in": membership; expects `val_key` to be a literal iterable and checks if any coerced element equals `value`.
-        - "gt", "gte", "lt", "lte": numeric/date comparisons; `val_key` is interpreted as a literal and coerced to `value`'s type.
-        - "contains", "startswith", "endswith": string containment/prefix/suffix checks; both sides are compared as strings.
-        - "regex": treats `val_key` as a regular expression pattern and tests it against the string form of `value`.
-
-        Behavior notes:
-        - If `value` is None the function only matches explicit null equality
-          or membership checks.
-        - ``val_key`` is a JSON-serialised string produced by
-          :func:`json.dumps`.  Parsing is done with :func:`json.loads`; if
-          JSON parsing or type coercion fails, the function falls back to
-          conservative comparisons or returns ``False`` where appropriate.
-        - Regex patterns that fail to compile are treated as non-matching.
-
-        Parameters:
-            op (str): The lookup operator name (one of the supported operators above).
-            value (Any): The runtime value to test.
-            val_key (Any): The stored comparison key (often a string representation) to interpret for the comparison.
-
-        Returns:
-            bool: `True` if the comparison defined by `op` and `val_key` matches `value`, `False` otherwise.
-        """
-        # eq
-        if op == "eq":
-            literal_val = _json_loads_val_key(val_key)
-            if literal_val is None:
-                return value is None
-            repr_marker = _repr_marker(literal_val)
-            if repr_marker is not None:
-                return repr(value) == repr_marker
-            comparable = _coerce_to_type(value, literal_val)
-            if comparable is None:
-                return repr(value) == val_key
-            return value == comparable
-
-        # in
-        if op == "in":
-            try:
-                seq = json.loads(val_key)
-            except (json.JSONDecodeError, ValueError):
-                return False
-            for item in seq:
-                if item is None:
-                    if value is None:
-                        return True
-                    continue
-                repr_marker = _repr_marker(item)
-                if repr_marker is not None:
-                    if repr(value) == repr_marker:
-                        return True
-                    continue
-                comparable = _coerce_to_type(value, item)
-                if comparable is not None:
-                    if value == comparable:
-                        return True
-                elif repr(value) == repr(item):
-                    return True
-            return False
-
-        # range comparisons
-        if op in ("gt", "gte", "lt", "lte"):
-            if value is None:
-                return False
-            literal_val = _json_loads_val_key(val_key)
-            thr = _coerce_to_type(value, literal_val)
-            if thr is None:
-                return False
-            if op == "gt":
-                return value > thr
-            if op == "gte":
-                return value >= thr
-            if op == "lt":
-                return value < thr
-            if op == "lte":
-                return value <= thr
-
-        # wildcard / regex comparisons
-        if op in ("contains", "startswith", "endswith", "regex"):
-            if value is None:
-                return False
-            try:
-                literal = json.loads(val_key)
-            except (json.JSONDecodeError, ValueError):
-                literal = val_key
-
-            # ensure we always work with strings to avoid TypeErrors
-            text = "" if value is None else str(value)
-            if op == "contains":
-                return literal in text
-            if op == "startswith":
-                return text.startswith(literal)
-            if op == "endswith":
-                return text.endswith(literal)
-            # regex: treat the stored key as the regex pattern
-            if op == "regex":
-                try:
-                    pattern_source = (
-                        literal if isinstance(literal, str) else str(literal)
-                    )
-                    pattern = re.compile(pattern_source)
-                except re.error:
-                    return False
-                return bool(pattern.search(text))
-
-        return False
+        """Evaluate whether a runtime value matches a stored lookup value."""
+        return matches_lookup_value(op, value, val_key)
 
     def current_value_for_path(path: list[str]) -> Any:
         """
@@ -1184,6 +1042,157 @@ def _generic_cache_invalidation_locked(
                             _remove_cache_keys_from_index_locked(idx, (ck,))
 
 
+def _generic_cache_invalidation_from_shards(
+    manager_name: str,
+    instance: GeneralManager,
+    old_relevant_values: dict[str, Any],
+) -> None:
+    def value_for_lookup(lookup: str, *, use_old_values: bool) -> Any:
+        spec = lookup_spec_from_key(lookup)
+        lookup_name = "__".join(spec.attr_path)
+        if use_old_values:
+            return old_relevant_values.get(lookup_name)
+        return resolve_current_value_for_path(instance, spec.attr_path)
+
+    def params_match(params: dict[str, Any], *, use_old_values: bool) -> bool:
+        for lookup, expected in params.items():
+            spec = lookup_spec_from_key(str(lookup))
+            expected_key = serialize_dependency_identifier(expected)
+            if not matches_lookup_value(
+                spec.operator,
+                value_for_lookup(spec.lookup, use_old_values=use_old_values),
+                expected_key,
+            ):
+                return False
+        return True
+
+    def dependency_matches(
+        action: str,
+        identifier: str,
+        *,
+        changed_lookup: str | None,
+    ) -> bool:
+        if action in {"all", "request_query"}:
+            return True
+        if action == "identification":
+            identification = getattr(instance, "identification", None)
+            return bool(
+                identification
+                and serialize_dependency_identifier(identification) == identifier
+            )
+        if action not in ACTIONS:
+            return False
+        params = parse_dependency_identifier(identifier)
+        if not isinstance(params, dict):
+            return False
+        if not params:
+            return True
+
+        sort_payloads = [
+            payload
+            for lookup, payload in params.items()
+            if str(lookup).startswith("__sort__")
+            and (
+                changed_lookup is None
+                or str(lookup).removeprefix("__sort__") == changed_lookup
+            )
+        ]
+        if sort_payloads:
+            for payload in sort_payloads:
+                if not isinstance(payload, dict):
+                    continue
+                filters = payload.get("filters", {})
+                excludes = payload.get("excludes", {})
+                if not isinstance(filters, dict) or not isinstance(excludes, dict):
+                    continue
+                old_in_bucket = params_match(filters, use_old_values=True) and not (
+                    params_match(excludes, use_old_values=True) if excludes else False
+                )
+                new_in_bucket = params_match(filters, use_old_values=False) and not (
+                    params_match(excludes, use_old_values=False) if excludes else False
+                )
+                if old_in_bucket or new_in_bucket:
+                    return True
+            return False
+
+        old_match = params_match(params, use_old_values=True)
+        new_match = params_match(params, use_old_values=False)
+        if action == "filter":
+            return old_match or new_match
+        return old_match != new_match
+
+    def candidate_should_invalidate(
+        cache_key: str,
+        action: str,
+        changed_lookup: str | None,
+    ) -> bool:
+        reverse = cache.get(reverse_membership_key(cache_key))
+        if not isinstance(reverse, ReverseDependencyMembership):
+            return True
+        for manager, dependency_action, identifier in reverse.simple_dependencies:
+            if manager == manager_name and dependency_matches(
+                dependency_action,
+                identifier,
+                changed_lookup=changed_lookup,
+            ):
+                return True
+        for manager, dependency_action, identifier in reverse.composite_dependencies:
+            if (
+                manager == manager_name
+                and dependency_action == action
+                and dependency_matches(
+                    dependency_action,
+                    identifier,
+                    changed_lookup=changed_lookup,
+                )
+            ):
+                return True
+        return False
+
+    invalidation_candidates: set[str] = set()
+
+    invalidation_candidates.update(request_query_cache_keys(manager_name))
+    invalidation_candidates.update(all_records_cache_keys(manager_name))
+    identification = getattr(instance, "identification", None)
+    if identification:
+        invalidation_candidates.update(
+            candidate_cache_keys_for_lookup(
+                manager_name,
+                "filter",
+                "identification",
+                old_value=serialize_dependency_identifier(identification),
+                new_value=serialize_dependency_identifier(identification),
+            )
+        )
+
+    for lookup in tracked_lookup_names(manager_name):
+        old_value = old_relevant_values.get(lookup)
+        new_value = resolve_current_value_for_path(instance, tuple(lookup.split("__")))
+        if old_value == new_value:
+            continue
+        for action in ACTIONS:
+            for cache_key in candidate_cache_keys_for_lookup(
+                manager_name,
+                action,
+                lookup,
+                old_value=old_value,
+                new_value=new_value,
+            ):
+                if candidate_should_invalidate(cache_key, action, lookup):
+                    invalidation_candidates.add(cache_key)
+
+    for cache_key in tuple(dict.fromkeys(invalidation_candidates)):
+        logger.info(
+            "invalidating cache key",
+            context={
+                "manager": manager_name,
+                "key": cache_key,
+            },
+        )
+        cache.delete(cache_key)
+        remove_cache_key_from_shards(cache_key)
+
+
 @receiver(post_data_change)
 def generic_cache_invalidation(
     sender: type[GeneralManager],
@@ -1204,13 +1213,23 @@ def generic_cache_invalidation(
     manager_name = sender.__name__
     acquire_lock_with_retry("generic_cache_invalidation")
     try:
-        idx = get_full_index()
-        _generic_cache_invalidation_locked(
-            idx,
+        if not reverse_memberships():
+            idx = get_full_index()
+            sections: tuple[Literal["filter", "exclude", "all", "request_query"], ...]
+            sections = ("filter", "exclude", "all", "request_query")
+            if any(idx.get(section) for section in sections):
+                _generic_cache_invalidation_locked(
+                    idx,
+                    manager_name,
+                    instance,
+                    old_relevant_values,
+                )
+                set_full_index(idx)
+                return
+        _generic_cache_invalidation_from_shards(
             manager_name,
             instance,
             old_relevant_values,
         )
-        set_full_index(idx)
     finally:
         release_lock()

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -1168,8 +1168,6 @@ def _generic_cache_invalidation_from_shards(
     for lookup in tracked_lookup_names(manager_name):
         old_value = old_relevant_values.get(lookup)
         new_value = resolve_current_value_for_path(instance, tuple(lookup.split("__")))
-        if old_value == new_value:
-            continue
         for action in ACTIONS:
             for cache_key in candidate_cache_keys_for_lookup(
                 manager_name,

--- a/src/general_manager/cache/dependency_matching.py
+++ b/src/general_manager/cache/dependency_matching.py
@@ -1,0 +1,242 @@
+"""Pure helpers for dependency-index lookup parsing and matching."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Literal
+
+LookupOperator = Literal[
+    "eq",
+    "in",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "contains",
+    "startswith",
+    "endswith",
+    "regex",
+]
+
+EXACT_OPERATORS = frozenset({"eq"})
+SCAN_OPERATORS = frozenset(
+    {"in", "gt", "gte", "lt", "lte", "contains", "startswith", "endswith", "regex"}
+)
+SUPPORTED_LOOKUP_OPERATORS = EXACT_OPERATORS | SCAN_OPERATORS
+UNDEFINED = object()
+
+
+@dataclass(frozen=True, slots=True)
+class LookupSpec:
+    lookup: str
+    attr_path: tuple[str, ...]
+    operator: LookupOperator
+
+
+def normalize_dependency_value(value: Any) -> Any:
+    """Return a deterministic JSON-compatible representation for dependency data."""
+    if isinstance(value, dict):
+        return {
+            str(key): normalize_dependency_value(val)
+            for key, val in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [normalize_dependency_value(item) for item in value]
+    if isinstance(value, set):
+        return [normalize_dependency_value(item) for item in sorted(value, key=str)]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    get_state = getattr(value, "__getstate__", None)
+    if callable(get_state):
+        state = get_state()
+        if isinstance(state, dict):
+            return {"__state__": normalize_dependency_value(state)}
+    return {"__repr__": repr(value)}
+
+
+def serialize_normalized_value(value: Any) -> str:
+    """Serialize dependency values in the canonical dependency format."""
+    return json.dumps(normalize_dependency_value(value), sort_keys=True)
+
+
+def stable_value_hash(value: Any) -> str:
+    """Return a stable hash suitable for shard keys."""
+    payload = serialize_normalized_value(value).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def lookup_spec_from_key(lookup: str) -> LookupSpec:
+    """Split a dependency lookup into an attribute path and lookup operator."""
+    parts = tuple(lookup.split("__"))
+    tail = parts[-1]
+    if tail in SUPPORTED_LOOKUP_OPERATORS - {"eq"}:
+        return LookupSpec(
+            lookup=lookup,
+            attr_path=parts[:-1],
+            operator=tail,  # type: ignore[arg-type]
+        )
+    return LookupSpec(lookup=lookup, attr_path=parts, operator="eq")
+
+
+def parse_dependency_identifier(identifier: str) -> Any:
+    """Parse a JSON-serialized dependency identifier, returning None on failure."""
+    try:
+        return json.loads(identifier)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def current_value_for_path(instance: object, attr_path: tuple[str, ...]) -> Any:
+    """Resolve a nested attribute path from an instance."""
+    current: object = instance
+    for attr in attr_path:
+        current = getattr(current, attr, UNDEFINED)
+        if current is UNDEFINED:
+            return None
+    return current
+
+
+def _json_loads_val_key(val_key: Any) -> Any:
+    if isinstance(val_key, str):
+        try:
+            return json.loads(val_key)
+        except (json.JSONDecodeError, ValueError):
+            return val_key
+    return val_key
+
+
+def _repr_marker(raw: Any) -> str | None:
+    if isinstance(raw, dict) and set(raw.keys()) == {"__repr__"}:
+        marker = raw.get("__repr__")
+        return marker if isinstance(marker, str) else None
+    return None
+
+
+def _coerce_to_type(sample: Any, raw: Any) -> Any | None:
+    if sample is None:
+        return None
+    if isinstance(sample, datetime):
+        if isinstance(raw, datetime):
+            parsed = raw
+        elif isinstance(raw, str):
+            candidate = raw.replace("Z", "+00:00").replace(" ", "T", 1)
+            try:
+                parsed = datetime.fromisoformat(candidate)
+            except ValueError:
+                return None
+        else:
+            return None
+        if sample.tzinfo and parsed.tzinfo is None:
+            return parsed.replace(tzinfo=sample.tzinfo)
+        if not sample.tzinfo and parsed.tzinfo is not None:
+            return parsed.replace(tzinfo=None)
+        return parsed
+    if isinstance(sample, date) and not isinstance(sample, datetime):
+        if isinstance(raw, date) and not isinstance(raw, datetime):
+            return raw
+        if isinstance(raw, str):
+            try:
+                return date.fromisoformat(raw)
+            except ValueError:
+                return None
+        return None
+    if isinstance(sample, bool):
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, int):
+            return bool(raw)
+        if isinstance(raw, str):
+            normalized = raw.strip().lower()
+            if normalized in {"true", "1", "yes", "y", "t"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "f"}:
+                return False
+        return None
+    if isinstance(raw, dict) and set(raw.keys()) == {"__state__"}:
+        state = raw["__state__"]
+        if isinstance(state, dict):
+            try:
+                return type(sample)(**state)
+            except (TypeError, ValueError):
+                if {"magnitude", "unit"} <= set(state):
+                    try:
+                        return type(sample)(state["magnitude"], state["unit"])
+                    except (TypeError, ValueError):
+                        return None
+        return None
+    try:
+        return type(sample)(raw)
+    except (TypeError, ValueError):
+        if isinstance(raw, type(sample)):
+            return raw
+        return None
+
+
+def matches_lookup_value(operator: str, value: Any, stored_value: Any) -> bool:
+    """Return whether a runtime value matches a serialized dependency value."""
+    if operator == "eq":
+        literal_val = _json_loads_val_key(stored_value)
+        if literal_val is None:
+            return value is None
+        repr_marker = _repr_marker(literal_val)
+        if repr_marker is not None:
+            return repr(value) == repr_marker
+        comparable = _coerce_to_type(value, literal_val)
+        if comparable is None:
+            return repr(value) == stored_value
+        return value == comparable
+    if operator == "in":
+        try:
+            sequence = json.loads(stored_value)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            return False
+        for item in sequence:
+            if item is None and value is None:
+                return True
+            repr_marker = _repr_marker(item)
+            if repr_marker is not None and repr(value) == repr_marker:
+                return True
+            comparable = _coerce_to_type(value, item)
+            if comparable is not None and value == comparable:
+                return True
+            if comparable is None and repr(value) == repr(item):
+                return True
+        return False
+    if operator in {"gt", "gte", "lt", "lte"}:
+        if value is None:
+            return False
+        threshold = _coerce_to_type(value, _json_loads_val_key(stored_value))
+        if threshold is None:
+            return False
+        if operator == "gt":
+            return value > threshold
+        if operator == "gte":
+            return value >= threshold
+        if operator == "lt":
+            return value < threshold
+        return value <= threshold
+    if operator in {"contains", "startswith", "endswith", "regex"}:
+        if value is None:
+            return False
+        literal = _json_loads_val_key(stored_value)
+        text = str(value)
+        pattern_text = literal if isinstance(literal, str) else str(literal)
+        if operator == "contains":
+            return pattern_text in text
+        if operator == "startswith":
+            return text.startswith(pattern_text)
+        if operator == "endswith":
+            return text.endswith(pattern_text)
+        try:
+            return bool(re.compile(pattern_text).search(text))
+        except re.error:
+            return False
+    return False

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -19,13 +19,13 @@ from general_manager.cache.dependency_cache import (
 from general_manager.cache.dependency_index import (
     LOCK_TIMEOUT,
     Dependency,
-    _record_dependencies_locked,
     acquire_lock_with_retry,
     get_dependency_generation,
-    get_full_index,
     is_dependency_data_change_active,
     release_lock,
-    set_full_index,
+)
+from general_manager.cache.dependency_shards import (
+    record_many_cache_dependencies,
 )
 
 
@@ -184,17 +184,12 @@ def publish_dependency_cache_entries(
         if not publishable_entries:
             return
 
-        idx = get_full_index()
-        for entry in publishable_entries:
-            if entry.dependencies:
-                _record_dependencies_locked(
-                    idx,
-                    entry.cache_key,
-                    entry.dependencies,
-                )
+        record_many_cache_dependencies(
+            (entry.cache_key, entry.dependencies)
+            for entry in publishable_entries
+            if entry.dependencies
+        )
 
-        _ensure_publish_current(current_generation)
-        set_full_index(idx)
         _ensure_publish_current(current_generation)
         _set_dependency_cache_entries(publishable_entries)
     finally:
@@ -230,11 +225,9 @@ def publish_dependency_cache_entry(
                 record_many_fn([(cache_key, dependency_set)])
             _ensure_publish_current(started_generation)
         else:
-            idx = get_full_index()
             if dependency_set:
-                _record_dependencies_locked(idx, cache_key, dependency_set)
+                record_many_cache_dependencies([(cache_key, dependency_set)])
             _ensure_publish_current(started_generation)
-            set_full_index(idx)
 
         cache_backend.set(
             cache_key,

--- a/src/general_manager/cache/dependency_shards.py
+++ b/src/general_manager/cache/dependency_shards.py
@@ -16,8 +16,10 @@ from general_manager.cache.dependency_matching import (
 )
 
 DEPENDENCY_SHARD_PREFIX = "general_manager:dependency:v1"
+LEGACY_DEPENDENCY_INDEX_KEY = "dependency_index"
 ALL_RECORDS_VALUE = "__all__"
 REVERSE_MEMBERSHIP_REGISTRY_KEY = f"{DEPENDENCY_SHARD_PREFIX}:reverse_keys"
+VALUE_NOT_PROVIDED = object()
 
 DependencyAction = Literal[
     "filter", "exclude", "identification", "request_query", "all"
@@ -126,6 +128,64 @@ def _register_lookup(manager_name: str, action: str, lookup: str) -> None:
     _cache_set_add(lookup_registry_key(manager_name, action), lookup)
 
 
+def _cache_keys_from_member_collection(value: Any) -> set[str]:
+    if not isinstance(value, (set, frozenset, list, tuple)):
+        return set()
+    return {member for member in value if isinstance(member, str)}
+
+
+def _legacy_dependency_cache_keys(legacy_index: Any) -> set[str]:
+    if not isinstance(legacy_index, dict):
+        return set()
+
+    cache_keys: set[str] = set()
+    all_section = legacy_index.get("all", {})
+    if isinstance(all_section, dict):
+        for key_set in all_section.values():
+            cache_keys.update(_cache_keys_from_member_collection(key_set))
+
+    request_query_section = legacy_index.get("request_query", {})
+    if isinstance(request_query_section, dict):
+        for query_section in request_query_section.values():
+            if not isinstance(query_section, dict):
+                continue
+            for key_set in query_section.values():
+                cache_keys.update(_cache_keys_from_member_collection(key_set))
+
+    for action in ("filter", "exclude"):
+        action_section = legacy_index.get(action, {})
+        if not isinstance(action_section, dict):
+            continue
+        for model_section in action_section.values():
+            if not isinstance(model_section, dict):
+                continue
+            cache_dependencies = model_section.get("__cache_dependencies__", {})
+            if isinstance(cache_dependencies, dict):
+                cache_keys.update(
+                    key for key in cache_dependencies if isinstance(key, str)
+                )
+            for lookup, lookup_map in model_section.items():
+                if lookup == "__cache_dependencies__" or not isinstance(
+                    lookup_map, dict
+                ):
+                    continue
+                for key_set in lookup_map.values():
+                    cache_keys.update(_cache_keys_from_member_collection(key_set))
+    return cache_keys
+
+
+def clear_legacy_dependency_index() -> set[str]:
+    """Delete legacy full-index metadata and cache values referenced by it."""
+    legacy_index = cache.get(LEGACY_DEPENDENCY_INDEX_KEY, None)
+    if legacy_index is None:
+        return set()
+    cache_keys = _legacy_dependency_cache_keys(legacy_index)
+    for cache_key in cache_keys:
+        cache.delete(cache_key)
+    cache.delete(LEGACY_DEPENDENCY_INDEX_KEY)
+    return cache_keys
+
+
 def _shard_keys_for_dependency(
     manager_name: str,
     action: DependencyAction,
@@ -225,6 +285,7 @@ def record_cache_dependencies(
     if not dependency_set:
         return
 
+    clear_legacy_dependency_index()
     remove_cache_key_from_shards(cache_key)
 
     shard_keys: set[str] = set()
@@ -283,15 +344,15 @@ def candidate_cache_keys_for_lookup(
     action: Literal["filter", "exclude"],
     lookup: str,
     *,
-    old_value: Any = None,
-    new_value: Any = None,
+    old_value: Any = VALUE_NOT_PROVIDED,
+    new_value: Any = VALUE_NOT_PROVIDED,
 ) -> set[str]:
     """Return cache keys stored in shards that may be affected by a lookup change."""
     candidates = set()
     candidate_lookup = _lookup_name_for_candidate(lookup)
 
     for value in (old_value, new_value):
-        if value is not None:
+        if value is not VALUE_NOT_PROVIDED:
             candidates.update(
                 cache_set_members(
                     exact_lookup_shard_key(

--- a/src/general_manager/cache/dependency_shards.py
+++ b/src/general_manager/cache/dependency_shards.py
@@ -1,0 +1,353 @@
+"""Cache-backed sharded dependency metadata for dependency-cached results."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Literal
+
+from django.core.cache import cache
+
+from general_manager.cache.dependency_matching import (
+    SCAN_OPERATORS,
+    lookup_spec_from_key,
+    parse_dependency_identifier,
+    stable_value_hash,
+)
+
+DEPENDENCY_SHARD_PREFIX = "general_manager:dependency:v1"
+ALL_RECORDS_VALUE = "__all__"
+REVERSE_MEMBERSHIP_REGISTRY_KEY = f"{DEPENDENCY_SHARD_PREFIX}:reverse_keys"
+
+DependencyAction = Literal[
+    "filter", "exclude", "identification", "request_query", "all"
+]
+Dependency = tuple[str, DependencyAction, str]
+CompositeDependency = tuple[str, Literal["filter", "exclude"], str]
+SimpleDependency = tuple[str, DependencyAction, str]
+
+
+@dataclass(frozen=True, slots=True)
+class ReverseDependencyMembership:
+    cache_key: str
+    shard_keys: frozenset[str]
+    composite_dependencies: frozenset[CompositeDependency]
+    simple_dependencies: frozenset[SimpleDependency] = field(default_factory=frozenset)
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def reverse_membership_key(cache_key: str) -> str:
+    """Return the reverse metadata cache key for an application cache key."""
+    return f"{DEPENDENCY_SHARD_PREFIX}:reverse:{_hash_text(cache_key)}"
+
+
+def exact_lookup_shard_key(
+    manager_name: str,
+    action: str,
+    lookup: str,
+    operator: str,
+    value: Any,
+) -> str:
+    """Return the shard key for an exact lookup/value dependency."""
+    return (
+        f"{DEPENDENCY_SHARD_PREFIX}:lookup:{manager_name}:{action}:"
+        f"{lookup}:{operator}:{stable_value_hash(value)}"
+    )
+
+
+def scan_lookup_shard_key(
+    manager_name: str,
+    action: str,
+    lookup: str,
+    operator: str,
+) -> str:
+    """Return the shard key for a lookup that must be predicate-scanned."""
+    return f"{DEPENDENCY_SHARD_PREFIX}:scan:{manager_name}:{action}:{lookup}:{operator}"
+
+
+def composite_lookup_shard_key(
+    manager_name: str,
+    action: str,
+    lookup: str,
+) -> str:
+    """Return the shard key containing composite candidates for one lookup."""
+    return (
+        f"{DEPENDENCY_SHARD_PREFIX}:composite_lookup:{manager_name}:{action}:{lookup}"
+    )
+
+
+def all_records_shard_key(manager_name: str) -> str:
+    """Return the shard key for cache entries affected by any row change."""
+    return f"{DEPENDENCY_SHARD_PREFIX}:all:{manager_name}"
+
+
+def request_query_shard_key(manager_name: str) -> str:
+    """Return the shard key for request-query cache entries for a manager."""
+    return f"{DEPENDENCY_SHARD_PREFIX}:request_query:{manager_name}"
+
+
+def lookup_registry_key(manager_name: str, action: str) -> str:
+    """Return the cache key that stores lookup names tracked for a manager/action."""
+    return f"{DEPENDENCY_SHARD_PREFIX}:lookups:{manager_name}:{action}"
+
+
+def cache_set_members(key: str) -> set[str]:
+    """Read a cache-backed set."""
+    members = cache.get(key, set())
+    if members is None:
+        return set()
+    return set(members)
+
+
+def _cache_set_add(key: str, member: str) -> None:
+    members = cache_set_members(key)
+    members.add(member)
+    cache.set(key, members, None)
+
+
+def _cache_set_discard(key: str, member: str) -> None:
+    members = cache_set_members(key)
+    members.discard(member)
+    if members:
+        cache.set(key, members, None)
+    else:
+        cache.delete(key)
+
+
+def _lookup_name_for_candidate(lookup: str) -> str:
+    spec = lookup_spec_from_key(lookup)
+    return "__".join(spec.attr_path)
+
+
+def _register_lookup(manager_name: str, action: str, lookup: str) -> None:
+    _cache_set_add(lookup_registry_key(manager_name, action), lookup)
+
+
+def _shard_keys_for_dependency(
+    manager_name: str,
+    action: DependencyAction,
+    identifier: str,
+) -> tuple[set[str], set[CompositeDependency], set[SimpleDependency]]:
+    shard_keys: set[str] = set()
+    composites: set[CompositeDependency] = set()
+    simple_dependencies: set[SimpleDependency] = set()
+
+    if action == "all":
+        shard_keys.add(all_records_shard_key(manager_name))
+        simple_dependencies.add((manager_name, action, identifier))
+        return shard_keys, composites, simple_dependencies
+
+    if action == "request_query":
+        shard_keys.add(request_query_shard_key(manager_name))
+        simple_dependencies.add((manager_name, action, identifier))
+        return shard_keys, composites, simple_dependencies
+
+    if action == "identification":
+        shard_keys.add(
+            exact_lookup_shard_key(
+                manager_name,
+                "filter",
+                "identification",
+                "eq",
+                identifier,
+            )
+        )
+        simple_dependencies.add((manager_name, action, identifier))
+        return shard_keys, composites, simple_dependencies
+
+    if action not in {"filter", "exclude"}:
+        return shard_keys, composites, simple_dependencies
+
+    params = parse_dependency_identifier(identifier)
+    if not isinstance(params, dict):
+        return shard_keys, composites, simple_dependencies
+
+    if not params:
+        shard_keys.add(all_records_shard_key(manager_name))
+        simple_dependencies.add((manager_name, action, identifier))
+        return shard_keys, composites, simple_dependencies
+
+    sort_lookups = [
+        str(lookup).removeprefix("__sort__")
+        for lookup in params
+        if str(lookup).startswith("__sort__")
+    ]
+    if sort_lookups:
+        composite = (manager_name, action, identifier)
+        composites.add(composite)
+        for sort_lookup in sort_lookups:
+            _register_lookup(manager_name, action, sort_lookup)
+            shard_keys.add(
+                composite_lookup_shard_key(manager_name, action, sort_lookup)
+            )
+        return shard_keys, composites, simple_dependencies
+
+    if len(params) > 1:
+        composite = (manager_name, action, identifier)
+        composites.add(composite)
+        for lookup in params:
+            candidate_lookup = _lookup_name_for_candidate(str(lookup))
+            _register_lookup(manager_name, action, candidate_lookup)
+            shard_keys.add(
+                composite_lookup_shard_key(
+                    manager_name,
+                    action,
+                    candidate_lookup,
+                )
+            )
+        return shard_keys, composites, simple_dependencies
+
+    lookup, value = next(iter(params.items()))
+    spec = lookup_spec_from_key(str(lookup))
+    candidate_lookup = "__".join(spec.attr_path)
+    _register_lookup(manager_name, action, candidate_lookup)
+    if spec.operator == "eq":
+        shard_keys.add(
+            exact_lookup_shard_key(manager_name, action, spec.lookup, "eq", value)
+        )
+    else:
+        shard_keys.add(
+            scan_lookup_shard_key(manager_name, action, spec.lookup, spec.operator)
+        )
+    simple_dependencies.add((manager_name, action, identifier))
+    return shard_keys, composites, simple_dependencies
+
+
+def record_cache_dependencies(
+    cache_key: str,
+    dependencies: Iterable[Dependency],
+) -> None:
+    """Record dependency metadata for one cache key in deterministic shards."""
+    dependency_set = set(dependencies)
+    if not dependency_set:
+        return
+
+    remove_cache_key_from_shards(cache_key)
+
+    shard_keys: set[str] = set()
+    composites: set[CompositeDependency] = set()
+    simple_dependencies: set[SimpleDependency] = set()
+    for manager_name, action, identifier in dependency_set:
+        new_shards, new_composites, new_simple = _shard_keys_for_dependency(
+            manager_name,
+            action,
+            identifier,
+        )
+        shard_keys.update(new_shards)
+        composites.update(new_composites)
+        simple_dependencies.update(new_simple)
+
+    for shard_key in shard_keys:
+        _cache_set_add(shard_key, cache_key)
+
+    cache.set(
+        reverse_membership_key(cache_key),
+        ReverseDependencyMembership(
+            cache_key=cache_key,
+            shard_keys=frozenset(shard_keys),
+            composite_dependencies=frozenset(composites),
+            simple_dependencies=frozenset(simple_dependencies),
+        ),
+        None,
+    )
+    _cache_set_add(REVERSE_MEMBERSHIP_REGISTRY_KEY, reverse_membership_key(cache_key))
+
+
+def record_many_cache_dependencies(
+    entries: Iterable[tuple[str, Iterable[Dependency]]],
+) -> None:
+    """Record dependency metadata for many cache keys."""
+    for cache_key, dependencies in entries:
+        record_cache_dependencies(cache_key, dependencies)
+
+
+def remove_cache_key_from_shards(cache_key: str) -> None:
+    """Remove a cache key from all shards using its reverse membership."""
+    reverse_key = reverse_membership_key(cache_key)
+    reverse = cache.get(reverse_key)
+    if not isinstance(reverse, ReverseDependencyMembership):
+        cache.delete(reverse_key)
+        _cache_set_discard(REVERSE_MEMBERSHIP_REGISTRY_KEY, reverse_key)
+        return
+    for shard_key in reverse.shard_keys:
+        _cache_set_discard(shard_key, cache_key)
+    cache.delete(reverse_key)
+    _cache_set_discard(REVERSE_MEMBERSHIP_REGISTRY_KEY, reverse_key)
+
+
+def candidate_cache_keys_for_lookup(
+    manager_name: str,
+    action: Literal["filter", "exclude"],
+    lookup: str,
+    *,
+    old_value: Any = None,
+    new_value: Any = None,
+) -> set[str]:
+    """Return cache keys stored in shards that may be affected by a lookup change."""
+    candidates = set()
+    candidate_lookup = _lookup_name_for_candidate(lookup)
+
+    for value in (old_value, new_value):
+        if value is not None:
+            candidates.update(
+                cache_set_members(
+                    exact_lookup_shard_key(
+                        manager_name,
+                        action,
+                        candidate_lookup,
+                        "eq",
+                        value,
+                    )
+                )
+            )
+
+    for operator in SCAN_OPERATORS:
+        scan_lookup = f"{candidate_lookup}__{operator}"
+        candidates.update(
+            cache_set_members(
+                scan_lookup_shard_key(manager_name, action, scan_lookup, operator)
+            )
+        )
+        candidates.update(
+            cache_set_members(
+                scan_lookup_shard_key(manager_name, action, candidate_lookup, operator)
+            )
+        )
+
+    candidates.update(
+        cache_set_members(
+            composite_lookup_shard_key(manager_name, action, candidate_lookup)
+        )
+    )
+    candidates.update(cache_set_members(all_records_shard_key(manager_name)))
+    return candidates
+
+
+def request_query_cache_keys(manager_name: str) -> set[str]:
+    """Return request-query cache keys for a manager."""
+    return cache_set_members(request_query_shard_key(manager_name))
+
+
+def all_records_cache_keys(manager_name: str) -> set[str]:
+    """Return all-records cache keys for a manager."""
+    return cache_set_members(all_records_shard_key(manager_name))
+
+
+def tracked_lookup_names(manager_name: str) -> set[str]:
+    """Return lookup attribute paths tracked for a manager across filter/exclude."""
+    return cache_set_members(
+        lookup_registry_key(manager_name, "filter")
+    ) | cache_set_members(lookup_registry_key(manager_name, "exclude"))
+
+
+def reverse_memberships() -> tuple[ReverseDependencyMembership, ...]:
+    """Return all reverse memberships known to the shard store."""
+    memberships = []
+    for reverse_key in cache_set_members(REVERSE_MEMBERSHIP_REGISTRY_KEY):
+        reverse = cache.get(reverse_key)
+        if isinstance(reverse, ReverseDependencyMembership):
+            memberships.append(reverse)
+    return tuple(memberships)

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -386,11 +386,9 @@ class TestRecordDependencies(TestCase):
                 "filter": {
                     "project": {
                         "name": {
-                            "123": {"abc123"},
                             "456": {"abc123"},
                         },
                         "identification": {
-                            '{"id": 1}': {"abc123"},
                             '{"id": 2}': {"abc123"},
                         },
                     },

--- a/tests/unit/test_dependency_matching.py
+++ b/tests/unit/test_dependency_matching.py
@@ -16,6 +16,16 @@ from general_manager.cache.dependency_matching import (
 from general_manager.measurement.measurement import Measurement
 
 
+class ReprOnly:
+    def __repr__(self) -> str:
+        return "ReprOnly(token)"
+
+
+class BadStateValue:
+    def __init__(self) -> None:
+        pass
+
+
 def test_lookup_spec_from_key_splits_operator_and_attribute_path() -> None:
     assert lookup_spec_from_key("status") == LookupSpec(
         lookup="status",
@@ -52,7 +62,14 @@ def test_operator_sets_classify_exact_and_scan_lookups() -> None:
 
 
 def test_normalize_dependency_value_and_hash_are_stable() -> None:
-    payload = {"day": date(2024, 7, 24), "members": {"b", "a"}, "active": True}
+    moment = datetime(2024, 7, 24, 12, 0, tzinfo=timezone.utc)
+    payload = {
+        "day": date(2024, 7, 24),
+        "members": {"b", "a"},
+        "active": True,
+        "moment": moment,
+        "opaque": ReprOnly(),
+    }
 
     normalized = normalize_dependency_value(payload)
 
@@ -60,9 +77,17 @@ def test_normalize_dependency_value_and_hash_are_stable() -> None:
         "active": True,
         "day": "2024-07-24",
         "members": ["a", "b"],
+        "moment": moment.isoformat(),
+        "opaque": {"__repr__": "ReprOnly(token)"},
     }
     assert stable_value_hash(payload) == stable_value_hash(
-        {"members": {"a", "b"}, "active": True, "day": date(2024, 7, 24)}
+        {
+            "members": {"a", "b"},
+            "active": True,
+            "day": date(2024, 7, 24),
+            "moment": moment,
+            "opaque": ReprOnly(),
+        }
     )
 
 
@@ -80,6 +105,27 @@ def test_matches_lookup_value_covers_supported_scalar_types() -> None:
     assert matches_lookup_value("regex", "alpha-123", '"^[a-z]+-[0-9]+$"')
     assert matches_lookup_value("eq", aware, '"2024-07-24T12:00:00Z"')
     assert matches_lookup_value("eq", True, '"true"')
+
+
+def test_matches_lookup_value_covers_coercion_and_fallback_edges() -> None:
+    aware = datetime(2024, 7, 24, 12, 0, tzinfo=timezone.utc)
+
+    assert matches_lookup_value("eq", aware, aware)
+    assert not matches_lookup_value("eq", aware, "42")
+    assert not matches_lookup_value("gt", date(2024, 7, 24), "42")
+    assert matches_lookup_value("eq", False, "false")
+    assert matches_lookup_value("eq", True, "1")
+    assert matches_lookup_value("eq", False, '"FALSE"')
+    assert not matches_lookup_value("eq", True, '"maybe"')
+    assert matches_lookup_value("eq", ReprOnly(), '{"__repr__": "ReprOnly(token)"}')
+    assert matches_lookup_value("in", ReprOnly(), '[{"__repr__": "ReprOnly(token)"}]')
+    assert not matches_lookup_value(
+        "eq",
+        BadStateValue(),
+        '{"__state__": {"magnitude": 1, "unit": "EUR"}}',
+    )
+    assert not matches_lookup_value("eq", BadStateValue(), '{"__state__": "bad"}')
+    assert not matches_lookup_value("unknown", "value", '"value"')
 
 
 def test_current_value_for_path_returns_none_for_missing_attributes() -> None:

--- a/tests/unit/test_dependency_matching.py
+++ b/tests/unit/test_dependency_matching.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+
+from general_manager.cache.dependency_matching import (
+    EXACT_OPERATORS,
+    SCAN_OPERATORS,
+    LookupSpec,
+    current_value_for_path,
+    lookup_spec_from_key,
+    matches_lookup_value,
+    normalize_dependency_value,
+    stable_value_hash,
+)
+from general_manager.measurement.measurement import Measurement
+
+
+def test_lookup_spec_from_key_splits_operator_and_attribute_path() -> None:
+    assert lookup_spec_from_key("status") == LookupSpec(
+        lookup="status",
+        attr_path=("status",),
+        operator="eq",
+    )
+    assert lookup_spec_from_key("count__gte") == LookupSpec(
+        lookup="count__gte",
+        attr_path=("count",),
+        operator="gte",
+    )
+    assert lookup_spec_from_key("owner__name__contains") == LookupSpec(
+        lookup="owner__name__contains",
+        attr_path=("owner", "name"),
+        operator="contains",
+    )
+
+
+def test_operator_sets_classify_exact_and_scan_lookups() -> None:
+    assert EXACT_OPERATORS == frozenset({"eq"})
+    assert SCAN_OPERATORS == frozenset(
+        {
+            "in",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "contains",
+            "startswith",
+            "endswith",
+            "regex",
+        }
+    )
+
+
+def test_normalize_dependency_value_and_hash_are_stable() -> None:
+    payload = {"day": date(2024, 7, 24), "members": {"b", "a"}, "active": True}
+
+    normalized = normalize_dependency_value(payload)
+
+    assert normalized == {
+        "active": True,
+        "day": "2024-07-24",
+        "members": ["a", "b"],
+    }
+    assert stable_value_hash(payload) == stable_value_hash(
+        {"members": {"a", "b"}, "active": True, "day": date(2024, 7, 24)}
+    )
+
+
+def test_matches_lookup_value_covers_supported_scalar_types() -> None:
+    aware = datetime(2024, 7, 24, 12, 0, tzinfo=timezone.utc)
+
+    assert matches_lookup_value("eq", "active", '"active"')
+    assert matches_lookup_value("eq", None, "null")
+    assert matches_lookup_value("in", 3, "[1, 3, 5]")
+    assert matches_lookup_value("gte", 5, "5")
+    assert matches_lookup_value("lt", date(2024, 7, 23), '"2024-07-24"')
+    assert matches_lookup_value("contains", "alpha bravo", '"bravo"')
+    assert matches_lookup_value("startswith", "alpha bravo", '"alpha"')
+    assert matches_lookup_value("endswith", "alpha bravo", '"bravo"')
+    assert matches_lookup_value("regex", "alpha-123", '"^[a-z]+-[0-9]+$"')
+    assert matches_lookup_value("eq", aware, '"2024-07-24T12:00:00Z"')
+    assert matches_lookup_value("eq", True, '"true"')
+
+
+def test_current_value_for_path_returns_none_for_missing_attributes() -> None:
+    instance = SimpleNamespace(owner=SimpleNamespace(name="Leia"))
+
+    assert current_value_for_path(instance, ("owner", "name")) == "Leia"
+    assert current_value_for_path(instance, ("owner", "rank")) is None
+
+
+def test_matches_lookup_value_coerces_stateful_values_for_range_comparison() -> None:
+    stored_value = normalize_dependency_value(Measurement(1000, "EUR"))
+
+    assert matches_lookup_value(
+        "gte",
+        Measurement(1500, "EUR"),
+        stable_json(stored_value),
+    )
+    assert not matches_lookup_value(
+        "gte",
+        Measurement(900, "EUR"),
+        stable_json(stored_value),
+    )
+
+
+def stable_json(value: object) -> str:
+    import json
+
+    return json.dumps(value, sort_keys=True)

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 import pickle
 from typing import Any
 from unittest import mock
@@ -585,19 +585,15 @@ class TestDependencyPublish(SimpleTestCase):
     ) -> None:
         cache_backend = FakeDependencyCacheSetManyBackend()
         recorded_cache_keys: list[str] = []
-        original_record_locked = dependency_publish._record_dependencies_locked
 
-        def capture_record_locked(
-            idx: Any,
-            cache_key: str,
-            dependencies: Any,
+        def capture_record_many(
+            entries: Iterable[tuple[str, Iterable[dependency_publish.Dependency]]],
         ) -> None:
-            recorded_cache_keys.append(cache_key)
-            original_record_locked(idx, cache_key, dependencies)
+            recorded_cache_keys.extend(cache_key for cache_key, _ in entries)
 
         with mock.patch(
-            "general_manager.cache.dependency_publish._record_dependencies_locked",
-            side_effect=capture_record_locked,
+            "general_manager.cache.dependency_publish.record_many_cache_dependencies",
+            side_effect=capture_record_many,
         ):
             publish_dependency_cache_entries(
                 [

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -14,8 +14,13 @@ from general_manager.cache.dependency_cache import (
 )
 from general_manager.cache.dependency_index import (
     begin_dependency_data_change,
+    cache,
     end_dependency_data_change,
     get_dependency_generation,
+)
+from general_manager.cache.dependency_shards import (
+    cache_set_members,
+    exact_lookup_shard_key,
 )
 from general_manager.cache.dependency_publish import (
     CacheComputeLease,
@@ -202,14 +207,14 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertEqual(cache_backend.timeouts[cache_key], 30)
         self.assertNotIn(f"{cache_key}:deps", cache_backend.store)
 
-    def test_batch_publish_records_index_once_before_bulk_value_write(self) -> None:
+    def test_batch_publish_records_shards_once_before_bulk_value_write(self) -> None:
         cache_backend = FakeDependencyCacheSetManyBackend()
         events: list[str] = []
-        original_set_full_index = dependency_publish.set_full_index
+        original_record_many = dependency_publish.record_many_cache_dependencies
 
-        def record_set_full_index(idx: Any) -> None:
-            events.append("index")
-            original_set_full_index(idx)
+        def record_many_shards(entries: Any) -> None:
+            events.append("shards")
+            original_record_many(entries)
 
         original_set_many = cache_backend.set_many
 
@@ -223,8 +228,8 @@ class TestDependencyPublish(SimpleTestCase):
         cache_backend.set_many = record_set_many  # type: ignore[method-assign]
 
         with mock.patch(
-            "general_manager.cache.dependency_publish.set_full_index",
-            side_effect=record_set_full_index,
+            "general_manager.cache.dependency_publish.record_many_cache_dependencies",
+            side_effect=record_many_shards,
         ):
             publish_dependency_cache_entries(
                 [
@@ -243,7 +248,20 @@ class TestDependencyPublish(SimpleTestCase):
                 ]
             )
 
-        self.assertEqual(events, ["index", "set_many"])
+        self.assertEqual(events, ["shards", "set_many"])
+        self.assertIsNone(cache.get("dependency_index"))
+        self.assertEqual(
+            cache_set_members(
+                exact_lookup_shard_key("Project", "filter", "identification", "eq", "1")
+            ),
+            {"cache-a"},
+        )
+        self.assertEqual(
+            cache_set_members(
+                exact_lookup_shard_key("Project", "filter", "identification", "eq", "2")
+            ),
+            {"cache-b"},
+        )
         self.assertEqual(len(cache_backend.set_many_calls), 1)
         self.assertEqual(
             set(cache_backend.set_many_calls[0][0]), {"cache-a", "cache-b"}

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from django.test import TestCase, override_settings
+
+from general_manager.cache.dependency_matching import stable_value_hash
+from general_manager.cache.dependency_shards import (
+    ALL_RECORDS_VALUE,
+    DEPENDENCY_SHARD_PREFIX,
+    ReverseDependencyMembership,
+    all_records_shard_key,
+    cache_set_members,
+    candidate_cache_keys_for_lookup,
+    exact_lookup_shard_key,
+    record_cache_dependencies,
+    remove_cache_key_from_shards,
+    request_query_shard_key,
+    reverse_membership_key,
+    scan_lookup_shard_key,
+)
+from general_manager.cache.dependency_index import cache
+from general_manager.cache.dependency_index import (
+    capture_old_values,
+    generic_cache_invalidation,
+    record_dependencies,
+)
+
+
+TEST_CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-dependency-shards",
+    }
+}
+
+
+@override_settings(CACHES=TEST_CACHES)
+class DependencyShardKeyTests(TestCase):
+    def setUp(self) -> None:
+        cache.clear()
+
+    def test_shard_keys_are_deterministic_and_namespaced(self) -> None:
+        value_hash = stable_value_hash("open")
+
+        assert exact_lookup_shard_key("Project", "filter", "status", "eq", "open") == (
+            f"{DEPENDENCY_SHARD_PREFIX}:lookup:Project:filter:status:eq:{value_hash}"
+        )
+        assert scan_lookup_shard_key("Project", "filter", "status__in", "in") == (
+            f"{DEPENDENCY_SHARD_PREFIX}:scan:Project:filter:status__in:in"
+        )
+        assert all_records_shard_key("Project") == (
+            f"{DEPENDENCY_SHARD_PREFIX}:all:Project"
+        )
+        assert request_query_shard_key("RemoteProject") == (
+            f"{DEPENDENCY_SHARD_PREFIX}:request_query:RemoteProject"
+        )
+
+    def test_record_cache_dependencies_writes_shards_and_reverse_membership(
+        self,
+    ) -> None:
+        record_cache_dependencies(
+            "cache-a",
+            [
+                ("Project", "filter", json.dumps({"status": "open"})),
+                ("Project", "filter", json.dumps({"priority__gte": 3})),
+                ("RemoteProject", "request_query", json.dumps({"operation": "list"})),
+                ("Project", "all", ""),
+            ],
+        )
+
+        exact_key = exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+        scan_key = scan_lookup_shard_key("Project", "filter", "priority__gte", "gte")
+        request_key = request_query_shard_key("RemoteProject")
+        all_key = all_records_shard_key("Project")
+
+        assert cache_set_members(exact_key) == {"cache-a"}
+        assert cache_set_members(scan_key) == {"cache-a"}
+        assert cache_set_members(request_key) == {"cache-a"}
+        assert cache_set_members(all_key) == {"cache-a"}
+
+        reverse = cache.get(reverse_membership_key("cache-a"))
+        assert reverse == ReverseDependencyMembership(
+            cache_key="cache-a",
+            shard_keys=frozenset({exact_key, scan_key, request_key, all_key}),
+            composite_dependencies=frozenset(),
+            simple_dependencies=frozenset(
+                {
+                    ("Project", "filter", json.dumps({"status": "open"})),
+                    ("Project", "filter", json.dumps({"priority__gte": 3})),
+                    (
+                        "RemoteProject",
+                        "request_query",
+                        json.dumps({"operation": "list"}),
+                    ),
+                    ("Project", "all", ""),
+                }
+            ),
+        )
+
+    def test_record_composite_dependencies_use_candidate_shards(self) -> None:
+        identifier = json.dumps({"status": "open", "priority__gte": 3})
+
+        record_cache_dependencies("cache-combo", [("Project", "filter", identifier)])
+
+        candidate_keys = candidate_cache_keys_for_lookup("Project", "filter", "status")
+
+        assert candidate_keys == {"cache-combo"}
+        reverse = cache.get(reverse_membership_key("cache-combo"))
+        assert reverse.composite_dependencies == frozenset(
+            {("Project", "filter", identifier)}
+        )
+
+    def test_remove_cache_key_uses_reverse_membership_without_scanning(self) -> None:
+        record_cache_dependencies(
+            "cache-a",
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+        shard_key = exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+
+        remove_cache_key_from_shards("cache-a")
+
+        assert cache_set_members(shard_key) == set()
+        assert cache.get(reverse_membership_key("cache-a")) is None
+
+    def test_empty_filter_dependency_tracks_all_records_shard(self) -> None:
+        record_cache_dependencies("cache-all-filter", [("Project", "filter", "{}")])
+
+        assert cache_set_members(all_records_shard_key("Project")) == {
+            "cache-all-filter"
+        }
+
+    def test_candidate_lookup_combines_exact_scan_and_composite_shards(self) -> None:
+        record_cache_dependencies(
+            "cache-exact",
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+        record_cache_dependencies(
+            "cache-scan",
+            [("Project", "filter", json.dumps({"status__in": ["open", "closed"]}))],
+        )
+        record_cache_dependencies(
+            "cache-combo",
+            [("Project", "filter", json.dumps({"status": "open", "priority": 3}))],
+        )
+
+        assert candidate_cache_keys_for_lookup(
+            "Project",
+            "filter",
+            "status",
+            old_value="closed",
+            new_value="open",
+        ) == {"cache-exact", "cache-scan", "cache-combo"}
+
+    def test_unknown_cache_key_cleanup_is_noop(self) -> None:
+        remove_cache_key_from_shards("missing")
+
+        assert cache.get(reverse_membership_key("missing")) is None
+
+    def test_all_records_value_constant_is_compatible_with_existing_index_name(
+        self,
+    ) -> None:
+        assert ALL_RECORDS_VALUE == "__all__"
+
+
+@override_settings(CACHES=TEST_CACHES)
+class DependencyIndexShardFacadeTests(TestCase):
+    def setUp(self) -> None:
+        cache.clear()
+
+    def test_record_dependencies_does_not_create_full_dependency_index(self) -> None:
+        record_dependencies(
+            "cache-a",
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+
+        assert cache.get("dependency_index") is None
+        assert cache_set_members(
+            exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+        ) == {"cache-a"}
+
+    def test_capture_old_values_uses_sharded_lookup_registry(self) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+        instance = SimpleNamespace(status="open", identification=1)
+
+        capture_old_values(sender=Project, instance=instance)
+
+        assert instance._old_values == {"status": "open"}
+
+    def test_generic_cache_invalidation_uses_sharded_candidates(self) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get("cache-a") is None
+        assert (
+            cache_set_members(
+                exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+            )
+            == set()
+        )

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -217,3 +217,77 @@ class DependencyIndexShardFacadeTests(TestCase):
             )
             == set()
         )
+
+    def test_generic_cache_invalidation_invalidates_matching_filter_when_lookup_unchanged(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="open", title="renamed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get("cache-a") is None
+        assert (
+            cache_set_members(
+                exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+            )
+            == set()
+        )
+
+    def test_generic_cache_invalidation_invalidates_exact_none_lookup(self) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [("Project", "filter", json.dumps({"status": None}))],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="open"),
+            old_relevant_values={"status": None},
+        )
+
+        assert cache.get("cache-a") is None
+        assert (
+            cache_set_members(
+                exact_lookup_shard_key("Project", "filter", "status", "eq", None)
+            )
+            == set()
+        )
+
+    def test_record_dependencies_clears_legacy_index_and_cached_values(self) -> None:
+        cache.set(
+            "dependency_index",
+            {
+                "filter": {"Project": {"status": {'"open"': {"legacy-cache"}}}},
+                "exclude": {},
+                "request_query": {},
+                "all": {},
+            },
+            None,
+        )
+        cache.set("legacy-cache", "legacy-value", None)
+
+        record_dependencies(
+            "cache-a",
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+
+        assert cache.get("dependency_index") is None
+        assert cache.get("legacy-cache") is None
+        assert cache_set_members(
+            exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+        ) == {"cache-a"}

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -13,6 +13,8 @@ from general_manager.cache.dependency_shards import (
     all_records_shard_key,
     cache_set_members,
     candidate_cache_keys_for_lookup,
+    clear_legacy_dependency_index,
+    composite_lookup_shard_key,
     exact_lookup_shard_key,
     record_cache_dependencies,
     remove_cache_key_from_shards,
@@ -163,6 +165,95 @@ class DependencyShardKeyTests(TestCase):
     ) -> None:
         assert ALL_RECORDS_VALUE == "__all__"
 
+    def test_cache_set_members_treats_none_as_empty_set(self) -> None:
+        cache.set("empty-set-key", None, None)
+
+        assert cache_set_members("empty-set-key") == set()
+
+    def test_clear_legacy_dependency_index_removes_known_legacy_cache_keys(
+        self,
+    ) -> None:
+        legacy_index = {
+            "all": {"Project": {"all-cache", 123}},
+            "request_query": {
+                "BadRemote": "not-a-query-section",
+                "RemoteProject": {"query": {"request-cache"}},
+            },
+            "filter": {
+                "Project": {
+                    "__cache_dependencies__": {"composite-cache": {"identifier"}},
+                    "status": {"not-a-cache-set": "not-a-member-collection"},
+                }
+            },
+            "exclude": {
+                "BadProject": "not-a-model-section",
+            },
+        }
+        cache.set("dependency_index", legacy_index, None)
+        for cache_key in ("all-cache", "request-cache", "composite-cache"):
+            cache.set(cache_key, "cached-value", None)
+
+        assert clear_legacy_dependency_index() == {
+            "all-cache",
+            "request-cache",
+            "composite-cache",
+        }
+        assert cache.get("dependency_index") is None
+        assert cache.get("all-cache") is None
+        assert cache.get("request-cache") is None
+        assert cache.get("composite-cache") is None
+
+    def test_clear_legacy_dependency_index_deletes_malformed_index(self) -> None:
+        cache.set("dependency_index", "not-an-index", None)
+
+        assert clear_legacy_dependency_index() == set()
+        assert cache.get("dependency_index") is None
+
+        cache.set("dependency_index", {"filter": "not-an-action-section"}, None)
+
+        assert clear_legacy_dependency_index() == set()
+        assert cache.get("dependency_index") is None
+
+    def test_invalid_dependencies_write_empty_reverse_membership(self) -> None:
+        record_cache_dependencies(
+            "cache-invalid",
+            [
+                ("Project", "unknown", ""),  # type: ignore[list-item]
+                ("Project", "filter", "{bad"),
+            ],
+        )
+
+        reverse = cache.get(reverse_membership_key("cache-invalid"))
+        assert reverse == ReverseDependencyMembership(
+            cache_key="cache-invalid",
+            shard_keys=frozenset(),
+            composite_dependencies=frozenset(),
+            simple_dependencies=frozenset(),
+        )
+
+    def test_sort_dependencies_use_composite_lookup_shards(self) -> None:
+        identifier = json.dumps(
+            {
+                "__sort__rank": {
+                    "filters": {"status": "open"},
+                    "excludes": {},
+                    "reverse": False,
+                }
+            }
+        )
+
+        record_cache_dependencies("cache-sort", [("Project", "filter", identifier)])
+
+        sort_shard_key = composite_lookup_shard_key("Project", "filter", "rank")
+        assert cache_set_members(sort_shard_key) == {"cache-sort"}
+        assert candidate_cache_keys_for_lookup("Project", "filter", "rank") == {
+            "cache-sort"
+        }
+        reverse = cache.get(reverse_membership_key("cache-sort"))
+        assert reverse.composite_dependencies == frozenset(
+            {("Project", "filter", identifier)}
+        )
+
 
 @override_settings(CACHES=TEST_CACHES)
 class DependencyIndexShardFacadeTests(TestCase):
@@ -291,3 +382,404 @@ class DependencyIndexShardFacadeTests(TestCase):
         assert cache_set_members(
             exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
         ) == {"cache-a"}
+
+    def test_generic_cache_invalidation_invalidates_identification_dependency(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [("Project", "identification", json.dumps({"id": 1}))],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(identification={"id": 1}),
+            old_relevant_values={},
+        )
+
+        assert cache.get("cache-a") is None
+
+    def test_generic_cache_invalidation_ignores_identification_mismatch(self) -> None:
+        class Project:
+            pass
+
+        cache_key = "cache-a"
+        identification = {"id": 2}
+        record_dependencies(
+            cache_key,
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+        cache.set(
+            reverse_membership_key(cache_key),
+            ReverseDependencyMembership(
+                cache_key=cache_key,
+                shard_keys=frozenset(),
+                composite_dependencies=frozenset(),
+                simple_dependencies=frozenset(
+                    {("Project", "identification", json.dumps({"id": 1}))}
+                ),
+            ),
+            None,
+        )
+        cache.set(cache_key, "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(identification=identification, status="closed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get(cache_key) == "cached-value"
+
+    def test_generic_cache_invalidation_uses_request_query_match_when_candidate(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [
+                ("Project", "request_query", json.dumps({"operation": "list"})),
+                ("Project", "filter", json.dumps({"status": "open"})),
+            ],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get("cache-a") is None
+
+    def test_generic_cache_invalidation_accepts_request_query_reverse_match(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        cache_key = "cache-a"
+        record_dependencies(
+            "registry-seed",
+            [("Project", "filter", json.dumps({"status": "seed"}))],
+        )
+        cache.set(
+            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            {cache_key},
+            None,
+        )
+        cache.set(
+            reverse_membership_key(cache_key),
+            ReverseDependencyMembership(
+                cache_key=cache_key,
+                shard_keys=frozenset(),
+                composite_dependencies=frozenset(),
+                simple_dependencies=frozenset(
+                    {("Project", "request_query", json.dumps({"operation": "list"}))}
+                ),
+            ),
+            None,
+        )
+        cache.set(cache_key, "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get(cache_key) is None
+
+    def test_generic_cache_invalidation_invalidates_candidate_without_reverse_metadata(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "registry-seed",
+            [("Project", "filter", json.dumps({"status": "seed"}))],
+        )
+        cache.set(
+            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            {"cache-a"},
+            None,
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get("cache-a") is None
+
+    def test_generic_cache_invalidation_ignores_malformed_reverse_identifier(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        cache_key = "cache-a"
+        record_dependencies(
+            "registry-seed",
+            [("Project", "filter", json.dumps({"status": "seed"}))],
+        )
+        cache.set(
+            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            {cache_key},
+            None,
+        )
+        cache.set(
+            reverse_membership_key(cache_key),
+            ReverseDependencyMembership(
+                cache_key=cache_key,
+                shard_keys=frozenset(),
+                composite_dependencies=frozenset(),
+                simple_dependencies=frozenset({("Project", "filter", "{bad")}),
+            ),
+            None,
+        )
+        cache.set(cache_key, "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get(cache_key) == "cached-value"
+
+    def test_generic_cache_invalidation_ignores_invalid_reverse_dependencies(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        cache_key = "cache-a"
+        record_dependencies(
+            "registry-seed",
+            [("Project", "filter", json.dumps({"status": "seed"}))],
+        )
+        cache.set(
+            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            {cache_key},
+            None,
+        )
+        cache.set(
+            reverse_membership_key(cache_key),
+            ReverseDependencyMembership(
+                cache_key=cache_key,
+                shard_keys=frozenset(),
+                composite_dependencies=frozenset(),
+                simple_dependencies=frozenset(
+                    {
+                        ("Project", "unknown", ""),  # type: ignore[arg-type]
+                        ("Project", "filter", "{bad"),
+                        ("Project", "filter", "{}"),
+                    }
+                ),
+            ),
+            None,
+        )
+        cache.set(cache_key, "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get(cache_key) is None
+
+    def test_generic_cache_invalidation_ignores_unknown_reverse_action(self) -> None:
+        class Project:
+            pass
+
+        cache_key = "cache-a"
+        record_dependencies(
+            "registry-seed",
+            [("Project", "filter", json.dumps({"status": "seed"}))],
+        )
+        cache.set(
+            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            {cache_key},
+            None,
+        )
+        cache.set(
+            reverse_membership_key(cache_key),
+            ReverseDependencyMembership(
+                cache_key=cache_key,
+                shard_keys=frozenset(),
+                composite_dependencies=frozenset(),
+                simple_dependencies=frozenset(
+                    {("Project", "unknown", "")}  # type: ignore[arg-type]
+                ),
+            ),
+            None,
+        )
+        cache.set(cache_key, "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed"),
+            old_relevant_values={"status": "open"},
+        )
+
+        assert cache.get(cache_key) == "cached-value"
+
+    def test_generic_cache_invalidation_respects_unchanged_exclude_dependency(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [("Project", "exclude", json.dumps({"status": "archived"}))],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="archived"),
+            old_relevant_values={"status": "archived"},
+        )
+
+        assert cache.get("cache-a") == "cached-value"
+
+    def test_generic_cache_invalidation_evaluates_composite_dependencies(self) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [
+                (
+                    "Project",
+                    "filter",
+                    json.dumps({"status": "open", "priority__gte": 3}),
+                )
+            ],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="open", priority=3),
+            old_relevant_values={"status": "closed", "priority": 3},
+        )
+
+        assert cache.get("cache-a") is None
+
+    def test_generic_cache_invalidation_skips_non_matching_composite_dependency(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [
+                (
+                    "Project",
+                    "filter",
+                    json.dumps({"status": "open", "priority__gte": 3}),
+                )
+            ],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed", priority=3),
+            old_relevant_values={"status": "closed", "priority": 3},
+        )
+
+        assert cache.get("cache-a") == "cached-value"
+
+    def test_generic_cache_invalidation_evaluates_sort_bucket_dependencies(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [
+                (
+                    "Project",
+                    "filter",
+                    json.dumps(
+                        {
+                            "__sort__rank": {
+                                "filters": {"status": "open"},
+                                "excludes": {"priority__lt": 0},
+                                "reverse": False,
+                            }
+                        }
+                    ),
+                )
+            ],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="open", priority=2, rank=5),
+            old_relevant_values={"status": "open", "priority": 2, "rank": 10},
+        )
+
+        assert cache.get("cache-a") is None
+
+    def test_generic_cache_invalidation_skips_malformed_sort_bucket_dependencies(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [
+                (
+                    "Project",
+                    "filter",
+                    json.dumps({"__sort__rank": "not-a-payload"}),
+                )
+            ],
+        )
+        record_dependencies(
+            "cache-b",
+            [
+                (
+                    "Project",
+                    "filter",
+                    json.dumps(
+                        {
+                            "__sort__rank": {
+                                "filters": "not-a-filter-map",
+                                "excludes": {},
+                            }
+                        }
+                    ),
+                )
+            ],
+        )
+        cache.set("cache-a", "cached-value-a", None)
+        cache.set("cache-b", "cached-value-b", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(rank=2),
+            old_relevant_values={"rank": 1},
+        )
+
+        assert cache.get("cache-a") == "cached-value-a"
+        assert cache.get("cache-b") == "cached-value-b"


### PR DESCRIPTION
## Summary
- Replace normal dependency-cache metadata writes with sharded dependency metadata and reverse membership cleanup.
- Extract pure dependency lookup parsing, normalization, hashing, and predicate matching helpers.
- Keep the dependency_index facade while materializing legacy full-index diagnostics from shards instead of writing the old dependency_index cache object.

## Test Plan
- python -m pytest -q
- ruff check src/general_manager/cache/dependency_matching.py src/general_manager/cache/dependency_shards.py src/general_manager/cache/dependency_index.py src/general_manager/cache/dependency_publish.py tests/unit/test_dependency_matching.py tests/unit/test_dependency_shards.py tests/unit/test_dependency_publish.py tests/unit/test_dependency_index.py
- ruff format --check src/general_manager/cache/dependency_matching.py src/general_manager/cache/dependency_shards.py src/general_manager/cache/dependency_index.py src/general_manager/cache/dependency_publish.py tests/unit/test_dependency_matching.py tests/unit/test_dependency_shards.py tests/unit/test_dependency_publish.py tests/unit/test_dependency_index.py
- mypy src/general_manager/cache/dependency_matching.py src/general_manager/cache/dependency_shards.py src/general_manager/cache/dependency_index.py src/general_manager/cache/dependency_publish.py

Refs #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized internal cache dependency tracking system with improved sharding strategy for more efficient invalidation performance.
  * Refactored dependency matching logic to use deterministic value normalization and stable serialization.
  * Enhanced cache key removal process with fast-path operations for better efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->