### PR TITLE
feat: add run-scoped caching for input possible values

### DIFF
--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -162,6 +162,12 @@ one-row-per-key lookups, and `group_by(...)` or `index_many(...)` when multiple
 rows share the same key. Use `discard_prefix(prefix)` when code that owns a
 structured key namespace needs to invalidate a group of run-scoped values.
 
+Callable `Input.possible_values` providers are also cached automatically inside
+an active `CalculationRunContext` when the caller can identify the owning manager
+class and input name. The cache key uses the manager class, the input name, and
+only the input's declared `depends_on` values. Static domains and static
+iterables are returned directly and are not copied into the run cache.
+
 ORM-backed managers use this explicit run context to deduplicate repeated row
 materialization for the same manager identity. The optimization is active only
 inside an existing `CalculationRunContext`; constructing managers outside a run

--- a/docs/concepts/interfaces/computed_data_interfaces.md
+++ b/docs/concepts/interfaces/computed_data_interfaces.md
@@ -62,6 +62,7 @@ Because calculation managers do not persist data, `create`, `update`, and `delet
 - Use `required=False` for optional inputs. Calculation metadata and parsing now treat those fields as nullable and default them to `None` when omitted.
 - Use `possible_values` to restrict input choices or provide a callable for dynamic options.
 - Callable or bucket-backed `possible_values` are not resolved during ordinary input casting unless a custom normalizer needs them. They are still resolved when enumerating calculation combinations or validating allowed values.
+- When `possible_values` is callable and resolution happens inside a managed run, GeneralManager caches the provider result for that run. Providers should be pure for a given set of declared dependency input values. If a provider returns a one-shot iterator or generator, GeneralManager materializes it before caching so later reads in the same run see the same values.
 - Use `min_value`, `max_value`, and `validator` for scalar constraints without eagerly enumerating every allowed value.
 - Employ `Input.date_range(...)`, `Input.monthly_date(...)`, and `Input.yearly_date(...)` for structured date domains such as month-end or year-start inputs.
 - Prefer domain objects such as `DateRangeDomain` and `NumericRangeDomain` when you need structured range metadata rather than an eager list.

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -640,7 +640,10 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         Raises:
             InvalidPossibleValuesError: If the input field's `possible_values` is neither callable nor an iterable/Bucket.
         """
-        possible_values = input_field.resolve_possible_values(current_combo)
+        possible_values = input_field.resolve_possible_values(
+            current_combo,
+            cache_context=(self._manager_class, key_name),
+        )
         if possible_values is None:
             if input_field.required:
                 raise InvalidPossibleValuesError(key_name)

--- a/src/general_manager/interface/base_interface.py
+++ b/src/general_manager/interface/base_interface.py
@@ -629,8 +629,13 @@ class InterfaceBase(ABC):
                     continue
                 depends_on = input_field.depends_on
                 if all(dep in processed for dep in depends_on):
+                    cache_context = type(self)._input_possible_values_cache_context(
+                        name
+                    )
                     value = self.input_fields[name].cast(
-                        kwargs.get(name), identification
+                        kwargs.get(name),
+                        identification,
+                        cache_context=cache_context,
                     )
                     self._process_input(name, value, identification)
                     identification[name] = value
@@ -641,6 +646,16 @@ class InterfaceBase(ABC):
                 unresolved = set(self.input_fields.keys()) - processed
                 raise CircularInputDependencyError(unresolved)
         return identification
+
+    @classmethod
+    def _input_possible_values_cache_context(
+        cls,
+        input_name: str,
+    ) -> tuple[type[Any], str] | None:
+        parent_class = getattr(cls, "_parent_class", None)
+        if parent_class is None:
+            return None
+        return (parent_class, input_name)
 
     @staticmethod
     def format_identification(identification: dict[str, Any]) -> dict[str, Any]:
@@ -713,7 +728,10 @@ class InterfaceBase(ABC):
         if not _should_validate_possible_values():
             return
 
-        allowed_values = input_field.resolve_possible_values(identification)
+        allowed_values = input_field.resolve_possible_values(
+            identification,
+            cache_context=type(self)._input_possible_values_cache_context(name),
+        )
         if allowed_values is None:
             return
         contains = getattr(allowed_values, "contains", None)

--- a/src/general_manager/interface/capabilities/calculation/lifecycle.py
+++ b/src/general_manager/interface/capabilities/calculation/lifecycle.py
@@ -113,6 +113,7 @@ class CalculationReadCapability(BaseCapability):
             value = input_field.cast(
                 interface_instance.identification.get(field_name),
                 dependency_values,
+                cache_context=(interface_cls._parent_class, field_name),
             )
             resolved_values[field_name] = value
             return value

--- a/src/general_manager/manager/input.py
+++ b/src/general_manager/manager/input.py
@@ -105,6 +105,14 @@ def _invoke_callable(func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> 
     return func(*bound_args, **bound_kwargs)
 
 
+def _materialize_cached_possible_values(possible_values: Any) -> Any:
+    """Store one-shot iterators as reusable values in the run cache."""
+
+    if isinstance(possible_values, Iterator):
+        return list(possible_values)
+    return possible_values
+
+
 def _month_start(value: date) -> date:
     return value.replace(day=1)
 
@@ -700,7 +708,10 @@ class Input(Generic[INPUT_TYPE]):
                 )
             except TypeError:
                 return invoke_possible_values()
-            return context.get_or_set(cache_key, invoke_possible_values)
+            return context.get_or_set(
+                cache_key,
+                lambda: _materialize_cached_possible_values(invoke_possible_values()),
+            )
         return cast(Any, self.possible_values)
 
     def normalize(

--- a/src/general_manager/manager/input.py
+++ b/src/general_manager/manager/input.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import calendar
 import builtins
 import inspect
-from collections.abc import Iterable, Iterator
+from collections.abc import Hashable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -646,15 +646,40 @@ class Input(Generic[INPUT_TYPE]):
         if self.possible_values is None:
             return None
         if callable(self.possible_values):
+            possible_values_provider = cast(Any, self.possible_values)
             dependency_values = self._build_dependency_values(identification)
-            return cast(
-                Any,
-                _invoke_callable(
-                    self.possible_values,
-                    *dependency_values.values(),
-                    **dependency_values,
+
+            def invoke_possible_values() -> Any:
+                return cast(
+                    Any,
+                    _invoke_callable(
+                        possible_values_provider,
+                        *dependency_values.values(),
+                        **dependency_values,
+                    ),
+                )
+
+            if cache_context is None:
+                return invoke_possible_values()
+
+            from general_manager.cache.run_context import (
+                current_calculation_run_context,
+            )
+
+            context = current_calculation_run_context()
+            if context is None:
+                return invoke_possible_values()
+
+            cache_key = cast(
+                tuple[Hashable, ...],
+                (
+                    "input_possible_values",
+                    cache_context[0],
+                    cache_context[1],
+                    (),
                 ),
             )
+            return context.get_or_set(cache_key, invoke_possible_values)
         return cast(Any, self.possible_values)
 
     def normalize(

--- a/src/general_manager/manager/input.py
+++ b/src/general_manager/manager/input.py
@@ -715,7 +715,11 @@ class Input(Generic[INPUT_TYPE]):
         return cast(Any, self.possible_values)
 
     def normalize(
-        self, value: Any, identification: dict[str, Any] | None = None
+        self,
+        value: Any,
+        identification: dict[str, Any] | None = None,
+        *,
+        cache_context: PossibleValuesCacheContext | None = None,
     ) -> Any:
         """Canonicalize a cast value using domain or explicit normalization rules."""
 
@@ -730,7 +734,10 @@ class Input(Generic[INPUT_TYPE]):
             value = possible_values.normalize(value)
         if self.normalizer is not None:
             if possible_values is None:
-                possible_values = self.resolve_possible_values(identification)
+                possible_values = self.resolve_possible_values(
+                    identification,
+                    cache_context=cache_context,
+                )
                 if isinstance(possible_values, InputDomain):
                     value = possible_values.normalize(value)
             dependency_values = self._build_dependency_values(identification)
@@ -785,7 +792,13 @@ class Input(Generic[INPUT_TYPE]):
             dependency_values[dependency_name] = identification[dependency_name]
         return dependency_values
 
-    def cast(self, value: Any, identification: dict[str, Any] | None = None) -> Any:
+    def cast(
+        self,
+        value: Any,
+        identification: dict[str, Any] | None = None,
+        *,
+        cache_context: PossibleValuesCacheContext | None = None,
+    ) -> Any:
         """
         Convert a raw value to the configured input type.
 
@@ -808,7 +821,11 @@ class Input(Generic[INPUT_TYPE]):
                 cast_value = value
             else:
                 cast_value = date.fromisoformat(value)
-            return self.normalize(cast_value, identification)
+            return self.normalize(
+                cast_value,
+                identification,
+                cache_context=cache_context,
+            )
         if self.type == datetime:
             if isinstance(value, datetime):
                 cast_value = value
@@ -816,13 +833,33 @@ class Input(Generic[INPUT_TYPE]):
                 cast_value = datetime.combine(value, datetime.min.time())
             else:
                 cast_value = datetime.fromisoformat(value)
-            return self.normalize(cast_value, identification)
+            return self.normalize(
+                cast_value,
+                identification,
+                cache_context=cache_context,
+            )
         if isinstance(value, self.type):
-            return self.normalize(value, identification)
+            return self.normalize(value, identification, cache_context=cache_context)
         if issubclass(self.type, GeneralManager):
             if isinstance(value, dict):
-                return self.normalize(self.type(**value), identification)  # type: ignore[misc]
-            return self.normalize(self.type(id=value), identification)  # type: ignore[misc]
+                return self.normalize(
+                    self.type(**value),  # type: ignore[misc]
+                    identification,
+                    cache_context=cache_context,
+                )
+            return self.normalize(
+                self.type(id=value),  # type: ignore[misc]
+                identification,
+                cache_context=cache_context,
+            )
         if self.type == Measurement and isinstance(value, str):
-            return self.normalize(Measurement.from_string(value), identification)
-        return self.normalize(self.type(value), identification)
+            return self.normalize(
+                Measurement.from_string(value),
+                identification,
+                cache_context=cache_context,
+            )
+        return self.normalize(
+            self.type(value),
+            identification,
+            cache_context=cache_context,
+        )

--- a/src/general_manager/manager/input.py
+++ b/src/general_manager/manager/input.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import calendar
 import builtins
 import inspect
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -15,7 +15,7 @@ from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement import Measurement
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable
 
     from general_manager.bucket.base_bucket import Bucket
 
@@ -29,6 +29,7 @@ type PossibleValues = (
     | "Bucket[Any]"
     | "Callable[..., InputDomain[Any] | Iterable[Any] | Bucket[Any]]"
 )
+type PossibleValuesCacheContext = tuple[type[Any], str]
 type ScalarConstraint = date | datetime | int | float | Decimal
 type Validator = Callable[..., bool | None]
 type Normalizer = Callable[..., Any]
@@ -637,6 +638,8 @@ class Input(Generic[INPUT_TYPE]):
     def resolve_possible_values(
         self,
         identification: dict[str, Any] | None = None,
+        *,
+        cache_context: PossibleValuesCacheContext | None = None,
     ) -> Any:
         """Resolve the configured possible values for the current dependency context."""
 

--- a/src/general_manager/manager/input.py
+++ b/src/general_manager/manager/input.py
@@ -635,6 +635,29 @@ class Input(Generic[INPUT_TYPE]):
             return cast(date, _invoke_callable(value, **dependency_values))
         return value
 
+    def _possible_values_run_cache_key(
+        self,
+        cache_context: PossibleValuesCacheContext,
+        dependency_values: dict[str, Any],
+    ) -> tuple[Hashable, ...]:
+        from general_manager.bucket.indexing import freeze_bucket_index_value
+
+        return cast(
+            tuple[Hashable, ...],
+            (
+                "input_possible_values",
+                cache_context[0],
+                cache_context[1],
+                tuple(
+                    (
+                        dependency_name,
+                        freeze_bucket_index_value(dependency_values[dependency_name]),
+                    )
+                    for dependency_name in self.depends_on
+                ),
+            ),
+        )
+
     def resolve_possible_values(
         self,
         identification: dict[str, Any] | None = None,
@@ -670,15 +693,13 @@ class Input(Generic[INPUT_TYPE]):
             if context is None:
                 return invoke_possible_values()
 
-            cache_key = cast(
-                tuple[Hashable, ...],
-                (
-                    "input_possible_values",
-                    cache_context[0],
-                    cache_context[1],
-                    (),
-                ),
-            )
+            try:
+                cache_key = self._possible_values_run_cache_key(
+                    cache_context,
+                    dependency_values,
+                )
+            except TypeError:
+                return invoke_possible_values()
             return context.get_or_set(cache_key, invoke_possible_values)
         return cast(Any, self.possible_values)
 

--- a/tests/unit/test_base_interface.py
+++ b/tests/unit/test_base_interface.py
@@ -5,7 +5,9 @@ from general_manager.interface.capabilities.builtin import BaseCapability
 from general_manager.interface.capabilities.configuration import (
     InterfaceCapabilityConfig,
 )
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.input import Input
 from typing import Callable, ClassVar, Type
 
 
@@ -38,7 +40,7 @@ class DummyInput:
         self.max_value = max_value
         self.validator = validator
 
-    def cast(self, value, _identification=None):
+    def cast(self, value, _identification=None, *, cache_context=None):
         """
         Returns the input value unchanged.
 
@@ -48,9 +50,11 @@ class DummyInput:
         Returns:
             The same value that was provided as input.
         """
+        del cache_context
         return value
 
-    def resolve_possible_values(self, identification=None):
+    def resolve_possible_values(self, identification=None, *, cache_context=None):
+        del cache_context
         if callable(self.possible_values):
             identification = identification or {}
             dependency_values = {
@@ -442,6 +446,43 @@ class InterfaceBaseTests(SimpleTestCase):
     def test_possible_values_toggle_accepts_falsey_string(self):
         inst = DummyInterface(a=1, b="foo", gm=DummyGM({"id": 8}), vals=99, c=1)
         self.assertEqual(inst.identification["vals"], 99)
+
+    def test_input_possible_values_cache_context_is_reused_during_cast_and_validation(
+        self,
+    ):
+        calls = 0
+
+        def possible_values():
+            nonlocal calls
+            calls += 1
+            return ["ABC"]
+
+        def normalize_code(value, domain):
+            del domain
+            return value.upper()
+
+        class ParentManager:
+            pass
+
+        class CachedInputInterface(InterfaceBase):
+            _parent_class = ParentManager
+            input_fields: ClassVar[dict] = {
+                "code": Input(
+                    str,
+                    possible_values=possible_values,
+                    normalizer=normalize_code,
+                )
+            }
+
+            def get_data(self, _search_date=None):
+                return self.identification
+
+        with override_settings(GENERAL_MANAGER_VALIDATE_INPUT_VALUES=True):
+            with CalculationRunContext():
+                interface = CachedInputInterface(code="abc")
+
+        self.assertEqual(interface.identification, {"code": "ABC"})
+        self.assertEqual(calls, 1)
 
     def test_dummy_input_validator_none_return_is_allowed(self):
         input_field = DummyInput(int, validator=lambda _value: None)

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -670,6 +670,40 @@ class TestGenerateCombinations(TestCase):
         ]
         self.assertCountEqual(combos, expected)
 
+    def test_generate_combinations_caches_callable_possible_values_by_dependencies(
+        self,
+        _mock_parse,
+    ):
+        calls: list[str] = []
+
+        def possible_cities(country):
+            calls.append(country)
+            return [f"{country}-city"]
+
+        fields = {
+            "country": Input(type=str, possible_values=["FR", "DE"]),
+            "segment": Input(type=str, possible_values=["retail", "enterprise"]),
+            "city": Input(
+                type=str,
+                possible_values=possible_cities,
+                depends_on=["country"],
+            ),
+        }
+        bucket = self._make_bucket_with_fields(fields)
+
+        combos = bucket.generate_combinations()
+
+        self.assertCountEqual(
+            combos,
+            [
+                {"country": "FR", "segment": "retail", "city": "FR-city"},
+                {"country": "FR", "segment": "enterprise", "city": "FR-city"},
+                {"country": "DE", "segment": "retail", "city": "DE-city"},
+                {"country": "DE", "segment": "enterprise", "city": "DE-city"},
+            ],
+        )
+        self.assertEqual(calls, ["FR", "DE"])
+
     def test_optional_field_does_not_expand_none(self, _mock_parse):
         fields = {
             "a": Input(type=int, possible_values=[1, 2]),

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -196,6 +196,36 @@ class TestInput(TestCase):
         self.assertEqual(third, [3])
         self.assertEqual(calls, [{"ids": [1, 2]}, {"ids": [3]}])
 
+    def test_callable_possible_values_materializes_one_shot_iterators_before_caching(
+        self,
+    ):
+        calls = 0
+
+        class Owner:
+            pass
+
+        def possible_values():
+            nonlocal calls
+            calls += 1
+            return (value for value in [1, 2])
+
+        input_obj = Input(int, possible_values=possible_values)
+
+        with CalculationRunContext():
+            first = input_obj.resolve_possible_values(
+                {},
+                cache_context=(Owner, "number"),
+            )
+            second = input_obj.resolve_possible_values(
+                {},
+                cache_context=(Owner, "number"),
+            )
+
+            self.assertEqual(list(first), [1, 2])
+            self.assertEqual(list(second), [1, 2])
+
+        self.assertEqual(calls, 1)
+
     def test_simple_input_casting(self):
         """
         Test that the Input class casts values to integers and preserves `None`.

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from decimal import Decimal
 from datetime import timedelta
 from unittest.mock import patch
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.manager.input import (
     DateRangeDomain,
     Input,
@@ -132,6 +133,33 @@ class TestInput(TestCase):
         self.assertEqual(first, [1])
         self.assertEqual(second, [2])
         self.assertEqual(calls, 2)
+
+    def test_callable_possible_values_are_cached_inside_run_context(self):
+        calls = 0
+
+        class Owner:
+            pass
+
+        def possible_values():
+            nonlocal calls
+            calls += 1
+            return [calls]
+
+        input_obj = Input(int, possible_values=possible_values)
+
+        with CalculationRunContext():
+            first = input_obj.resolve_possible_values(
+                {},
+                cache_context=(Owner, "number"),
+            )
+            second = input_obj.resolve_possible_values(
+                {},
+                cache_context=(Owner, "number"),
+            )
+
+        self.assertEqual(first, [1])
+        self.assertEqual(second, [1])
+        self.assertEqual(calls, 1)
 
     def test_simple_input_casting(self):
         """

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -107,6 +107,32 @@ class TestInput(TestCase):
         input_obj = Input(int, possible_values=possible_values_func)
         self.assertEqual(input_obj.depends_on, ["a", "b"])
 
+    def test_callable_possible_values_are_not_cached_outside_run_context(self):
+        calls = 0
+
+        class Owner:
+            pass
+
+        def possible_values():
+            nonlocal calls
+            calls += 1
+            return [calls]
+
+        input_obj = Input(int, possible_values=possible_values)
+
+        first = input_obj.resolve_possible_values(
+            {},
+            cache_context=(Owner, "number"),
+        )
+        second = input_obj.resolve_possible_values(
+            {},
+            cache_context=(Owner, "number"),
+        )
+
+        self.assertEqual(first, [1])
+        self.assertEqual(second, [2])
+        self.assertEqual(calls, 2)
+
     def test_simple_input_casting(self):
         """
         Test that the Input class casts values to integers and preserves `None`.

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -161,6 +161,41 @@ class TestInput(TestCase):
         self.assertEqual(second, [1])
         self.assertEqual(calls, 1)
 
+    def test_callable_possible_values_cache_key_uses_declared_dependencies_only(self):
+        calls: list[dict[str, list[int]]] = []
+
+        class Owner:
+            pass
+
+        def possible_values(filters):
+            calls.append(filters)
+            return [sum(filters["ids"])]
+
+        input_obj = Input(
+            int,
+            possible_values=possible_values,
+            depends_on=["filters"],
+        )
+
+        with CalculationRunContext():
+            first = input_obj.resolve_possible_values(
+                {"filters": {"ids": [1, 2]}, "unrelated": "a"},
+                cache_context=(Owner, "total"),
+            )
+            second = input_obj.resolve_possible_values(
+                {"filters": {"ids": [1, 2]}, "unrelated": "b"},
+                cache_context=(Owner, "total"),
+            )
+            third = input_obj.resolve_possible_values(
+                {"filters": {"ids": [3]}, "unrelated": "b"},
+                cache_context=(Owner, "total"),
+            )
+
+        self.assertEqual(first, [3])
+        self.assertEqual(second, [3])
+        self.assertEqual(third, [3])
+        self.assertEqual(calls, [{"ids": [1, 2]}, {"ids": [3]}])
+
     def test_simple_input_casting(self):
         """
         Test that the Input class casts values to integers and preserves `None`.


### PR DESCRIPTION
## Summary
- Add automatic run-scoped caching for callable `Input.possible_values` providers.
- Key cache entries by owning manager class, input name, and declared dependency input values.
- Materialize one-shot iterators before storing cached provider results.
- Pass cache context through calculation enumeration, interface validation, and calculation input casting.
- Document the new caching behavior and provider expectations.

Closes #295.

## Test Plan
- `python -m pytest tests/unit/test_input.py tests/unit/test_calculation_bucket.py tests/unit/test_base_interface.py tests/docs/test_public_api_docs_coverage.py -q`
- `ruff check src/general_manager/manager/input.py src/general_manager/bucket/calculation_bucket.py src/general_manager/interface/base_interface.py src/general_manager/interface/capabilities/calculation/lifecycle.py tests/unit/test_input.py tests/unit/test_calculation_bucket.py tests/unit/test_base_interface.py`
- `ruff format --check src/general_manager/manager/input.py src/general_manager/bucket/calculation_bucket.py src/general_manager/interface/base_interface.py src/general_manager/interface/capabilities/calculation/lifecycle.py tests/unit/test_input.py tests/unit/test_calculation_bucket.py tests/unit/test_base_interface.py`
- `mypy src/general_manager`
- `python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation describing caching behavior for callable possible_values within active calculation runs.

* **New Features**
  * Callable possible_values are now automatically cached within active calculation runs based on declared dependencies; one-shot iterators are materialized before caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->