### PR TITLE
[codex] skip unchanged read-only sync

### DIFF
--- a/src/general_manager/interface/capabilities/read_only/management.py
+++ b/src/general_manager/interface/capabilities/read_only/management.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from hashlib import sha256
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Type, cast
 
 from django.core.checks import Warning
@@ -441,6 +442,9 @@ class ReadOnlyManagementCapability(BaseCapability):
 
             model_opts = getattr(model, "_meta", None)
             local_fields = getattr(model_opts, "local_fields", []) or []
+            local_field_names = {
+                getattr(f, "name", "") for f in local_fields if getattr(f, "name", None)
+            }
             editable_fields = {
                 getattr(f, "name", "")
                 for f in local_fields
@@ -460,6 +464,11 @@ class ReadOnlyManagementCapability(BaseCapability):
                 for f in getattr(model_opts, "get_fields", lambda: [])()
                 if getattr(f, "is_relation", False)
                 and not getattr(f, "auto_created", False)
+            }
+            measurement_field_names = {
+                name
+                for name, field in vars(model).items()
+                if isinstance(field, MeasurementField)
             }
 
             related_interfaces: list[type["OrmInterfaceBase[Any]"]] = []
@@ -499,6 +508,151 @@ class ReadOnlyManagementCapability(BaseCapability):
                     unique_fields=None,
                     schema_validated=schema_validated,
                 )
