### PR TITLE
fix: share calculation run context during bulk enumeration

### DIFF
--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -521,21 +521,21 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         if self._data is None:
             from general_manager.cache.run_context import ensure_calculation_run_context
 
-            sorted_inputs = self.topological_sort_inputs()
-            sorted_filters = self._sort_filters(sorted_inputs)
-            current_combinations = self._generate_input_combinations(
-                sorted_inputs,
-                sorted_filters["input_filters"],
-                sorted_filters["input_excludes"],
-            )
-            sort_key = self._normalized_sort_key()
-            needs_manager_access = (
-                bool(sorted_filters["prop_filters"])
-                or bool(sorted_filters["prop_excludes"])
-                or not self._sort_uses_only_inputs(sort_key)
-            )
-
             with ensure_calculation_run_context():
+                sorted_inputs = self.topological_sort_inputs()
+                sorted_filters = self._sort_filters(sorted_inputs)
+                current_combinations = self._generate_input_combinations(
+                    sorted_inputs,
+                    sorted_filters["input_filters"],
+                    sorted_filters["input_excludes"],
+                )
+                sort_key = self._normalized_sort_key()
+                needs_manager_access = (
+                    bool(sorted_filters["prop_filters"])
+                    or bool(sorted_filters["prop_excludes"])
+                    or not self._sort_uses_only_inputs(sort_key)
+                )
+
                 if needs_manager_access:
                     manager_combinations = self._manager_combinations(
                         current_combinations
@@ -564,9 +564,9 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                             sort_key,
                         )
 
-            if self.reverse:
-                identifications.reverse()
-            self._data = identifications
+                if self.reverse:
+                    identifications.reverse()
+                self._data = identifications
 
         return self._data
 

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -356,9 +356,6 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             sql, params = self._data.query.sql_with_params()
         except (EmptyResultSet, FieldError, TypeError, ValueError):
             return None
-        # Unordered SQL can produce different row order across equivalent querysets.
-        # Keep same-bucket snapshot reuse, but do not share it across bucket objects.
-        unordered_identity = None if self._data.ordered else id(self)
         return (
             self._manager_class,
             self._data.model,
@@ -368,7 +365,6 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             self._search_date,
             self._sort_keys,
             self._sort_reverse,
-            unordered_identity,
         )
 
     def _bucket_index_source_signature(self) -> Hashable:

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -356,6 +356,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             sql, params = self._data.query.sql_with_params()
         except (EmptyResultSet, FieldError, TypeError, ValueError):
             return None
+        # Unordered SQL can produce different row order across equivalent querysets.
+        # Keep same-bucket snapshot reuse, but do not share it across bucket objects.
+        unordered_identity = None if self._data.ordered else id(self)
         return (
             self._manager_class,
             self._data.model,
@@ -365,6 +368,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             self._search_date,
             self._sort_keys,
             self._sort_reverse,
+            unordered_identity,
         )
 
     def _bucket_index_source_signature(self) -> Hashable:
@@ -398,11 +402,17 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         if cached is not None:
             return cached  # type: ignore[return-value]
 
-        primary_keys = tuple(
-            self._data.values_list("pk", flat=True)[
-                : MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 1
-            ]
-        )
+        if self._data.ordered:
+            primary_keys = tuple(
+                self._data.values_list("pk", flat=True)[
+                    : MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 1
+                ]
+            )
+        else:
+            # Preserve the order normal queryset iteration would expose.
+            primary_keys = tuple(
+                row.pk for row in self._data[: MAX_RUN_SCOPED_BUCKET_RESULT_ROWS + 1]
+            )
         if len(primary_keys) > MAX_RUN_SCOPED_BUCKET_RESULT_ROWS:
             return None
         context.set_orm_bucket_result(signature, primary_keys)

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from datetime import date
 from unittest.mock import patch
 from general_manager.bucket.calculation_bucket import CalculationBucket
+from general_manager.cache.run_context import current_calculation_run_context
 from general_manager.interface import CalculationInterface
 from general_manager.manager.input import DateRangeDomain, Input
 from general_manager.manager import GeneralManager
@@ -382,6 +383,51 @@ class TestGenerateCombinations(TestCase):
         self.assertEqual(
             calls,
             [{"num": 1}, {"num": 2}, {"num": 3}],
+        )
+
+    def test_generate_combinations_uses_one_run_context_for_bulk_work(
+        self, _mock_parse
+    ):
+        possible_value_contexts = []
+        property_contexts = []
+
+        def possible_values():
+            possible_value_contexts.append(current_calculation_run_context())
+            return [1, 2, 3]
+
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "num": Input(type=int, possible_values=possible_values),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+                self.num = kwargs["num"]
+
+            @property
+            def doubled(self):
+                property_contexts.append(current_calculation_run_context())
+                return self.num * 2
+
+        DynInterface._parent_class = DynManager
+
+        bucket = CalculationBucket(DynManager)
+        bucket._filters = {"doubled": {"filter_funcs": [lambda value: value >= 4]}}
+
+        combos = bucket.generate_combinations()
+
+        self.assertEqual(combos, [{"num": 2}, {"num": 3}])
+        self.assertIsNone(current_calculation_run_context())
+        self.assertEqual(len(possible_value_contexts), 1)
+        self.assertEqual(len(property_contexts), 3)
+        all_contexts = [*possible_value_contexts, *property_contexts]
+        self.assertTrue(all_contexts)
+        self.assertTrue(all(context is not None for context in all_contexts))
+        self.assertEqual(
+            {id(context) for context in all_contexts}, {id(all_contexts[0])}
         )
 
     def test_property_exclude_still_instantiates_managers_for_property_access(

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -304,6 +304,38 @@ class DatabaseBucketTestCase(TestCase):
                     [self.u1.id, self.u2.id],
                 )
 
