### PR TITLE
fix: batch dependency shard recording

### DIFF
--- a/src/general_manager/cache/dependency_shards.py
+++ b/src/general_manager/cache/dependency_shards.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Literal
+from typing import Any, Iterable, Literal, Mapping
 
 from django.core.cache import cache
 
@@ -35,6 +36,14 @@ class ReverseDependencyMembership:
     shard_keys: frozenset[str]
     composite_dependencies: frozenset[CompositeDependency]
     simple_dependencies: frozenset[SimpleDependency] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True, slots=True)
+class _DependencyShardPlan:
+    shard_keys: frozenset[str]
+    composite_dependencies: frozenset[CompositeDependency]
+    simple_dependencies: frozenset[SimpleDependency]
+    lookup_registrations: frozenset[tuple[str, str, str]]
 
 
 def _hash_text(value: str) -> str:
@@ -104,19 +113,78 @@ def cache_set_members(key: str) -> set[str]:
     return set(members)
 
 
+def _cache_get_many(keys: Iterable[str]) -> dict[str, Any]:
+    key_tuple = tuple(dict.fromkeys(keys))
+    if not key_tuple:
+        return {}
+    return dict(cache.get_many(key_tuple))
+
+
+def _cache_set_many(payloads: Mapping[str, Any]) -> None:
+    if payloads:
+        cache.set_many(dict(payloads), None)
+
+
+def _cache_delete_many(keys: Iterable[str]) -> None:
+    key_tuple = tuple(dict.fromkeys(keys))
+    if not key_tuple:
+        return
+    delete_many = getattr(cache, "delete_many", None)
+    if callable(delete_many):
+        delete_many(key_tuple)
+        return
+    for key in key_tuple:
+        cache.delete(key)
+
+
+def _cache_member_set(value: Any) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, (set, frozenset, list, tuple)):
+        return {member for member in value if isinstance(member, str)}
+    return set()
+
+
+def _cache_set_add_many(additions: Mapping[str, set[str]]) -> None:
+    pending = {key: set(members) for key, members in additions.items() if members}
+    if not pending:
+        return
+
+    existing_sets = _cache_get_many(pending)
+    payloads: dict[str, set[str]] = {}
+    for key, members in pending.items():
+        current = _cache_member_set(existing_sets.get(key, set()))
+        current.update(members)
+        payloads[key] = current
+    _cache_set_many(payloads)
+
+
+def _cache_set_discard_many(removals: Mapping[str, set[str]]) -> None:
+    pending = {key: set(members) for key, members in removals.items() if members}
+    if not pending:
+        return
+
+    existing_sets = _cache_get_many(pending)
+    payloads: dict[str, set[str]] = {}
+    delete_keys: list[str] = []
+    for key, members in pending.items():
+        current = _cache_member_set(existing_sets.get(key, set()))
+        current.difference_update(members)
+        if current:
+            payloads[key] = current
+        else:
+            delete_keys.append(key)
+
+    _cache_set_many(payloads)
+    _cache_delete_many(delete_keys)
+
+
 def _cache_set_add(key: str, member: str) -> None:
-    members = cache_set_members(key)
-    members.add(member)
-    cache.set(key, members, None)
+    _cache_set_add_many({key: {member}})
 
 
 def _cache_set_discard(key: str, member: str) -> None:
-    members = cache_set_members(key)
-    members.discard(member)
-    if members:
-        cache.set(key, members, None)
-    else:
-        cache.delete(key)
+    _cache_set_discard_many({key: {member}})
 
 
 def _lookup_name_for_candidate(lookup: str) -> str:
@@ -190,20 +258,31 @@ def _shard_keys_for_dependency(
     manager_name: str,
     action: DependencyAction,
     identifier: str,
-) -> tuple[set[str], set[CompositeDependency], set[SimpleDependency]]:
+) -> _DependencyShardPlan:
     shard_keys: set[str] = set()
     composites: set[CompositeDependency] = set()
     simple_dependencies: set[SimpleDependency] = set()
