### PR TITLE
feat: hydrate ORM managers from trusted rows

### DIFF
--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -185,10 +185,14 @@ The trusted ORM hydration path is private framework infrastructure. It is safe
 only for Django model or historical rows returned by GeneralManager-owned ORM
 querysets. Public construction, GraphQL mutations, imports, factories, and other
 user-controlled payloads still use the regular manager constructor and full
-interface input validation. Managers that override `__init__` also use the
-regular constructor so manager-local initialization is preserved. Querysets with
-`prefetch_related()` bypass run-scoped bucket snapshots because prefetch plans
-can change loaded row state without changing the main SQL signature.
+interface input validation. Managers or ORM interfaces that override `__init__`
+also use the regular constructor so local initialization is preserved. Trusted
+hydration falls back to primary-key construction when a row comes from a
+different model, when a `search_date` bucket is holding a live row instead of a
+historical/as-of row, or when the instance has deferred fields. Querysets with
+`prefetch_related()` or deferred fields bypass run-scoped bucket snapshots
+because those query plans can change loaded row state without changing the main
+SQL signature.
 
 ## Manual dependency-index helpers
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -185,7 +185,10 @@ The trusted ORM hydration path is private framework infrastructure. It is safe
 only for Django model or historical rows returned by GeneralManager-owned ORM
 querysets. Public construction, GraphQL mutations, imports, factories, and other
 user-controlled payloads still use the regular manager constructor and full
-interface input validation.
+interface input validation. Managers that override `__init__` also use the
+regular constructor so manager-local initialization is preserved. Querysets with
+`prefetch_related()` bypass run-scoped bucket snapshots because prefetch plans
+can change loaded row state without changing the main SQL signature.
 
 ## Manual dependency-index helpers
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -170,14 +170,22 @@ cached, and ORM update/delete paths clear affected row entries in the active run
 context after successful mutations.
 
 ORM-backed `DatabaseBucket` terminal operations also reuse conservative
-run-scoped primary-key snapshots inside the active context. Equivalent bounded
-bucket evaluations can share the materialized result for iteration, length,
-`count()`, `first()`, `last()`, scalar indexing, primary-key `get()`, and
-membership checks after a snapshot exists. The cache is intentionally
-conservative: unsupported query shapes and large buckets bypass reuse, count-only
-paths do not force full materialization, dependencies are still tracked on every
-terminal operation, and any framework mutation clears bucket snapshots in the
-active run before the data changes.
+run-scoped snapshots inside the active context. Iteration materializes a bounded
+row snapshot and hydrates managers through GeneralManager's private trusted ORM
+path, so rows that were already loaded by the queryset are not fetched again by
+primary key. The same evaluation stores primary keys for length, `count()`,
+`first()`, `last()`, scalar indexing, primary-key `get()`, and membership checks
+after a snapshot exists. The cache is intentionally conservative: unsupported
+query shapes and large buckets bypass reuse, count-only paths do not force full
+materialization, dependencies are still tracked on every terminal operation, and
+any framework mutation clears bucket snapshots in the active run before the data
+changes.
+
+The trusted ORM hydration path is private framework infrastructure. It is safe
+only for Django model or historical rows returned by GeneralManager-owned ORM
+querysets. Public construction, GraphQL mutations, imports, factories, and other
+user-controlled payloads still use the regular manager constructor and full
+interface input validation.
 
 ## Manual dependency-index helpers
 

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -331,6 +331,8 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             return None
         if query.distinct:
             return None
+        if getattr(self._data, "_prefetch_related_lookups", ()):
+            return None
         try:
             sql, params = self._data.query.sql_with_params()
         except (EmptyResultSet, FieldError, TypeError, ValueError):

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -262,6 +262,22 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             return self._manager_class(pk)
         return self._manager_class(pk, search_date=self._search_date)
 
+    def _can_trust_orm_instance(self, instance: models.Model) -> bool:
+        interface_model = getattr(self._manager_class.Interface, "_model", None)
+        if isinstance(interface_model, type) and issubclass(
+            interface_model, models.Model
+        ):
+            if not isinstance(instance, interface_model):
+                return False
+        get_deferred_fields = getattr(instance, "get_deferred_fields", None)
+        if callable(get_deferred_fields) and get_deferred_fields():
+            return False
+        if self._search_date is not None and not (
+            hasattr(instance, "_history") or hasattr(instance, "history_date")
+        ):
+            return False
+        return True
+
     def _build_manager_from_instance(
         self,
         instance: models.Model,
@@ -270,7 +286,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             self._manager_class.Interface, "_from_trusted_orm_instance", None
         )
         manager_hydrate = self._manager_class._from_trusted_orm_instance
-        if callable(interface_hydrate):
+        if callable(interface_hydrate) and self._can_trust_orm_instance(instance):
             return manager_hydrate(instance, search_date=self._search_date)
         return self._build_manager_from_primary_key(instance.pk)
 
@@ -332,6 +348,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         if query.distinct:
             return None
         if getattr(self._data, "_prefetch_related_lookups", ()):
