### PR TITLE
fix: drop duplicate GraphQL relation id inputs

### DIFF
--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -66,6 +66,24 @@ def _normalize_mutation_kwargs_for_manager(
 # ---------------------------------------------------------------------------
 
 
+def _is_direct_relation_raw_id_alias(
+    name: str,
+    attribute_types: dict[str, Any],
+) -> bool:
+    """Return true when ``name`` is the raw ``*_id`` alias for a direct relation."""
+    if not name.endswith("_id"):
+        return False
+
+    relation_name = name.removesuffix("_id")
+    relation_info = attribute_types.get(relation_name)
+    if relation_info is None:
+        return False
+
+    return relation_info.get("relation_kind") == "direct" and not relation_info.get(
+        "is_derived", False
+    )
+
+
 def create_write_fields(
     interface_cls: InterfaceBase,
     *,
@@ -74,8 +92,10 @@ def create_write_fields(
     """
     Create Graphene input fields for writable attributes defined by an Interface.
 
-    Skips system fields (``changed_by``, ``created_at``, ``updated_at``) and
-    attributes marked as derived.  For attributes whose type is a
+    Skips system fields (``changed_by``, ``created_at``, ``updated_at``),
+    attributes marked as derived, and raw ``*_id`` aliases for direct
+    relations already exposed by their canonical relation field.  For
+    attributes whose type is a
     ``GeneralManager``, produces an ID field or a list of ID fields for names
     ending with ``"_list"``.  Always includes an optional ``history_comment``
     string field.
@@ -91,10 +111,13 @@ def create_write_fields(
         Mapping from attribute name to a Graphene input field instance.
     """
     fields: dict[str, Any] = {}
-    for name, info in interface_cls.get_attribute_types().items():
+    attribute_types = interface_cls.get_attribute_types()
+    for name, info in attribute_types.items():
         if name in ["changed_by", "created_at", "updated_at"]:
             continue
         if info["is_derived"]:
+            continue
+        if _is_direct_relation_raw_id_alias(name, attribute_types):
             continue
 
         typ = info["type"]
@@ -184,6 +207,7 @@ def generate_create_mutation_class(
                     field_name: field
                     for field_name, field in create_write_fields(interface_cls).items()
                     if field_name not in generalManagerClass.Interface.input_fields
+                    and field.editable
                 },
             ),
             "mutate": create_mutation,

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -1168,6 +1168,81 @@ class TestGrapQlMutation(TestCase):
         with self.assertRaises(GraphQLError):
             mutation_result = mutation_class.mutate(None, info, field1="test_value")
 
+    def test_create_and_update_mutations_exclude_raw_relation_id_aliases(self):
+        class DummyManager:
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @classmethod
+                def get_attribute_types(cls):
+                    return {
+                        "relation": {
+                            "type": GeneralManager,
+                            "is_required": True,
+                            "is_editable": True,
+                            "is_derived": False,
+                            "default": None,
+                            "relation_kind": "direct",
+                            "filter_lookup": "relation",
+                        },
+                        "relation_id": {
+                            "type": int,
+                            "is_required": True,
+                            "is_editable": True,
+                            "is_derived": False,
+                            "default": None,
+                            "filter_lookup": "relation_id",
+                        },
+                        "external_id": {
+                            "type": int,
+                            "is_required": True,
+                            "is_editable": True,
+                            "is_derived": False,
+                            "default": None,
+                        },
+                    }
+
+        default_return_values = {"success": graphene.Boolean()}
+
+        create_mutation = GraphQL.generate_create_mutation_class(
+            DummyManager, default_return_values
+        )
+        update_mutation = GraphQL.generate_update_mutation_class(
+            DummyManager, default_return_values
+        )
+
+        self.assertIn("relation", create_mutation._meta.arguments)
+        self.assertNotIn("relation_id", create_mutation._meta.arguments)
+        self.assertIn("external_id", create_mutation._meta.arguments)
+        self.assertIn("relation", update_mutation._meta.arguments)
+        self.assertNotIn("relation_id", update_mutation._meta.arguments)
+        self.assertIn("external_id", update_mutation._meta.arguments)
+
+    def test_create_mutation_excludes_non_editable_canonical_relation(self):
+        class DummyManager:
+            class Interface(InterfaceBase):
+                input_fields: ClassVar[dict] = {}
+
+                @classmethod
+                def get_attribute_types(cls):
+                    return {
+                        "relation": {
+                            "type": GeneralManager,
+                            "is_required": True,
+                            "is_editable": False,
+                            "is_derived": False,
+                            "default": None,
+                            "relation_kind": "direct",
+                            "filter_lookup": "relation",
+                        },
+                    }
+
+        mutation_class = GraphQL.generate_create_mutation_class(
+            DummyManager, {"success": graphene.Boolean()}
+        )
+
+        self.assertNotIn("relation", mutation_class._meta.arguments)
+
     def test_generate_update_mutation_class(self):
         """
         Test that the generated update mutation class defines correct arguments, applies default values, and enforces mutation behavior.


### PR DESCRIPTION
## Summary
- Suppress raw direct relation `*_id` aliases from generated GraphQL mutation inputs when the canonical relation field is present.
- Apply editability filtering to create mutation arguments so non-editable canonical fields are not exposed.
- Add regression coverage for structural raw FK alias exclusion and non-editable create mutation fields.

Fixes #286

## Test Plan
- `python -m pytest tests/unit/test_graph_ql.py -q`
- `python -m pytest tests/integration/test_graphql_mutation_relation_aliases.py -q`
- `python -m pytest tests/unit/test_graph_ql.py tests/integration/test_graphql_mutation_relation_aliases.py -q`
- `ruff check src/general_manager/api/graphql_mutations.py tests/unit/test_graph_ql.py`
- `ruff format --check src/general_manager/api/graphql_mutations.py tests/unit/test_graph_ql.py`
- `mypy src/general_manager/api/graphql_mutations.py`
- `python -m pytest -q`