+    lookup_registrations: set[tuple[str, str, str]] = set()
 
     if action == "all":
         shard_keys.add(all_records_shard_key(manager_name))
         simple_dependencies.add((manager_name, action, identifier))
-        return shard_keys, composites, simple_dependencies
+        return _DependencyShardPlan(
+            frozenset(shard_keys),
+            frozenset(composites),
+            frozenset(simple_dependencies),
+            frozenset(lookup_registrations),
+        )
 
     if action == "request_query":
         shard_keys.add(request_query_shard_key(manager_name))
         simple_dependencies.add((manager_name, action, identifier))
-        return shard_keys, composites, simple_dependencies
+        return _DependencyShardPlan(
+            frozenset(shard_keys),
+            frozenset(composites),
+            frozenset(simple_dependencies),
+            frozenset(lookup_registrations),
+        )
 
     if action == "identification":
         shard_keys.add(
@@ -216,19 +295,39 @@ def _shard_keys_for_dependency(
             )
         )
         simple_dependencies.add((manager_name, action, identifier))
-        return shard_keys, composites, simple_dependencies
+        return _DependencyShardPlan(
+            frozenset(shard_keys),
+            frozenset(composites),
+            frozenset(simple_dependencies),
+            frozenset(lookup_registrations),
+        )
 
     if action not in {"filter", "exclude"}:
-        return shard_keys, composites, simple_dependencies
+        return _DependencyShardPlan(
+            frozenset(),
+            frozenset(),
+            frozenset(),
+            frozenset(),
+        )
 
     params = parse_dependency_identifier(identifier)
     if not isinstance(params, dict):
-        return shard_keys, composites, simple_dependencies
+        return _DependencyShardPlan(
+            frozenset(),
+            frozenset(),
+            frozenset(),
+            frozenset(),
+        )
 
     if not params:
         shard_keys.add(all_records_shard_key(manager_name))
         simple_dependencies.add((manager_name, action, identifier))