+            return None
+        deferred_loading = getattr(query, "deferred_loading", None)
+        if isinstance(deferred_loading, tuple) and deferred_loading[0]:
             return None
         try:
             sql, params = self._data.query.sql_with_params()

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -257,10 +257,27 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             ),
         )
 
-    def _build_manager(self, pk: Any) -> GeneralManagerType:
+    def _build_manager_from_primary_key(self, pk: Any) -> GeneralManagerType:
         if self._search_date is None:
             return self._manager_class(pk)
         return self._manager_class(pk, search_date=self._search_date)
+
+    def _build_manager_from_instance(
+        self,
+        instance: models.Model,
+    ) -> GeneralManagerType:
+        interface_hydrate = getattr(
+            self._manager_class.Interface, "_from_trusted_orm_instance", None
+        )
+        manager_hydrate = self._manager_class._from_trusted_orm_instance
+        if callable(interface_hydrate):
+            return manager_hydrate(instance, search_date=self._search_date)
+        return self._build_manager_from_primary_key(instance.pk)
+
+    def _build_manager(self, value: Any) -> GeneralManagerType:
+        if isinstance(value, models.Model):
+            return self._build_manager_from_instance(value)
+        return self._build_manager_from_primary_key(value)
 
     @staticmethod
     def _copy_filter_definitions(
@@ -370,6 +387,28 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         context.set_orm_bucket_result(signature, primary_keys)
         return primary_keys
 
+    def _get_run_scoped_rows(self) -> tuple[models.Model, ...] | None:
+        """
+        Load or reuse a bounded model-row snapshot for trusted hydration.
+        """
+        context = current_calculation_run_context()
+        if context is None:
+            return None
+        signature = self._query_signature()
+        if signature is None:
+            return None
+        cached = context.get_orm_bucket_rows(signature)
+        if cached is not None:
+            return cached  # type: ignore[return-value]
+
+        rows = tuple(self._data[: MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 1])
+        if len(rows) > MAX_RUN_SCOPED_BUCKET_RESULT_ROWS:
+            return None
+        primary_keys = tuple(row.pk for row in rows)
+        context.set_orm_bucket_rows(signature, rows)
+        context.set_orm_bucket_result(signature, primary_keys)
+        return rows
+
     def _peek_run_scoped_primary_keys(self) -> tuple[Any, ...] | None:
         """
         Return an already cached primary-key snapshot without evaluating the ORM.
@@ -389,6 +428,19 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         if signature is None:
             return None
         cached = context.get_orm_bucket_result(signature)
+        if cached is None:
+            return None
+        return cached  # type: ignore[return-value]
+
+    def _peek_run_scoped_rows(self) -> tuple[models.Model, ...] | None:
+        """Return cached model rows without evaluating the ORM."""
+        context = current_calculation_run_context()
+        if context is None:
+            return None
+        signature = self._query_signature()
+        if signature is None:
+            return None
+        cached = context.get_orm_bucket_rows(signature)
         if cached is None:
             return None
         return cached  # type: ignore[return-value]
@@ -458,13 +510,18 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             GeneralManagerType: Manager instance for each primary key in the queryset.
         """
         self._track_effective_dependencies()
-        primary_keys = self._get_run_scoped_primary_keys()
+        rows = self._get_run_scoped_rows()
+        if rows is not None:
+            for row in rows:
+                yield self._build_manager_from_instance(row)
+            return
+        primary_keys = self._peek_run_scoped_primary_keys()
         if primary_keys is not None:
             for primary_key in primary_keys:
-                yield self._build_manager(primary_key)
+                yield self._build_manager_from_primary_key(primary_key)
             return
         for item in self._data:
-            yield self._build_manager(item.pk)
+            yield self._build_manager_from_instance(item)
 
     def __or__(
         self,
@@ -585,7 +642,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         """
         ids: list[int] = []
         for obj in query_set:
-            inst = self._build_manager(obj.pk)
+            inst = self._build_manager_from_instance(obj)
             keep = True
             for k, val, root in python_filters:
                 lookup = k.split("__", 1)[1] if "__" in k else ""
@@ -704,15 +761,20 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             GeneralManagerType | None: First manager instance if available.
         """
         self._track_effective_dependencies()
+        rows = self._peek_run_scoped_rows()
+        if rows is not None:
+            if not rows:
+                return None
+            return self._build_manager_from_instance(rows[0])
         primary_keys = self._peek_run_scoped_primary_keys()
         if primary_keys is not None:
             if not primary_keys:
                 return None
-            return self._build_manager(primary_keys[0])
+            return self._build_manager_from_primary_key(primary_keys[0])
         first_element = self._data.first()
         if first_element is None:
             return None
-        return self._build_manager(first_element.pk)
+        return self._build_manager_from_instance(first_element)
 
     def last(self) -> GeneralManagerType | None:
         """
@@ -722,15 +784,20 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             GeneralManagerType | None: Last manager instance if available.
         """
         self._track_effective_dependencies()
+        rows = self._peek_run_scoped_rows()
+        if rows is not None:
+            if not rows:
+                return None
+            return self._build_manager_from_instance(rows[-1])
         primary_keys = self._peek_run_scoped_primary_keys()
         if primary_keys is not None:
             if not primary_keys:
                 return None
-            return self._build_manager(primary_keys[-1])
+            return self._build_manager_from_primary_key(primary_keys[-1])
         first_element = self._data.last()
         if first_element is None:
             return None
-        return self._build_manager(first_element.pk)
+        return self._build_manager_from_instance(first_element)
 
     def count(self) -> int:
         """
@@ -778,18 +845,28 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             models.MultipleObjectsReturned: Propagated when multiple rows satisfy the lookup.
         """
         self._track_effective_dependencies()
+        rows = self._peek_run_scoped_rows()
+        if rows is not None:
+            requested_primary_key = self._snapshot_get_primary_key(kwargs)
+            if requested_primary_key is not None:
+                matches = [row for row in rows if row.pk == requested_primary_key]
+                if len(matches) == 1:
+                    return self._build_manager_from_instance(matches[0])
+                if len(matches) > 1:
+                    raise self._data.model.MultipleObjectsReturned
+                raise self._data.model.DoesNotExist
         primary_keys = self._peek_run_scoped_primary_keys()
         if primary_keys is not None:
             requested_primary_key = self._snapshot_get_primary_key(kwargs)
             if requested_primary_key is not None:
                 match_count = primary_keys.count(requested_primary_key)
                 if match_count == 1:
-                    return self._build_manager(requested_primary_key)
+                    return self._build_manager_from_primary_key(requested_primary_key)
                 if match_count > 1:
                     raise self._data.model.MultipleObjectsReturned
                 raise self._data.model.DoesNotExist
         element = self._data.get(**kwargs)
-        return self._build_manager(element.pk)
+        return self._build_manager_from_instance(element)
 
     def __getitem__(
         self, item: int | slice
@@ -815,12 +892,17 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
                 run_scoped_cacheable=self._run_scoped_cacheable,
             )
         self._track_effective_dependencies()
+        rows = self._peek_run_scoped_rows()
+        if rows is not None:
+            if item < 0:
+                raise ValueError
+            return self._build_manager_from_instance(rows[item])
         primary_keys = self._peek_run_scoped_primary_keys()
         if primary_keys is not None:
             if item < 0:
                 raise ValueError
-            return self._build_manager(primary_keys[item])
-        return self._build_manager(self._data[item].pk)
+            return self._build_manager_from_primary_key(primary_keys[item])
+        return self._build_manager_from_instance(self._data[item])
 
     def __len__(self) -> int:
         """
@@ -926,7 +1008,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             objs = list(qs)
 
             def key_func(obj: models.Model) -> tuple[object, ...]:
-                inst = self._build_manager(obj.pk)
+                inst = self._build_manager_from_instance(obj)
                 values = []
                 for k in key:
                     if k in properties:

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -26,6 +26,7 @@ _active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
     default=None,
 )
 ORM_BUCKET_RESULT_PREFIX = "orm_bucket_result"
+ORM_BUCKET_ROW_RESULT_PREFIX = "orm_bucket_row_result"
 BUCKET_INDEX_PREFIX = "bucket_index"
 DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE = 1000
 logger = get_logger("cache.run_context")
@@ -191,9 +192,18 @@ class CalculationRunContext:
         """Store an ORM bucket result for the active run."""
         self.set((ORM_BUCKET_RESULT_PREFIX, key), value)
 
+    def get_orm_bucket_rows(self, key: Hashable) -> object:
+        """Return cached ORM bucket rows for key, or None when absent."""
+        return self.get((ORM_BUCKET_ROW_RESULT_PREFIX, key))
+
+    def set_orm_bucket_rows(self, key: Hashable, value: object) -> None:
+        """Store ORM bucket rows for the active run."""
+        self.set((ORM_BUCKET_ROW_RESULT_PREFIX, key), value)
+
     def clear_orm_bucket_results(self) -> None:
         """Discard all run-scoped ORM bucket result entries."""
         self.discard_prefix((ORM_BUCKET_RESULT_PREFIX,))
+        self.discard_prefix((ORM_BUCKET_ROW_RESULT_PREFIX,))
 
     def _bucket_index_cache_key(
         self,

--- a/src/general_manager/interface/orm_interface.py
+++ b/src/general_manager/interface/orm_interface.py
@@ -74,8 +74,13 @@ class OrmInterfaceBase(InterfaceBase, Generic[HistoryModelT]):
         historical rows that came from Django ORM querysets owned by this
         interface. External/API/user payloads must continue through __init__.
         """
-        interface = cls.__new__(cls)
         pk = cast(Any, instance).pk
+        if cls.__init__ is not OrmInterfaceBase.__init__:
+            if search_date is None:
+                return cls(pk)
+            return cls(pk, search_date=search_date)
+
+        interface = cls.__new__(cls)
         identification = {"id": pk}
         interface.identification = identification
         interface.pk = pk

--- a/src/general_manager/interface/orm_interface.py
+++ b/src/general_manager/interface/orm_interface.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import ClassVar, Generic, Type, TypeVar, cast
+from typing import Any, ClassVar, Generic, Type, TypeVar, cast
 
 from django.db import models
 from django.utils import timezone
@@ -59,6 +59,29 @@ class OrmInterfaceBase(InterfaceBase, Generic[HistoryModelT]):
         self.pk = self.identification["id"]
         self._search_date = self.normalize_search_date(search_date)
         self._instance: HistoryModelT = self.get_data()
+
+    @classmethod
+    def _from_trusted_orm_instance(
+        cls,
+        instance: HistoryModelT,
+        *,
+        search_date: datetime | None = None,
+    ) -> "OrmInterfaceBase[HistoryModelT]":
+        """
+        Build an interface from an ORM-loaded row without public input validation.
+
+        This is an internal trusted path. Callers must only pass model or
+        historical rows that came from Django ORM querysets owned by this
+        interface. External/API/user payloads must continue through __init__.
+        """
+        interface = cls.__new__(cls)
+        pk = cast(Any, instance).pk
+        identification = {"id": pk}
+        interface.identification = identification
+        interface.pk = pk
+        interface._search_date = cls.normalize_search_date(search_date)
+        interface._instance = instance
+        return interface
 
     @staticmethod
     def normalize_search_date(search_date: datetime | None) -> datetime | None:

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Iterator, Self, Type
+from typing import TYPE_CHECKING, Any, Iterator, Self, Type, cast
 
 from general_manager.api.property import GraphQLProperty
 from general_manager.bucket.base_bucket import Bucket
@@ -22,6 +22,13 @@ class UnsupportedUnionOperandError(TypeError):
             operand_type (type): The operand type that is not supported for the union; its representation is included in the exception message.
         """
         super().__init__(f"Unsupported type for union: {operand_type}.")
+
+
+class TrustedOrmHydrationNotSupportedError(TypeError):
+    """Raised when trusted ORM hydration is requested for a non-ORM interface."""
+
+    def __init__(self, interface_name: str) -> None:
+        super().__init__(f"{interface_name} does not support trusted ORM hydration.")
 
 
 if TYPE_CHECKING:
@@ -64,6 +71,43 @@ class GeneralManager(metaclass=GeneralManagerMeta):
                 "identification": self.__id,
             },
         )
+
+    @classmethod
+    def _from_trusted_orm_instance(
+        cls,
+        instance: Any,
+        *,
+        search_date: Any = None,
+    ) -> Self:
+        """
+        Build a manager around an ORM-loaded row without public input validation.
+
+        This private path is only for framework-owned Django ORM rows. It must
+        not be used for GraphQL, mutation, import, factory, or other external
+        payloads because it bypasses Interface input validation.
+        """
+        hydrate = getattr(cls.Interface, "_from_trusted_orm_instance", None)
+        if not callable(hydrate):
+            raise TrustedOrmHydrationNotSupportedError(cls.Interface.__name__)
+
+        manager = cls.__new__(cls)
+        manager._interface = hydrate(instance, search_date=search_date)
+        manager.__id = manager._interface.identification
+        manager._manager_state_valid = True
+        manager._manager_state_reason = None
+        DependencyTracker.track(
+            cls.__name__,
+            "identification",
+            serialize_dependency_identifier(manager.__id),
+        )
+        logger.debug(
+            "trusted orm manager hydrated",
+            context={
+                "manager": cls.__name__,
+                "identification": manager.__id,
+            },
+        )
+        return cast(Self, manager)
 
     def __str__(self) -> str:
         """Return a user-friendly representation showing the identification."""

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -90,6 +90,12 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         if not callable(hydrate):
             raise TrustedOrmHydrationNotSupportedError(cls.Interface.__name__)
 
+        if cls.__init__ is not GeneralManager.__init__:
+            pk = instance.pk
+            if search_date is None:
+                return cls(pk)
+            return cls(pk, search_date=search_date)
+
         manager = cls.__new__(cls)
         manager._interface = hydrate(instance, search_date=search_date)
         manager.__id = manager._interface.identification

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -1,7 +1,7 @@
 # type: ignore
 
 from __future__ import annotations
-from datetime import timedelta
+from datetime import datetime, timedelta
 from django.db import models
 from django.core.exceptions import ValidationError, FieldError
 from django.contrib.auth.models import User
@@ -255,6 +255,80 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         for human in humans:
             self.assertEqual(human.name, dict(human)["name"])
             self.assertEqual(human.country, dict(human)["country"])
+
+    def test_trusted_orm_hydration_uses_loaded_row_without_query(self):
+        row = self.TestHuman.Interface._model.objects.get(
+            pk=self.test_human1.identification["id"]
+        )
+
+        with self.assertNumQueries(0):
+            manager = self.TestHuman._from_trusted_orm_instance(row)
+            self.assertEqual(manager.identification, {"id": row.pk})
+            self.assertEqual(manager.name, "Alice")
+
+        self.assertIs(manager._interface._instance, row)
+        self.assertTrue(manager._manager_state_valid)
+
+    def test_trusted_orm_hydration_normalizes_search_date(self):
+        row = self.TestHuman.Interface._model.objects.get(
+            pk=self.test_human1.identification["id"]
+        )
+        naive_search_date = datetime(2026, 1, 1, 12, 30)
+
+        manager = self.TestHuman._from_trusted_orm_instance(
+            row,
+            search_date=naive_search_date,
+        )
+
+        self.assertEqual(manager.identification, {"id": row.pk})
+        self.assertIsNotNone(manager._interface._search_date.tzinfo)
+
+    def test_public_constructor_still_rejects_invalid_external_input(self):
+        with self.assertRaises(ValueError):
+            self.TestHuman(id="not-an-integer")
+
+    def test_create_path_does_not_use_trusted_hydration(self):
+        with patch.object(
+            self.TestHuman,
+            "_from_trusted_orm_instance",
+            wraps=self.TestHuman._from_trusted_orm_instance,
+        ) as trusted_hydrate:
+            created = self.TestHuman.create(
+                creator_id=None,
+                name="Charlie",
+                ignore_permission=True,
+            )
+
+        self.assertEqual(created.name, "Charlie")
+        trusted_hydrate.assert_not_called()
+
+    def test_bucket_iteration_hydrates_loaded_rows_without_per_row_queries(self):
+        self.TestHuman.create(
+            creator_id=None,
+            name="Charlie",
+            ignore_permission=True,
+        )
+
+        with self.assertNumQueries(1):
+            names = sorted(human.name for human in self.TestHuman.all())
+
+        self.assertEqual(names, ["Alice", "Bob", "Charlie"])
+
+    def test_run_context_reuses_trusted_bucket_rows_without_per_row_queries(self):
+        self.TestHuman.create(
+            creator_id=None,
+            name="Charlie",
+            ignore_permission=True,
+        )
+        first_bucket = self.TestHuman.filter(name__in=["Alice", "Bob", "Charlie"])
+        second_bucket = self.TestHuman.filter(name__in=["Alice", "Bob", "Charlie"])
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            first_names = sorted(human.name for human in first_bucket)
+            second_names = sorted(human.name for human in second_bucket)
+
+        self.assertEqual(first_names, ["Alice", "Bob", "Charlie"])
+        self.assertEqual(second_names, ["Alice", "Bob", "Charlie"])
 
     def test_soft_delete_behavior(self):
         """

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -11,6 +11,7 @@ from typing import ClassVar
 from unittest.mock import patch
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface import DatabaseInterface, ReadOnlyInterface
+from general_manager.bucket.database_bucket import DatabaseBucket
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.cache.run_context import CalculationRunContext
 
@@ -148,6 +149,16 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
                     related_name="change_request_reviews",
                 )
 
+        class CustomInitRecord(GeneralManager):
+            name: str
+
+            class Interface(DatabaseInterface):
+                name = models.CharField(max_length=50)
+
+                def __init__(self, *args, **kwargs):
+                    self.initialized_by_interface = True
+                    super().__init__(*args, **kwargs)
+
         cls.TestCountry = TestCountry
         cls.TestHuman = TestHuman
         cls.TestFamily = TestFamily
@@ -157,6 +168,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         cls.ChangeRequestApproval = ChangeRequestApproval
         cls.ChangeRequestFeasibility = ChangeRequestFeasibility
         cls.ChangeRequestReview = ChangeRequestReview
+        cls.CustomInitRecord = CustomInitRecord
         cls.general_manager_classes = [
             TestCountry,
             TestHuman,
@@ -167,6 +179,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             ChangeRequestApproval,
             ChangeRequestFeasibility,
             ChangeRequestReview,
+            CustomInitRecord,
         ]
 
     def setUp(self):
@@ -242,6 +255,7 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.ChangeRequestApproval.Interface._model._meta.model.objects.all().delete()
         self.ChangeRequestFeasibility.Interface._model._meta.model.objects.all().delete()
         self.ChangeRequestReview.Interface._model._meta.model.objects.all().delete()
+        self.CustomInitRecord.Interface._model._meta.model.objects.all().delete()
         super().tearDown()
 
     def test_iter(self):
@@ -329,6 +343,61 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
         self.assertEqual(first_names, ["Alice", "Bob", "Charlie"])
         self.assertEqual(second_names, ["Alice", "Bob", "Charlie"])
+
+    def test_live_queryset_with_search_date_uses_historical_lookup(self):
+        old_buffer_seconds = self.TestHuman.Interface.historical_lookup_buffer_seconds
+        self.TestHuman.Interface.historical_lookup_buffer_seconds = 0
+        self.addCleanup(
+            setattr,
+            self.TestHuman.Interface,
+            "historical_lookup_buffer_seconds",
+            old_buffer_seconds,
+        )
+
+        human_id = self.test_human1.identification["id"]
+        created_history = (
+            self.TestHuman.Interface._model.history.filter(id=human_id)
+            .order_by("history_date")
+            .last()
+        )
+        self.assertIsNotNone(created_history)
+
+        self.test_human1.update(name="Alice Updated", ignore_permission=True)
+        live_queryset = self.TestHuman.Interface._model.objects.filter(pk=human_id)
+        bucket = DatabaseBucket(
+            live_queryset,
+            self.TestHuman,
+            search_date=created_history.history_date,
+        )
+
+        historical_manager = next(iter(bucket))
+
+        self.assertEqual(historical_manager.name, "Alice")
+        self.assertEqual(self.TestHuman(id=human_id).name, "Alice Updated")
+
+    def test_trusted_hydration_preserves_custom_interface_initializer(self):
+        self.CustomInitRecord.create(
+            creator_id=None,
+            name="Custom",
+            ignore_permission=True,
+        )
+
+        manager = next(iter(self.CustomInitRecord.all()))
+
+        self.assertTrue(manager._interface.initialized_by_interface)
+        self.assertEqual(manager.name, "Custom")
+
+    def test_deferred_queryset_rows_use_full_interface_load(self):
+        model = self.TestHuman.Interface._model
+        bucket = DatabaseBucket(
+            model.objects.only("id").filter(pk=self.test_human1.identification["id"]),
+            self.TestHuman,
+        )
+
+        manager = next(iter(bucket))
+
+        self.assertEqual(manager._interface._instance.get_deferred_fields(), set())
+        self.assertEqual(manager.name, "Alice")
 
     def test_soft_delete_behavior(self):
         """

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -266,6 +266,30 @@ def test_orm_bucket_result_helpers_distinguish_empty_tuple_from_missing() -> Non
         assert ctx.get_orm_bucket_result(("query", "missing")) is None
 
 
+def test_orm_bucket_row_results_are_stored_and_cleared() -> None:
+    rows = (object(), object())
+
+    with CalculationRunContext() as ctx:
+        ctx.set_orm_bucket_rows(("query", "rows"), rows)
+
+        assert ctx.get_orm_bucket_rows(("query", "rows")) == rows
+
+        ctx.clear_orm_bucket_results()
+
+        assert ctx.get_orm_bucket_rows(("query", "rows")) is None
+
+
+def test_clear_orm_bucket_results_clears_primary_keys_and_rows() -> None:
+    with CalculationRunContext() as ctx:
+        ctx.set_orm_bucket_result(("query", "a"), ("pk1", "pk2"))
+        ctx.set_orm_bucket_rows(("query", "a"), ("row1", "row2"))
+
+        ctx.clear_orm_bucket_results()
+
+        assert ctx.get_orm_bucket_result(("query", "a")) is None
+        assert ctx.get_orm_bucket_rows(("query", "a")) is None
+
+
 def test_bucket_index_helpers_store_replay_and_clear_dependencies() -> None:
     """Store a bucket index, replay its dependencies on hit, then clear it."""
     dependencies: set[Dependency] = {

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -209,6 +209,14 @@ class TrustedUserManager(GeneralManager):
     pass
 
 
+class GroupBackedTrustedInterface(TrustedDummyInterface):
+    _model = Group
+
+
+class GroupBackedTrustedUserManager(GeneralManager):
+    pass
+
+
 class InitTrackingTrustedManager(GeneralManager):
     def __init__(self, pk, **kwargs):
         self.initialized_by_constructor = True
@@ -227,6 +235,7 @@ class DatabaseBucketTestCase(TestCase):
         AnotherManager.Interface = DummyInterface
         SearchDateManager.Interface = DummyInterface
         TrustedUserManager.Interface = TrustedDummyInterface
+        GroupBackedTrustedUserManager.Interface = GroupBackedTrustedInterface
         InitTrackingTrustedManager.Interface = TrustedDummyInterface
         DummyInterface._parent_class = UserManager
         TrustedDummyInterface._parent_class = TrustedUserManager
@@ -353,6 +362,17 @@ class DatabaseBucketTestCase(TestCase):
             ],
             [blocked.pk],
         )
+
+    def test_model_mismatch_falls_back_to_primary_key_hydration(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(pk=self.u1.pk),
+            GroupBackedTrustedUserManager,
+        )
+
+        manager = next(iter(bucket))
+
+        self.assertEqual(manager.identification["id"], self.u1.pk)
+        self.assertFalse(hasattr(manager._interface, "_instance"))
 
     def test_equivalent_bucket_queries_share_iter_sql_inside_run_context(self):
         first_bucket = DatabaseBucket(

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Group
-from django.db.models import functions
+from django.db.models import Prefetch, functions
 from django.db.models.query import QuerySet
 from django.test import TestCase
 
@@ -150,6 +150,17 @@ class DummyInterface(InterfaceBase):
         return pre_creation, post_creation
 
 
+class TrustedDummyInterface(DummyInterface):
+    @classmethod
+    def _from_trusted_orm_instance(cls, instance, *, search_date=None):
+        interface = cls.__new__(cls)
+        interface.identification = {"id": instance.pk}
+        interface.pk = instance.pk
+        interface._search_date = search_date
+        interface._instance = instance
+        return interface
+
+
 class UserManager(GeneralManager):
     """
     Simple GeneralManager subclass for wrapping User PKs.
@@ -194,6 +205,17 @@ class SearchDateManager(GeneralManager):
         super().__init__(pk, **kwargs)
 
 
+class TrustedUserManager(GeneralManager):
+    pass
+
+
+class InitTrackingTrustedManager(GeneralManager):
+    def __init__(self, pk, **kwargs):
+        self.initialized_by_constructor = True
+        self.received_search_date = kwargs.get("search_date")
+        super().__init__(pk, **kwargs)
+
+
 class DatabaseBucketTestCase(TestCase):
     def setUp(self):
         """
@@ -204,7 +226,10 @@ class DatabaseBucketTestCase(TestCase):
         UserManager.Interface = DummyInterface  # Set the interface for UserManager
         AnotherManager.Interface = DummyInterface
         SearchDateManager.Interface = DummyInterface
+        TrustedUserManager.Interface = TrustedDummyInterface
+        InitTrackingTrustedManager.Interface = TrustedDummyInterface
         DummyInterface._parent_class = UserManager
+        TrustedDummyInterface._parent_class = TrustedUserManager
         # Create some test users
         self.u1 = User.objects.create(username="alice")
         self.u2 = User.objects.create(username="bob")
@@ -269,6 +294,65 @@ class DatabaseBucketTestCase(TestCase):
                     [manager.identification["id"] for manager in bucket],
                     [self.u1.id, self.u2.id],
                 )
+
+    def test_trusted_hydration_preserves_custom_manager_initializer(self):
+        search_date = datetime(2024, 1, 1)
+        bucket = DatabaseBucket(
+            User.objects.filter(pk=self.u1.pk),
+            InitTrackingTrustedManager,
+            search_date=search_date,
+        )
+
+        manager = next(iter(bucket))
+
+        self.assertTrue(manager.initialized_by_constructor)
+        self.assertEqual(manager.received_search_date, search_date)
+        self.assertEqual(manager.identification["id"], self.u1.pk)
+
+    def test_prefetched_querysets_do_not_share_trusted_row_snapshots(self):
+        allowed = Group.objects.create(name="allowed")
+        blocked = Group.objects.create(name="blocked")
+        self.u1.groups.add(allowed, blocked)
+
+        allowed_bucket = DatabaseBucket(
+            User.objects.filter(pk=self.u1.pk).prefetch_related(
+                Prefetch(
+                    "groups",
+                    queryset=Group.objects.filter(pk=allowed.pk),
+                    to_attr="filtered_groups",
+                )
+            ),
+            TrustedUserManager,
+        )
+        blocked_bucket = DatabaseBucket(
+            User.objects.filter(pk=self.u1.pk).prefetch_related(
+                Prefetch(
+                    "groups",
+                    queryset=Group.objects.filter(pk=blocked.pk),
+                    to_attr="filtered_groups",
+                )
+            ),
+            TrustedUserManager,
+        )
+
+        with CalculationRunContext():
+            allowed_manager = next(iter(allowed_bucket))
+            blocked_manager = next(iter(blocked_bucket))
+
+        self.assertEqual(
+            [
+                group.pk
+                for group in allowed_manager._interface._instance.filtered_groups
+            ],
+            [allowed.pk],
+        )
+        self.assertEqual(
+            [
+                group.pk
+                for group in blocked_manager._interface._instance.filtered_groups
+            ],
+            [blocked.pk],
+        )
 
     def test_equivalent_bucket_queries_share_iter_sql_inside_run_context(self):
         first_bucket = DatabaseBucket(

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -226,6 +226,50 @@ class DatabaseBucketTestCase(TestCase):
         self.assertEqual(len(self.bucket), 3)
         self.assertEqual(self.bucket.count(), 3)
 
+    def test_build_manager_dispatches_model_instances_and_primary_keys(self):
+        with (
+            patch.object(
+                self.bucket,
+                "_build_manager_from_instance",
+                wraps=self.bucket._build_manager_from_instance,
+            ) as from_instance,
+            patch.object(
+                self.bucket,
+                "_build_manager_from_primary_key",
+                wraps=self.bucket._build_manager_from_primary_key,
+            ) as from_primary_key,
+        ):
+            self.assertEqual(
+                self.bucket._build_manager(self.u1).identification["id"],
+                self.u1.id,
+            )
+            self.assertEqual(
+                self.bucket._build_manager(self.u2.pk).identification["id"],
+                self.u2.id,
+            )
+
+        from_instance.assert_called_once_with(self.u1)
+        self.assertEqual(
+            [call.args[0] for call in from_primary_key.call_args_list],
+            [self.u1.pk, self.u2.pk],
+        )
+
+    def test_primary_key_snapshot_iteration_fallback_when_rows_are_absent(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+        )
+
+        with CalculationRunContext() as context:
+            signature = bucket._query_signature()
+            context.set_orm_bucket_result(signature, (self.u1.id, self.u2.id))
+
+            with patch.object(bucket, "_get_run_scoped_rows", return_value=None):
+                self.assertEqual(
+                    [manager.identification["id"] for manager in bucket],
+                    [self.u1.id, self.u2.id],
+                )
+
     def test_equivalent_bucket_queries_share_iter_sql_inside_run_context(self):
         first_bucket = DatabaseBucket(
             User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
@@ -333,6 +377,55 @@ class DatabaseBucketTestCase(TestCase):
             self.assertEqual(bucket.get(pk=self.u1.pk).identification["id"], self.u1.id)
             self.assertEqual(bucket[1].identification["id"], self.u2.id)
             self.assertIn(self.u1, bucket)
+
+    def test_primary_key_snapshot_terminal_operations_without_row_snapshot(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+        )
+
+        with CalculationRunContext() as context:
+            signature = bucket._query_signature()
+            context.set_orm_bucket_result(signature, (self.u1.id, self.u2.id))
+
+            self.assertEqual(bucket.first().identification["id"], self.u1.id)
+            self.assertEqual(bucket.last().identification["id"], self.u2.id)
+            self.assertEqual(bucket.get(pk=self.u1.pk).identification["id"], self.u1.id)
+            self.assertEqual(bucket[1].identification["id"], self.u2.id)
+
+            with self.assertRaises(ValueError):
+                bucket[-1]
+
+    def test_empty_primary_key_snapshot_first_and_last_return_none(self):
+        bucket = DatabaseBucket(User.objects.filter(username="nobody"), UserManager)
+
+        with CalculationRunContext() as context:
+            context.set_orm_bucket_result(bucket._query_signature(), ())
+
+            self.assertIsNone(bucket.first())
+            self.assertIsNone(bucket.last())
+
+    def test_primary_key_snapshot_get_missing_and_duplicate_raise(self):
+        bucket = DatabaseBucket(User.objects.filter(username="alice"), UserManager)
+
+        with CalculationRunContext() as context:
+            signature = bucket._query_signature()
+            context.set_orm_bucket_result(signature, (self.u1.id,))
+            with self.assertRaises(User.DoesNotExist):
+                bucket.get(pk=self.u2.pk)
+
+            context.set_orm_bucket_result(signature, (self.u1.id, self.u1.id))
+            with self.assertRaises(User.MultipleObjectsReturned):
+                bucket.get(pk=self.u1.pk)
+
+    def test_peek_run_scoped_rows_returns_none_without_cached_rows(self):
+        bucket = DatabaseBucket(User.objects.filter(username="alice"), UserManager)
+
+        self.assertIsNone(bucket._peek_run_scoped_rows())
+        with CalculationRunContext():
+            self.assertIsNone(bucket._peek_run_scoped_rows())
+            with patch.object(bucket, "_query_signature", return_value=None):
+                self.assertIsNone(bucket._peek_run_scoped_rows())
 
     def test_contains_does_not_materialize_uncached_bucket(self):
         bucket = DatabaseBucket(User.objects.all(), UserManager)

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -4,7 +4,10 @@ from general_manager.bootstrap import (
     check_permission_class,
 )
 from general_manager.interface.capabilities.orm import HistoryNotSupportedError
-from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.general_manager import (
+    GeneralManager,
+    TrustedOrmHydrationNotSupportedError,
+)
 from general_manager.manager.meta import InvalidManagerStateError
 from general_manager.permission.manager_based_permission import (
     AdditiveManagerPermission,
@@ -415,3 +418,10 @@ class GeneralManagerTestCase(TestCase):
         ):
             manager_obj.delete(creator_id=1)
         mock_delete.assert_not_called()
+
+    def test_trusted_orm_hydration_requires_orm_interface(self):
+        with self.assertRaisesRegex(
+            TrustedOrmHydrationNotSupportedError,
+            "DummyInterface does not support trusted ORM hydration",
+        ):
+            self.manager._from_trusted_orm_instance(object())


### PR DESCRIPTION
## Summary
- Add a private trusted hydration path for ORM-backed managers created from loaded Django rows.
- Use loaded queryset rows in DatabaseBucket iteration and row-producing terminal paths to avoid per-row primary-key refetches.
- Store run-scoped row snapshots alongside primary-key snapshots and document the private trusted boundary.

## Test Plan
- python -m pytest tests/integration/test_database_manager.py tests/unit/test_database_bucket.py tests/unit/test_calculation_run_context.py -q
- ruff check src/general_manager/interface/orm_interface.py src/general_manager/manager/general_manager.py src/general_manager/bucket/database_bucket.py src/general_manager/cache/run_context.py tests/integration/test_database_manager.py tests/unit/test_database_bucket.py tests/unit/test_calculation_run_context.py
- ruff format --check src/general_manager/interface/orm_interface.py src/general_manager/manager/general_manager.py src/general_manager/bucket/database_bucket.py src/general_manager/cache/run_context.py tests/integration/test_database_manager.py tests/unit/test_database_bucket.py tests/unit/test_calculation_run_context.py
- mypy
- python -m pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized bulk operations and iteration to reduce redundant database queries.
  * Enhanced handling of complex query patterns (prefetch and deferred queries).

* **Documentation**
  * Updated technical documentation to explain caching behavior and optimization techniques.

* **Tests**
  * Added comprehensive tests validating performance improvements and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->