+    def test_ordered_primary_key_snapshot_materializes_primary_keys(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            primary_keys = bucket._get_run_scoped_primary_keys()
+
+        self.assertEqual(primary_keys, (self.u1.id, self.u2.id))
+
+    def test_unordered_primary_key_snapshot_preserves_queryset_iteration_order(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]),
+            UserManager,
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            primary_keys = bucket._get_run_scoped_primary_keys()
+
+        self.assertEqual(set(primary_keys), {self.u1.id, self.u2.id})
+
+        with CalculationRunContext() as context:
+            context.set_orm_bucket_result(bucket._query_signature(), primary_keys)
+            with patch.object(bucket._data, "values_list") as values_list:
+                self.assertEqual(
+                    bucket._get_run_scoped_primary_keys(),
+                    primary_keys,
+                )
+
+        values_list.assert_not_called()
+
     def test_trusted_hydration_preserves_custom_manager_initializer(self):
         search_date = datetime(2024, 1, 1)
         bucket = DatabaseBucket(

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -396,19 +396,16 @@ class DatabaseBucketTestCase(TestCase):
                 [self.u1.id, self.u2.id],
             )
 
-    def test_unordered_bucket_queries_do_not_share_iter_sql_inside_run_context(self):
+    def test_unordered_bucket_queries_share_loaded_rows_inside_run_context(self):
         first_bucket = DatabaseBucket(User.objects.all(), UserManager)
         second_bucket = DatabaseBucket(User.objects.all(), UserManager)
 
-        with CalculationRunContext(), self.assertNumQueries(2):
-            self.assertEqual(
-                sorted(manager.identification["id"] for manager in first_bucket),
-                [self.u1.id, self.u2.id, self.u3.id],
-            )
-            self.assertEqual(
-                sorted(manager.identification["id"] for manager in second_bucket),
-                [self.u1.id, self.u2.id, self.u3.id],
-            )
+        with CalculationRunContext(), self.assertNumQueries(1):
+            first_ids = [manager.identification["id"] for manager in first_bucket]
+            second_ids = [manager.identification["id"] for manager in second_bucket]
+
+        self.assertEqual(second_ids, first_ids)
+        self.assertEqual(sorted(first_ids), [self.u1.id, self.u2.id, self.u3.id])
 
     def test_equivalent_database_buckets_share_index_inside_run_context(self):
         """Share a bucket index for equivalent querysets in one run context."""

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -396,6 +396,20 @@ class DatabaseBucketTestCase(TestCase):
                 [self.u1.id, self.u2.id],
             )
 
+    def test_unordered_bucket_queries_do_not_share_iter_sql_inside_run_context(self):
+        first_bucket = DatabaseBucket(User.objects.all(), UserManager)
+        second_bucket = DatabaseBucket(User.objects.all(), UserManager)
+
+        with CalculationRunContext(), self.assertNumQueries(2):
+            self.assertEqual(
+                sorted(manager.identification["id"] for manager in first_bucket),
+                [self.u1.id, self.u2.id, self.u3.id],
+            )
+            self.assertEqual(
+                sorted(manager.identification["id"] for manager in second_bucket),
+                [self.u1.id, self.u2.id, self.u3.id],
+            )
+
     def test_equivalent_database_buckets_share_index_inside_run_context(self):
         """Share a bucket index for equivalent querysets in one run context."""
         first_bucket = DatabaseBucket(


### PR DESCRIPTION
Summary: wrap full calculation combination generation in one CalculationRunContext; keep unordered database bucket snapshots scoped to the bucket object so calculation input ordering is preserved. Tests: python -m pytest tests/unit/test_calculation_bucket.py tests/unit/test_database_bucket.py -q; python -m pytest tests/integration/test_calculation_manager.py tests/integration/test_graphql_calculation_input_options.py -q; ruff check src/general_manager/bucket/calculation_bucket.py src/general_manager/bucket/database_bucket.py tests/unit/test_calculation_bucket.py tests/unit/test_database_bucket.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved calculation run context management for bulk operations to ensure consistent context isolation.
  * Optimized database query handling for unordered querysets to preserve iteration order and reduce redundant queries.

* **Tests**
  * Added tests verifying calculation context lifecycle and database query caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->