+
+            def _fingerprint(rows: list[dict[str, Any]]) -> str | None:
+                """
+                Return a deterministic fingerprint for comparable row snapshots.
+                """
+                try:
+                    payload = json.dumps(
+                        rows,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                except TypeError:
+                    return None
+                return sha256(
+                    payload.encode("utf-8"), usedforsecurity=False
+                ).hexdigest()
+
+            def _row_sort_key(row: dict[str, Any]) -> str | None:
+                """
+                Build a stable sort key for a comparable row snapshot.
+                """
+                try:
+                    return json.dumps(
+                        row["key"],
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                except TypeError:
+                    return None
+
+            def _sort_rows(
+                rows: list[dict[str, Any]],
+            ) -> list[dict[str, Any]] | None:
+                """
+                Sort comparable row snapshots or return None when keys are unsafe.
+                """
+                keyed_rows: list[tuple[str, dict[str, Any]]] = []
+                for row in rows:
+                    sort_key = _row_sort_key(row)
+                    if sort_key is None:
+                        return None
+                    keyed_rows.append((sort_key, row))
+                return [row for _, row in sorted(keyed_rows, key=lambda item: item[0])]
+
+            def _active_database_matches_payload() -> bool:
+                """
+                Check whether active DB rows already match the read-only payload.
+
+                The fast path is intentionally conservative. Payloads that use
+                relation fields, non-concrete measurement descriptors, duplicate
+                unique identifiers, or fields we cannot compare directly fall back
+                to the full synchronization path.
+                """
+                unique_field_set = set(unique_field_order)
+                if not unique_field_set.issubset(local_field_names):
+                    return False
+                if unique_field_set.intersection(relation_fields):
+                    return False
+                if unique_field_set.intersection(measurement_field_names):
+                    return False
+
+                comparable_fields = unique_field_set | editable_fields
+                payload_rows: list[dict[str, Any]] = []
+                expected_fields_by_key: dict[tuple[Any, ...], tuple[str, ...]] = {}
+
+                for data in data_list:
+                    if not isinstance(data, dict):
+                        return False
+                    if any(field_name in data for field_name in relation_fields):
+                        return False
+                    if any(
+                        field_name in data for field_name in measurement_field_names
+                    ):
+                        return False
+                    try:
+                        key = tuple(data[field] for field in unique_field_order)
+                    except KeyError:
+                        return False
+                    try:
+                        if key in expected_fields_by_key:
+                            return False
+                    except TypeError:
+                        return False
+
+                    field_names = tuple(
+                        sorted(
+                            field
+                            for field in comparable_fields
+                            if field in data and field in local_field_names
+                        )
+                    )
+                    expected_fields_by_key[key] = field_names
+                    payload_rows.append(
+                        {
+                            "key": list(key),
+                            "fields": {field: data[field] for field in field_names},
+                        }
+                    )
+
+                try:
+                    active_instances = list(model.objects.filter(is_active=True))
+                except (AttributeError, TypeError, ValueError):
+                    return False
+
+                if len(active_instances) != len(payload_rows):
+                    return False
+
+                active_rows: list[dict[str, Any]] = []
+                seen_keys: set[tuple[Any, ...]] = set()
+                for instance in active_instances:
+                    try:
+                        key = tuple(
+                            getattr(instance, field) for field in unique_field_order
+                        )
+                    except (AttributeError, TypeError, ValueError):
+                        return False
+                    try:
+                        db_field_names = expected_fields_by_key.get(key)
+                        if db_field_names is None or key in seen_keys:
+                            return False
+                        seen_keys.add(key)
+                    except TypeError:
+                        return False
+
+                    try:
+                        fields = {
+                            field: getattr(instance, field) for field in db_field_names
+                        }
+                    except (AttributeError, TypeError, ValueError):
+                        return False
+                    active_rows.append({"key": list(key), "fields": fields})
+
+                sorted_payload_rows = _sort_rows(payload_rows)
+                sorted_active_rows = _sort_rows(active_rows)
+                if sorted_payload_rows is None or sorted_active_rows is None:
+                    return False
+
+                payload_fingerprint = _fingerprint(sorted_payload_rows)
+                active_fingerprint = _fingerprint(sorted_active_rows)
+                if payload_fingerprint is None or active_fingerprint is None:
+                    return False
+                return payload_fingerprint == active_fingerprint
+
+            if _active_database_matches_payload():
+                return
 
             def _resolve_to_instance(
                 field_name: str,

--- a/tests/unit/test_read_only_interface.py
+++ b/tests/unit/test_read_only_interface.py
@@ -127,6 +127,24 @@ class FakeManager:
         return FakeQuerySet(filtered)
 
 
+class UnsafeJsonValue:
+    """
+    Hashable value object that is intentionally not JSON serializable.
+    """
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, UnsafeJsonValue) and other.value == self.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+
 class FakeField:
     """
     Minimal stand-in for a Django model field that exposes the attributes required in tests.
@@ -556,7 +574,7 @@ class SyncDataTests(SimpleTestCase):
             "general_manager.interface.capabilities.read_only.management.django_transaction.atomic",
             return_value=mock.MagicMock(__enter__=_atomic_enter, __exit__=_atomic_exit),
         )
-        self.atomic_patch.start()
+        self.atomic_mock = self.atomic_patch.start()
         # Stub get_unique_fields to return {'name'}
         self.gu_patch = mock.patch.object(
             ReadOnlyManagementCapability, "get_unique_fields", return_value={"name"}
@@ -680,6 +698,183 @@ class SyncDataTests(SimpleTestCase):
         self.assertEqual(msg["created"], 1)
         self.assertEqual(msg["updated"], 1)
         self.assertEqual(msg["deactivated"], 0)
+
+    def test_sync_skips_full_reconcile_when_database_matches_payload(self):
+        """
+        Ensure an already-synchronized read-only payload avoids the expensive write path.
+        """
+        DummyManager._data = [{"name": "a", "other": 2}, {"name": "b", "other": 3}]
+        self.capability.sync_data(DummyInterface)
+        self.atomic_mock.reset_mock()
+        self.logger.info.reset_mock()
+
+        self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_not_called()
+        self.logger.info.assert_not_called()
+
+    def test_sync_falls_back_when_payload_item_is_not_mapping(self):
+        """
+        Ensure non-mapping payload entries do not use the fingerprint fast path.
+        """
+        DummyManager._data = [[]]
+
+        with self.assertRaises(InvalidReadOnlyDataFormatError):
+            self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+
+    def test_sync_falls_back_when_payload_missing_unique_field(self):
+        """
+        Ensure malformed payload rows still go through the existing validation path.
+        """
+        DummyManager._data = [{"other": 2}]
+
+        with self.assertRaises(InvalidReadOnlyDataFormatError):
+            self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+
+    def test_sync_falls_back_when_payload_has_duplicate_unique_values(self):
+        """
+        Ensure duplicate unique identifiers are handled by the existing sync logic.
+        """
+        DummyModel.objects._instances = [
+            FakeInstance(name="a", other=2),
+            FakeInstance(name="b", other=3),
+        ]
+        original_filter = DummyModel.objects.filter
+        active_query_before_atomic = []
+
+        def filter_spy(**kwargs):
+            if kwargs == {"is_active": True} and not self.atomic_mock.called:
+                active_query_before_atomic.append(kwargs)
+            return original_filter(**kwargs)
+
+        DummyModel.objects.filter = filter_spy
+        DummyManager._data = [{"name": "a", "other": 2}, {"name": "a", "other": 2}]
+
+        self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+        self.assertEqual(active_query_before_atomic, [])
+
+    def test_sync_falls_back_when_payload_unique_value_is_unhashable(self):
+        """
+        Ensure unhashable unique identifiers bypass the fingerprint fast path.
+        """
+        DummyManager._data = [{"name": ["a"], "other": 2}]
+
+        with self.assertRaises(TypeError):
+            self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+
+    def test_sync_falls_back_when_payload_value_is_not_json_serializable(self):
+        """
+        Ensure unsafe value serialization does not produce a fingerprint match.
+        """
+        existing = FakeInstance(name="a", other=UnsafeJsonValue("same"))
+        DummyModel.objects._instances = [existing]
+        DummyManager._data = [{"name": "a", "other": UnsafeJsonValue("same")}]
+
+        self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+
+    def test_sync_falls_back_when_sort_key_is_not_json_serializable(self):
+        """
+        Ensure unsafe unique-key serialization does not produce a fingerprint match.
+        """
+        key = UnsafeJsonValue("key")
+        DummyModel.objects._instances = [FakeInstance(name=key, other=2)]
+        DummyManager._data = [{"name": key, "other": 2}]
+
+        self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+
+    def test_sync_falls_back_when_active_query_is_unavailable(self):
+        """
+        Ensure incompatible model managers bypass the fingerprint fast path.
+        """
+
+        class BrokenQueryModel:
+            objects = object()
+
+            class _meta:
+                db_table = "broken_query_table"
+                local_fields = (
+                    FakeField("id", editable=False, primary_key=True),
+                    FakeField("name"),
+                    FakeField("is_active", editable=False),
+                )
+
+                @staticmethod
+                def get_fields() -> list[object]:
+                    return []
+
+        class BrokenQueryManager:
+            _data: ClassVar[list[dict[str, str]]] = [{"name": "a"}]
+
+        class BrokenQueryInterface(ReadOnlyInterface):
+            _model = BrokenQueryModel
+            _parent_class = BrokenQueryManager
+
+        with self.assertRaises(AttributeError):
+            self.capability.sync_data(BrokenQueryInterface)
+
+        self.atomic_mock.assert_called_once()
+
+    def test_sync_falls_back_when_active_row_lacks_unique_field(self):
+        """
+        Ensure rows that cannot expose the unique key use the full sync path.
+        """
+        DummyModel.objects._instances = [FakeInstance(other=1)]
+        DummyManager._data = [{"name": "a", "other": 2}]
+
+        with self.assertRaises(AttributeError):
+            self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+
+    def test_sync_falls_back_when_active_database_key_differs_from_payload(self):
+        """
+        Ensure database drift is repaired when active keys do not match the payload.
+        """
+        stale = FakeInstance(name="b", other=1)
+        DummyModel.objects._instances = [stale]
+        DummyManager._data = [{"name": "a", "other": 2}]
+
+        self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+        self.assertFalse(stale.is_active)
+
+    def test_sync_falls_back_when_active_database_key_is_unhashable(self):
+        """
+        Ensure unhashable persisted unique values bypass the fingerprint fast path.
+        """
+        DummyModel.objects._instances = [FakeInstance(name=["b"], other=1)]
+        DummyManager._data = [{"name": "a", "other": 2}]
+
+        with self.assertRaises(TypeError):
+            self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+
+    def test_sync_falls_back_when_active_row_lacks_payload_field(self):
+        """
+        Ensure partial active rows are updated by the existing sync path.
+        """
+        existing = FakeInstance(name="a")
+        DummyModel.objects._instances = [existing]
+        DummyManager._data = [{"name": "a", "other": 2}]
+
+        self.capability.sync_data(DummyInterface)
+
+        self.atomic_mock.assert_called_once()
+        self.assertEqual(existing.other, 2)
 
 
 class SyncDataMetadataValidationTests(SimpleTestCase):


### PR DESCRIPTION
## Summary

- Add a conservative DB-computed fingerprint fast path for read-only interface syncs.
- Skip the expensive full reconcile when active database rows already match the configured `_data` payload.
- Add regression coverage for the no-op path and the conservative fallback branches.

## Why

Read-only startup hooks currently run on management commands and always perform the full synchronization path, even when data is already present and unchanged. That makes command startup slower than necessary.

## Notes

The fast path intentionally falls back to the existing full sync for relation payloads, non-concrete measurement descriptors, duplicate unique identifiers, malformed payload rows, unsafe JSON serialization, or fields that cannot be compared directly.

## Validation

- `python -m pytest tests/unit/test_read_only_interface.py tests/integration/test_readonly_interface_manager.py tests/integration/test_database_manager.py::DatabaseIntegrationTest::test_readonly_interface_sync`
- `python -m pytest tests/unit/test_read_only_interface.py tests/integration/test_readonly_interface_manager.py tests/integration/test_database_manager.py::DatabaseIntegrationTest::test_readonly_interface_sync --cov=general_manager.interface.capabilities.read_only.management --cov-report=term-missing:skip-covered`
- `ruff check src/general_manager/interface/capabilities/read_only/management.py tests/unit/test_read_only_interface.py`
- `mypy src/general_manager/interface/capabilities/read_only/management.py`
- pre-commit during commit: ruff lint, ruff format, mypy, whitespace/end-of-file checks