-        return shard_keys, composites, simple_dependencies
+        return _DependencyShardPlan(
+            frozenset(shard_keys),
+            frozenset(composites),
+            frozenset(simple_dependencies),
+            frozenset(lookup_registrations),
+        )
 
     sort_lookups = [
         str(lookup).removeprefix("__sort__")
@@ -239,18 +338,23 @@ def _shard_keys_for_dependency(
         composite = (manager_name, action, identifier)
         composites.add(composite)
         for sort_lookup in sort_lookups:
-            _register_lookup(manager_name, action, sort_lookup)
+            lookup_registrations.add((manager_name, action, sort_lookup))
             shard_keys.add(
                 composite_lookup_shard_key(manager_name, action, sort_lookup)
             )
-        return shard_keys, composites, simple_dependencies
+        return _DependencyShardPlan(
+            frozenset(shard_keys),
+            frozenset(composites),
+            frozenset(simple_dependencies),
+            frozenset(lookup_registrations),
+        )
 
     if len(params) > 1:
         composite = (manager_name, action, identifier)
         composites.add(composite)
         for lookup in params:
             candidate_lookup = _lookup_name_for_candidate(str(lookup))
-            _register_lookup(manager_name, action, candidate_lookup)
+            lookup_registrations.add((manager_name, action, candidate_lookup))
             shard_keys.add(
                 composite_lookup_shard_key(
                     manager_name,
@@ -258,12 +362,17 @@ def _shard_keys_for_dependency(
                     candidate_lookup,
                 )
             )
-        return shard_keys, composites, simple_dependencies
+        return _DependencyShardPlan(
+            frozenset(shard_keys),
+            frozenset(composites),
+            frozenset(simple_dependencies),
+            frozenset(lookup_registrations),
+        )
 
     lookup, value = next(iter(params.items()))
     spec = lookup_spec_from_key(str(lookup))
     candidate_lookup = "__".join(spec.attr_path)
-    _register_lookup(manager_name, action, candidate_lookup)
+    lookup_registrations.add((manager_name, action, candidate_lookup))
     if spec.operator == "eq":
         shard_keys.add(
             exact_lookup_shard_key(manager_name, action, spec.lookup, "eq", value)
@@ -273,7 +382,39 @@ def _shard_keys_for_dependency(
             scan_lookup_shard_key(manager_name, action, spec.lookup, spec.operator)
         )
     simple_dependencies.add((manager_name, action, identifier))
-    return shard_keys, composites, simple_dependencies
+    return _DependencyShardPlan(
+        frozenset(shard_keys),
+        frozenset(composites),
+        frozenset(simple_dependencies),
+        frozenset(lookup_registrations),
+    )
+
+
+def _reverse_membership_for_dependencies(
+    cache_key: str,
+    dependency_set: set[Dependency],
+) -> tuple[ReverseDependencyMembership, set[tuple[str, str, str]]]:
+    shard_keys: set[str] = set()
+    composites: set[CompositeDependency] = set()
+    simple_dependencies: set[SimpleDependency] = set()
+    lookup_registrations: set[tuple[str, str, str]] = set()
+
+    for manager_name, action, identifier in dependency_set:
+        plan = _shard_keys_for_dependency(manager_name, action, identifier)
+        shard_keys.update(plan.shard_keys)
+        composites.update(plan.composite_dependencies)
+        simple_dependencies.update(plan.simple_dependencies)
+        lookup_registrations.update(plan.lookup_registrations)
+
+    return (
+        ReverseDependencyMembership(
+            cache_key=cache_key,
+            shard_keys=frozenset(shard_keys),
+            composite_dependencies=frozenset(composites),
+            simple_dependencies=frozenset(simple_dependencies),
+        ),
+        lookup_registrations,
+    )
 
 
 def record_cache_dependencies(
@@ -281,48 +422,56 @@ def record_cache_dependencies(
     dependencies: Iterable[Dependency],
 ) -> None:
     """Record dependency metadata for one cache key in deterministic shards."""
-    dependency_set = set(dependencies)
-    if not dependency_set:
-        return
-
-    clear_legacy_dependency_index()
-    remove_cache_key_from_shards(cache_key)
-
-    shard_keys: set[str] = set()
-    composites: set[CompositeDependency] = set()
-    simple_dependencies: set[SimpleDependency] = set()
-    for manager_name, action, identifier in dependency_set:
-        new_shards, new_composites, new_simple = _shard_keys_for_dependency(
-            manager_name,
-            action,
-            identifier,
-        )
-        shard_keys.update(new_shards)
-        composites.update(new_composites)
-        simple_dependencies.update(new_simple)
-
-    for shard_key in shard_keys:
-        _cache_set_add(shard_key, cache_key)
-
-    cache.set(
-        reverse_membership_key(cache_key),
-        ReverseDependencyMembership(
-            cache_key=cache_key,
-            shard_keys=frozenset(shard_keys),
-            composite_dependencies=frozenset(composites),
-            simple_dependencies=frozenset(simple_dependencies),
-        ),
-        None,
-    )
-    _cache_set_add(REVERSE_MEMBERSHIP_REGISTRY_KEY, reverse_membership_key(cache_key))
+    record_many_cache_dependencies(((cache_key, dependencies),))
 
 
 def record_many_cache_dependencies(
     entries: Iterable[tuple[str, Iterable[Dependency]]],
 ) -> None:
     """Record dependency metadata for many cache keys."""
+    normalized: dict[str, set[Dependency]] = {}
     for cache_key, dependencies in entries:
-        record_cache_dependencies(cache_key, dependencies)
+        dependency_set = set(dependencies)
+        if dependency_set:
+            normalized.setdefault(cache_key, set()).update(dependency_set)
+    if not normalized:
+        return
+
+    clear_legacy_dependency_index()
+
+    reverse_keys = {
+        cache_key: reverse_membership_key(cache_key) for cache_key in normalized
+    }
+    existing_reverses = _cache_get_many(reverse_keys.values())
+
+    shard_removals: dict[str, set[str]] = defaultdict(set)
+    for cache_key, reverse_key in reverse_keys.items():
+        reverse = existing_reverses.get(reverse_key)
+        if isinstance(reverse, ReverseDependencyMembership):
+            for shard_key in reverse.shard_keys:
+                shard_removals[shard_key].add(cache_key)
+
+    _cache_set_discard_many(shard_removals)
+
+    set_additions: dict[str, set[str]] = defaultdict(set)
+    reverse_payloads: dict[str, ReverseDependencyMembership] = {}
+
+    for cache_key, dependency_set in normalized.items():
+        reverse, lookup_registrations = _reverse_membership_for_dependencies(
+            cache_key,
+            dependency_set,
+        )
+        for shard_key in reverse.shard_keys:
+            set_additions[shard_key].add(cache_key)
+        for manager_name, action, lookup in lookup_registrations:
+            set_additions[lookup_registry_key(manager_name, action)].add(lookup)
+
+        reverse_key = reverse_keys[cache_key]
+        reverse_payloads[reverse_key] = reverse
+        set_additions[REVERSE_MEMBERSHIP_REGISTRY_KEY].add(reverse_key)
+
+    _cache_set_add_many(set_additions)
+    _cache_set_many(reverse_payloads)
 
 
 def remove_cache_key_from_shards(cache_key: str) -> None:

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -367,6 +367,125 @@ class DependencyShardKeyTests(TestCase):
         assert len(counting_cache.get_many_calls) <= 2
         assert len(counting_cache.set_many_calls) <= 2
 
+    def test_record_many_cache_dependencies_replaces_existing_memberships_in_bulk(
+        self,
+    ) -> None:
+        counting_cache = CountingShardCache()
+        old_shard = exact_lookup_shard_key(
+            "Project",
+            "filter",
+            "status",
+            "eq",
+            "old",
+        )
+        new_shard = exact_lookup_shard_key(
+            "Project",
+            "filter",
+            "status",
+            "eq",
+            "new",
+        )
+        reverse_a = reverse_membership_key("cache-a")
+        reverse_b = reverse_membership_key("cache-b")
+        counting_cache.store[old_shard] = {"cache-a", "cache-b", "untouched"}
+        counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY] = {
+            reverse_a,
+            reverse_b,
+        }
+        counting_cache.store[reverse_a] = ReverseDependencyMembership(
+            cache_key="cache-a",
+            shard_keys=frozenset({old_shard}),
+            composite_dependencies=frozenset(),
+            simple_dependencies=frozenset(
+                {("Project", "filter", json.dumps({"status": "old"}))}
+            ),
+        )
+        counting_cache.store[reverse_b] = ReverseDependencyMembership(
+            cache_key="cache-b",
+            shard_keys=frozenset({old_shard}),
+            composite_dependencies=frozenset(),
+            simple_dependencies=frozenset(
+                {("Project", "filter", json.dumps({"status": "old"}))}
+            ),
+        )
+
+        with mock.patch(
+            "general_manager.cache.dependency_shards.cache",
+            counting_cache,
+        ):
+            record_many_cache_dependencies(
+                [
+                    (
+                        "cache-a",
+                        {("Project", "filter", json.dumps({"status": "new"}))},
+                    ),
+                    (
+                        "cache-b",
+                        {("Project", "filter", json.dumps({"status": "new"}))},
+                    ),
+                ]
+            )
+
+        assert counting_cache.store[old_shard] == {"untouched"}
+        assert counting_cache.store[new_shard] == {"cache-a", "cache-b"}
+        assert counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY] == {
+            reverse_a,
+            reverse_b,
+        }
+        assert counting_cache.store[reverse_a] == ReverseDependencyMembership(
+            cache_key="cache-a",
+            shard_keys=frozenset({new_shard}),
+            composite_dependencies=frozenset(),
+            simple_dependencies=frozenset(
+                {("Project", "filter", json.dumps({"status": "new"}))}
+            ),
+        )
+        assert counting_cache.store[reverse_b] == ReverseDependencyMembership(
+            cache_key="cache-b",
+            shard_keys=frozenset({new_shard}),
+            composite_dependencies=frozenset(),
+            simple_dependencies=frozenset(
+                {("Project", "filter", json.dumps({"status": "new"}))}
+            ),
+        )
+        assert counting_cache.get_calls == ["dependency_index"]
+        assert counting_cache.set_calls == []
+        assert len(counting_cache.get_many_calls) <= 4
+        assert len(counting_cache.set_many_calls) <= 4
+
+    def test_record_many_cache_dependencies_clears_legacy_index_once_per_batch(
+        self,
+    ) -> None:
+        counting_cache = CountingShardCache()
+        counting_cache.store["dependency_index"] = {
+            "filter": {
+                "Project": {
+                    "status": {'"legacy"': {"legacy-cache"}},
+                },
+            },
+            "exclude": {},
+            "request_query": {},
+            "all": {},
+        }
+        counting_cache.store["legacy-cache"] = "legacy-value"
+        entries = [
+            (
+                f"cache-{index}",
+                {("Project", "filter", json.dumps({"status": "open"}))},
+            )
+            for index in range(5)
+        ]
+
+        with mock.patch(
+            "general_manager.cache.dependency_shards.cache",
+            counting_cache,
+        ):
+            record_many_cache_dependencies(entries)
+
+        assert "dependency_index" not in counting_cache.store
+        assert "legacy-cache" not in counting_cache.store
+        assert counting_cache.get_calls.count("dependency_index") == 1
+
 
 @override_settings(CACHES=TEST_CACHES)
 class DependencyIndexShardFacadeTests(TestCase):

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from types import SimpleNamespace
+from typing import Any
+from unittest import mock
 
 from django.test import TestCase, override_settings
 
@@ -9,6 +12,7 @@ from general_manager.cache.dependency_matching import stable_value_hash
 from general_manager.cache.dependency_shards import (
     ALL_RECORDS_VALUE,
     DEPENDENCY_SHARD_PREFIX,
+    REVERSE_MEMBERSHIP_REGISTRY_KEY,
     ReverseDependencyMembership,
     all_records_shard_key,
     cache_set_members,
@@ -17,6 +21,7 @@ from general_manager.cache.dependency_shards import (
     composite_lookup_shard_key,
     exact_lookup_shard_key,
     record_cache_dependencies,
+    record_many_cache_dependencies,
     remove_cache_key_from_shards,
     request_query_shard_key,
     reverse_membership_key,
@@ -36,6 +41,62 @@ TEST_CACHES = {
         "LOCATION": "test-dependency-shards",
     }
 }
+
+
+class CountingShardCache:
+    def __init__(self) -> None:
+        self.store: dict[str, Any] = {}
+        self.get_calls: list[str] = []
+        self.get_many_calls: list[tuple[str, ...]] = []
+        self.set_calls: list[str] = []
+        self.set_many_calls: list[tuple[str, ...]] = []
+        self.delete_calls: list[str] = []
+        self.delete_many_calls: list[tuple[str, ...]] = []
+
+    def _clone(self, value: Any) -> Any:
+        if isinstance(value, set):
+            return set(value)
+        if isinstance(value, frozenset):
+            return frozenset(value)
+        return value
+
+    def get(self, key: str, default: Any = None) -> Any:
+        self.get_calls.append(key)
+        if key in self.store:
+            return self._clone(self.store[key])
+        return default
+
+    def get_many(self, keys: Any) -> dict[str, Any]:
+        key_tuple = tuple(keys)
+        self.get_many_calls.append(key_tuple)
+        return {
+            key: self._clone(self.store[key]) for key in key_tuple if key in self.store
+        }
+
+    def set(self, key: str, value: Any, timeout: int | None = None) -> None:
+        self.set_calls.append(key)
+        self.store[key] = self._clone(value)
+
+    def set_many(
+        self,
+        data: Mapping[str, Any],
+        timeout: int | None = None,
+    ) -> list[str]:
+        payload = dict(data)
+        self.set_many_calls.append(tuple(payload))
+        for key, value in payload.items():
+            self.store[key] = self._clone(value)
+        return []
+
+    def delete(self, key: str) -> None:
+        self.delete_calls.append(key)
+        self.store.pop(key, None)
+
+    def delete_many(self, keys: Any) -> None:
+        key_tuple = tuple(keys)
+        self.delete_many_calls.append(key_tuple)
+        for key in key_tuple:
+            self.store.pop(key, None)
 
 
 @override_settings(CACHES=TEST_CACHES)
@@ -253,6 +314,58 @@ class DependencyShardKeyTests(TestCase):
         assert reverse.composite_dependencies == frozenset(
             {("Project", "filter", identifier)}
         )
+
+    def test_record_many_cache_dependencies_batches_shared_shard_writes(
+        self,
+    ) -> None:
+        counting_cache = CountingShardCache()
+        dependencies = {
+            ("Project", "filter", json.dumps({"status": "open"})),
+            ("Project", "filter", json.dumps({"priority": 3})),
+            ("Project", "filter", json.dumps({"owner": "team-a"})),
+            ("Project", "filter", json.dumps({"region": "emea"})),
+            ("Project", "filter", json.dumps({"stage": "draft"})),
+        }
+        entries = [(f"cache-{index}", dependencies) for index in range(25)]
+
+        with mock.patch(
+            "general_manager.cache.dependency_shards.cache",
+            counting_cache,
+        ):
+            record_many_cache_dependencies(entries)
+
+        cache_keys = {f"cache-{index}" for index in range(25)}
+        status_shard = exact_lookup_shard_key(
+            "Project",
+            "filter",
+            "status",
+            "eq",
+            "open",
+        )
+        priority_shard = exact_lookup_shard_key(
+            "Project",
+            "filter",
+            "priority",
+            "eq",
+            3,
+        )
+
+        assert counting_cache.store[status_shard] == cache_keys
+        assert counting_cache.store[priority_shard] == cache_keys
+
+        reverse = counting_cache.store[reverse_membership_key("cache-0")]
+        assert isinstance(reverse, ReverseDependencyMembership)
+        assert reverse.cache_key == "cache-0"
+        assert status_shard in reverse.shard_keys
+        assert priority_shard in reverse.shard_keys
+
+        assert counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY] == {
+            reverse_membership_key(f"cache-{index}") for index in range(25)
+        }
+        assert counting_cache.get_calls == ["dependency_index"]
+        assert counting_cache.set_calls == []
+        assert len(counting_cache.get_many_calls) <= 2
+        assert len(counting_cache.set_many_calls) <= 2
 
 
 @override_settings(CACHES=TEST_CACHES)


### PR DESCRIPTION
## Summary
- Batch dependency shard metadata recording so publication no longer performs per-entry read-modify-write work for every shard membership.
- Make shard planning pure and apply grouped get_many/set_many updates for shard additions, old-membership removals, registries, and reverse memberships.
- Add regression coverage for shared-shard batching, existing membership replacement, and legacy-index cleanup once per batch.

Fixes #292

## Test Plan
- [x] python -m pytest tests/unit/test_dependency_shards.py -q
- [x] python -m pytest tests/unit/test_dependency_publish.py -q
- [x] python -m pytest tests/unit/test_dependency_index.py -q
- [x] ruff check src/general_manager/cache/dependency_shards.py tests/unit/test_dependency_shards.py
- [x] ruff format --check src/general_manager/cache/dependency_shards.py tests/unit/test_dependency_shards.py
- [x] mypy src/general_manager/cache/dependency_shards.py
- [x] python -m pytest tests/unit/test_dependency_cache.py tests/unit/test_dependency_publish.py tests/unit/test_dependency_shards.py tests/unit/test_dependency_index.py tests/unit/test_calculation_run_context.py -q
- [x] python -m pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal cache dependency handling through batched operations for improved performance.

* **Tests**
  * Added comprehensive test coverage for bulk cache dependency recording, including batching behavior, bulk replacement, and legacy index cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->