### PR TITLE
[codex] Add search index reconciliation

### DIFF
--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -201,7 +201,7 @@ GeneralManager keeps search fresh in two layers:
 The reconciler stores one state row per searchable manager/index pair. Missing
 state means the pair has not been initialized. A changed schema fingerprint
 means the configured fields, filters, sorts, boosts, type label, document id, or
-document serializer changed.
+document serializer, or update strategy changed.
 
 Production deployments should enable
 `GENERAL_MANAGER["SEARCH_RECONCILE_ENABLED"] = True` and run Celery Beat.
@@ -215,7 +215,11 @@ handling.
 
 ### Backend contract and result models
 
-`SearchBackend` is the extension point for adapters. Backends receive index names, queries, filters, sorting, and pagination options, then return a `SearchResult`.
+`SearchBackend` is the extension point for adapters. Backends receive index
+names, queries, filters, sorting, and pagination options, then return a
+`SearchResult`. Adapters must also expose stored document IDs through
+`list_document_ids()` so reconciliation can remove stale documents after a
+manager/index reindex.
 
 Search result models have stable responsibilities:
 

--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -189,19 +189,27 @@ dispatch index updates through Celery. When disabled, updates run inline.
 
 Celery is required for production async indexing; development can remain sync.
 
-## Development auto-reindex (optional)
+## Search reconciliation
 
-To avoid manual reindexing when using the in-memory dev backend, enable:
+GeneralManager keeps search fresh in two layers:
 
-```python
-GENERAL_MANAGER = {
-    "SEARCH_AUTO_REINDEX": True,
-}
-```
+1. Manager create/update/delete operations update the affected search document.
+2. The search reconciler periodically checks durable index state and rebuilds
+   manager/index pairs that need initialization, schema updates, or recovery
+   after missed writes.
 
-When enabled (and `DEBUG=True`), GeneralManager reindexes once on the first
-request in the runserver process. This keeps dev search results available
-without running `search_index --reindex` manually.
+The reconciler stores one state row per searchable manager/index pair. Missing
+state means the pair has not been initialized. A changed schema fingerprint
+means the configured fields, filters, sorts, boosts, type label, document id, or
+document serializer changed.
+
+Production deployments should enable
+`GENERAL_MANAGER["SEARCH_RECONCILE_ENABLED"] = True` and run Celery Beat.
+Development can either run the same Celery Beat path or use
+`python manage.py search_reconcile --watch`.
+
+Search initialization is not coupled to GraphQL traffic or WSGI/ASGI request
+handling.
 
 ## Backends
 

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -15,5 +15,6 @@ These tutorials walk you through common development tasks when working with Gene
 11. [Handle database migrations](migrations_gotchas.md)
 12. [Build workflow event triggers](workflow_events.md)
 13. [Operate workflow outbox/dead letters](workflow_ops.md)
+14. [Run search reconciliation](search_reconciliation.md)
 
 Follow them in order when you start a new project, or jump to the topic relevant to your current task.

