### PR TITLE
docs: fix measurement string parsing example

### DIFF
--- a/docs/concepts/measurement/units_currency.md
+++ b/docs/concepts/measurement/units_currency.md
@@ -26,7 +26,7 @@ freight_eur = Measurement(100, "USD/t").to("EUR/t", exchange_rate=0.92)
 - Comparisons compare magnitudes after converting to a common unit.
 
 ```python
-width = Measurement("50 cm")
+width = Measurement.from_string("50 cm")
 area = length * width           # 2.5 m ** 2
 is_longer = length > width       # True
 ```


### PR DESCRIPTION
## Summary
- Replace the invalid Measurement("50 cm") docs example with Measurement.from_string("50 cm").
- Align the measurement arithmetic docs with the supported string parsing API.

## Test Plan
- python -m pytest tests/unit/test_measurement.py tests/unit/test_input.py::TestInput::test_input_casting_with_measurement