--- a/docs/howto/search.md
+++ b/docs/howto/search.md
@@ -108,19 +108,10 @@ GENERAL_MANAGER = {
 Run a Celery worker so index updates can be dispatched. When async is disabled,
 updates run inline.
 
-## Step 6: Auto-reindex in development (optional)
+## Step 6: Keep indexes initialized and reconciled
 
-The dev search backend is in-memory, so indexes are empty on every process
-start. To automatically reindex once per runserver process, enable:
-
-```python
-GENERAL_MANAGER = {
-    **GENERAL_MANAGER,
-    "SEARCH_AUTO_REINDEX": True,
-}
-```
-
-This runs `search_index --reindex` on the first request when `DEBUG=True`.
+For production and development reconciliation setup, see
+[Run search reconciliation](search_reconciliation.md).
 
 ## Step 7: Non-GraphQL usage
 

--- a/docs/howto/search_reconciliation.md
+++ b/docs/howto/search_reconciliation.md
@@ -1,0 +1,89 @@
+# Run search reconciliation
+
+Search reconciliation initializes and repairs search indexes without tying work
+to a user request. It works alongside normal per-object indexing from manager
+create, update, and delete operations.
+
+## What reconciliation does
+
+Each searchable manager/index pair gets a durable state row. The reconciler:
+
+- creates missing state rows and marks them for first initialization
+- detects search configuration changes with a schema fingerprint
+- rebuilds dirty manager/index pairs
+- clears dirty state only after a successful backend write
+- keeps the dirty marker and records `last_error` when reconciliation fails
+
+## Production with Celery Beat
+
+Enable async indexing and reconciliation:
+
+```python
+GENERAL_MANAGER = {
+    "SEARCH_BACKEND": {
+        "class": "general_manager.search.backends.meilisearch.MeilisearchBackend",
+        "options": {
+            "url": "http://meilisearch:7700",
+            "api_key": MEILISEARCH_API_KEY,
+        },
+    },
+    "SEARCH_ASYNC": True,
+    "SEARCH_RECONCILE_ENABLED": True,
+    "SEARCH_RECONCILE_INTERVAL_SECONDS": 60,
+}
+```
+
+Run a Celery worker and Celery Beat. This example assumes the Django project
+package is `mysite`; replace only the Celery app path if the project already
+uses a different package name.
+
+```bash
+celery -A mysite worker -l info
+celery -A mysite beat -l info
+```
+
+Celery Beat schedules
+`general_manager.search.tasks.reconcile_search_indexes_task`. When no index
+state is dirty, the task exits quickly. If an index is dirty, one worker claims
+the state row, reindexes the affected manager/index pair, and clears the marker
+after success.
+
+## Development with Celery
+
+Use the same settings and commands as production. This is the best local setup
+when you want to exercise deployment behavior.
+
+## Development without Celery
+
+Run one initialization pass:
+
+```bash
+python manage.py search_reconcile --once
+```
+
+Keep the in-memory development backend initialized while you work:
+
+```bash
+python manage.py search_reconcile --watch --interval 5
+```
+
+The watch command uses the same reconciliation service as Celery Beat, so
+behavior stays consistent without adding request-time side effects.
+
+## Force a rebuild
+
+Use `--force` after large imports, backend recovery, or manual index deletion:
+
+```bash
+python manage.py search_reconcile --once --force
+```
+
+## Troubleshooting
+
+- If searches return no results after startup, run
+  `python manage.py search_reconcile --once`.
+- If reconciliation keeps retrying, inspect `SearchIndexState.last_error`.
+- If production never reconciles, confirm Celery Beat is running and
+  `SEARCH_RECONCILE_ENABLED` is `True`.
+- If normal mutations are not reflected quickly, confirm `SEARCH_ASYNC` and the
+  Celery worker are configured correctly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
       - howto/permission_walkthrough.md
       - howto/expose_via_graphql.md
       - howto/search.md
+      - howto/search_reconciliation.md
       - howto/cache_dependent_calculation.md
       - howto/write_custom_interface.md
       - howto/create_custom_interface_type.md

--- a/src/general_manager/apps.py
+++ b/src/general_manager/apps.py
@@ -4,10 +4,6 @@ Boot logic lives in ``general_manager.bootstrap``; this module is a thin
 ``AppConfig`` adapter that coordinates startup phases and re-exports the
 bootstrap helpers so existing imports (e.g.
 ``from general_manager.apps import GeneralmanagerConfig``) continue to work.
-
-The search auto-reindex helpers are defined here (not in bootstrap) because
-they depend on a module-level ``_SEARCH_REINDEXED`` flag that tests reset via
-``gm_apps._SEARCH_REINDEXED = False``.
 """
 
 from __future__ import annotations
@@ -17,8 +13,6 @@ from typing import TYPE_CHECKING, Any, Iterable, Type
 
 from django.apps import AppConfig, apps as django_apps
 from django.conf import settings
-from django.core.management import call_command
-from django.core.signals import request_started
 
 from general_manager.bootstrap import (
     MissingRootUrlconfError,
@@ -55,9 +49,6 @@ if TYPE_CHECKING:
     from general_manager.manager.general_manager import GeneralManager
 
 logger = get_logger("apps")
-
-# Module-level flag so tests can reset it via ``gm_apps._SEARCH_REINDEXED = False``.
-_SEARCH_REINDEXED = False
 
 # Re-export for backward compatibility
 __all__ = [
@@ -108,77 +99,6 @@ def configure_search_reconcile_beat_schedule_from_settings(
     return _configure(django_settings)
 
 
-# ---------------------------------------------------------------------------
-# Search auto-reindex helpers (kept here to stay coupled to _SEARCH_REINDEXED)
-# ---------------------------------------------------------------------------
-
-
-def _normalize_graphql_path(raw_path: str) -> str:
-    if not raw_path.startswith("/"):
-        raw_path = f"/{raw_path}"
-    if not raw_path.endswith("/"):
-        raw_path = f"{raw_path}/"
-    return raw_path
-
-
-def _should_auto_reindex(django_settings: Any) -> bool:
-    """
-    Return True when search should be auto-reindexed on first request in development.
-
-    Reads from ``django_settings`` directly (rather than the global ``settings`` object)
-    so that callers can inject a settings-like object in tests.
-    """
-    config = getattr(django_settings, "GENERAL_MANAGER", {})
-    if isinstance(config, dict) and "SEARCH_AUTO_REINDEX" in config:
-        reindex = config["SEARCH_AUTO_REINDEX"]
-    else:
-        reindex = getattr(django_settings, "SEARCH_AUTO_REINDEX", False)
-    return bool(reindex) and bool(getattr(django_settings, "DEBUG", False))
-
-
-def _auto_reindex_search(*_args: object, **kwargs: object) -> None:
-    global _SEARCH_REINDEXED
-    environ = kwargs.get("environ")
-    if not isinstance(environ, dict):
-        return
-    request_path = environ.get("PATH_INFO")
-    if not isinstance(request_path, str):
-        return
-    from general_manager.conf import get_setting
-
-    graphql_path = _normalize_graphql_path(get_setting("GRAPHQL_URL", "graphql"))
-    if _normalize_graphql_path(request_path) != graphql_path:
-        return
-    if _SEARCH_REINDEXED:
-        return
-    _SEARCH_REINDEXED = True
-    try:
-        call_command("search_index", reindex=True)
-        logger.info("auto reindex complete", context={"component": "search"})
-    except Exception:  # pragma: no cover - defensive log
-        logger.exception("auto reindex failed", context={"component": "search"})
-
-
-def install_search_auto_reindex() -> None:
-    """
-    Optionally reindex search data once on first request in development.
-
-    Enabled via ``GENERAL_MANAGER["SEARCH_AUTO_REINDEX"]`` (or legacy
-    ``SEARCH_AUTO_REINDEX`` top-level setting).
-    """
-    if not _should_auto_reindex(settings):
-        return
-    request_started.connect(
-        _auto_reindex_search,
-        dispatch_uid="general_manager_auto_reindex_search",
-    )
-
-
-# ---------------------------------------------------------------------------
-# AppConfig
-# ---------------------------------------------------------------------------
-
-
 class GeneralmanagerConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "general_manager"
@@ -202,8 +122,6 @@ class GeneralmanagerConfig(AppConfig):
         configure_search_reconcile_beat_schedule_from_settings(settings)
         from general_manager.search import indexer as _search_indexer  # noqa: F401
 
-        self.install_search_auto_reindex()
-
         from general_manager.conf import get_setting
 
         if get_setting("AUTOCREATE_GRAPHQL", False):
@@ -221,10 +139,6 @@ class GeneralmanagerConfig(AppConfig):
     @staticmethod
     def register_system_checks() -> None:
         register_system_checks()
-
-    @staticmethod
-    def install_search_auto_reindex() -> None:
-        install_search_auto_reindex()
 
     @staticmethod
     def initialize_general_manager_classes(

--- a/src/general_manager/apps.py
+++ b/src/general_manager/apps.py
@@ -97,6 +97,17 @@ def _autoload_app_managers_modules(
     return imported_modules
 
 
+def configure_search_reconcile_beat_schedule_from_settings(
+    django_settings: Any,
+) -> bool:
+    """Configure search reconciliation Beat schedule after apps are ready."""
+    from general_manager.search.tasks import (
+        configure_search_reconcile_beat_schedule_from_settings as _configure,
+    )
+
+    return _configure(django_settings)
+
+
 # ---------------------------------------------------------------------------
 # Search auto-reindex helpers (kept here to stay coupled to _SEARCH_REINDEXED)
 # ---------------------------------------------------------------------------
@@ -188,6 +199,7 @@ class GeneralmanagerConfig(AppConfig):
         configure_event_registry_from_settings(settings)
         configure_workflow_signal_bridge_from_settings(settings)
         configure_workflow_beat_schedule_from_settings(settings)
+        configure_search_reconcile_beat_schedule_from_settings(settings)
         from general_manager.search import indexer as _search_indexer  # noqa: F401
 
         self.install_search_auto_reindex()

--- a/src/general_manager/apps.py
+++ b/src/general_manager/apps.py
@@ -134,10 +134,12 @@ class GeneralmanagerConfig(AppConfig):
 
     @staticmethod
     def install_startup_hook_runner() -> None:
+        """Install the startup hook runner through the bootstrap module."""
         install_startup_hook_runner()
 
     @staticmethod
     def register_system_checks() -> None:
+        """Register GeneralManager system checks through the bootstrap module."""
         register_system_checks()
 
     @staticmethod
@@ -145,30 +147,36 @@ class GeneralmanagerConfig(AppConfig):
         pending_attribute_initialization: list[Type[GeneralManager]],
         all_classes: list[Type[GeneralManager]],
     ) -> None:
+        """Initialize pending manager classes through the bootstrap module."""
         initialize_general_manager_classes(
             pending_attribute_initialization, all_classes
         )
 
     @staticmethod
     def check_permission_class(general_manager_class: Type[GeneralManager]) -> None:
+        """Validate a manager permission class through the bootstrap module."""
         check_permission_class(general_manager_class)
 
     @staticmethod
     def handle_graph_ql(
         pending_graphql_interfaces: list[Type[GeneralManager]],
     ) -> None:
+        """Build GraphQL integration for pending manager interfaces."""
         handle_graph_ql(pending_graphql_interfaces)
 
     @staticmethod
     def handle_remote_api(
         manager_classes: list[Type[GeneralManager]],
     ) -> None:
+        """Register remote API integration for manager classes."""
         handle_remote_api(manager_classes)
 
     @staticmethod
     def add_graphql_url(schema: Any) -> None:
+        """Add the generated GraphQL URL to the configured URLConf."""
         add_graphql_url(schema)
 
     @staticmethod
     def _ensure_asgi_subscription_route(graphql_url: str) -> None:
+        """Ensure the ASGI subscription route exists for the GraphQL URL."""
         _ensure_asgi_subscription_route(graphql_url)

--- a/src/general_manager/management/commands/search_reconcile.py
+++ b/src/general_manager/management/commands/search_reconcile.py
@@ -11,15 +11,18 @@ from general_manager.search.reconciliation import reconcile_search_indexes
 
 class InvalidSearchReconcileModeError(CommandError):
     def __init__(self) -> None:
+        """Initialize the error raised for missing or conflicting run modes."""
         super().__init__("Pass exactly one of --once or --watch.")
 
 
 class PositiveIntegerArgumentError(argparse.ArgumentTypeError):
     def __init__(self) -> None:
+        """Initialize the parser error raised for non-positive integers."""
         super().__init__("must be a positive integer")
 
 
 def positive_int(value: str) -> int:
+    """Parse a command-line value as an integer greater than zero."""
     try:
         parsed = int(value)
     except ValueError as exc:
@@ -33,6 +36,7 @@ class Command(BaseCommand):
     help = "Reconcile dirty search indexes."
 
     def add_arguments(self, parser) -> None:  # type: ignore[override]
+        """Register command-line options for search reconciliation."""
         parser.add_argument(
             "--once", action="store_true", help="Run one sweep and exit."
         )
@@ -56,6 +60,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *_: Any, **options: Any) -> None:
+        """Run one reconciliation sweep or watch continuously."""
         once = bool(options["once"])
         watch = bool(options["watch"])
         if once == watch:

--- a/src/general_manager/management/commands/search_reconcile.py
+++ b/src/general_manager/management/commands/search_reconcile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import time
 from typing import Any
 
@@ -11,6 +12,21 @@ from general_manager.search.reconciliation import reconcile_search_indexes
 class InvalidSearchReconcileModeError(CommandError):
     def __init__(self) -> None:
         super().__init__("Pass exactly one of --once or --watch.")
+
+
+class PositiveIntegerArgumentError(argparse.ArgumentTypeError):
+    def __init__(self) -> None:
+        super().__init__("must be a positive integer")
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise PositiveIntegerArgumentError from exc
+    if parsed <= 0:
+        raise PositiveIntegerArgumentError
+    return parsed
 
 
 class Command(BaseCommand):
@@ -34,7 +50,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--max-states",
-            type=int,
+            type=positive_int,
             default=None,
             help="Maximum dirty states to reconcile per sweep.",
         )

--- a/src/general_manager/management/commands/search_reconcile.py
+++ b/src/general_manager/management/commands/search_reconcile.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+from general_manager.search.reconciliation import reconcile_search_indexes
+
+
+class InvalidSearchReconcileModeError(CommandError):
+    def __init__(self) -> None:
+        super().__init__("Pass exactly one of --once or --watch.")
+
+
+class Command(BaseCommand):
+    help = "Reconcile dirty search indexes."
+
+    def add_arguments(self, parser) -> None:  # type: ignore[override]
+        parser.add_argument(
+            "--once", action="store_true", help="Run one sweep and exit."
+        )
+        parser.add_argument("--watch", action="store_true", help="Run continuously.")
+        parser.add_argument(
+            "--interval",
+            type=float,
+            default=60.0,
+            help="Watch interval in seconds.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Mark all configured search states dirty before reconciling.",
+        )
+        parser.add_argument(
+            "--max-states",
+            type=int,
+            default=None,
+            help="Maximum dirty states to reconcile per sweep.",
+        )
+
+    def handle(self, *_: Any, **options: Any) -> None:
+        once = bool(options["once"])
+        watch = bool(options["watch"])
+        if once == watch:
+            raise InvalidSearchReconcileModeError
+
+        interval = max(1.0, float(options["interval"]))
+        force = bool(options["force"])
+        max_states = options["max_states"]
+
+        while True:
+            result = reconcile_search_indexes(force=force, max_states=max_states)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Reconciled "
+                    f"{result.reconciled} search index states "
+                    f"({result.documents} documents, {result.failed} failures)."
+                )
+            )
+            if once:
+                return
+            force = False
+            time.sleep(interval)

--- a/src/general_manager/migrations/0004_search_index_state.py
+++ b/src/general_manager/migrations/0004_search_index_state.py
@@ -41,6 +41,12 @@ class Migration(migrations.Migration):
                         max_length=32,
                     ),
                 ),
+                (
+                    "claim_token",
+                    models.CharField(blank=True, default="", max_length=64),
+                ),
+                ("claimed_at", models.DateTimeField(blank=True, null=True)),
+                ("claim_expires_at", models.DateTimeField(blank=True, null=True)),
                 ("last_error", models.TextField(blank=True, default="")),
                 ("created_at", models.DateTimeField(auto_now_add=True)),
                 ("updated_at", models.DateTimeField(auto_now=True)),
@@ -65,6 +71,20 @@ class Migration(migrations.Migration):
             index=models.Index(
                 fields=["manager_path", "index_name"],
                 name="general_man_manager_9982f5_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="searchindexstate",
+            index=models.Index(
+                fields=["claim_token"],
+                name="general_man_claim_t_8dc8c8_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="searchindexstate",
+            index=models.Index(
+                fields=["claim_expires_at"],
+                name="general_man_claim_e_b9800f_idx",
             ),
         ),
         migrations.AddIndex(

--- a/src/general_manager/migrations/0004_search_index_state.py
+++ b/src/general_manager/migrations/0004_search_index_state.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("general_manager", "0003_workflow_execution_correlation_constraint")
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SearchIndexState",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("manager_path", models.CharField(max_length=512)),
+                ("index_name", models.CharField(max_length=255)),
+                ("schema_fingerprint", models.CharField(max_length=64)),
+                ("initialized_at", models.DateTimeField(blank=True, null=True)),
+                ("last_reconciled_at", models.DateTimeField(blank=True, null=True)),
+                ("dirty_since", models.DateTimeField(blank=True, null=True)),
+                (
+                    "dirty_reason",
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ("initialization", "Initialization"),
+                            ("schema_changed", "Schema changed"),
+                            ("data_changed", "Data changed"),
+                            ("forced", "Forced"),
+                        ],
+                        default="",
+                        max_length=32,
+                    ),
+                ),
+                ("last_error", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="searchindexstate",
+            constraint=models.UniqueConstraint(
+                fields=("manager_path", "index_name"),
+                name="general_manager_search_state_manager_index_uniq",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="searchindexstate",
+            index=models.Index(
+                fields=["dirty_since", "index_name"],
+                name="general_man_dirty__61cc37_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="searchindexstate",
+            index=models.Index(
+                fields=["manager_path", "index_name"],
+                name="general_man_manager_9982f5_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="searchindexstate",
+            index=models.Index(
+                fields=["last_reconciled_at"],
+                name="general_man_last_re_829c4b_idx",
+            ),
+        ),
+    ]

--- a/src/general_manager/migrations/0004_search_index_state.py
+++ b/src/general_manager/migrations/0004_search_index_state.py
@@ -63,35 +63,28 @@ class Migration(migrations.Migration):
             model_name="searchindexstate",
             index=models.Index(
                 fields=["dirty_since", "index_name"],
-                name="general_man_dirty__61cc37_idx",
-            ),
-        ),
-        migrations.AddIndex(
-            model_name="searchindexstate",
-            index=models.Index(
-                fields=["manager_path", "index_name"],
-                name="general_man_manager_9982f5_idx",
+                name="general_man_dirty_s_71fc00_idx",
             ),
         ),
         migrations.AddIndex(
             model_name="searchindexstate",
             index=models.Index(
                 fields=["claim_token"],
-                name="general_man_claim_t_8dc8c8_idx",
+                name="general_man_claim_t_3aaacc_idx",
             ),
         ),
         migrations.AddIndex(
             model_name="searchindexstate",
             index=models.Index(
                 fields=["claim_expires_at"],
-                name="general_man_claim_e_b9800f_idx",
+                name="general_man_claim_e_1fa228_idx",
             ),
         ),
         migrations.AddIndex(
             model_name="searchindexstate",
             index=models.Index(
                 fields=["last_reconciled_at"],
-                name="general_man_last_re_829c4b_idx",
+                name="general_man_last_re_81038c_idx",
             ),
         ),
     ]

--- a/src/general_manager/models.py
+++ b/src/general_manager/models.py
@@ -1,5 +1,6 @@
 """General Manager package models."""
 
+from general_manager.search.models import SearchIndexState
 from general_manager.workflow.models import (
     WorkflowDeliveryAttempt,
     WorkflowEventRecord,
@@ -8,6 +9,7 @@ from general_manager.workflow.models import (
 )
 
 __all__ = [
+    "SearchIndexState",
     "WorkflowDeliveryAttempt",
     "WorkflowEventRecord",
     "WorkflowExecutionRecord",

--- a/src/general_manager/search/backend.py
+++ b/src/general_manager/search/backend.py
@@ -71,6 +71,23 @@ class SearchBackend(Protocol):
             ids (Sequence[str]): Sequence of document IDs to delete.
         """
 
+    def list_document_ids(
+        self,
+        index_name: str,
+        *,
+        types: Sequence[str] | None = None,
+    ) -> set[str]:
+        """
+        Return all document IDs currently stored in an index.
+
+        Parameters:
+            index_name (str): Name of the index to inspect.
+            types (Sequence[str] | None): Optional document type labels to include.
+
+        Returns:
+            set[str]: Backend document IDs in their original GeneralManager form.
+        """
+
     def search(
         self,
         index_name: str,

--- a/src/general_manager/search/backend.py
+++ b/src/general_manager/search/backend.py
@@ -148,6 +148,7 @@ class SearchBackendNotConfiguredError(RuntimeError):
 
     @classmethod
     def from_setting(cls, backend_setting: object) -> "SearchBackendNotConfiguredError":
+        """Build an error message from a backend setting with secrets masked."""
         masked_setting = _mask_backend_setting(backend_setting)
         message = (
             f"Search backend could not be resolved from setting: {masked_setting!r}"
@@ -156,6 +157,7 @@ class SearchBackendNotConfiguredError(RuntimeError):
 
 
 def _mask_backend_setting(setting: object) -> object:
+    """Return a backend setting representation with sensitive values removed."""
     secret_keys = {"password", "secret", "api_key", "apikey", "token", "auth"}
     if isinstance(setting, Mapping):
         masked: dict[object, object] = {}

--- a/src/general_manager/search/backends/dev.py
+++ b/src/general_manager/search/backends/dev.py
@@ -67,6 +67,21 @@ class DevSearchBackend:
             store.documents.pop(doc_id, None)
             store.token_index.pop(doc_id, None)
 
+    def list_document_ids(
+        self,
+        index_name: str,
+        *,
+        types: Sequence[str] | None = None,
+    ) -> set[str]:
+        """Return stored document IDs, optionally restricted by document type."""
+        store = self._indexes.setdefault(index_name, _IndexStore())
+        type_filter = set(types or ())
+        return {
+            document.id
+            for document in store.documents.values()
+            if not type_filter or document.type in type_filter
+        }
+
     def search(
         self,
         index_name: str,

--- a/src/general_manager/search/backends/dev.py
+++ b/src/general_manager/search/backends/dev.py
@@ -141,6 +141,7 @@ class DevSearchBackend:
             def _value_key(
                 item: tuple[SearchDocument, float],
             ) -> tuple[int, float, str]:
+                """Build a stable sort key for numeric, string, and missing values."""
                 value = item[0].data.get(sort_by)
                 if value is None:
                     return (2, 0.0, "")

--- a/src/general_manager/search/backends/meilisearch.py
+++ b/src/general_manager/search/backends/meilisearch.py
@@ -410,6 +410,7 @@ class MeilisearchBackend:
 
     @staticmethod
     def _extract_task_status(result: Any) -> str | None:
+        """Read a normalized task status from a Meilisearch task response."""
         if result is None:
             return None
         if isinstance(result, Mapping):
@@ -446,6 +447,7 @@ class MeilisearchBackend:
 
     @staticmethod
     def _extract_documents_results(response: Any) -> list[Any]:
+        """Read document result entries from a Meilisearch documents response."""
         if response is None:
             return []
         if isinstance(response, Mapping):
@@ -458,6 +460,7 @@ class MeilisearchBackend:
 
     @staticmethod
     def _extract_documents_total(response: Any) -> int | None:
+        """Read the total document count from a Meilisearch documents response."""
         if response is None:
             return None
         if isinstance(response, Mapping):
@@ -468,6 +471,7 @@ class MeilisearchBackend:
 
     @staticmethod
     def _read_document_field(document: Any, field: str) -> Any:
+        """Read a field from a mapping or object document payload."""
         if isinstance(document, Mapping):
             return document.get(field)
         return getattr(document, field, None)
@@ -491,6 +495,7 @@ class MeilisearchBackend:
 
 
 def _meilisearch_error_code(error: Exception) -> str:
+    """Extract a normalized Meilisearch error code from known error shapes."""
     for attr in ("error_code", "code", "errorCode"):
         value = getattr(error, attr, None)
         if value:
@@ -499,6 +504,7 @@ def _meilisearch_error_code(error: Exception) -> str:
 
 
 def _meilisearch_status_code(error: Exception) -> int | None:
+    """Extract an HTTP status code from known Meilisearch error shapes."""
     for attr in ("status_code", "statusCode", "http_status", "status"):
         value = getattr(error, attr, None)
         if isinstance(value, int):
@@ -507,12 +513,14 @@ def _meilisearch_status_code(error: Exception) -> int | None:
 
 
 def _is_meilisearch_not_found(error: Exception) -> bool:
+    """Return whether a Meilisearch error represents a missing resource."""
     code = _meilisearch_error_code(error)
     status = _meilisearch_status_code(error)
     return status == 404 or "not_found" in code
 
 
 def _is_meilisearch_already_exists(error: Exception) -> bool:
+    """Return whether a Meilisearch error represents an existing resource."""
     code = _meilisearch_error_code(error)
     status = _meilisearch_status_code(error)
     return status == 409 or "already_exists" in code

--- a/src/general_manager/search/backends/meilisearch.py
+++ b/src/general_manager/search/backends/meilisearch.py
@@ -113,6 +113,48 @@ class MeilisearchBackend:
             task = index.delete_documents(normalized_ids)
             self._wait_for_task(task)
 
+    def list_document_ids(
+        self,
+        index_name: str,
+        *,
+        types: Sequence[str] | None = None,
+    ) -> set[str]:
+        """Return stored GeneralManager document IDs from a Meilisearch index."""
+        index = self._get_or_create_index(index_name)
+        document_ids: set[str] = set()
+        type_filter = set(types or ())
+        limit = 1000
+        offset = 0
+
+        while True:
+            response = index.get_documents(
+                {
+                    "limit": limit,
+                    "offset": offset,
+                    "fields": ["id", "gm_document_id", "type"],
+                }
+            )
+            documents = self._extract_documents_results(response)
+            for document in documents:
+                document_type = self._read_document_field(document, "type")
+                if type_filter and document_type not in type_filter:
+                    continue
+                document_id = self._read_document_field(
+                    document, "gm_document_id"
+                ) or self._read_document_field(document, "id")
+                if document_id is not None:
+                    document_ids.add(str(document_id))
+
+            count = len(documents)
+            if count == 0:
+                break
+            offset += count
+            total = self._extract_documents_total(response)
+            if count < limit or (total is not None and offset >= total):
+                break
+
+        return document_ids
+
     def search(
         self,
         index_name: str,
@@ -401,6 +443,34 @@ class MeilisearchBackend:
         normalized_status = str(status).lower() if status is not None else ""
         if normalized_status in {"failed", "canceled"}:
             raise MeilisearchTaskFailedError(status, error)
+
+    @staticmethod
+    def _extract_documents_results(response: Any) -> list[Any]:
+        if response is None:
+            return []
+        if isinstance(response, Mapping):
+            results = response.get("results")
+        else:
+            results = getattr(response, "results", None)
+        if results is None:
+            return []
+        return list(results)
+
+    @staticmethod
+    def _extract_documents_total(response: Any) -> int | None:
+        if response is None:
+            return None
+        if isinstance(response, Mapping):
+            total = response.get("total")
+        else:
+            total = getattr(response, "total", None)
+        return total if isinstance(total, int) else None
+
+    @staticmethod
+    def _read_document_field(document: Any, field: str) -> Any:
+        if isinstance(document, Mapping):
+            return document.get(field)
+        return getattr(document, field, None)
 
     @staticmethod
     def _normalize_document_id(raw_id: Any) -> str:

--- a/src/general_manager/search/backends/opensearch.py
+++ b/src/general_manager/search/backends/opensearch.py
@@ -59,6 +59,20 @@ class OpenSearchBackend:
         """
         raise SearchBackendNotImplementedError("OpenSearch")
 
+    def list_document_ids(
+        self,
+        index_name: str,
+        *,
+        types: Sequence[str] | None = None,
+    ) -> set[str]:
+        """
+        List stored document IDs in the specified index.
+
+        Raises:
+            SearchBackendNotImplementedError: Always raised because the OpenSearch backend is not implemented.
+        """
+        raise SearchBackendNotImplementedError("OpenSearch")
+
     def search(
         self,
         index_name: str,

--- a/src/general_manager/search/backends/typesense.py
+++ b/src/general_manager/search/backends/typesense.py
@@ -62,6 +62,20 @@ class TypesenseBackend:
         """
         raise SearchBackendNotImplementedError("Typesense")
 
+    def list_document_ids(
+        self,
+        index_name: str,
+        *,
+        types: Sequence[str] | None = None,
+    ) -> set[str]:
+        """
+        List stored document IDs in the specified index.
+
+        Raises:
+            SearchBackendNotImplementedError: Always raised because the Typesense backend is not implemented.
+        """
+        raise SearchBackendNotImplementedError("Typesense")
+
     def search(
         self,
         index_name: str,

--- a/src/general_manager/search/indexer.py
+++ b/src/general_manager/search/indexer.py
@@ -228,6 +228,38 @@ class SearchIndexer:
             if documents:
                 self.backend.upsert(index_name, documents)
 
+    def reindex_manager_index(
+        self,
+        manager_class: type[GeneralManager],
+        index_name: str,
+    ) -> int:
+        """
+        Rebuild one manager's documents for one configured search index.
+
+        Returns the number of documents upserted.
+        """
+        config = get_search_config(manager_class)
+        if config is None:
+            return 0
+        index_config = get_index_config(manager_class, index_name)
+        if index_config is None:
+            raise MissingIndexConfigurationError(manager_class.__name__, index_name)
+
+        _ensure_index(self.backend, index_config.name)
+        documents: list[SearchDocument] = []
+        for instance in manager_class.all():
+            manager_instance = cast(GeneralManager, instance)
+            document = _serialize_document(
+                manager_instance,
+                index_name=index_config.name,
+                config=config,
+            )
+            documents.append(document)
+
+        if documents:
+            self.backend.upsert(index_config.name, documents)
+        return len(documents)
+
 
 @receiver(post_data_change)
 def _handle_search_post_change(

--- a/src/general_manager/search/indexer.py
+++ b/src/general_manager/search/indexer.py
@@ -258,8 +258,16 @@ class SearchIndexer:
             )
             documents.append(document)
 
+        current_ids = {document.id for document in documents}
         if documents:
             self.backend.upsert(index_config.name, documents)
+        existing_ids = self.backend.list_document_ids(
+            index_config.name,
+            types=[get_type_label(manager_class)],
+        )
+        stale_ids = sorted(existing_ids - current_ids)
+        if stale_ids:
+            self.backend.delete(index_config.name, stale_ids)
         return len(documents)
 
 
@@ -288,6 +296,13 @@ def _handle_search_post_change(
             instance.__class__,
             reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
         )
+    except (SearchBackendError, RuntimeError, ValueError, TypeError) as exc:
+        logger.warning(
+            "search dirty marker failed",
+            context={"manager": instance.__class__.__name__, "action": action},
+            exc_info=exc,
+        )
+    try:
         dispatch_index_update(
             action="index",
             manager_path=manager_path,
@@ -327,6 +342,13 @@ def _handle_search_pre_delete(
             instance.__class__,
             reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
         )
+    except (SearchBackendError, RuntimeError, ValueError, TypeError) as exc:
+        logger.warning(
+            "search delete dirty marker failed",
+            context={"manager": instance.__class__.__name__, "action": action},
+            exc_info=exc,
+        )
+    try:
         dispatch_index_update(
             action="delete",
             manager_path=manager_path,

--- a/src/general_manager/search/indexer.py
+++ b/src/general_manager/search/indexer.py
@@ -18,6 +18,8 @@ from general_manager.search.backend import (
 from general_manager.search.backend_registry import get_search_backend
 from general_manager.search.async_tasks import dispatch_index_update
 from general_manager.search.config import SearchConfigSpec
+from general_manager.search.models import SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED
+from general_manager.search.reconciliation import mark_search_indexes_dirty
 from general_manager.search.registry import (
     collect_index_settings,
     get_index_config,
@@ -282,6 +284,10 @@ def _handle_search_post_change(
         return
     manager_path = f"{instance.__class__.__module__}.{instance.__class__.__name__}"
     try:
+        mark_search_indexes_dirty(
+            instance.__class__,
+            reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+        )
         dispatch_index_update(
             action="index",
             manager_path=manager_path,
@@ -317,6 +323,10 @@ def _handle_search_pre_delete(
         return
     manager_path = f"{instance.__class__.__module__}.{instance.__class__.__name__}"
     try:
+        mark_search_indexes_dirty(
+            instance.__class__,
+            reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+        )
         dispatch_index_update(
             action="delete",
             manager_path=manager_path,

--- a/src/general_manager/search/models.py
+++ b/src/general_manager/search/models.py
@@ -53,7 +53,6 @@ class SearchIndexState(models.Model):
             models.Index(fields=["dirty_since", "index_name"]),
             models.Index(fields=["claim_token"]),
             models.Index(fields=["claim_expires_at"]),
-            models.Index(fields=["manager_path", "index_name"]),
             models.Index(fields=["last_reconciled_at"]),
         )
 

--- a/src/general_manager/search/models.py
+++ b/src/general_manager/search/models.py
@@ -35,6 +35,9 @@ class SearchIndexState(models.Model):
         blank=True,
         default="",
     )
+    claim_token: Any = models.CharField(max_length=64, blank=True, default="")
+    claimed_at: Any = models.DateTimeField(null=True, blank=True)
+    claim_expires_at: Any = models.DateTimeField(null=True, blank=True)
     last_error: Any = models.TextField(blank=True, default="")
     created_at: Any = models.DateTimeField(auto_now_add=True)
     updated_at: Any = models.DateTimeField(auto_now=True)
@@ -48,6 +51,8 @@ class SearchIndexState(models.Model):
         )
         indexes = (
             models.Index(fields=["dirty_since", "index_name"]),
+            models.Index(fields=["claim_token"]),
+            models.Index(fields=["claim_expires_at"]),
             models.Index(fields=["manager_path", "index_name"]),
             models.Index(fields=["last_reconciled_at"]),
         )
@@ -67,6 +72,9 @@ class SearchIndexState(models.Model):
         self.last_reconciled_at = now
         self.dirty_since = None
         self.dirty_reason = ""
+        self.claim_token = ""
+        self.claimed_at = None
+        self.claim_expires_at = None
         self.last_error = ""
         self.save(
             update_fields=[
@@ -74,6 +82,9 @@ class SearchIndexState(models.Model):
                 "last_reconciled_at",
                 "dirty_since",
                 "dirty_reason",
+                "claim_token",
+                "claimed_at",
+                "claim_expires_at",
                 "last_error",
                 "updated_at",
             ]

--- a/src/general_manager/search/models.py
+++ b/src/general_manager/search/models.py
@@ -1,0 +1,80 @@
+"""Persistent search reconciliation state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import models
+from django.utils import timezone
+
+SEARCH_INDEX_DIRTY_REASON_INITIALIZATION = "initialization"
+SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED = "schema_changed"
+SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED = "data_changed"
+SEARCH_INDEX_DIRTY_REASON_FORCED = "forced"
+
+SEARCH_INDEX_DIRTY_REASONS = (
+    (SEARCH_INDEX_DIRTY_REASON_INITIALIZATION, "Initialization"),
+    (SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED, "Schema changed"),
+    (SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED, "Data changed"),
+    (SEARCH_INDEX_DIRTY_REASON_FORCED, "Forced"),
+)
+
+
+class SearchIndexState(models.Model):
+    """Durable reconciliation state for one manager/index pair."""
+
+    manager_path: Any = models.CharField(max_length=512)
+    index_name: Any = models.CharField(max_length=255)
+    schema_fingerprint: Any = models.CharField(max_length=64)
+    initialized_at: Any = models.DateTimeField(null=True, blank=True)
+    last_reconciled_at: Any = models.DateTimeField(null=True, blank=True)
+    dirty_since: Any = models.DateTimeField(null=True, blank=True)
+    dirty_reason: Any = models.CharField(
+        max_length=32,
+        choices=SEARCH_INDEX_DIRTY_REASONS,
+        blank=True,
+        default="",
+    )
+    last_error: Any = models.TextField(blank=True, default="")
+    created_at: Any = models.DateTimeField(auto_now_add=True)
+    updated_at: Any = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = (
+            models.UniqueConstraint(
+                fields=("manager_path", "index_name"),
+                name="general_manager_search_state_manager_index_uniq",
+            ),
+        )
+        indexes = (
+            models.Index(fields=["dirty_since", "index_name"]),
+            models.Index(fields=["manager_path", "index_name"]),
+            models.Index(fields=["last_reconciled_at"]),
+        )
+
+    def mark_dirty(self, reason: str) -> None:
+        """Mark this state dirty while preserving the first dirty timestamp."""
+        if self.dirty_since is None:
+            self.dirty_since = timezone.now()
+        self.dirty_reason = reason
+        self.save(update_fields=["dirty_since", "dirty_reason", "updated_at"])
+
+    def clear_dirty(self) -> None:
+        """Clear dirty/error fields and record a successful reconciliation."""
+        now = timezone.now()
+        if self.initialized_at is None:
+            self.initialized_at = now
+        self.last_reconciled_at = now
+        self.dirty_since = None
+        self.dirty_reason = ""
+        self.last_error = ""
+        self.save(
+            update_fields=[
+                "initialized_at",
+                "last_reconciled_at",
+                "dirty_since",
+                "dirty_reason",
+                "last_error",
+                "updated_at",
+            ]
+        )

--- a/src/general_manager/search/reconciliation.py
+++ b/src/general_manager/search/reconciliation.py
@@ -67,6 +67,7 @@ def manager_import_path(manager_class: type[GeneralManager]) -> str:
 
 
 def _callable_path(value: Any) -> str | None:
+    """Return a stable import-like path for a callable when one is available."""
     if value is None:
         return None
     module = getattr(value, "__module__", "")
@@ -75,6 +76,7 @@ def _callable_path(value: Any) -> str | None:
 
 
 def _index_payload(index_config: IndexConfig) -> dict[str, Any]:
+    """Serialize index configuration into the schema fingerprint payload."""
     return {
         "name": index_config.name,
         "fields": [
@@ -192,6 +194,7 @@ def mark_search_indexes_dirty(
 
 
 def _resolve_manager_path(manager_path: str) -> type[GeneralManager]:
+    """Import and return the manager class for a stored manager path."""
     return import_string(manager_path)
 
 
@@ -200,6 +203,7 @@ def _claim_dirty_states(
     max_states: int | None = None,
     claim_ttl_seconds: int = 300,
 ) -> list[SearchIndexState]:
+    """Atomically claim dirty states that are unclaimed or expired."""
     now = timezone.now()
     claim_token = uuid.uuid4().hex
     claim_expires_at = now + timedelta(seconds=claim_ttl_seconds)
@@ -231,6 +235,7 @@ def _claim_dirty_states(
 
 
 def _release_claim_with_error(state: SearchIndexState, error: str) -> None:
+    """Release a state claim and persist the reconciliation error message."""
     state.claim_token = ""
     state.claimed_at = None
     state.claim_expires_at = None

--- a/src/general_manager/search/reconciliation.py
+++ b/src/general_manager/search/reconciliation.py
@@ -1,0 +1,142 @@
+"""Search index reconciliation services."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from django.db import transaction
+
+from general_manager.logging import get_logger
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.search.config import IndexConfig
+from general_manager.search.models import (
+    SEARCH_INDEX_DIRTY_REASON_FORCED,
+    SEARCH_INDEX_DIRTY_REASON_INITIALIZATION,
+    SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED,
+    SearchIndexState,
+)
+from general_manager.search.registry import get_search_config, iter_searchable_managers
+
+logger = get_logger("search.reconciliation")
+
+
+@dataclass(frozen=True)
+class SearchIndexTarget:
+    """Configured manager/index pair that can be reconciled."""
+
+    manager_class: type[GeneralManager]
+    manager_path: str
+    index_name: str
+    schema_fingerprint: str
+
+
+@dataclass(frozen=True)
+class SearchStateEnsureResult:
+    """Counts produced while ensuring search reconciliation state rows."""
+
+    created: int = 0
+    updated: int = 0
+    unchanged: int = 0
+
+
+def manager_import_path(manager_class: type[GeneralManager]) -> str:
+    """Return the import path used to identify a searchable manager."""
+    return f"{manager_class.__module__}.{manager_class.__name__}"
+
+
+def _callable_path(value: Any) -> str | None:
+    if value is None:
+        return None
+    module = getattr(value, "__module__", "")
+    name = getattr(value, "__qualname__", getattr(value, "__name__", repr(value)))
+    return f"{module}.{name}" if module else name
+
+
+def _index_payload(index_config: IndexConfig) -> dict[str, Any]:
+    return {
+        "name": index_config.name,
+        "fields": [
+            {"name": field.name, "boost": field.boost}
+            for field in index_config.iter_fields()
+        ],
+        "filters": list(index_config.filters),
+        "sorts": list(index_config.sorts),
+        "boost": index_config.boost,
+        "min_score": index_config.min_score,
+    }
+
+
+def build_search_schema_fingerprint(
+    manager_class: type[GeneralManager],
+    index_config: IndexConfig,
+) -> str:
+    """Build a stable fingerprint for one manager/index search configuration."""
+    config = get_search_config(manager_class)
+    payload = {
+        "manager_path": manager_import_path(manager_class),
+        "index": _index_payload(index_config),
+        "document_id": _callable_path(config.document_id if config else None),
+        "to_document": _callable_path(config.to_document if config else None),
+        "type_label": config.type_label if config else None,
+        "update_strategy": config.update_strategy if config else None,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def iter_search_index_targets() -> Iterable[SearchIndexTarget]:
+    """Yield all configured searchable manager/index targets."""
+    for manager_class in iter_searchable_managers():
+        config = get_search_config(manager_class)
+        if config is None:
+            continue
+        manager_path = manager_import_path(manager_class)
+        for index_config in config.indexes:
+            yield SearchIndexTarget(
+                manager_class=manager_class,
+                manager_path=manager_path,
+                index_name=index_config.name,
+                schema_fingerprint=build_search_schema_fingerprint(
+                    manager_class,
+                    index_config,
+                ),
+            )
+
+
+def ensure_search_index_states(*, force: bool = False) -> SearchStateEnsureResult:
+    """Ensure durable state rows exist and mark missing/changed targets dirty."""
+    created = 0
+    updated = 0
+    unchanged = 0
+    for target in iter_search_index_targets():
+        with transaction.atomic():
+            state, was_created = (
+                SearchIndexState.objects.select_for_update().get_or_create(
+                    manager_path=target.manager_path,
+                    index_name=target.index_name,
+                    defaults={"schema_fingerprint": target.schema_fingerprint},
+                )
+            )
+            if was_created:
+                state.mark_dirty(SEARCH_INDEX_DIRTY_REASON_INITIALIZATION)
+                created += 1
+                continue
+            if force:
+                state.schema_fingerprint = target.schema_fingerprint
+                state.save(update_fields=["schema_fingerprint", "updated_at"])
+                state.mark_dirty(SEARCH_INDEX_DIRTY_REASON_FORCED)
+                updated += 1
+                continue
+            if state.schema_fingerprint != target.schema_fingerprint:
+                state.schema_fingerprint = target.schema_fingerprint
+                state.save(update_fields=["schema_fingerprint", "updated_at"])
+                state.mark_dirty(SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED)
+                updated += 1
+                continue
+            unchanged += 1
+    return SearchStateEnsureResult(
+        created=created, updated=updated, unchanged=unchanged
+    )

--- a/src/general_manager/search/reconciliation.py
+++ b/src/general_manager/search/reconciliation.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import uuid
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, Iterable
 
 from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+from django.utils.module_loading import import_string
 
 from general_manager.logging import get_logger
 from general_manager.manager.general_manager import GeneralManager
@@ -41,6 +46,19 @@ class SearchStateEnsureResult:
     created: int = 0
     updated: int = 0
     unchanged: int = 0
+
+
+@dataclass(frozen=True)
+class SearchReconcileResult:
+    """Counts produced by one search reconciliation sweep."""
+
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+    claimed: int = 0
+    reconciled: int = 0
+    failed: int = 0
+    documents: int = 0
 
 
 def manager_import_path(manager_class: type[GeneralManager]) -> str:
@@ -171,3 +189,122 @@ def mark_search_indexes_dirty(
             state.mark_dirty(reason)
         marked += 1
     return marked
+
+
+def _resolve_manager_path(manager_path: str) -> type[GeneralManager]:
+    return import_string(manager_path)
+
+
+def _claim_dirty_states(
+    *,
+    max_states: int | None = None,
+    claim_ttl_seconds: int = 300,
+) -> list[SearchIndexState]:
+    now = timezone.now()
+    claim_token = uuid.uuid4().hex
+    claim_expires_at = now + timedelta(seconds=claim_ttl_seconds)
+    claim_filter = Q(claim_token="") | Q(claim_expires_at__lte=now)
+
+    with transaction.atomic():
+        queryset = (
+            SearchIndexState.objects.select_for_update()
+            .filter(dirty_since__isnull=False)
+            .filter(claim_filter)
+            .order_by("dirty_since", "id")
+        )
+        if max_states is not None:
+            queryset = queryset[:max_states]
+        states = list(queryset)
+        for state in states:
+            state.claim_token = claim_token
+            state.claimed_at = now
+            state.claim_expires_at = claim_expires_at
+            state.save(
+                update_fields=[
+                    "claim_token",
+                    "claimed_at",
+                    "claim_expires_at",
+                    "updated_at",
+                ]
+            )
+    return states
+
+
+def _release_claim_with_error(state: SearchIndexState, error: str) -> None:
+    state.claim_token = ""
+    state.claimed_at = None
+    state.claim_expires_at = None
+    state.last_error = error
+    state.save(
+        update_fields=[
+            "claim_token",
+            "claimed_at",
+            "claim_expires_at",
+            "last_error",
+            "updated_at",
+        ]
+    )
+
+
+def reconcile_search_indexes(
+    *,
+    force: bool = False,
+    max_states: int | None = None,
+) -> SearchReconcileResult:
+    """Reconcile dirty search index states."""
+    ensure_result = ensure_search_index_states(force=force)
+    claimed_states = _claim_dirty_states(max_states=max_states)
+
+    if not claimed_states:
+        skipped = SearchIndexState.objects.filter(dirty_since__isnull=True).count()
+        logger.info(
+            "search reconciliation skipped; no dirty indexes",
+            context={"skipped": skipped},
+        )
+        return SearchReconcileResult(
+            created=ensure_result.created,
+            updated=ensure_result.updated,
+            skipped=skipped,
+        )
+
+    from general_manager.search.backend_registry import get_search_backend
+    from general_manager.search.indexer import SearchIndexer
+
+    indexer = SearchIndexer(get_search_backend())
+    reconciled = 0
+    failed = 0
+    documents = 0
+    for state in claimed_states:
+        try:
+            manager_class = _resolve_manager_path(state.manager_path)
+            document_count = indexer.reindex_manager_index(
+                manager_class,
+                state.index_name,
+            )
+            documents += document_count
+            state.clear_dirty()
+            reconciled += 1
+            logger.info(
+                "search index reconciled",
+                context={
+                    "manager": state.manager_path,
+                    "index": state.index_name,
+                    "documents": document_count,
+                },
+            )
+        except Exception as exc:
+            failed += 1
+            _release_claim_with_error(state, str(exc))
+            logger.exception(
+                "search index reconciliation failed",
+                context={"manager": state.manager_path, "index": state.index_name},
+            )
+
+    return SearchReconcileResult(
+        created=ensure_result.created,
+        updated=ensure_result.updated,
+        claimed=len(claimed_states),
+        reconciled=reconciled,
+        failed=failed,
+        documents=documents,
+    )

--- a/src/general_manager/search/reconciliation.py
+++ b/src/general_manager/search/reconciliation.py
@@ -13,6 +13,7 @@ from general_manager.logging import get_logger
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.search.config import IndexConfig
 from general_manager.search.models import (
+    SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
     SEARCH_INDEX_DIRTY_REASON_FORCED,
     SEARCH_INDEX_DIRTY_REASON_INITIALIZATION,
     SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED,
@@ -140,3 +141,33 @@ def ensure_search_index_states(*, force: bool = False) -> SearchStateEnsureResul
     return SearchStateEnsureResult(
         created=created, updated=updated, unchanged=unchanged
     )
+
+
+def mark_search_indexes_dirty(
+    manager_class: type[GeneralManager],
+    *,
+    reason: str = SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+) -> int:
+    """Mark all configured search indexes for a manager dirty."""
+    marked = 0
+    config = get_search_config(manager_class)
+    if config is None:
+        return 0
+    for index_config in config.indexes:
+        target_fingerprint = build_search_schema_fingerprint(
+            manager_class, index_config
+        )
+        with transaction.atomic():
+            state, _created = (
+                SearchIndexState.objects.select_for_update().get_or_create(
+                    manager_path=manager_import_path(manager_class),
+                    index_name=index_config.name,
+                    defaults={"schema_fingerprint": target_fingerprint},
+                )
+            )
+            if state.schema_fingerprint != target_fingerprint:
+                state.schema_fingerprint = target_fingerprint
+                state.save(update_fields=["schema_fingerprint", "updated_at"])
+            state.mark_dirty(reason)
+        marked += 1
+    return marked

--- a/src/general_manager/search/tasks.py
+++ b/src/general_manager/search/tasks.py
@@ -20,7 +20,10 @@ except ImportError:  # pragma: no cover - optional dependency boundary
     current_app = cast(Any | None, None)  # type: ignore[assignment, no-redef]
 
     def shared_task(func: Any | None = None, **_kwargs: Any):  # type: ignore[no-redef]
+        """Return a no-op task decorator when Celery is not installed."""
+
         def decorator(inner):
+            """Return the wrapped callable unchanged."""
             return inner
 
         if func is None:
@@ -32,6 +35,7 @@ SEARCH_RECONCILE_BEAT_SCHEDULE_KEY = "general_manager.search.reconcile"
 
 
 def _config(django_settings: Any = settings) -> Mapping[str, Any]:
+    """Return the GENERAL_MANAGER settings mapping when configured."""
     value = getattr(django_settings, "GENERAL_MANAGER", {})
     if isinstance(value, Mapping):
         return value

--- a/src/general_manager/search/tasks.py
+++ b/src/general_manager/search/tasks.py
@@ -1,0 +1,104 @@
+"""Celery tasks and schedule setup for search reconciliation."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from django.conf import settings
+
+from general_manager.logging import get_logger
+from general_manager.search.reconciliation import reconcile_search_indexes
+
+logger = get_logger("search.tasks")
+
+try:
+    from celery import current_app, shared_task
+
+    CELERY_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency boundary
+    CELERY_AVAILABLE = False
+    current_app = cast(Any | None, None)  # type: ignore[assignment, no-redef]
+
+    def shared_task(func: Any | None = None, **_kwargs: Any):  # type: ignore[no-redef]
+        def decorator(inner):
+            return inner
+
+        if func is None:
+            return decorator
+        return decorator(func)
+
+
+SEARCH_RECONCILE_BEAT_SCHEDULE_KEY = "general_manager.search.reconcile"
+
+
+def _config(django_settings: Any = settings) -> Mapping[str, Any]:
+    value = getattr(django_settings, "GENERAL_MANAGER", {})
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def search_reconcile_enabled(django_settings: Any = settings) -> bool:
+    """Return whether periodic search reconciliation is enabled."""
+    config = _config(django_settings)
+    value = config.get(
+        "SEARCH_RECONCILE_ENABLED",
+        getattr(django_settings, "SEARCH_RECONCILE_ENABLED", False),
+    )
+    return bool(value)
+
+
+def search_reconcile_interval_seconds(django_settings: Any = settings) -> int:
+    """Return the periodic reconciliation interval in seconds."""
+    config = _config(django_settings)
+    raw = config.get(
+        "SEARCH_RECONCILE_INTERVAL_SECONDS",
+        getattr(django_settings, "SEARCH_RECONCILE_INTERVAL_SECONDS", 60),
+    )
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return 60
+
+
+def configure_search_reconcile_beat_schedule_from_settings(
+    django_settings: Any = settings,
+) -> bool:
+    """Register periodic search reconciliation in Celery Beat."""
+    if not search_reconcile_enabled(django_settings):
+        return False
+    if not CELERY_AVAILABLE or current_app is None:
+        logger.warning(
+            "search reconciliation beat schedule skipped; celery unavailable"
+        )
+        return False
+
+    schedule: dict[str, Any] = dict(
+        getattr(current_app.conf, "beat_schedule", {}) or {}
+    )
+    interval_seconds = float(search_reconcile_interval_seconds(django_settings))
+    schedule[SEARCH_RECONCILE_BEAT_SCHEDULE_KEY] = {
+        "task": "general_manager.search.tasks.reconcile_search_indexes_task",
+        "schedule": interval_seconds,
+        "options": {"queue": "search.reconciliation"},
+    }
+    current_app.conf.beat_schedule = schedule
+    logger.info(
+        "search reconciliation beat schedule configured",
+        context={
+            "schedule_key": SEARCH_RECONCILE_BEAT_SCHEDULE_KEY,
+            "interval_seconds": interval_seconds,
+        },
+    )
+    return True
+
+
+@shared_task(queue="search.reconciliation")
+def reconcile_search_indexes_task() -> dict[str, int]:
+    """Run one search reconciliation sweep."""
+    result = reconcile_search_indexes()
+    return {
+        "reconciled": result.reconciled,
+        "failed": result.failed,
+        "documents": result.documents,
+    }

--- a/tests/unit/test_apps_utilities.py
+++ b/tests/unit/test_apps_utilities.py
@@ -11,40 +11,6 @@ from general_manager import apps as gm_apps
 
 
 class AppsUtilitiesTests(SimpleTestCase):
-    def tearDown(self) -> None:
-        gm_apps._SEARCH_REINDEXED = False
-        super().tearDown()
-
-    def test_normalize_graphql_path(self) -> None:
-        assert gm_apps._normalize_graphql_path("graphql") == "/graphql/"
-        assert gm_apps._normalize_graphql_path("/graphql") == "/graphql/"
-        assert gm_apps._normalize_graphql_path("/graphql/") == "/graphql/"
-
-    def test_should_auto_reindex(self) -> None:
-        settings = SimpleNamespace(
-            GENERAL_MANAGER={"SEARCH_AUTO_REINDEX": True}, DEBUG=True
-        )
-        assert gm_apps._should_auto_reindex(settings) is True
-
-        settings = SimpleNamespace(
-            GENERAL_MANAGER={"SEARCH_AUTO_REINDEX": True}, DEBUG=False
-        )
-        assert gm_apps._should_auto_reindex(settings) is False
-
-    def test_auto_reindex_search_skips_invalid_env(self) -> None:
-        gm_apps._SEARCH_REINDEXED = False
-        gm_apps._auto_reindex_search()
-        gm_apps._auto_reindex_search(environ={"PATH_INFO": None})
-        assert gm_apps._SEARCH_REINDEXED is False
-
-    def test_auto_reindex_search_triggers_on_graphql_path(self) -> None:
-        gm_apps._SEARCH_REINDEXED = False
-        with patch("general_manager.apps.call_command") as call_command:
-            gm_apps._auto_reindex_search(environ={"PATH_INFO": "/graphql"})
-            call_command.assert_called_once_with("search_index", reindex=True)
-            assert gm_apps._SEARCH_REINDEXED is True
-        gm_apps._SEARCH_REINDEXED = False
-
     def test_import_optional_managers_module_imports_existing_module(self) -> None:
         app_config = SimpleNamespace(
             name="tests.custom_user_app",
@@ -156,13 +122,6 @@ class AppsUtilitiesTests(SimpleTestCase):
                                     "configure_search_reconcile_beat_schedule"
                                 ),
                             ),
-                            patch.object(
-                                config,
-                                "install_search_auto_reindex",
-                                side_effect=lambda *_args, **_kwargs: call_order.append(
-                                    "install_search_auto_reindex"
-                                ),
-                            ),
                         ):
                             config.ready()
 
@@ -178,5 +137,4 @@ class AppsUtilitiesTests(SimpleTestCase):
             "configure_signal_bridge",
             "configure_beat_schedule",
             "configure_search_reconcile_beat_schedule",
-            "install_search_auto_reindex",
         ]

--- a/tests/unit/test_apps_utilities.py
+++ b/tests/unit/test_apps_utilities.py
@@ -150,6 +150,12 @@ class AppsUtilitiesTests(SimpleTestCase):
                                     "configure_beat_schedule"
                                 ),
                             ),
+                            patch(
+                                "general_manager.apps.configure_search_reconcile_beat_schedule_from_settings",
+                                side_effect=lambda *_args, **_kwargs: call_order.append(
+                                    "configure_search_reconcile_beat_schedule"
+                                ),
+                            ),
                             patch.object(
                                 config,
                                 "install_search_auto_reindex",
@@ -171,5 +177,6 @@ class AppsUtilitiesTests(SimpleTestCase):
             "configure_event_registry",
             "configure_signal_bridge",
             "configure_beat_schedule",
+            "configure_search_reconcile_beat_schedule",
             "install_search_auto_reindex",
         ]

--- a/tests/unit/test_apps_utilities.py
+++ b/tests/unit/test_apps_utilities.py
@@ -12,6 +12,7 @@ from general_manager import apps as gm_apps
 
 class AppsUtilitiesTests(SimpleTestCase):
     def test_import_optional_managers_module_imports_existing_module(self) -> None:
+        """Import an app managers module when Django can find it."""
         app_config = SimpleNamespace(
             name="tests.custom_user_app",
             label="custom_user_app",
@@ -22,6 +23,7 @@ class AppsUtilitiesTests(SimpleTestCase):
         import_mod.assert_called_once_with("tests.custom_user_app.managers")
 
     def test_import_optional_managers_module_skips_missing_module(self) -> None:
+        """Skip importing managers when the optional module is absent."""
         app_config = SimpleNamespace(name="tests.no_managers_app", label="no_managers")
         with patch("general_manager.apps.util.find_spec", return_value=None):
             with patch("general_manager.apps.import_module") as import_mod:
@@ -31,6 +33,7 @@ class AppsUtilitiesTests(SimpleTestCase):
     def test_import_optional_managers_module_propagates_real_import_errors(
         self,
     ) -> None:
+        """Propagate errors raised while importing an existing managers module."""
         app_config = SimpleNamespace(
             name="tests.custom_user_app",
             label="custom_user_app",
@@ -52,6 +55,7 @@ class AppsUtilitiesTests(SimpleTestCase):
 
     @override_settings(AUTOCREATE_GRAPHQL=False)
     def test_ready_autoloads_managers_before_initialization(self) -> None:
+        """Autoload app managers before initializing manager classes."""
         config = gm_apps.GeneralmanagerConfig(
             "general_manager", import_module("general_manager")
         )

--- a/tests/unit/test_meilisearch_backend.py
+++ b/tests/unit/test_meilisearch_backend.py
@@ -27,6 +27,7 @@ class _FakeIndex:
         self.added: list[dict[str, object]] = []
         self.deleted: list[list[str]] = []
         self.settings: list[dict[str, object]] = []
+        self.documents: list[dict[str, object]] = []
 
     def update_settings(self, payload: dict[str, object]) -> dict[str, int]:
         """
@@ -82,6 +83,14 @@ class _FakeIndex:
                 - "processingTimeMs": 0.
         """
         return {"hits": [], "estimatedTotalHits": 0, "processingTimeMs": 0}
+
+    def get_documents(self, payload: dict[str, object]) -> dict[str, object]:
+        limit = int(payload["limit"])
+        offset = int(payload["offset"])
+        return {
+            "results": self.documents[offset : offset + limit],
+            "total": len(self.documents),
+        }
 
 
 class _FakeClient:
@@ -314,6 +323,29 @@ def test_meilisearch_backend_search_prefers_gm_document_id() -> None:
     backend = MeilisearchBackend(client=_FakeClient(_SearchIndex()))
     result = backend.search("index", "Alpha")
     assert result.hits[0].id == 'Project:{"id": 9}'
+
+
+def test_meilisearch_backend_lists_original_document_ids_by_type() -> None:
+    index = _FakeIndex()
+    index.documents = [
+        {
+            "id": "gm_hash_a",
+            "gm_document_id": 'Project:{"id": 1}',
+            "type": "Project",
+        },
+        {
+            "id": "gm_hash_b",
+            "gm_document_id": 'Other:{"id": 1}',
+            "type": "Other",
+        },
+        {"id": "legacy_id", "type": "Project"},
+    ]
+    backend = MeilisearchBackend(client=_FakeClient(index))
+
+    assert backend.list_document_ids("index", types=["Project"]) == {
+        'Project:{"id": 1}',
+        "legacy_id",
+    }
 
 
 def test_meilisearch_backend_document_payload_reserved_keys() -> None:

--- a/tests/unit/test_meilisearch_backend.py
+++ b/tests/unit/test_meilisearch_backend.py
@@ -85,6 +85,7 @@ class _FakeIndex:
         return {"hits": [], "estimatedTotalHits": 0, "processingTimeMs": 0}
 
     def get_documents(self, payload: dict[str, object]) -> dict[str, object]:
+        """Return a paginated fake documents response."""
         limit = int(payload["limit"])
         offset = int(payload["offset"])
         return {
@@ -111,6 +112,7 @@ class _FakeClient:
     def get_or_create_index(
         self, _name: str, _payload: dict[str, object]
     ) -> _FakeIndex:
+        """Return the configured fake index."""
         return self.index
 
     def get_index(self, _name: str) -> _FakeIndex:
@@ -173,6 +175,7 @@ class _FailingClient(_FakeClient):
 
 
 def test_meilisearch_backend_waits_for_tasks() -> None:
+    """Wait for Meilisearch settings, upsert, and delete tasks."""
     index = _FakeIndex()
     client = _FakeClient(index)
     backend = MeilisearchBackend(client=client)
@@ -201,6 +204,7 @@ def test_meilisearch_backend_waits_for_tasks() -> None:
 
 
 def test_meilisearch_backend_extract_task_uid() -> None:
+    """Extract task UIDs from mapping and object task payloads."""
     backend = MeilisearchBackend(client=_FakeClient(_FakeIndex()))
     assert backend._extract_task_uid({"taskUid": 9}) == 9
 
@@ -211,6 +215,8 @@ def test_meilisearch_backend_extract_task_uid() -> None:
 
 
 def test_meilisearch_backend_get_task_fallback() -> None:
+    """Poll get_task when wait_for_task is not available."""
+
     class _Client:
         def __init__(self, index: _FakeIndex) -> None:
             """
@@ -227,6 +233,7 @@ def test_meilisearch_backend_get_task_fallback() -> None:
         def get_or_create_index(
             self, _name: str, _payload: dict[str, object]
         ) -> _FakeIndex:
+            """Return the configured fake index."""
             return self.index
 
         def get_index(self, _name: str) -> _FakeIndex:
@@ -278,12 +285,15 @@ def test_meilisearch_backend_get_task_fallback() -> None:
 
 
 def test_meilisearch_backend_normalize_document_id() -> None:
+    """Normalize invalid Meilisearch document IDs deterministically."""
     backend = MeilisearchBackend(client=_FakeClient(_FakeIndex()))
     assert backend._normalize_document_id("valid-id_1") == "valid-id_1"
     assert backend._normalize_document_id("invalid:{id}") != "invalid:{id}"
 
 
 def test_meilisearch_backend_search_prefers_gm_document_id() -> None:
+    """Return original GeneralManager document IDs from search hits."""
+
     class _SearchIndex(_FakeIndex):
         def search(self, _query: str, _payload: dict[str, object]) -> dict[str, object]:
             """
@@ -326,6 +336,7 @@ def test_meilisearch_backend_search_prefers_gm_document_id() -> None:
 
 
 def test_meilisearch_backend_lists_original_document_ids_by_type() -> None:
+    """List original document IDs for the requested type labels."""
     index = _FakeIndex()
     index.documents = [
         {
@@ -349,6 +360,7 @@ def test_meilisearch_backend_lists_original_document_ids_by_type() -> None:
 
 
 def test_meilisearch_backend_document_payload_reserved_keys() -> None:
+    """Preserve reserved user data keys under the nested data payload."""
     document = SearchDocument(
         id='Project:{"id": 5}',
         type="Project",
@@ -380,6 +392,7 @@ def test_meilisearch_backend_document_payload_reserved_keys() -> None:
 
 
 def test_meilisearch_backend_build_filter_expression_escapes() -> None:
+    """Escape quotes and backslashes in filter expression values."""
     expr = MeilisearchBackend._build_filter_expression(
         {"status": 'a"b\\c'},
         types=['Type"X'],
@@ -389,30 +402,38 @@ def test_meilisearch_backend_build_filter_expression_escapes() -> None:
 
 
 def test_meilisearch_backend_non_terminal_status() -> None:
+    """Ignore non-terminal task statuses when checking for failures."""
     MeilisearchBackend._raise_for_failed_task({"status": "processing"})
 
 
 def test_meilisearch_backend_wait_for_task_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Raise a timeout error when fallback task polling never completes."""
+
     class _Client:
         def __init__(self) -> None:
+            """Initialize fallback client call counters."""
             self.calls = 0
 
         def get_or_create_index(
             self, _name: str, _payload: dict[str, object]
         ) -> _FakeIndex:
+            """Return a new fake index for creation and settings calls."""
             return _FakeIndex()
 
         def get_index(self, _name: str) -> _FakeIndex:
+            """Return a new fake index for index lookup calls."""
             return _FakeIndex()
 
         def create_index(
             self, _name: str, _payload: dict[str, object]
         ) -> dict[str, int]:
+            """Return a fake create-index task UID."""
             return {"taskUid": 1}
 
         def get_task(self, _task_uid: int) -> dict[str, object]:
+            """Return a non-terminal task status for every poll."""
             self.calls += 1
             return {"status": "processing"}
 
@@ -428,6 +449,7 @@ def test_meilisearch_backend_wait_for_task_timeout(
 
 
 def test_meilisearch_backend_raises_on_failed_task() -> None:
+    """Raise SearchBackendError when a Meilisearch task fails."""
     index = _FakeIndex()
     client = _FailingClient(index)
     backend = MeilisearchBackend(client=client)
@@ -449,6 +471,7 @@ def test_meilisearch_backend_raises_on_failed_task() -> None:
 
 
 def test_meilisearch_backend_build_filter_expression_in_lookup() -> None:
+    """Build filter expressions for __in lookups."""
     expr = MeilisearchBackend._build_filter_expression(
         {"status__in": ["ready", "paused"], "team": "alpha"},
         types=None,
@@ -459,6 +482,7 @@ def test_meilisearch_backend_build_filter_expression_in_lookup() -> None:
 
 
 def test_meilisearch_backend_build_filter_expression_groups() -> None:
+    """Build grouped OR filter expressions with type restrictions."""
     expr = MeilisearchBackend._build_filter_expression(
         [{"status": "ready"}, {"status": "paused"}],
         types=["TypeA", "TypeB"],
@@ -470,12 +494,16 @@ def test_meilisearch_backend_build_filter_expression_groups() -> None:
 
 
 def test_meilisearch_backend_build_filter_expression_empty() -> None:
+    """Return no filter expression when no filters or types are provided."""
     assert MeilisearchBackend._build_filter_expression(None, None) is None
 
 
 def test_meilisearch_error_helpers() -> None:
+    """Classify Meilisearch error helpers by code and HTTP status."""
+
     class _Error(Exception):
         def __init__(self, code: str | None, status: int | None) -> None:
+            """Store fake Meilisearch error code and status values."""
             self.error_code = code
             self.status_code = status
 

--- a/tests/unit/test_read_only_interface.py
+++ b/tests/unit/test_read_only_interface.py
@@ -60,6 +60,7 @@ class FakeQuerySet:
     """
 
     def __init__(self, items: list[FakeInstance]) -> None:
+        """Store fake queryset items in iteration order."""
         self._items = items
 
     def first(self):
@@ -69,12 +70,15 @@ class FakeQuerySet:
         return self._items[0] if self._items else None
 
     def __iter__(self):
+        """Return an iterator over the stored fake instances."""
         return iter(self._items)
 
     def __len__(self):
+        """Return the number of stored fake instances."""
         return len(self._items)
 
     def __bool__(self):
+        """Return whether the fake queryset contains any instances."""
         return bool(self._items)
 
 
@@ -121,6 +125,7 @@ class FakeManager:
         """
 
         def matches(inst: FakeInstance) -> bool:
+            """Return whether the fake instance matches all lookup values."""
             return all(getattr(inst, key) == value for key, value in kwargs.items())
 
         filtered = [inst for inst in self._instances if matches(inst)]
@@ -133,15 +138,19 @@ class UnsafeJsonValue:
     """
 
     def __init__(self, value: str) -> None:
+        """Store the string value used for comparisons and hashing."""
         self.value = value
 
     def __str__(self) -> str:
+        """Return the wrapped value as a string."""
         return self.value
 
     def __eq__(self, other: object) -> bool:
+        """Compare unsafe JSON values by wrapped value."""
         return isinstance(other, UnsafeJsonValue) and other.value == self.value
 
     def __hash__(self) -> int:
+        """Return the hash of the wrapped string value."""
         return hash(self.value)
 
 
@@ -158,6 +167,7 @@ class FakeField:
         primary_key: bool = False,
         column: str | None = None,
     ) -> None:
+        """Store fake field metadata used by read-only sync tests."""
         self.name = name
         self.editable = editable
         self.primary_key = primary_key
@@ -747,6 +757,7 @@ class SyncDataTests(SimpleTestCase):
         active_query_before_atomic = []
 
         def filter_spy(**kwargs):
+            """Record active-row queries made before the atomic fallback path."""
             if kwargs == {"is_active": True} and not self.atomic_mock.called:
                 active_query_before_atomic.append(kwargs)
             return original_filter(**kwargs)
@@ -812,6 +823,7 @@ class SyncDataTests(SimpleTestCase):
 
                 @staticmethod
                 def get_fields() -> list[object]:
+                    """Return no related fields for the broken query model."""
                     return []
 
         class BrokenQueryManager:
@@ -879,6 +891,8 @@ class SyncDataTests(SimpleTestCase):
 
 class SyncDataMetadataValidationTests(SimpleTestCase):
     def test_missing_binding_raises(self):
+        """Raise when a read-only interface is missing manager/model metadata."""
+
         class IncompleteInterface(ReadOnlyInterface):
             pass
 
@@ -1164,6 +1178,7 @@ class SyncDataRelatedInterfaceTests(SimpleTestCase):
 
 class SystemCheckHookTests(SimpleTestCase):
     def test_get_system_checks_invokes_capability(self):
+        """Build system check hooks that call schema validation."""
         capability = ReadOnlyManagementCapability()
         DummyInterface._parent_class = DummyManager
         hooks = capability.get_system_checks(DummyInterface)
@@ -1241,6 +1256,8 @@ class ReadOnlyLifecycleCapabilityTests(SimpleTestCase):
         GeneralManagerMeta.read_only_classes = self._original
 
     def test_pre_create_enforces_soft_delete_and_base_model(self):
+        """Force read-only managers onto soft-delete base model behavior."""
+
         class DummyInterface(ReadOnlyInterface):
             pass
 
@@ -1266,6 +1283,7 @@ class ReadOnlyLifecycleCapabilityTests(SimpleTestCase):
         )
 
     def test_post_create_registers_read_only_class(self):
+        """Register created read-only manager classes in global metadata."""
         from general_manager.manager.meta import GeneralManagerMeta
 
         class DummyManager:

--- a/tests/unit/test_search_auto_reindex.py
+++ b/tests/unit/test_search_auto_reindex.py
@@ -6,7 +6,7 @@ from general_manager import apps as gm_apps
 
 
 class SearchAutoReindexRemovedTests(SimpleTestCase):
-    def test_request_started_auto_reindex_helpers_are_removed(self) -> None:
+    def test_legacy_auto_reindex_helpers_are_removed(self) -> None:
         assert not hasattr(gm_apps, "_SEARCH_REINDEXED")
         assert not hasattr(gm_apps, "_auto_reindex_search")
         assert not hasattr(gm_apps, "install_search_auto_reindex")

--- a/tests/unit/test_search_auto_reindex.py
+++ b/tests/unit/test_search_auto_reindex.py
@@ -7,6 +7,7 @@ from general_manager import apps as gm_apps
 
 class SearchAutoReindexRemovedTests(SimpleTestCase):
     def test_legacy_auto_reindex_helpers_are_removed(self) -> None:
+        """Keep removed request-triggered auto-reindex helpers unavailable."""
         assert not hasattr(gm_apps, "_SEARCH_REINDEXED")
         assert not hasattr(gm_apps, "_auto_reindex_search")
         assert not hasattr(gm_apps, "install_search_auto_reindex")
@@ -15,6 +16,7 @@ class SearchAutoReindexRemovedTests(SimpleTestCase):
 
 class DevSearchPrefixTests(TestCase):
     def test_dev_search_prefix_match(self) -> None:
+        """Match documents when the query is a prefix of an indexed token."""
         from general_manager.search.backends.dev import DevSearchBackend
         from general_manager.search.backend import SearchDocument
 

--- a/tests/unit/test_search_auto_reindex.py
+++ b/tests/unit/test_search_auto_reindex.py
@@ -1,52 +1,19 @@
 from __future__ import annotations
 
-from unittest.mock import patch
-
-from django.core.signals import request_started
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase
 
 from general_manager import apps as gm_apps
-from general_manager.apps import GeneralmanagerConfig
 
 
-class SearchAutoReindexTests(TestCase):
-    def tearDown(self) -> None:
-        request_started.disconnect(dispatch_uid="general_manager_auto_reindex_search")
-        gm_apps._SEARCH_REINDEXED = False
-        super().tearDown()
-
-    @override_settings(GENERAL_MANAGER={"SEARCH_AUTO_REINDEX": True}, DEBUG=True)
-    def test_auto_reindex_runs_once(self) -> None:
-        gm_apps._SEARCH_REINDEXED = False
-        with patch("general_manager.apps.call_command") as call_command:
-            GeneralmanagerConfig.install_search_auto_reindex()
-            request_started.send(
-                sender=self.__class__, environ={"PATH_INFO": "/graphql/"}
-            )
-            request_started.send(
-                sender=self.__class__, environ={"PATH_INFO": "/graphql/"}
-            )
-
-            call_command.assert_called_once_with("search_index", reindex=True)
-
-    @override_settings(
-        GENERAL_MANAGER={"SEARCH_AUTO_REINDEX": True},
-        DEBUG=True,
-        GRAPHQL_URL="graphql/",
-    )
-    def test_auto_reindex_skips_other_paths(self) -> None:
-        gm_apps._SEARCH_REINDEXED = False
-        with patch("general_manager.apps.call_command") as call_command:
-            GeneralmanagerConfig.install_search_auto_reindex()
-            request_started.send(
-                sender=self.__class__, environ={"PATH_INFO": "/admin/"}
-            )
-
-            call_command.assert_not_called()
+class SearchAutoReindexRemovedTests(SimpleTestCase):
+    def test_request_started_auto_reindex_helpers_are_removed(self) -> None:
+        assert not hasattr(gm_apps, "_SEARCH_REINDEXED")
+        assert not hasattr(gm_apps, "_auto_reindex_search")
+        assert not hasattr(gm_apps, "install_search_auto_reindex")
+        assert not hasattr(gm_apps.GeneralmanagerConfig, "install_search_auto_reindex")
 
 
 class DevSearchPrefixTests(TestCase):
-    @override_settings(GENERAL_MANAGER={"SEARCH_AUTO_REINDEX": True}, DEBUG=True)
     def test_dev_search_prefix_match(self) -> None:
         from general_manager.search.backends.dev import DevSearchBackend
         from general_manager.search.backend import SearchDocument

--- a/tests/unit/test_search_backend_stubs.py
+++ b/tests/unit/test_search_backend_stubs.py
@@ -10,6 +10,7 @@ from general_manager.search.backends.typesense import TypesenseBackend
 
 class SearchBackendStubTests(SimpleTestCase):
     def test_opensearch_backend_methods_raise(self) -> None:
+        """Raise not-implemented errors for every OpenSearch stub method."""
         backend = object.__new__(OpenSearchBackend)
         with pytest.raises(SearchBackendNotImplementedError):
             OpenSearchBackend.__init__(backend)

--- a/tests/unit/test_search_backend_stubs.py
+++ b/tests/unit/test_search_backend_stubs.py
@@ -20,6 +20,8 @@ class SearchBackendStubTests(SimpleTestCase):
         with pytest.raises(SearchBackendNotImplementedError):
             backend.delete("index", [])
         with pytest.raises(SearchBackendNotImplementedError):
+            backend.list_document_ids("index")
+        with pytest.raises(SearchBackendNotImplementedError):
             backend.search("index", "query")
 
     def test_typesense_backend_methods_raise(self) -> None:
@@ -37,5 +39,7 @@ class SearchBackendStubTests(SimpleTestCase):
             backend.upsert("index", [])
         with pytest.raises(SearchBackendNotImplementedError):
             backend.delete("index", [])
+        with pytest.raises(SearchBackendNotImplementedError):
+            backend.list_document_ids("index")
         with pytest.raises(SearchBackendNotImplementedError):
             backend.search("index", "query")

--- a/tests/unit/test_search_dev_backend.py
+++ b/tests/unit/test_search_dev_backend.py
@@ -55,3 +55,10 @@ class DevSearchBackendTests(SimpleTestCase):
     def test_search_sorting(self) -> None:
         result = self.backend.search("global", "", sort_by="name", sort_desc=True)
         assert result.hits[0].data["name"] == "Beta Project"
+
+    def test_list_document_ids_filters_by_type(self) -> None:
+        assert self.backend.list_document_ids("global", types=["Project"]) == {
+            "Project:1",
+            "Project:2",
+        }
+        assert self.backend.list_document_ids("global", types=["OtherProject"]) == set()

--- a/tests/unit/test_search_dev_backend.py
+++ b/tests/unit/test_search_dev_backend.py
@@ -53,10 +53,12 @@ class DevSearchBackendTests(SimpleTestCase):
         assert result.total == 2
 
     def test_search_sorting(self) -> None:
+        """Sort search results by a stored document field."""
         result = self.backend.search("global", "", sort_by="name", sort_desc=True)
         assert result.hits[0].data["name"] == "Beta Project"
 
     def test_list_document_ids_filters_by_type(self) -> None:
+        """Return indexed document IDs restricted to requested type labels."""
         assert self.backend.list_document_ids("global", types=["Project"]) == {
             "Project:1",
             "Project:2",

--- a/tests/unit/test_search_indexer.py
+++ b/tests/unit/test_search_indexer.py
@@ -171,6 +171,7 @@ class SearchIndexerTests(SimpleTestCase):
         assert result.total == 0
 
     def test_indexer_reindex_manager(self) -> None:
+        """Reindex all configured documents for a manager class."""
         backend = DevSearchBackend()
         indexer = SearchIndexer(backend)
 
@@ -181,6 +182,7 @@ class SearchIndexerTests(SimpleTestCase):
     def test_indexer_reindex_manager_index_deletes_stale_same_type_documents(
         self,
     ) -> None:
+        """Delete stale same-type documents during manager/index reindexing."""
         backend = DevSearchBackend()
         indexer = SearchIndexer(backend)
         backend.ensure_index("global", {})
@@ -219,6 +221,7 @@ class SearchIndexerTests(SimpleTestCase):
 
 
 def test_indexer_reindex_manager_index_limits_backend_writes() -> None:
+    """Reindex only the requested index for multi-index managers."""
     GeneralmanagerConfig.initialize_general_manager_classes(
         [MultiIndexProject], [MultiIndexProject]
     )
@@ -233,9 +236,11 @@ def test_indexer_reindex_manager_index_limits_backend_writes() -> None:
 
 class SearchIndexerSignalStateTests(TestCase):
     def setUp(self) -> None:
+        """Initialize manager classes for signal state tests."""
         GeneralmanagerConfig.initialize_general_manager_classes([Project], [Project])
 
     def test_post_change_marks_search_state_dirty(self) -> None:
+        """Mark search state dirty after create or update signals."""
         from general_manager.search.indexer import _handle_search_post_change
 
         _handle_search_post_change(
@@ -246,6 +251,7 @@ class SearchIndexerSignalStateTests(TestCase):
         assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED
 
     def test_pre_delete_marks_search_state_dirty(self) -> None:
+        """Mark search state dirty before delete signals."""
         from general_manager.search.indexer import _handle_search_pre_delete
 
         _handle_search_pre_delete(
@@ -256,6 +262,7 @@ class SearchIndexerSignalStateTests(TestCase):
         assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED
 
     def test_post_change_dispatches_when_dirty_marker_fails(self) -> None:
+        """Dispatch immediate indexing even when dirty marking fails."""
         from general_manager.search.indexer import _handle_search_post_change
 
         with (
@@ -272,6 +279,7 @@ class SearchIndexerSignalStateTests(TestCase):
         dispatch.assert_called_once()
 
     def test_pre_delete_dispatches_when_dirty_marker_fails(self) -> None:
+        """Dispatch immediate deletion even when dirty marking fails."""
         from general_manager.search.indexer import _handle_search_pre_delete
 
         with (

--- a/tests/unit/test_search_indexer.py
+++ b/tests/unit/test_search_indexer.py
@@ -106,6 +106,20 @@ class Project(GeneralManager):
             }
 
 
+class MultiIndexProjectInterface(ProjectInterface):
+    pass
+
+
+class MultiIndexProject(GeneralManager):
+    Interface = MultiIndexProjectInterface
+
+    class SearchConfig:
+        indexes: ClassVar[list[IndexConfig]] = [
+            IndexConfig(name="global", fields=["name"], filters=["status"]),
+            IndexConfig(name="private", fields=["status"], filters=["status"]),
+        ]
+
+
 class SearchIndexerTests(SimpleTestCase):
     def setUp(self) -> None:
         """
@@ -156,3 +170,16 @@ class SearchIndexerTests(SimpleTestCase):
         indexer.reindex_manager(Project)
         result = backend.search("global", "Alpha", filters={"status": "public"})
         assert result.total == 1
+
+
+def test_indexer_reindex_manager_index_limits_backend_writes() -> None:
+    GeneralmanagerConfig.initialize_general_manager_classes(
+        [MultiIndexProject], [MultiIndexProject]
+    )
+    backend = DevSearchBackend()
+    indexer = SearchIndexer(backend)
+
+    indexer.reindex_manager_index(MultiIndexProject, "global")
+
+    assert backend.search("global", "Alpha", filters={"status": "public"}).total == 1
+    assert backend.search("private", "public", filters={"status": "public"}).total == 0

--- a/tests/unit/test_search_indexer.py
+++ b/tests/unit/test_search_indexer.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from typing import ClassVar
+from unittest.mock import patch
 
 from django.test import SimpleTestCase, TestCase
 
 from general_manager.apps import GeneralmanagerConfig
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.input import Input
+from general_manager.search.backend import SearchDocument
 from general_manager.search.backends.dev import DevSearchBackend
 from general_manager.search.config import IndexConfig
 from general_manager.search.indexer import SearchIndexer
@@ -14,6 +16,7 @@ from general_manager.search.models import (
     SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
     SearchIndexState,
 )
+from general_manager.search.utils import build_document_id
 from tests.utils.simple_manager_interface import BaseTestInterface, SimpleBucket
 
 
@@ -175,6 +178,45 @@ class SearchIndexerTests(SimpleTestCase):
         result = backend.search("global", "Alpha", filters={"status": "public"})
         assert result.total == 1
 
+    def test_indexer_reindex_manager_index_deletes_stale_same_type_documents(
+        self,
+    ) -> None:
+        backend = DevSearchBackend()
+        indexer = SearchIndexer(backend)
+        backend.ensure_index("global", {})
+        stale_project_id = build_document_id("Project", {"id": 999})
+        other_type_id = build_document_id("OtherProject", {"id": 1})
+        backend.upsert(
+            "global",
+            [
+                SearchDocument(
+                    id=stale_project_id,
+                    type="Project",
+                    identification={"id": 999},
+                    index="global",
+                    data={"name": "Stale Project", "status": "public"},
+                    field_boosts={},
+                ),
+                SearchDocument(
+                    id=other_type_id,
+                    type="OtherProject",
+                    identification={"id": 1},
+                    index="global",
+                    data={"name": "Other Project", "status": "public"},
+                    field_boosts={},
+                ),
+            ],
+        )
+
+        indexed = indexer.reindex_manager_index(Project, "global")
+
+        assert indexed == 2
+        existing_ids = backend.list_document_ids("global")
+        assert stale_project_id not in existing_ids
+        assert build_document_id("Project", {"id": 1}) in existing_ids
+        assert build_document_id("Project", {"id": 2}) in existing_ids
+        assert other_type_id in existing_ids
+
 
 def test_indexer_reindex_manager_index_limits_backend_writes() -> None:
     GeneralmanagerConfig.initialize_general_manager_classes(
@@ -212,3 +254,35 @@ class SearchIndexerSignalStateTests(TestCase):
 
         state = SearchIndexState.objects.get(index_name="global")
         assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED
+
+    def test_post_change_dispatches_when_dirty_marker_fails(self) -> None:
+        from general_manager.search.indexer import _handle_search_post_change
+
+        with (
+            patch(
+                "general_manager.search.indexer.mark_search_indexes_dirty",
+                side_effect=RuntimeError("state store unavailable"),
+            ),
+            patch("general_manager.search.indexer.dispatch_index_update") as dispatch,
+        ):
+            _handle_search_post_change(
+                sender=Project, instance=Project(id=1), action="update"
+            )
+
+        dispatch.assert_called_once()
+
+    def test_pre_delete_dispatches_when_dirty_marker_fails(self) -> None:
+        from general_manager.search.indexer import _handle_search_pre_delete
+
+        with (
+            patch(
+                "general_manager.search.indexer.mark_search_indexes_dirty",
+                side_effect=RuntimeError("state store unavailable"),
+            ),
+            patch("general_manager.search.indexer.dispatch_index_update") as dispatch,
+        ):
+            _handle_search_pre_delete(
+                sender=Project, instance=Project(id=1), action="delete"
+            )
+
+        dispatch.assert_called_once()

--- a/tests/unit/test_search_indexer.py
+++ b/tests/unit/test_search_indexer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from general_manager.apps import GeneralmanagerConfig
 from general_manager.manager.general_manager import GeneralManager
@@ -10,6 +10,10 @@ from general_manager.manager.input import Input
 from general_manager.search.backends.dev import DevSearchBackend
 from general_manager.search.config import IndexConfig
 from general_manager.search.indexer import SearchIndexer
+from general_manager.search.models import (
+    SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+    SearchIndexState,
+)
 from tests.utils.simple_manager_interface import BaseTestInterface, SimpleBucket
 
 
@@ -183,3 +187,28 @@ def test_indexer_reindex_manager_index_limits_backend_writes() -> None:
 
     assert backend.search("global", "Alpha", filters={"status": "public"}).total == 1
     assert backend.search("private", "public", filters={"status": "public"}).total == 0
+
+
+class SearchIndexerSignalStateTests(TestCase):
+    def setUp(self) -> None:
+        GeneralmanagerConfig.initialize_general_manager_classes([Project], [Project])
+
+    def test_post_change_marks_search_state_dirty(self) -> None:
+        from general_manager.search.indexer import _handle_search_post_change
+
+        _handle_search_post_change(
+            sender=Project, instance=Project(id=1), action="update"
+        )
+
+        state = SearchIndexState.objects.get(index_name="global")
+        assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED
+
+    def test_pre_delete_marks_search_state_dirty(self) -> None:
+        from general_manager.search.indexer import _handle_search_pre_delete
+
+        _handle_search_pre_delete(
+            sender=Project, instance=Project(id=1), action="delete"
+        )
+
+        state = SearchIndexState.objects.get(index_name="global")
+        assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED

--- a/tests/unit/test_search_reconcile_command.py
+++ b/tests/unit/test_search_reconcile_command.py
@@ -10,6 +10,7 @@ from django.test import SimpleTestCase
 
 class SearchReconcileCommandTests(SimpleTestCase):
     def test_search_reconcile_once_runs_service(self) -> None:
+        """Run one reconciliation sweep when --once is provided."""
         stdout = StringIO()
         with patch(
             "general_manager.management.commands.search_reconcile.reconcile_search_indexes"
@@ -24,6 +25,7 @@ class SearchReconcileCommandTests(SimpleTestCase):
         assert "Reconciled 1 search index states" in stdout.getvalue()
 
     def test_search_reconcile_force_passes_force(self) -> None:
+        """Pass the force flag through to the reconciliation service."""
         with patch(
             "general_manager.management.commands.search_reconcile.reconcile_search_indexes"
         ) as reconcile:
@@ -36,6 +38,7 @@ class SearchReconcileCommandTests(SimpleTestCase):
         reconcile.assert_called_once_with(force=True, max_states=None)
 
     def test_search_reconcile_max_states_passes_limit(self) -> None:
+        """Pass a positive max-state limit through to the service."""
         with patch(
             "general_manager.management.commands.search_reconcile.reconcile_search_indexes"
         ) as reconcile:
@@ -48,6 +51,7 @@ class SearchReconcileCommandTests(SimpleTestCase):
         reconcile.assert_called_once_with(force=False, max_states=2)
 
     def test_search_reconcile_rejects_non_positive_max_states(self) -> None:
+        """Reject zero and negative max-state limits before service execution."""
         for max_states in ("0", "-1"):
             with (
                 self.subTest(max_states=max_states),
@@ -65,17 +69,21 @@ class SearchReconcileCommandTests(SimpleTestCase):
             reconcile.assert_not_called()
 
     def test_search_reconcile_rejects_conflicting_modes(self) -> None:
+        """Reject mutually exclusive once and watch modes used together."""
         with self.assertRaises(CommandError):
             call_command("search_reconcile", "--once", "--watch")
 
     def test_search_reconcile_rejects_missing_mode(self) -> None:
+        """Reject command execution when no run mode is provided."""
         with self.assertRaises(CommandError):
             call_command("search_reconcile")
 
     def test_search_reconcile_watch_repeats_until_interrupted(self) -> None:
+        """Keep watching until the sleep loop is interrupted."""
         calls = []
 
         def _reconcile(*, force=False, max_states=None):
+            """Return a fake reconciliation result and record the sweep."""
             del force, max_states
             result = type(
                 "Result",

--- a/tests/unit/test_search_reconcile_command.py
+++ b/tests/unit/test_search_reconcile_command.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import SimpleTestCase
+
+
+class SearchReconcileCommandTests(SimpleTestCase):
+    def test_search_reconcile_once_runs_service(self) -> None:
+        stdout = StringIO()
+        with patch(
+            "general_manager.management.commands.search_reconcile.reconcile_search_indexes"
+        ) as reconcile:
+            reconcile.return_value.reconciled = 1
+            reconcile.return_value.failed = 0
+            reconcile.return_value.documents = 3
+
+            call_command("search_reconcile", "--once", stdout=stdout)
+
+        reconcile.assert_called_once_with(force=False, max_states=None)
+        assert "Reconciled 1 search index states" in stdout.getvalue()
+
+    def test_search_reconcile_force_passes_force(self) -> None:
+        with patch(
+            "general_manager.management.commands.search_reconcile.reconcile_search_indexes"
+        ) as reconcile:
+            reconcile.return_value.reconciled = 0
+            reconcile.return_value.failed = 0
+            reconcile.return_value.documents = 0
+
+            call_command("search_reconcile", "--once", "--force")
+
+        reconcile.assert_called_once_with(force=True, max_states=None)
+
+    def test_search_reconcile_max_states_passes_limit(self) -> None:
+        with patch(
+            "general_manager.management.commands.search_reconcile.reconcile_search_indexes"
+        ) as reconcile:
+            reconcile.return_value.reconciled = 0
+            reconcile.return_value.failed = 0
+            reconcile.return_value.documents = 0
+
+            call_command("search_reconcile", "--once", "--max-states", "2")
+
+        reconcile.assert_called_once_with(force=False, max_states=2)
+
+    def test_search_reconcile_watch_repeats_until_interrupted(self) -> None:
+        calls = []
+
+        def _reconcile(*, force=False, max_states=None):
+            del force, max_states
+            result = type(
+                "Result",
+                (),
+                {"reconciled": 0, "failed": 0, "documents": 0},
+            )()
+            calls.append(result)
+            return result
+
+        with (
+            patch(
+                "general_manager.management.commands.search_reconcile.reconcile_search_indexes",
+                side_effect=_reconcile,
+            ),
+            patch(
+                "general_manager.management.commands.search_reconcile.time.sleep",
+                side_effect=KeyboardInterrupt,
+            ),
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            call_command("search_reconcile", "--watch", "--interval", "1")
+
+        assert len(calls) == 1

--- a/tests/unit/test_search_reconcile_command.py
+++ b/tests/unit/test_search_reconcile_command.py
@@ -4,6 +4,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import SimpleTestCase
 
 
@@ -45,6 +46,31 @@ class SearchReconcileCommandTests(SimpleTestCase):
             call_command("search_reconcile", "--once", "--max-states", "2")
 
         reconcile.assert_called_once_with(force=False, max_states=2)
+
+    def test_search_reconcile_rejects_non_positive_max_states(self) -> None:
+        for max_states in ("0", "-1"):
+            with (
+                self.subTest(max_states=max_states),
+                patch(
+                    "general_manager.management.commands.search_reconcile.reconcile_search_indexes"
+                ) as reconcile,
+                self.assertRaises(CommandError),
+            ):
+                call_command(
+                    "search_reconcile",
+                    "--once",
+                    "--max-states",
+                    max_states,
+                )
+            reconcile.assert_not_called()
+
+    def test_search_reconcile_rejects_conflicting_modes(self) -> None:
+        with self.assertRaises(CommandError):
+            call_command("search_reconcile", "--once", "--watch")
+
+    def test_search_reconcile_rejects_missing_mode(self) -> None:
+        with self.assertRaises(CommandError):
+            call_command("search_reconcile")
 
     def test_search_reconcile_watch_repeats_until_interrupted(self) -> None:
         calls = []

--- a/tests/unit/test_search_reconciliation.py
+++ b/tests/unit/test_search_reconciliation.py
@@ -34,10 +34,12 @@ class ReconcileProjectInterface(BaseTestInterface):
 
     @classmethod
     def get_attribute_types(cls):
+        """Return search-visible attribute type metadata."""
         return {"name": {"type": str}, "status": {"type": str}}
 
     @classmethod
     def get_attributes(cls):
+        """Return static attribute extractors for reconciliation tests."""
         return {
             "name": lambda _interface: "Alpha",
             "status": lambda _interface: "public",
@@ -62,6 +64,7 @@ class ReconcileProject(GeneralManager):
 
 class SearchReconciliationDiscoveryTests(TestCase):
     def setUp(self) -> None:
+        """Register the searchable manager class for discovery tests."""
         self._original_all_classes = list(GeneralManagerMeta.all_classes)
         GeneralManagerMeta.all_classes = [ReconcileProject]
         GeneralmanagerConfig.initialize_general_manager_classes(
@@ -69,13 +72,16 @@ class SearchReconciliationDiscoveryTests(TestCase):
         )
 
     def tearDown(self) -> None:
+        """Restore the global manager class registry after each test."""
         GeneralManagerMeta.all_classes = self._original_all_classes
         super().tearDown()
 
     def test_manager_import_path_is_stable(self) -> None:
+        """Build a stable import path for a manager class."""
         assert manager_import_path(ReconcileProject).endswith(".ReconcileProject")
 
     def test_iter_search_index_targets_includes_fingerprint(self) -> None:
+        """Discover search targets with their schema fingerprints."""
         targets = list(iter_search_index_targets())
 
         assert len(targets) == 1
@@ -86,6 +92,7 @@ class SearchReconciliationDiscoveryTests(TestCase):
         assert len(target.schema_fingerprint) == 64
 
     def test_fingerprint_changes_when_index_config_changes(self) -> None:
+        """Change schema fingerprints when index configuration changes."""
         original = build_search_schema_fingerprint(
             ReconcileProject,
             ReconcileProject.SearchConfig.indexes[0],
@@ -101,6 +108,7 @@ class SearchReconciliationDiscoveryTests(TestCase):
         assert original != changed
 
     def test_ensure_states_marks_missing_targets_dirty_for_initialization(self) -> None:
+        """Create missing state rows as dirty initialization work."""
         result = ensure_search_index_states()
 
         assert result.created == 1
@@ -109,6 +117,7 @@ class SearchReconciliationDiscoveryTests(TestCase):
         assert state.dirty_since is not None
 
     def test_ensure_states_marks_schema_changes_dirty(self) -> None:
+        """Mark existing state dirty when the stored fingerprint changes."""
         ensure_search_index_states()
         state = SearchIndexState.objects.get()
         state.schema_fingerprint = "outdated"
@@ -134,6 +143,7 @@ class SearchReconciliationDiscoveryTests(TestCase):
 
 class SearchDirtyMarkerTests(TestCase):
     def setUp(self) -> None:
+        """Register the searchable manager class for dirty marker tests."""
         self._original_all_classes = list(GeneralManagerMeta.all_classes)
         GeneralManagerMeta.all_classes = [ReconcileProject]
         GeneralmanagerConfig.initialize_general_manager_classes(
@@ -141,10 +151,12 @@ class SearchDirtyMarkerTests(TestCase):
         )
 
     def tearDown(self) -> None:
+        """Restore the global manager class registry after each test."""
         GeneralManagerMeta.all_classes = self._original_all_classes
         super().tearDown()
 
     def test_mark_dirty_creates_state_for_all_manager_indexes(self) -> None:
+        """Create and dirty state rows for all configured manager indexes."""
         marked = mark_search_indexes_dirty(
             ReconcileProject,
             reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
@@ -159,6 +171,7 @@ class SearchDirtyMarkerTests(TestCase):
         assert state.dirty_since is not None
 
     def test_mark_dirty_preserves_existing_dirty_since(self) -> None:
+        """Keep the original dirty timestamp when marking dirty again."""
         mark_search_indexes_dirty(
             ReconcileProject,
             reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
@@ -177,6 +190,7 @@ class SearchDirtyMarkerTests(TestCase):
 
 class SearchReconcileEngineTests(TestCase):
     def setUp(self) -> None:
+        """Register the searchable manager class for reconcile engine tests."""
         self._original_all_classes = list(GeneralManagerMeta.all_classes)
         GeneralManagerMeta.all_classes = [ReconcileProject]
         GeneralmanagerConfig.initialize_general_manager_classes(
@@ -184,10 +198,12 @@ class SearchReconcileEngineTests(TestCase):
         )
 
     def tearDown(self) -> None:
+        """Restore the global manager class registry after each test."""
         GeneralManagerMeta.all_classes = self._original_all_classes
         super().tearDown()
 
     def test_reconcile_skips_when_nothing_dirty(self) -> None:
+        """Skip backend writes when all search states are clean."""
         ensure_search_index_states()
         state = SearchIndexState.objects.get()
         state.clear_dirty()
@@ -202,6 +218,7 @@ class SearchReconcileEngineTests(TestCase):
         indexer.assert_not_called()
 
     def test_reconcile_reindexes_dirty_state_and_clears_it(self) -> None:
+        """Reindex dirty states and clear their dirty and claim fields."""
         ensure_search_index_states()
 
         from general_manager.search.reconciliation import reconcile_search_indexes
@@ -223,6 +240,7 @@ class SearchReconcileEngineTests(TestCase):
         )
 
     def test_reconcile_keeps_state_dirty_after_failure(self) -> None:
+        """Keep failed states dirty and record the backend error."""
         ensure_search_index_states()
 
         from general_manager.search.reconciliation import reconcile_search_indexes
@@ -241,6 +259,7 @@ class SearchReconcileEngineTests(TestCase):
         assert "backend down" in state.last_error
 
     def test_force_reconcile_marks_clean_state_dirty_and_reindexes(self) -> None:
+        """Force clean states back through reconciliation."""
         ensure_search_index_states()
         state = SearchIndexState.objects.get()
         state.clear_dirty()
@@ -255,6 +274,7 @@ class SearchReconcileEngineTests(TestCase):
         assert result.reconciled == 1
 
     def test_reconcile_skips_actively_claimed_dirty_state(self) -> None:
+        """Skip dirty states claimed by another active worker."""
         ensure_search_index_states()
         state = SearchIndexState.objects.get()
         state.claim_token = uuid.uuid4().hex
@@ -271,6 +291,7 @@ class SearchReconcileEngineTests(TestCase):
         indexer.assert_not_called()
 
     def test_reconcile_reclaims_expired_dirty_state(self) -> None:
+        """Reclaim dirty states whose worker claim has expired."""
         ensure_search_index_states()
         state = SearchIndexState.objects.get()
         state.claim_token = uuid.uuid4().hex

--- a/tests/unit/test_search_reconciliation.py
+++ b/tests/unit/test_search_reconciliation.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import uuid
+from datetime import timedelta
 from typing import ClassVar
+from unittest.mock import patch
 
 from django.test import TestCase
+from django.utils import timezone
 
 from general_manager.apps import GeneralmanagerConfig
 from general_manager.manager.general_manager import GeneralManager
@@ -169,3 +173,116 @@ class SearchDirtyMarkerTests(TestCase):
         state.refresh_from_db()
 
         assert state.dirty_since == original_dirty_since
+
+
+class SearchReconcileEngineTests(TestCase):
+    def setUp(self) -> None:
+        self._original_all_classes = list(GeneralManagerMeta.all_classes)
+        GeneralManagerMeta.all_classes = [ReconcileProject]
+        GeneralmanagerConfig.initialize_general_manager_classes(
+            [ReconcileProject], [ReconcileProject]
+        )
+
+    def tearDown(self) -> None:
+        GeneralManagerMeta.all_classes = self._original_all_classes
+        super().tearDown()
+
+    def test_reconcile_skips_when_nothing_dirty(self) -> None:
+        ensure_search_index_states()
+        state = SearchIndexState.objects.get()
+        state.clear_dirty()
+
+        from general_manager.search.reconciliation import reconcile_search_indexes
+
+        with patch("general_manager.search.indexer.SearchIndexer") as indexer:
+            result = reconcile_search_indexes()
+
+        assert result.reconciled == 0
+        assert result.skipped == 1
+        indexer.assert_not_called()
+
+    def test_reconcile_reindexes_dirty_state_and_clears_it(self) -> None:
+        ensure_search_index_states()
+
+        from general_manager.search.reconciliation import reconcile_search_indexes
+
+        with patch("general_manager.search.indexer.SearchIndexer") as indexer:
+            indexer.return_value.reindex_manager_index.return_value = 2
+
+            result = reconcile_search_indexes()
+
+        assert result.reconciled == 1
+        assert result.documents == 2
+        state = SearchIndexState.objects.get()
+        assert state.dirty_since is None
+        assert state.last_reconciled_at is not None
+        assert state.claim_token == ""
+        indexer.return_value.reindex_manager_index.assert_called_once_with(
+            ReconcileProject,
+            "global",
+        )
+
+    def test_reconcile_keeps_state_dirty_after_failure(self) -> None:
+        ensure_search_index_states()
+
+        from general_manager.search.reconciliation import reconcile_search_indexes
+
+        with patch("general_manager.search.indexer.SearchIndexer") as indexer:
+            indexer.return_value.reindex_manager_index.side_effect = RuntimeError(
+                "backend down"
+            )
+
+            result = reconcile_search_indexes()
+
+        assert result.failed == 1
+        state = SearchIndexState.objects.get()
+        assert state.dirty_since is not None
+        assert state.claim_token == ""
+        assert "backend down" in state.last_error
+
+    def test_force_reconcile_marks_clean_state_dirty_and_reindexes(self) -> None:
+        ensure_search_index_states()
+        state = SearchIndexState.objects.get()
+        state.clear_dirty()
+
+        from general_manager.search.reconciliation import reconcile_search_indexes
+
+        with patch("general_manager.search.indexer.SearchIndexer") as indexer:
+            indexer.return_value.reindex_manager_index.return_value = 1
+
+            result = reconcile_search_indexes(force=True)
+
+        assert result.reconciled == 1
+
+    def test_reconcile_skips_actively_claimed_dirty_state(self) -> None:
+        ensure_search_index_states()
+        state = SearchIndexState.objects.get()
+        state.claim_token = uuid.uuid4().hex
+        state.claim_expires_at = timezone.now() + timedelta(minutes=5)
+        state.save(update_fields=["claim_token", "claim_expires_at", "updated_at"])
+
+        from general_manager.search.reconciliation import reconcile_search_indexes
+
+        with patch("general_manager.search.indexer.SearchIndexer") as indexer:
+            result = reconcile_search_indexes()
+
+        assert result.claimed == 0
+        assert result.reconciled == 0
+        indexer.assert_not_called()
+
+    def test_reconcile_reclaims_expired_dirty_state(self) -> None:
+        ensure_search_index_states()
+        state = SearchIndexState.objects.get()
+        state.claim_token = uuid.uuid4().hex
+        state.claim_expires_at = timezone.now() - timedelta(seconds=1)
+        state.save(update_fields=["claim_token", "claim_expires_at", "updated_at"])
+
+        from general_manager.search.reconciliation import reconcile_search_indexes
+
+        with patch("general_manager.search.indexer.SearchIndexer") as indexer:
+            indexer.return_value.reindex_manager_index.return_value = 1
+
+            result = reconcile_search_indexes()
+
+        assert result.claimed == 1
+        assert result.reconciled == 1

--- a/tests/unit/test_search_reconciliation.py
+++ b/tests/unit/test_search_reconciliation.py
@@ -10,6 +10,7 @@ from general_manager.manager.input import Input
 from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.search.config import FieldConfig, IndexConfig
 from general_manager.search.models import (
+    SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
     SEARCH_INDEX_DIRTY_REASON_INITIALIZATION,
     SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED,
     SearchIndexState,
@@ -18,6 +19,7 @@ from general_manager.search.reconciliation import (
     build_search_schema_fingerprint,
     ensure_search_index_states,
     iter_search_index_targets,
+    mark_search_indexes_dirty,
     manager_import_path,
 )
 from tests.utils.simple_manager_interface import BaseTestInterface
@@ -124,3 +126,46 @@ class SearchReconciliationDiscoveryTests(TestCase):
         assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED
         assert state.dirty_since is not None
         assert state.schema_fingerprint != "outdated"
+
+
+class SearchDirtyMarkerTests(TestCase):
+    def setUp(self) -> None:
+        self._original_all_classes = list(GeneralManagerMeta.all_classes)
+        GeneralManagerMeta.all_classes = [ReconcileProject]
+        GeneralmanagerConfig.initialize_general_manager_classes(
+            [ReconcileProject], [ReconcileProject]
+        )
+
+    def tearDown(self) -> None:
+        GeneralManagerMeta.all_classes = self._original_all_classes
+        super().tearDown()
+
+    def test_mark_dirty_creates_state_for_all_manager_indexes(self) -> None:
+        marked = mark_search_indexes_dirty(
+            ReconcileProject,
+            reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+        )
+
+        assert marked == 1
+        state = SearchIndexState.objects.get(
+            manager_path=manager_import_path(ReconcileProject),
+            index_name="global",
+        )
+        assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED
+        assert state.dirty_since is not None
+
+    def test_mark_dirty_preserves_existing_dirty_since(self) -> None:
+        mark_search_indexes_dirty(
+            ReconcileProject,
+            reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+        )
+        state = SearchIndexState.objects.get()
+        original_dirty_since = state.dirty_since
+
+        mark_search_indexes_dirty(
+            ReconcileProject,
+            reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+        )
+        state.refresh_from_db()
+
+        assert state.dirty_since == original_dirty_since

--- a/tests/unit/test_search_reconciliation.py
+++ b/tests/unit/test_search_reconciliation.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from django.test import TestCase
+
+from general_manager.apps import GeneralmanagerConfig
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.input import Input
+from general_manager.manager.meta import GeneralManagerMeta
+from general_manager.search.config import FieldConfig, IndexConfig
+from general_manager.search.models import (
+    SEARCH_INDEX_DIRTY_REASON_INITIALIZATION,
+    SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED,
+    SearchIndexState,
+)
+from general_manager.search.reconciliation import (
+    build_search_schema_fingerprint,
+    ensure_search_index_states,
+    iter_search_index_targets,
+    manager_import_path,
+)
+from tests.utils.simple_manager_interface import BaseTestInterface
+
+
+class ReconcileProjectInterface(BaseTestInterface):
+    input_fields: ClassVar[dict[str, Input]] = {"id": Input(int)}
+
+    @classmethod
+    def get_attribute_types(cls):
+        return {"name": {"type": str}, "status": {"type": str}}
+
+    @classmethod
+    def get_attributes(cls):
+        return {
+            "name": lambda _interface: "Alpha",
+            "status": lambda _interface: "public",
+        }
+
+
+class ReconcileProject(GeneralManager):
+    Interface = ReconcileProjectInterface
+
+    class SearchConfig:
+        indexes: ClassVar[list[IndexConfig]] = [
+            IndexConfig(
+                name="global",
+                fields=[FieldConfig("name", boost=2.0)],
+                filters=["status"],
+                sorts=["name"],
+            )
+        ]
+        type_label = "ProjectDoc"
+        update_strategy = "inline"
+
+
+class SearchReconciliationDiscoveryTests(TestCase):
+    def setUp(self) -> None:
+        self._original_all_classes = list(GeneralManagerMeta.all_classes)
+        GeneralManagerMeta.all_classes = [ReconcileProject]
+        GeneralmanagerConfig.initialize_general_manager_classes(
+            [ReconcileProject], [ReconcileProject]
+        )
+
+    def tearDown(self) -> None:
+        GeneralManagerMeta.all_classes = self._original_all_classes
+        super().tearDown()
+
+    def test_manager_import_path_is_stable(self) -> None:
+        assert manager_import_path(ReconcileProject).endswith(".ReconcileProject")
+
+    def test_iter_search_index_targets_includes_fingerprint(self) -> None:
+        targets = list(iter_search_index_targets())
+
+        assert len(targets) == 1
+        target = targets[0]
+        assert target.manager_class is ReconcileProject
+        assert target.manager_path == manager_import_path(ReconcileProject)
+        assert target.index_name == "global"
+        assert len(target.schema_fingerprint) == 64
+
+    def test_fingerprint_changes_when_index_config_changes(self) -> None:
+        original = build_search_schema_fingerprint(
+            ReconcileProject,
+            ReconcileProject.SearchConfig.indexes[0],
+        )
+        changed_index = IndexConfig(
+            name="global",
+            fields=["name", "status"],
+            filters=["status"],
+        )
+
+        changed = build_search_schema_fingerprint(ReconcileProject, changed_index)
+
+        assert original != changed
+
+    def test_ensure_states_marks_missing_targets_dirty_for_initialization(self) -> None:
+        result = ensure_search_index_states()
+
+        assert result.created == 1
+        state = SearchIndexState.objects.get()
+        assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_INITIALIZATION
+        assert state.dirty_since is not None
+
+    def test_ensure_states_marks_schema_changes_dirty(self) -> None:
+        ensure_search_index_states()
+        state = SearchIndexState.objects.get()
+        state.schema_fingerprint = "outdated"
+        state.dirty_since = None
+        state.dirty_reason = ""
+        state.save(
+            update_fields=[
+                "schema_fingerprint",
+                "dirty_since",
+                "dirty_reason",
+                "updated_at",
+            ]
+        )
+
+        result = ensure_search_index_states()
+        state.refresh_from_db()
+
+        assert result.updated == 1
+        assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_SCHEMA_CHANGED
+        assert state.dirty_since is not None
+        assert state.schema_fingerprint != "outdated"

--- a/tests/unit/test_search_reconciliation_models.py
+++ b/tests/unit/test_search_reconciliation_models.py
@@ -25,6 +25,17 @@ class SearchIndexStateModelTests(TestCase):
                 schema_fingerprint="def",
             )
 
+    def test_search_index_state_does_not_define_duplicate_unique_lookup_index(
+        self,
+    ) -> None:
+        duplicate_indexes = [
+            index
+            for index in SearchIndexState._meta.indexes
+            if list(index.fields) == ["manager_path", "index_name"]
+        ]
+
+        assert duplicate_indexes == []
+
     def test_mark_dirty_records_reason_without_clearing_existing_timestamp(
         self,
     ) -> None:

--- a/tests/unit/test_search_reconciliation_models.py
+++ b/tests/unit/test_search_reconciliation_models.py
@@ -12,6 +12,7 @@ from general_manager.search.models import (
 
 class SearchIndexStateModelTests(TestCase):
     def test_search_index_state_is_unique_per_manager_and_index(self) -> None:
+        """Enforce one state row per manager and index pair."""
         SearchIndexState.objects.create(
             manager_path="tests.Project",
             index_name="global",
@@ -28,6 +29,7 @@ class SearchIndexStateModelTests(TestCase):
     def test_search_index_state_does_not_define_duplicate_unique_lookup_index(
         self,
     ) -> None:
+        """Avoid a redundant explicit index for the unique lookup fields."""
         duplicate_indexes = [
             index
             for index in SearchIndexState._meta.indexes
@@ -39,6 +41,7 @@ class SearchIndexStateModelTests(TestCase):
     def test_mark_dirty_records_reason_without_clearing_existing_timestamp(
         self,
     ) -> None:
+        """Preserve the first dirty timestamp when marking dirty again."""
         first_dirty = timezone.now()
         state = SearchIndexState.objects.create(
             manager_path="tests.Project",
@@ -55,6 +58,7 @@ class SearchIndexStateModelTests(TestCase):
         assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED
 
     def test_clear_dirty_records_success(self) -> None:
+        """Clear dirty/error fields and record reconciliation success."""
         state = SearchIndexState.objects.create(
             manager_path="tests.Project",
             index_name="global",

--- a/tests/unit/test_search_reconciliation_models.py
+++ b/tests/unit/test_search_reconciliation_models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from django.db import IntegrityError
+from django.test import TestCase
+from django.utils import timezone
+
+from general_manager.search.models import (
+    SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+    SearchIndexState,
+)
+
+
+class SearchIndexStateModelTests(TestCase):
+    def test_search_index_state_is_unique_per_manager_and_index(self) -> None:
+        SearchIndexState.objects.create(
+            manager_path="tests.Project",
+            index_name="global",
+            schema_fingerprint="abc",
+        )
+
+        with self.assertRaises(IntegrityError):
+            SearchIndexState.objects.create(
+                manager_path="tests.Project",
+                index_name="global",
+                schema_fingerprint="def",
+            )
+
+    def test_mark_dirty_records_reason_without_clearing_existing_timestamp(
+        self,
+    ) -> None:
+        first_dirty = timezone.now()
+        state = SearchIndexState.objects.create(
+            manager_path="tests.Project",
+            index_name="global",
+            schema_fingerprint="abc",
+            dirty_since=first_dirty,
+            dirty_reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+        )
+
+        state.mark_dirty(SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED)
+        state.refresh_from_db()
+
+        assert state.dirty_since == first_dirty
+        assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED
+
+    def test_clear_dirty_records_success(self) -> None:
+        state = SearchIndexState.objects.create(
+            manager_path="tests.Project",
+            index_name="global",
+            schema_fingerprint="abc",
+            dirty_since=timezone.now(),
+            dirty_reason=SEARCH_INDEX_DIRTY_REASON_DATA_CHANGED,
+            last_error="boom",
+        )
+
+        state.clear_dirty()
+        state.refresh_from_db()
+
+        assert state.dirty_since is None
+        assert state.dirty_reason == ""
+        assert state.last_error == ""
+        assert state.last_reconciled_at is not None

--- a/tests/unit/test_search_tasks.py
+++ b/tests/unit/test_search_tasks.py
@@ -29,6 +29,14 @@ class SearchReconcileSettingsTests(SimpleTestCase):
     def test_search_reconcile_interval_seconds_falls_back_to_default(self) -> None:
         assert search_reconcile_interval_seconds() == 60
 
+    @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_INTERVAL_SECONDS": 0})
+    def test_search_reconcile_interval_seconds_uses_minimum_for_zero(self) -> None:
+        assert search_reconcile_interval_seconds() == 1
+
+    @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_INTERVAL_SECONDS": -10})
+    def test_search_reconcile_interval_seconds_uses_minimum_for_negative(self) -> None:
+        assert search_reconcile_interval_seconds() == 1
+
 
 class SearchReconcileTaskTests(SimpleTestCase):
     def test_reconcile_search_indexes_task_calls_service(self) -> None:

--- a/tests/unit/test_search_tasks.py
+++ b/tests/unit/test_search_tasks.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from general_manager.search.tasks import (
+    SEARCH_RECONCILE_BEAT_SCHEDULE_KEY,
+    configure_search_reconcile_beat_schedule_from_settings,
+    reconcile_search_indexes_task,
+    search_reconcile_enabled,
+    search_reconcile_interval_seconds,
+)
+
+
+class SearchReconcileSettingsTests(SimpleTestCase):
+    @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_ENABLED": True})
+    def test_search_reconcile_enabled_reads_general_manager_setting(self) -> None:
+        assert search_reconcile_enabled() is True
+
+    @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_INTERVAL_SECONDS": 30})
+    def test_search_reconcile_interval_seconds_reads_general_manager_setting(
+        self,
+    ) -> None:
+        assert search_reconcile_interval_seconds() == 30
+
+    @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_INTERVAL_SECONDS": "bad"})
+    def test_search_reconcile_interval_seconds_falls_back_to_default(self) -> None:
+        assert search_reconcile_interval_seconds() == 60
+
+
+class SearchReconcileTaskTests(SimpleTestCase):
+    def test_reconcile_search_indexes_task_calls_service(self) -> None:
+        with patch(
+            "general_manager.search.tasks.reconcile_search_indexes"
+        ) as reconcile:
+            reconcile.return_value.reconciled = 2
+            reconcile.return_value.failed = 0
+            reconcile.return_value.documents = 7
+            result = reconcile_search_indexes_task()
+
+        assert result == {"reconciled": 2, "failed": 0, "documents": 7}
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "SEARCH_RECONCILE_ENABLED": True,
+            "SEARCH_RECONCILE_INTERVAL_SECONDS": 60,
+        }
+    )
+    def test_configure_search_reconcile_beat_schedule_registers_task(self) -> None:
+        fake_conf = SimpleNamespace(beat_schedule={})
+        fake_app = SimpleNamespace(conf=fake_conf)
+        with (
+            patch("general_manager.search.tasks.CELERY_AVAILABLE", True),
+            patch("general_manager.search.tasks.current_app", fake_app),
+        ):
+            configured = configure_search_reconcile_beat_schedule_from_settings()
+
+        assert configured is True
+        entry = fake_conf.beat_schedule[SEARCH_RECONCILE_BEAT_SCHEDULE_KEY]
+        assert (
+            entry["task"]
+            == "general_manager.search.tasks.reconcile_search_indexes_task"
+        )
+        assert entry["schedule"] == 60.0
+        assert entry["options"] == {"queue": "search.reconciliation"}
+
+    @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_ENABLED": False})
+    def test_configure_search_reconcile_beat_schedule_skips_when_disabled(self) -> None:
+        configured = configure_search_reconcile_beat_schedule_from_settings()
+
+        assert configured is False

--- a/tests/unit/test_search_tasks.py
+++ b/tests/unit/test_search_tasks.py
@@ -17,29 +17,35 @@ from general_manager.search.tasks import (
 class SearchReconcileSettingsTests(SimpleTestCase):
     @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_ENABLED": True})
     def test_search_reconcile_enabled_reads_general_manager_setting(self) -> None:
+        """Read the reconciliation enabled flag from GENERAL_MANAGER settings."""
         assert search_reconcile_enabled() is True
 
     @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_INTERVAL_SECONDS": 30})
     def test_search_reconcile_interval_seconds_reads_general_manager_setting(
         self,
     ) -> None:
+        """Read the reconciliation interval from GENERAL_MANAGER settings."""
         assert search_reconcile_interval_seconds() == 30
 
     @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_INTERVAL_SECONDS": "bad"})
     def test_search_reconcile_interval_seconds_falls_back_to_default(self) -> None:
+        """Fall back to the default interval when the setting is invalid."""
         assert search_reconcile_interval_seconds() == 60
 
     @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_INTERVAL_SECONDS": 0})
     def test_search_reconcile_interval_seconds_uses_minimum_for_zero(self) -> None:
+        """Clamp a zero reconciliation interval to one second."""
         assert search_reconcile_interval_seconds() == 1
 
     @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_INTERVAL_SECONDS": -10})
     def test_search_reconcile_interval_seconds_uses_minimum_for_negative(self) -> None:
+        """Clamp a negative reconciliation interval to one second."""
         assert search_reconcile_interval_seconds() == 1
 
 
 class SearchReconcileTaskTests(SimpleTestCase):
     def test_reconcile_search_indexes_task_calls_service(self) -> None:
+        """Return reconciliation counts from the Celery task wrapper."""
         with patch(
             "general_manager.search.tasks.reconcile_search_indexes"
         ) as reconcile:
@@ -57,6 +63,7 @@ class SearchReconcileTaskTests(SimpleTestCase):
         }
     )
     def test_configure_search_reconcile_beat_schedule_registers_task(self) -> None:
+        """Register the configured reconciliation task in Celery Beat."""
         fake_conf = SimpleNamespace(beat_schedule={})
         fake_app = SimpleNamespace(conf=fake_conf)
         with (
@@ -76,6 +83,7 @@ class SearchReconcileTaskTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"SEARCH_RECONCILE_ENABLED": False})
     def test_configure_search_reconcile_beat_schedule_skips_when_disabled(self) -> None:
+        """Skip Celery Beat registration when reconciliation is disabled."""
         configured = configure_search_reconcile_beat_schedule_from_settings()
 
         assert configured is False


### PR DESCRIPTION
## Summary

Refs #195.

- Replace request-triggered search auto-reindex with durable `SearchIndexState` reconciliation for first initialization, schema drift, missed updates, and backend recovery.
- Add manager/index-specific reindexing, dirty markers from search mutation signals, Celery Beat scheduling, and a `search_reconcile` management command for production and development operation.
- Update search docs and add a production/development how-to for search reconciliation.

## Validation

- `python -m pytest tests/unit/test_search_reconciliation_models.py tests/unit/test_search_reconciliation.py tests/unit/test_search_indexer.py tests/unit/test_search_tasks.py tests/unit/test_search_reconcile_command.py tests/unit/test_search_auto_reindex.py tests/unit/test_apps_utilities.py -q` -> 38 passed
- `python -m pytest tests/unit/test_search_async.py tests/unit/test_search_async_tasks.py tests/unit/test_search_backend_registry.py tests/unit/test_search_command.py tests/unit/test_search_config.py tests/unit/test_search_registry.py tests/unit/test_search_utils.py tests/unit/test_search_dev_backend.py -q` -> 40 passed
- `ruff check src/general_manager/search src/general_manager/apps.py src/general_manager/management/commands/search_reconcile.py tests/unit/test_search_reconciliation_models.py tests/unit/test_search_reconciliation.py tests/unit/test_search_indexer.py tests/unit/test_search_tasks.py tests/unit/test_search_reconcile_command.py tests/unit/test_search_auto_reindex.py tests/unit/test_apps_utilities.py` -> passed
- `ruff format --check src/general_manager/search src/general_manager/apps.py src/general_manager/management/commands/search_reconcile.py tests/unit/test_search_reconciliation_models.py tests/unit/test_search_reconciliation.py tests/unit/test_search_indexer.py tests/unit/test_search_tasks.py tests/unit/test_search_reconcile_command.py tests/unit/test_search_auto_reindex.py tests/unit/test_apps_utilities.py` -> passed
- `mypy src/general_manager/search src/general_manager/apps.py src/general_manager/management/commands/search_reconcile.py` -> passed
- `python -m pytest tests/docs/test_public_api_docs_coverage.py -q` -> 2 passed
- `python -m pytest -q` -> 2668 passed, 1 skipped, 1744 subtests passed; 1 existing Django model reload warning

## Notes

- `gh auth status` reports the local GitHub CLI token is invalid, so PR creation used the GitHub connector after pushing with git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable “search reconciliation” to keep search indexes fresh, with schema-change detection and automatic recovery.
  * Added `search_reconcile` management command (`--once`, `--watch`, `--force`, `--max-states`, `--interval`).
  * Added periodic reconciliation support via Celery Beat when enabled.
* **Documentation**
  * Updated tutorials and how-tos with “Run search reconciliation” instructions and revised search guidance.
* **Chores / Refactor**
  * Removed legacy request-triggered auto-reindex; search updates/deletes now mark indexes for reconciliation and clean up stale documents.
* **Tests**
  * Expanded coverage for reconciliation, command validation, and backend document ID listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->