### PR TITLE
[codex] add GraphQL property warmup

### DIFF
--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -50,6 +50,14 @@ def cheap_label(self) -> str:
     return f"{self.project.name}: {self.date:%Y-%m-%d}"
 ```
 
+Use timeout caching when a value may be reused for a fixed interval:
+
+```python
+@graph_ql_property(cache="timeout", timeout=300)
+def five_minute_summary(self) -> int:
+    return self.project.derivative_list.count()
+```
+
 ## Step 3: Verify invalidation
 
 For dependency-aware properties, update a derivative that contributes to the summary. The dependency tracker captures the relationship and invalidates the cache entry automatically.
@@ -58,7 +66,48 @@ For dependency-aware properties, update a derivative that contributes to the sum
 DerivativeVolume(id=volume_id).update(quantity=42)
 ```
 
-## Step 4: Monitor cache usage
+## Step 4: Warm selected properties proactively
+
+Set `warm_up=True` only on properties that are safe and useful to compute
+outside a user request. Warm-up is valid for dependency and timeout cache scopes:
+
+```python
+@graph_ql_property(cache="dependency", warm_up=True)
+def expensive_summary(self) -> int:
+    return self.project.derivative_list.filter(date=self.date).count()
+
+@graph_ql_property(cache="timeout", timeout=300, warm_up=True)
+def five_minute_summary(self) -> int:
+    return self.project.derivative_list.count()
+```
+
+When enabled in settings, the framework can enumerate `Manager.all()`, execute
+each opted-in property, and record warm-up recipes. Dependency entries can be
+re-warmed after invalidation when a recipe exists. Timeout entries can be
+refreshed before expiry by the built-in Celery Beat task or by a scheduler that
+calls `graphql_warmup_refresh_due`.
+
+Warm-up can be expensive because it starts from `.all()`. Keep automatic startup
+warm-up disabled unless the deployment has a worker or startup budget for it,
+and monitor warning logs for large manager enumerations.
+
+```python
+GENERAL_MANAGER = {
+    "GRAPHQL_WARMUP_ENABLED": True,
+    "GRAPHQL_WARMUP_STARTUP_ENABLED": True,
+    "GRAPHQL_WARMUP_STARTUP_MODE": "enqueue",
+    "GRAPHQL_WARMUP_BEAT_ENABLED": True,
+}
+```
+
+Applications that use another scheduler can keep Beat disabled and run:
+
+```bash
+python manage.py graphql_warmup
+python manage.py graphql_warmup_refresh_due --limit 1000
+```
+
+## Step 5: Monitor cache usage
 
 Enable Django cache logging or use Redis monitoring tools to ensure cache hits increase and invalidations behave as expected.
 

--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -85,7 +85,8 @@ When enabled in settings, the framework can enumerate `Manager.all()`, execute
 each opted-in property, and record warm-up recipes. Dependency entries can be
 re-warmed after invalidation when a recipe exists. Timeout entries can be
 refreshed before expiry by the built-in Celery Beat task or by a scheduler that
-calls `graphql_warmup_refresh_due`.
+calls `refresh_due_graphql_warmup_recipes` directly. Schedulers that execute
+management commands can run `graphql_warmup_refresh_due` instead.
 
 Warm-up can be expensive because it starts from `.all()`. Keep automatic startup
 warm-up disabled unless the deployment has a worker or startup budget for it,

--- a/docs/superpowers/specs/2026-06-18-graphql-warmup-design.md
+++ b/docs/superpowers/specs/2026-06-18-graphql-warmup-design.md
@@ -1,0 +1,311 @@
+# GraphQL Property Warm-Up
+
+## Problem
+
+Dependency-scoped `@graph_ql_property` values are warmed lazily today. A normal
+GraphQL query computes a cold selected property through the existing cached
+wrapper, records dependencies, and stores the dependency-cache entry. List
+queries also bulk-read already-hot dependency-cache entries for selected fields
+to avoid one cache read per item.
+
+That request-path behavior does not proactively prepare expensive values before
+clients ask for them. It also does not refresh timeout-based values before they
+expire. Issue #194 calls out the operational risk: warm-up affects startup
+behavior, cache state, background work, and cost, so it must be explicit,
+bounded in lifecycle, observable, and opt in.
+
+## Goals
+
+- Provide framework-owned warm-up for selected GraphQL properties at startup.
+- Re-warm dependency-cache entries after dependency invalidation when the
+  framework knows how to reconstruct the entry.
+- Keep timeout-cached warm entries fresh by refreshing them shortly before
+  their configured timeout expires.
+- Make the feature opt in at both the property level and the application
+  settings level.
+- Expose the same internals through public functions and management commands so
+  applications can use their own scheduler instead of the built-in Celery/Beat
+  integration.
+
+## Scope
+
+Warm-up applies only to `@graph_ql_property` descriptors with `warm_up=True`.
+The only valid warm-up cache scopes are `cache="dependency"` and
+`cache="timeout"`.
+
+```python
+@graph_ql_property(cache="dependency", warm_up=True)
+def score(self) -> int:
+    ...
+
+@graph_ql_property(cache="timeout", timeout=300, warm_up=True)
+def expensive_label(self) -> str:
+    ...
+```
+
+Invalid declarations fail when the descriptor is created:
+
+- `warm_up=True` with `cache="run"`.
+- `warm_up=True` with `cache="none"`.
+- `cache="timeout"` without a `timeout`.
+- `timeout` with any cache scope other than `cache="timeout"`.
+
+The first implementation uses `manager_class.all()` as the warm-up source for
+every manager class that has at least one warmable property. For each instance,
+warm-up executes each opted-in property with `getattr(instance, property_name)`.
+That is the critical operation: property access reuses the existing cached
+wrapper, compute lease, dependency tracking, and cache publication behavior.
+
+There is no hard framework item limit. Warm-up executes in batches and logs a
+warning when a manager crosses the configured warning threshold.
+
+## Non-Goals
+
+- Changing request-path GraphQL resolution semantics.
+- Replacing the existing dependency-cache implementation.
+- Adding a database-backed warm-up registry in the first version.
+- Re-warming timeout-cache entries after data invalidation. Timeout entries are
+  freshness-by-time, not dependency-indexed.
+- Supporting custom warm-up scopes beyond `.all()` in the first version.
+
+## Public API
+
+`graph_ql_property` gains `cache="timeout"`, `timeout=...`, and `warm_up=...`
+support:
+
+```python
+def graph_ql_property(
+    func=None,
+    *,
+    sortable=False,
+    filterable=False,
+    query_annotation=None,
+    cache="run",
+    timeout=None,
+    warm_up=False,
+):
+    ...
+```
+
+The framework exposes public functions for applications and management commands
+to call directly:
+
+- `warm_up_graphql_properties(manager_classes=None, property_names=None)`
+- `warm_up_graphql_recipe(cache_key)`
+- `refresh_due_graphql_warmup_recipes(limit=None)`
+- `enqueue_graphql_warmup(manager_classes=None)`
+- `enqueue_graphql_recipe_warmup(cache_keys)`
+
+The first implementation places these functions in
+`general_manager.api.graphql_warmup`. Re-exporting them from higher-level
+modules is a separate public API decision.
+
+## Settings
+
+Settings use `GENERAL_MANAGER` keys with the existing legacy top-level fallback
+style.
+
+```python
+GENERAL_MANAGER = {
+    "GRAPHQL_WARMUP_ENABLED": False,
+    "GRAPHQL_WARMUP_STARTUP_ENABLED": False,
+    "GRAPHQL_WARMUP_STARTUP_MODE": "enqueue",  # "enqueue" or "sync"
+    "GRAPHQL_WARMUP_BEAT_ENABLED": False,
+    "GRAPHQL_WARMUP_BATCH_SIZE": 100,
+    "GRAPHQL_WARMUP_WARNING_ITEMS_PER_MANAGER": 1000,
+    "GRAPHQL_WARMUP_TIMEOUT_REFRESH_RATIO": 0.8,
+    "GRAPHQL_WARMUP_REWARM_AFTER_INVALIDATION": True,
+}
+```
+
+`GRAPHQL_WARMUP_ENABLED` gates all framework-owned automatic behavior.
+Management commands and public functions will honor it by default, with
+an explicit force option only if a command needs one.
+
+## Warm-Up Execution
+
+Startup warm-up discovery scans registered manager classes for warmable
+GraphQL properties. A property is warmable when:
+
+- it is a `GraphQLProperty`;
+- `prop.warm_up` is true;
+- `prop.cache` is `"dependency"` or `"timeout"`.
+
+For each manager class, warm-up iterates `manager_class.all()`. It processes
+instances in batches controlled by `GRAPHQL_WARMUP_BATCH_SIZE`. Each batch runs
+inside a `CalculationRunContext`, so dependency-cache misses are buffered and
+published through the existing batch-publication path at the end of the batch.
+
+For every instance/property pair, warm-up executes:
+
+```python
+getattr(instance, property_name)
+```
+
+If evaluation succeeds, the framework records the instance/property pair as a
+candidate recipe. After the batch context exits successfully and dependency
+publications have been flushed, it writes or updates the warm-up recipe for each
+successful candidate. If evaluation fails, it logs manager, property,
+identification, and exception information, then continues with the remaining
+warm-up work.
+
+Warm-up will not call private resolver internals to bypass the descriptor.
+The descriptor path is the source of truth for cache keys, dependency tracking,
+compute leases, and cache publication.
+
+## Recipe Registry
+
+The first implementation uses a cache-backed recipe registry. A recipe stores
+the information required to reconstruct a warmed cache entry without scanning
+`.all()` again.
+
+```python
+{
+    "version": 1,
+    "cache_key": "...",
+    "manager_path": "myapp.managers.ProjectSummary",
+    "property_name": "score",
+    "identification": {"project": {"id": 1}, "date": "2026-06-18"},
+    "cache": "dependency",
+    "timeout": None,
+    "refresh_at": None,
+}
+```
+
+For timeout entries, `timeout` is the configured timeout in seconds and
+`refresh_at` is the next pre-expiry refresh time. For dependency entries,
+`refresh_at` is `None`.
+
+The registry maintains:
+
+- a per-cache-key recipe payload;
+- an index of all recipe keys;
+- an index of timeout recipe keys due for refresh.
+
+The registry is best-effort and migration-free. If the cache is flushed, recipes
+are lost. Startup or manual warm-up rebuilds them. This tradeoff keeps the first
+version small and leaves room for a future database-backed registry if durable
+refresh state becomes necessary.
+
+## Dependency Invalidation Re-Warm
+
+Dependency invalidation remains correctness-first:
+
+1. Delete stale cache entries immediately.
+2. Remove invalidated keys from the dependency index.
+3. Collect invalidated cache keys.
+4. Release the dependency-index lock.
+5. Release the data-change publish barrier.
+6. Look up warm-up recipes for the invalidated keys.
+7. Enqueue recipe re-warm tasks for recipe-backed dependency entries.
+
+Re-warm must not run while the dependency-index lock is held or while the
+data-change publish barrier is active. The implementation will add a small
+post-data-change drain point so invalidation can collect cache keys during the
+signal receiver and enqueue re-warm only after `end_dependency_data_change()`.
+
+Re-warm is best-effort. Missing recipes are ignored. Failed recomputes are
+logged. The next lazy request-path access, startup warm-up, or manual warm-up can
+repair missing entries.
+
+## Timeout Refresh
+
+`cache="timeout"` warm-up uses time freshness rather than dependency
+invalidation. The warm-up recipe records `refresh_at` using:
+
+```python
+refresh_at = warmed_at + timeout * GRAPHQL_WARMUP_TIMEOUT_REFRESH_RATIO
+```
+
+The ratio defaults to `0.8`, so a 300-second entry is refreshed around 240
+seconds after it was warmed. A periodic refresh task scans due timeout recipes,
+acquires a per-recipe lock, reconstructs the manager instance, executes the
+property, stores the refreshed cache entry through the normal timeout cache
+path, and updates `refresh_at`.
+
+If refresh fails, the task logs the failure and leaves the previous cache entry
+to expire normally. A later refresh attempt or lazy request-path access can
+recompute it.
+
+## Scheduling
+
+The framework owns optional scheduling while leaving escape hatches for
+applications.
+
+Built-in scheduling:
+
+- Startup hook: when `GRAPHQL_WARMUP_ENABLED` and
+  `GRAPHQL_WARMUP_STARTUP_ENABLED` are true.
+- Startup mode: `enqueue` by default, `sync` only when explicitly configured.
+- Celery task queue: `graphql.warmup`.
+- Beat schedule: when `GRAPHQL_WARMUP_BEAT_ENABLED` is true.
+
+App-owned scheduling:
+
+- Call public warm-up functions directly.
+- Run management commands from another scheduler.
+- Disable built-in Beat while keeping recipes and tasks available.
+
+Management commands:
+
+```bash
+python manage.py graphql_warmup
+python manage.py graphql_warmup --manager ProjectSummary
+python manage.py graphql_warmup_refresh_due --limit 1000
+```
+
+## Observability And Failure Handling
+
+Warm-up logs include manager class, property name, count or batch number,
+cache scope, and whether work ran synchronously or through a task.
+
+Warnings:
+
+- a manager crosses `GRAPHQL_WARMUP_WARNING_ITEMS_PER_MANAGER`;
+- Celery/Beat scheduling is requested but Celery is unavailable;
+- startup synchronous mode is enabled.
+
+Failures:
+
+- property evaluation errors are logged with identification and continue;
+- recipe import or reconstruction errors remove or ignore that recipe;
+- enqueue errors are logged and do not block mutations;
+- timeout refresh failures do not delete the still-valid old timeout entry.
+
+## Compatibility
+
+Existing `@graph_ql_property` declarations keep their current behavior. The
+default cache scope remains `cache="run"` and `warm_up` defaults to false.
+
+Existing dependency-cached GraphQL properties still warm lazily on request-path
+access. The new feature only adds proactive startup, re-warm, and timeout
+refresh behavior for explicit opt-ins.
+
+The addition of `cache="timeout"` to GraphQL properties mirrors the existing
+lower-level `@cached(cache="timeout", timeout=...)` support.
+
+## Testing
+
+Implementation should be test-driven:
+
+1. Add unit tests for descriptor validation:
+   `warm_up=True` rejects `run` and `none`; timeout cache requires `timeout`;
+   timeout is rejected for other scopes.
+2. Add unit tests showing `graph_ql_property(cache="timeout", timeout=...)`
+   uses the lower-level timeout cache path.
+3. Add unit tests for recipe registry set/get/index/due behavior.
+4. Add a warm-up execution test proving `.all()` is enumerated and the property
+   is executed for each entry.
+5. Add an integration test showing startup/manual warm-up creates dependency
+   cache entries and recipes.
+6. Add an integration or unit-level invalidation test showing invalidated keys
+   are collected and recipe re-warm is enqueued only after the publish barrier
+   is released.
+7. Add timeout refresh tests showing due recipes recompute before expiry and
+   update `refresh_at`.
+8. Add settings tests showing no startup warm-up or Beat schedule is configured
+   by default.
+
+Relevant verification commands include focused unit tests for the new modules,
+the existing GraphQL dependency-cache prefetch tests, and the caching integration
+tests.

--- a/docs/superpowers/specs/2026-06-18-graphql-warmup-design.md
+++ b/docs/superpowers/specs/2026-06-18-graphql-warmup-design.md
@@ -121,6 +121,12 @@ GENERAL_MANAGER = {
 `GRAPHQL_WARMUP_ENABLED` gates all framework-owned automatic behavior.
 Management commands and public functions will honor it by default, with
 an explicit force option only if a command needs one.
+The block above shows defaults. Applications must set
+`GRAPHQL_WARMUP_ENABLED=True` before startup warm-up, Beat refresh, or
+invalidation re-warm settings can perform framework-owned work.
+`GRAPHQL_WARMUP_TIMEOUT_REFRESH_RATIO` accepts values in the inclusive range
+`[0, 1]`; out-of-range values are clamped so refreshes cannot be scheduled
+before the previous warm time or after the configured timeout window.
 
 ## Warm-Up Execution
 
@@ -218,10 +224,11 @@ refresh_at = warmed_at + timeout * GRAPHQL_WARMUP_TIMEOUT_REFRESH_RATIO
 ```
 
 The ratio defaults to `0.8`, so a 300-second entry is refreshed around 240
-seconds after it was warmed. A periodic refresh task scans due timeout recipes,
-acquires a per-recipe lock, reconstructs the manager instance, executes the
-property, stores the refreshed cache entry through the normal timeout cache
-path, and updates `refresh_at`.
+seconds after it was warmed. Valid values are in the inclusive range `[0, 1]`;
+out-of-range values are clamped for the same reason as the settings parser.
+A periodic refresh task scans due timeout recipes, acquires a per-recipe lock,
+reconstructs the manager instance, executes the property, stores the refreshed
+cache entry through the normal timeout cache path, and updates `refresh_at`.
 
 If refresh fails, the task logs the failure and leaves the previous cache entry
 to expire normally. A later refresh attempt or lazy request-path access can

--- a/src/general_manager/api/graphql_warmup.py
+++ b/src/general_manager/api/graphql_warmup.py
@@ -1,0 +1,295 @@
+"""GraphQL property warm-up execution helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from django.core.cache import cache as django_cache
+from django.utils import timezone
+from django.utils.module_loading import import_string
+
+from general_manager.api.property import GraphQLProperty
+from general_manager.cache.run_context import CalculationRunContext
+from general_manager.conf import get_setting
+from general_manager.logging import get_logger
+from general_manager.utils.make_cache_key import make_cache_key
+from general_manager.api.graphql_warmup_registry import (
+    GraphQLWarmUpRecipe,
+    acquire_graphql_warmup_recipe_lock,
+    due_timeout_graphql_warmup_recipe_keys,
+    get_graphql_warmup_recipe,
+    register_graphql_warmup_recipe,
+    release_graphql_warmup_recipe_lock,
+)
+
+logger = get_logger("api.graphql_warmup")
+
+
+@dataclass(frozen=True, slots=True)
+class GraphQLWarmUpSummary:
+    """Counts from one warm-up execution."""
+
+    evaluated: int = 0
+    failed: int = 0
+    recipes: int = 0
+
+
+def warmable_graphql_properties(
+    manager_class: type[Any],
+    property_names: Iterable[str] | None = None,
+) -> dict[str, GraphQLProperty]:
+    """Return warm-up-eligible GraphQL properties for a manager class."""
+    interface_cls = getattr(manager_class, "Interface", None)
+    if interface_cls is None:
+        return {}
+    available_properties = interface_cls.get_graph_ql_properties()
+    selected = set(property_names) if property_names is not None else None
+    return {
+        name: prop
+        for name, prop in available_properties.items()
+        if isinstance(prop, GraphQLProperty)
+        and prop.warm_up
+        and prop.cache in {"dependency", "timeout"}
+        and (selected is None or name in selected)
+    }
+
+
+def warm_up_graphql_properties(
+    manager_classes: Iterable[type[Any]] | None = None,
+    property_names: Iterable[str] | None = None,
+) -> GraphQLWarmUpSummary:
+    """Warm opted-in GraphQL properties by enumerating each manager's ``.all()``."""
+    if not graphql_warmup_enabled():
+        return GraphQLWarmUpSummary()
+    classes = tuple(manager_classes) if manager_classes is not None else _all_managers()
+    batch_size = _positive_int_setting("GRAPHQL_WARMUP_BATCH_SIZE", 100)
+    warning_threshold = _positive_int_setting(
+        "GRAPHQL_WARMUP_WARNING_ITEMS_PER_MANAGER",
+        1000,
+    )
+    total_evaluated = 0
+    total_failed = 0
+    total_recipes = 0
+
+    for manager_class in classes:
+        properties = warmable_graphql_properties(manager_class, property_names)
+        if not properties:
+            continue
+        manager_path = _manager_path(manager_class)
+        instances_seen = 0
+        warned = False
+        batch: list[Any] = []
+        for instance in manager_class.all():
+            instances_seen += 1
+            if not warned and instances_seen > warning_threshold:
+                warned = True
+                logger.warning(
+                    "graphql warm-up manager crossed warning threshold",
+                    context={
+                        "manager": manager_class.__name__,
+                        "threshold": warning_threshold,
+                    },
+                )
+            batch.append(instance)
+            if len(batch) >= batch_size:
+                evaluated, failed, recipes = _warm_batch(
+                    batch,
+                    properties,
+                    manager_path,
+                )
+                total_evaluated += evaluated
+                total_failed += failed
+                total_recipes += recipes
+                batch = []
+        if batch:
+            evaluated, failed, recipes = _warm_batch(batch, properties, manager_path)
+            total_evaluated += evaluated
+            total_failed += failed
+            total_recipes += recipes
+
+    return GraphQLWarmUpSummary(
+        evaluated=total_evaluated,
+        failed=total_failed,
+        recipes=total_recipes,
+    )
+
+
+def warm_up_graphql_recipe(cache_key: str) -> bool:
+    """Reconstruct and warm one recipe-backed GraphQL property."""
+    if not graphql_warmup_enabled():
+        return False
+    recipe = get_graphql_warmup_recipe(cache_key)
+    if recipe is None:
+        return False
+    lock = acquire_graphql_warmup_recipe_lock(cache_key)
+    if lock is None:
+        return False
+    warmed = False
+    try:
+        manager_class = import_string(recipe.manager_path)
+        instance = manager_class(**recipe.identification)
+        interface_cls = getattr(manager_class, "Interface", None)
+        if interface_cls is not None:
+            prop = interface_cls.get_graph_ql_properties().get(recipe.property_name)
+            if isinstance(prop, GraphQLProperty):
+                if recipe.cache == "timeout":
+                    warmed = _refresh_timeout_recipe(instance, prop, recipe)
+                else:
+                    with CalculationRunContext():
+                        getattr(instance, recipe.property_name)
+                    register_graphql_warmup_recipe(
+                        _recipe_for(instance, prop, recipe.property_name)
+                    )
+                    warmed = True
+    except Exception:
+        logger.exception(
+            "graphql warm-up recipe failed",
+            context={"cache_key": cache_key},
+        )
+    finally:
+        release_graphql_warmup_recipe_lock(lock)
+    return warmed
+
+
+def refresh_due_graphql_warmup_recipes(limit: int | None = None) -> int:
+    """Refresh due timeout recipes and return the number refreshed."""
+    if not graphql_warmup_enabled():
+        return 0
+    refreshed = 0
+    for cache_key in due_timeout_graphql_warmup_recipe_keys(limit=limit):
+        if warm_up_graphql_recipe(cache_key):
+            refreshed += 1
+    return refreshed
+
+
+def enqueue_graphql_warmup(
+    manager_classes: Iterable[type[Any]] | None = None,
+) -> bool:
+    """Enqueue or run all-entry warm-up through the built-in task adapter."""
+    if not graphql_warmup_enabled():
+        return False
+    from general_manager.api.graphql_warmup_tasks import dispatch_graphql_warmup
+
+    return dispatch_graphql_warmup(manager_classes)
+
+
+def enqueue_graphql_recipe_warmup(cache_keys: Iterable[str]) -> bool:
+    """Enqueue recipe re-warm through the built-in task adapter."""
+    if not (
+        graphql_warmup_enabled()
+        and bool(get_setting("GRAPHQL_WARMUP_REWARM_AFTER_INVALIDATION", True))
+    ):
+        return False
+    keys = tuple(dict.fromkeys(cache_keys))
+    if not keys:
+        return False
+    from general_manager.api.graphql_warmup_tasks import dispatch_graphql_recipe_warmup
+
+    return dispatch_graphql_recipe_warmup(keys)
+
+
+def graphql_warmup_enabled() -> bool:
+    """Return whether framework-owned GraphQL warm-up behavior is enabled."""
+    return bool(get_setting("GRAPHQL_WARMUP_ENABLED", False))
+
+
+def _warm_batch(
+    instances: list[Any],
+    properties: dict[str, GraphQLProperty],
+    manager_path: str | None,
+) -> tuple[int, int, int]:
+    candidates: list[GraphQLWarmUpRecipe] = []
+    evaluated = 0
+    failed = 0
+    with CalculationRunContext():
+        for instance in instances:
+            for property_name, prop in properties.items():
+                try:
+                    getattr(instance, property_name)
+                except Exception:
+                    failed += 1
+                    logger.exception(
+                        "graphql property warm-up failed",
+                        context={
+                            "manager": instance.__class__.__name__,
+                            "property": property_name,
+                            "identification": getattr(
+                                instance,
+                                "identification",
+                                None,
+                            ),
+                        },
+                    )
+                    continue
+                evaluated += 1
+                if manager_path is not None:
+                    candidates.append(_recipe_for(instance, prop, property_name))
+    for recipe in candidates:
+        register_graphql_warmup_recipe(recipe)
+    return evaluated, failed, len(candidates)
+
+
+def _refresh_timeout_recipe(
+    instance: Any,
+    prop: GraphQLProperty,
+    recipe: GraphQLWarmUpRecipe,
+) -> bool:
+    result = prop._raw_fget(instance)
+    django_cache.set(recipe.cache_key, result, recipe.timeout)
+    register_graphql_warmup_recipe(_recipe_for(instance, prop, recipe.property_name))
+    return True
+
+
+def _recipe_for(
+    instance: Any,
+    prop: GraphQLProperty,
+    property_name: str,
+) -> GraphQLWarmUpRecipe:
+    cache_key = make_cache_key(prop._get_cached_fget(), (instance,), {})
+    timeout = prop.timeout if prop.cache == "timeout" else None
+    refresh_at = None
+    if prop.cache == "timeout" and timeout is not None:
+        refresh_at = timezone.now() + timedelta(
+            seconds=timeout * _timeout_refresh_ratio()
+        )
+    return GraphQLWarmUpRecipe(
+        cache_key=cache_key,
+        manager_path=_manager_path(instance.__class__) or "",
+        property_name=property_name,
+        identification=dict(getattr(instance, "identification", {})),
+        cache="timeout" if prop.cache == "timeout" else "dependency",
+        timeout=timeout,
+        refresh_at=refresh_at,
+    )
+
+
+def _manager_path(manager_class: type[Any]) -> str | None:
+    qualname = getattr(manager_class, "__qualname__", manager_class.__name__)
+    if "<locals>" in qualname:
+        return None
+    return f"{manager_class.__module__}.{qualname}"
+
+
+def _all_managers() -> tuple[type[Any], ...]:
+    from general_manager.api.graphql import GraphQL
+
+    return tuple(GraphQL.manager_registry.values())
+
+
+def _positive_int_setting(key: str, default: int) -> int:
+    raw = get_setting(key, default)
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _timeout_refresh_ratio() -> float:
+    raw = get_setting("GRAPHQL_WARMUP_TIMEOUT_REFRESH_RATIO", 0.8)
+    try:
+        return max(0.0, min(1.0, float(raw)))
+    except (TypeError, ValueError):
+        return 0.8

--- a/src/general_manager/api/graphql_warmup.py
+++ b/src/general_manager/api/graphql_warmup.py
@@ -201,6 +201,7 @@ def _warm_batch(
     properties: dict[str, GraphQLProperty],
     manager_path: str | None,
 ) -> tuple[int, int, int]:
+    """Evaluate one batch of instances and persist successful recipes."""
     candidates: list[GraphQLWarmUpRecipe] = []
     evaluated = 0
     failed = 0
@@ -237,6 +238,7 @@ def _refresh_timeout_recipe(
     prop: GraphQLProperty,
     recipe: GraphQLWarmUpRecipe,
 ) -> bool:
+    """Refresh one timeout-backed recipe without evicting the old value first."""
     result = prop._raw_fget(instance)
     django_cache.set(recipe.cache_key, result, recipe.timeout)
     register_graphql_warmup_recipe(_recipe_for(instance, prop, recipe.property_name))
@@ -248,6 +250,7 @@ def _recipe_for(
     prop: GraphQLProperty,
     property_name: str,
 ) -> GraphQLWarmUpRecipe:
+    """Build the registry payload for a warmed instance/property pair."""
     cache_key = make_cache_key(prop._get_cached_fget(), (instance,), {})
     timeout = prop.timeout if prop.cache == "timeout" else None
     refresh_at = None
@@ -267,6 +270,7 @@ def _recipe_for(
 
 
 def _manager_path(manager_class: type[Any]) -> str | None:
+    """Return an import path for reconstructable manager classes."""
     qualname = getattr(manager_class, "__qualname__", manager_class.__name__)
     if "<locals>" in qualname:
         return None
@@ -274,12 +278,14 @@ def _manager_path(manager_class: type[Any]) -> str | None:
 
 
 def _all_managers() -> tuple[type[Any], ...]:
+    """Return all manager classes registered with the GraphQL integration."""
     from general_manager.api.graphql import GraphQL
 
     return tuple(GraphQL.manager_registry.values())
 
 
 def _positive_int_setting(key: str, default: int) -> int:
+    """Read a positive integer warm-up setting with a fallback."""
     raw = get_setting(key, default)
     try:
         return max(1, int(raw))
@@ -288,6 +294,7 @@ def _positive_int_setting(key: str, default: int) -> int:
 
 
 def _timeout_refresh_ratio() -> float:
+    """Read and clamp the timeout refresh ratio setting."""
     raw = get_setting("GRAPHQL_WARMUP_TIMEOUT_REFRESH_RATIO", 0.8)
     try:
         return max(0.0, min(1.0, float(raw)))

--- a/src/general_manager/api/graphql_warmup_registry.py
+++ b/src/general_manager/api/graphql_warmup_registry.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
+import threading
+import time
 import uuid
 
 from django.core.cache import cache as django_cache
@@ -17,7 +20,12 @@ KEY_PREFIX = "general_manager:graphql_warmup"
 RECIPE_INDEX_KEY = f"{KEY_PREFIX}:recipes"
 TIMEOUT_RECIPE_INDEX_KEY = f"{KEY_PREFIX}:timeout_recipes"
 LOCK_PREFIX = f"{KEY_PREFIX}:lock"
+INDEX_LOCK_PREFIX = f"{LOCK_PREFIX}:index"
 DEFAULT_RECIPE_LOCK_TIMEOUT = 300
+DEFAULT_INDEX_LOCK_TIMEOUT = 30
+DEFAULT_INDEX_LOCK_WAIT_SECONDS = 1.0
+_LOCAL_LOCKS_GUARD = threading.Lock()
+_LOCAL_LOCKS: dict[str, threading.Lock] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,6 +48,14 @@ class GraphQLWarmUpRecipeLock:
 
     key: str
     token: str
+
+
+class GraphQLWarmUpRecipeLockTimeoutError(TimeoutError):
+    """Raised when an index update lock cannot be acquired quickly."""
+
+    def __init__(self, lock_key: str) -> None:
+        """Build an error message for a cache lock acquisition timeout."""
+        super().__init__(f"Timed out acquiring GraphQL warm-up lock: {lock_key}")
 
 
 def register_graphql_warmup_recipe(
@@ -161,20 +177,21 @@ def release_graphql_warmup_recipe_lock(
     cache_backend: Any = django_cache,
 ) -> None:
     """Release a recipe lock without deleting another worker's newer lock."""
-    if cache_backend.get(lock.key) != lock.token:
-        return
-    cache_backend.delete(lock.key)
+    _delete_lock_if_owned(lock, cache_backend=cache_backend)
 
 
 def _recipe_key(cache_key: str) -> str:
+    """Return the cache key used for one recipe payload."""
     return f"{KEY_PREFIX}:recipe:{cache_key}"
 
 
 def _lock_key(cache_key: str) -> str:
+    """Return the cache key used for one recipe lock."""
     return f"{LOCK_PREFIX}:{cache_key}"
 
 
 def _read_index(index_key: str, *, cache_backend: Any) -> frozenset[str]:
+    """Read an index payload, ignoring malformed values."""
     value = cache_backend.get(index_key, frozenset())
     if not isinstance(value, frozenset):
         return frozenset()
@@ -187,6 +204,7 @@ def _write_index(
     *,
     cache_backend: Any,
 ) -> None:
+    """Write an index payload as an immutable set."""
     cache_backend.set(index_key, frozenset(values), None)
 
 
@@ -196,11 +214,13 @@ def _add_index_member(
     *,
     cache_backend: Any,
 ) -> None:
-    _write_index(
-        index_key,
-        _read_index(index_key, cache_backend=cache_backend) | frozenset((member,)),
-        cache_backend=cache_backend,
-    )
+    """Add one member to an index under an index-level cache lock."""
+    with _locked_index_update(index_key, cache_backend=cache_backend):
+        _write_index(
+            index_key,
+            _read_index(index_key, cache_backend=cache_backend) | frozenset((member,)),
+            cache_backend=cache_backend,
+        )
 
 
 def _remove_index_member(
@@ -209,8 +229,87 @@ def _remove_index_member(
     *,
     cache_backend: Any,
 ) -> None:
-    _write_index(
-        index_key,
-        _read_index(index_key, cache_backend=cache_backend) - frozenset((member,)),
+    """Remove one member from an index under an index-level cache lock."""
+    with _locked_index_update(index_key, cache_backend=cache_backend):
+        _write_index(
+            index_key,
+            _read_index(index_key, cache_backend=cache_backend) - frozenset((member,)),
+            cache_backend=cache_backend,
+        )
+
+
+@contextmanager
+def _locked_index_update(index_key: str, *, cache_backend: Any):
+    """Acquire and release the cache lock guarding one index update."""
+    lock = _acquire_cache_lock(
+        f"{INDEX_LOCK_PREFIX}:{index_key}",
+        timeout=DEFAULT_INDEX_LOCK_TIMEOUT,
+        wait_seconds=DEFAULT_INDEX_LOCK_WAIT_SECONDS,
         cache_backend=cache_backend,
     )
+    try:
+        yield
+    finally:
+        release_graphql_warmup_recipe_lock(lock, cache_backend=cache_backend)
+
+
+def _acquire_cache_lock(
+    lock_key: str,
+    *,
+    timeout: int,
+    wait_seconds: float,
+    cache_backend: Any,
+) -> GraphQLWarmUpRecipeLock:
+    """Acquire a cache-backed lock, waiting briefly for contention to clear."""
+    token = uuid.uuid4().hex
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        if cache_backend.add(lock_key, token, timeout):
+            return GraphQLWarmUpRecipeLock(key=lock_key, token=token)
+        if time.monotonic() >= deadline:
+            raise GraphQLWarmUpRecipeLockTimeoutError(lock_key)
+        time.sleep(0.01)
+
+
+def _delete_lock_if_owned(
+    lock: GraphQLWarmUpRecipeLock,
+    *,
+    cache_backend: Any,
+) -> None:
+    """Delete a lock only when the backend still stores the caller's token."""
+    if _delete_redis_lock_if_owned(lock, cache_backend=cache_backend):
+        return
+    with _local_lock_for(lock.key):
+        if cache_backend.get(lock.key) != lock.token:
+            return
+        if cache_backend.get(lock.key) != lock.token:
+            return
+        cache_backend.delete(lock.key)
+
+
+def _delete_redis_lock_if_owned(
+    lock: GraphQLWarmUpRecipeLock,
+    *,
+    cache_backend: Any,
+) -> bool:
+    """Use Redis compare-and-delete when the cache backend exposes a client."""
+    client_holder = getattr(cache_backend, "client", None)
+    get_client = getattr(client_holder, "get_client", None)
+    if get_client is None:
+        return False
+    make_key = getattr(cache_backend, "make_key", lambda key: key)
+    script = (
+        "if redis.call('get', KEYS[1]) == ARGV[1] "
+        "then return redis.call('del', KEYS[1]) else return 0 end"
+    )
+    try:
+        get_client(write=True).eval(script, 1, make_key(lock.key), lock.token)
+    except (AttributeError, OSError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _local_lock_for(lock_key: str) -> threading.Lock:
+    """Return a process-local fallback mutex for non-Redis cache backends."""
+    with _LOCAL_LOCKS_GUARD:
+        return _LOCAL_LOCKS.setdefault(lock_key, threading.Lock())

--- a/src/general_manager/api/graphql_warmup_registry.py
+++ b/src/general_manager/api/graphql_warmup_registry.py
@@ -1,0 +1,216 @@
+"""Cache-backed recipe registry for GraphQL property warm-up."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+import uuid
+
+from django.core.cache import cache as django_cache
+
+GraphQLWarmUpCacheScope = Literal["dependency", "timeout"]
+
+RECIPE_VERSION = 1
+KEY_PREFIX = "general_manager:graphql_warmup"
+RECIPE_INDEX_KEY = f"{KEY_PREFIX}:recipes"
+TIMEOUT_RECIPE_INDEX_KEY = f"{KEY_PREFIX}:timeout_recipes"
+LOCK_PREFIX = f"{KEY_PREFIX}:lock"
+DEFAULT_RECIPE_LOCK_TIMEOUT = 300
+
+
+@dataclass(frozen=True, slots=True)
+class GraphQLWarmUpRecipe:
+    """Information required to reconstruct one warmed GraphQL property entry."""
+
+    cache_key: str
+    manager_path: str
+    property_name: str
+    identification: dict[str, Any]
+    cache: GraphQLWarmUpCacheScope
+    timeout: int | None
+    refresh_at: datetime | None
+    version: int = RECIPE_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class GraphQLWarmUpRecipeLock:
+    """Token proving ownership of one recipe warm-up attempt."""
+
+    key: str
+    token: str
+
+
+def register_graphql_warmup_recipe(
+    recipe: GraphQLWarmUpRecipe,
+    *,
+    cache_backend: Any = django_cache,
+) -> None:
+    """Persist one warm-up recipe and update registry indexes."""
+    cache_backend.set(_recipe_key(recipe.cache_key), recipe, None)
+    _add_index_member(RECIPE_INDEX_KEY, recipe.cache_key, cache_backend=cache_backend)
+    if recipe.cache == "timeout" and recipe.refresh_at is not None:
+        _add_index_member(
+            TIMEOUT_RECIPE_INDEX_KEY,
+            recipe.cache_key,
+            cache_backend=cache_backend,
+        )
+    else:
+        _remove_index_member(
+            TIMEOUT_RECIPE_INDEX_KEY,
+            recipe.cache_key,
+            cache_backend=cache_backend,
+        )
+
+
+def get_graphql_warmup_recipe(
+    cache_key: str,
+    *,
+    cache_backend: Any = django_cache,
+) -> GraphQLWarmUpRecipe | None:
+    """Return the recipe for *cache_key*, if it exists and matches this version."""
+    recipe = cache_backend.get(_recipe_key(cache_key))
+    if not isinstance(recipe, GraphQLWarmUpRecipe):
+        return None
+    if recipe.version != RECIPE_VERSION:
+        return None
+    return recipe
+
+
+def get_graphql_warmup_recipes(
+    cache_keys: Iterable[str],
+    *,
+    cache_backend: Any = django_cache,
+) -> dict[str, GraphQLWarmUpRecipe]:
+    """Return existing recipes for *cache_keys* keyed by cache key."""
+    recipes: dict[str, GraphQLWarmUpRecipe] = {}
+    for cache_key in tuple(dict.fromkeys(cache_keys)):
+        recipe = get_graphql_warmup_recipe(cache_key, cache_backend=cache_backend)
+        if recipe is not None:
+            recipes[cache_key] = recipe
+    return recipes
+
+
+def graphql_warmup_recipe_keys(
+    *,
+    cache_backend: Any = django_cache,
+) -> tuple[str, ...]:
+    """Return known recipe cache keys in deterministic order."""
+    return tuple(sorted(_read_index(RECIPE_INDEX_KEY, cache_backend=cache_backend)))
+
+
+def due_timeout_graphql_warmup_recipe_keys(
+    *,
+    now: datetime | None = None,
+    limit: int | None = None,
+    cache_backend: Any = django_cache,
+) -> tuple[str, ...]:
+    """Return timeout recipe keys whose refresh time has arrived."""
+    current_time = now or datetime.now(UTC)
+    due: list[tuple[datetime, str]] = []
+    for cache_key in _read_index(TIMEOUT_RECIPE_INDEX_KEY, cache_backend=cache_backend):
+        recipe = get_graphql_warmup_recipe(cache_key, cache_backend=cache_backend)
+        if recipe is None or recipe.cache != "timeout" or recipe.refresh_at is None:
+            _remove_index_member(
+                TIMEOUT_RECIPE_INDEX_KEY,
+                cache_key,
+                cache_backend=cache_backend,
+            )
+            continue
+        if recipe.refresh_at <= current_time:
+            due.append((recipe.refresh_at, cache_key))
+    ordered = tuple(cache_key for _refresh_at, cache_key in sorted(due))
+    if limit is None:
+        return ordered
+    return ordered[: max(0, limit)]
+
+
+def delete_graphql_warmup_recipe(
+    cache_key: str,
+    *,
+    cache_backend: Any = django_cache,
+) -> None:
+    """Remove one recipe and all index references to it."""
+    cache_backend.delete(_recipe_key(cache_key))
+    _remove_index_member(RECIPE_INDEX_KEY, cache_key, cache_backend=cache_backend)
+    _remove_index_member(
+        TIMEOUT_RECIPE_INDEX_KEY,
+        cache_key,
+        cache_backend=cache_backend,
+    )
+
+
+def acquire_graphql_warmup_recipe_lock(
+    cache_key: str,
+    *,
+    timeout: int = DEFAULT_RECIPE_LOCK_TIMEOUT,
+    cache_backend: Any = django_cache,
+) -> GraphQLWarmUpRecipeLock | None:
+    """Acquire a best-effort per-recipe execution lock."""
+    lock_key = _lock_key(cache_key)
+    token = uuid.uuid4().hex
+    if not cache_backend.add(lock_key, token, timeout):
+        return None
+    return GraphQLWarmUpRecipeLock(key=lock_key, token=token)
+
+
+def release_graphql_warmup_recipe_lock(
+    lock: GraphQLWarmUpRecipeLock,
+    *,
+    cache_backend: Any = django_cache,
+) -> None:
+    """Release a recipe lock without deleting another worker's newer lock."""
+    if cache_backend.get(lock.key) != lock.token:
+        return
+    cache_backend.delete(lock.key)
+
+
+def _recipe_key(cache_key: str) -> str:
+    return f"{KEY_PREFIX}:recipe:{cache_key}"
+
+
+def _lock_key(cache_key: str) -> str:
+    return f"{LOCK_PREFIX}:{cache_key}"
+
+
+def _read_index(index_key: str, *, cache_backend: Any) -> frozenset[str]:
+    value = cache_backend.get(index_key, frozenset())
+    if not isinstance(value, frozenset):
+        return frozenset()
+    return value
+
+
+def _write_index(
+    index_key: str,
+    values: Iterable[str],
+    *,
+    cache_backend: Any,
+) -> None:
+    cache_backend.set(index_key, frozenset(values), None)
+
+
+def _add_index_member(
+    index_key: str,
+    member: str,
+    *,
+    cache_backend: Any,
+) -> None:
+    _write_index(
+        index_key,
+        _read_index(index_key, cache_backend=cache_backend) | frozenset((member,)),
+        cache_backend=cache_backend,
+    )
+
+
+def _remove_index_member(
+    index_key: str,
+    member: str,
+    *,
+    cache_backend: Any,
+) -> None:
+    _write_index(
+        index_key,
+        _read_index(index_key, cache_backend=cache_backend) - frozenset((member,)),
+        cache_backend=cache_backend,
+    )

--- a/src/general_manager/api/graphql_warmup_tasks.py
+++ b/src/general_manager/api/graphql_warmup_tasks.py
@@ -1,0 +1,173 @@
+"""Celery-compatible tasks for GraphQL property warm-up."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, cast
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+from general_manager.api.graphql_warmup import (
+    refresh_due_graphql_warmup_recipes,
+    warm_up_graphql_properties,
+    warm_up_graphql_recipe,
+)
+from general_manager.logging import get_logger
+
+logger = get_logger("api.graphql_warmup_tasks")
+
+try:
+    from celery import current_app, shared_task
+
+    CELERY_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency boundary
+    CELERY_AVAILABLE = False
+    current_app = cast(Any | None, None)  # type: ignore[assignment, no-redef]
+
+    def shared_task(func: Any | None = None, **_kwargs: Any):  # type: ignore[no-redef]
+        def decorator(inner):
+            return inner
+
+        if func is None:
+            return decorator
+        return decorator(func)
+
+
+GRAPHQL_WARMUP_BEAT_SCHEDULE_KEY = "general_manager.graphql_warmup.refresh_due"
+GRAPHQL_WARMUP_QUEUE = "graphql.warmup"
+
+
+def configure_graphql_warmup_beat_schedule_from_settings(
+    django_settings: Any = settings,
+) -> bool:
+    """Register the periodic timeout refresh task in Celery Beat."""
+    if not _bool_setting(django_settings, "GRAPHQL_WARMUP_BEAT_ENABLED", False):
+        return False
+    if not CELERY_AVAILABLE or current_app is None:
+        logger.warning("graphql warm-up beat schedule skipped; celery unavailable")
+        return False
+    schedule: dict[str, Any] = dict(
+        getattr(current_app.conf, "beat_schedule", {}) or {}
+    )
+    interval_seconds = float(
+        _int_setting(django_settings, "GRAPHQL_WARMUP_BEAT_INTERVAL_SECONDS", 60)
+    )
+    schedule[GRAPHQL_WARMUP_BEAT_SCHEDULE_KEY] = {
+        "task": (
+            "general_manager.api.graphql_warmup_tasks."
+            "refresh_due_graphql_warmup_recipes_task"
+        ),
+        "schedule": interval_seconds,
+        "options": {"queue": GRAPHQL_WARMUP_QUEUE},
+    }
+    current_app.conf.beat_schedule = schedule
+    logger.info(
+        "graphql warm-up beat schedule configured",
+        context={
+            "schedule_key": GRAPHQL_WARMUP_BEAT_SCHEDULE_KEY,
+            "interval_seconds": interval_seconds,
+        },
+    )
+    return True
+
+
+@shared_task(queue=GRAPHQL_WARMUP_QUEUE)
+def warm_up_graphql_properties_task(
+    manager_paths: list[str] | None = None,
+) -> dict[str, int]:
+    """Resolve optional manager paths and run all-entry GraphQL warm-up."""
+    manager_classes = None
+    if manager_paths is not None:
+        manager_classes = [import_string(path) for path in manager_paths]
+    summary = warm_up_graphql_properties(manager_classes)
+    return {
+        "evaluated": summary.evaluated,
+        "failed": summary.failed,
+        "recipes": summary.recipes,
+    }
+
+
+@shared_task(queue=GRAPHQL_WARMUP_QUEUE)
+def warm_up_graphql_recipes_task(cache_keys: list[str]) -> int:
+    """Warm recipe-backed cache entries with per-key failure isolation."""
+    warmed = 0
+    for cache_key in cache_keys:
+        try:
+            if warm_up_graphql_recipe(cache_key):
+                warmed += 1
+        except Exception:
+            logger.exception(
+                "graphql warm-up recipe task item failed",
+                context={"cache_key": cache_key},
+            )
+    return warmed
+
+
+@shared_task(queue=GRAPHQL_WARMUP_QUEUE)
+def refresh_due_graphql_warmup_recipes_task(limit: int | None = None) -> int:
+    """Refresh due timeout recipes."""
+    return refresh_due_graphql_warmup_recipes(limit=limit)
+
+
+def dispatch_graphql_warmup(
+    manager_classes: Iterable[type[Any]] | None = None,
+) -> bool:
+    """Dispatch all-entry warm-up to Celery when available."""
+    if not CELERY_AVAILABLE:
+        return False
+    manager_paths = None
+    if manager_classes is not None:
+        manager_paths = [
+            path
+            for path in (
+                _manager_path(manager_class) for manager_class in manager_classes
+            )
+            if path
+        ]
+        if not manager_paths:
+            return False
+    try:
+        warm_up_graphql_properties_task.delay(manager_paths)
+    except Exception:
+        logger.exception("failed to enqueue graphql warm-up task")
+        return False
+    return True
+
+
+def dispatch_graphql_recipe_warmup(cache_keys: Iterable[str]) -> bool:
+    """Dispatch recipe re-warm to Celery when available."""
+    keys = list(dict.fromkeys(cache_keys))
+    if not (CELERY_AVAILABLE and keys):
+        return False
+    try:
+        warm_up_graphql_recipes_task.delay(keys)
+    except Exception:
+        logger.exception("failed to enqueue graphql recipe warm-up task")
+        return False
+    return True
+
+
+def _config(django_settings: Any) -> dict[str, Any]:
+    value = getattr(django_settings, "GENERAL_MANAGER", {})
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _bool_setting(django_settings: Any, key: str, default: bool) -> bool:
+    config = _config(django_settings)
+    return bool(config.get(key, getattr(django_settings, key, default)))
+
+
+def _int_setting(django_settings: Any, key: str, default: int) -> int:
+    config = _config(django_settings)
+    raw = config.get(key, getattr(django_settings, key, default))
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _manager_path(manager_class: type[Any]) -> str | None:
+    qualname = getattr(manager_class, "__qualname__", manager_class.__name__)
+    if "<locals>" in qualname:
+        return None
+    return f"{manager_class.__module__}.{qualname}"

--- a/src/general_manager/api/graphql_warmup_tasks.py
+++ b/src/general_manager/api/graphql_warmup_tasks.py
@@ -25,7 +25,10 @@ except ImportError:  # pragma: no cover - optional dependency boundary
     current_app = cast(Any | None, None)  # type: ignore[assignment, no-redef]
 
     def shared_task(func: Any | None = None, **_kwargs: Any):  # type: ignore[no-redef]
+        """Return a no-op task decorator when Celery is not installed."""
+
         def decorator(inner):
+            """Return the wrapped function unchanged."""
             return inner
 
         if func is None:
@@ -35,6 +38,8 @@ except ImportError:  # pragma: no cover - optional dependency boundary
 
 GRAPHQL_WARMUP_BEAT_SCHEDULE_KEY = "general_manager.graphql_warmup.refresh_due"
 GRAPHQL_WARMUP_QUEUE = "graphql.warmup"
+FALSE_SETTING_STRINGS = {"", "0", "false", "no", "off", "none", "null"}
+TRUE_SETTING_STRINGS = {"1", "true", "yes", "on"}
 
 
 def configure_graphql_warmup_beat_schedule_from_settings(
@@ -148,16 +153,26 @@ def dispatch_graphql_recipe_warmup(cache_keys: Iterable[str]) -> bool:
 
 
 def _config(django_settings: Any) -> dict[str, Any]:
+    """Return the nested GENERAL_MANAGER settings dictionary."""
     value = getattr(django_settings, "GENERAL_MANAGER", {})
     return dict(value) if isinstance(value, dict) else {}
 
 
 def _bool_setting(django_settings: Any, key: str, default: bool) -> bool:
+    """Read a boolean setting while accepting common string values."""
     config = _config(django_settings)
-    return bool(config.get(key, getattr(django_settings, key, default)))
+    raw = config.get(key, getattr(django_settings, key, default))
+    if isinstance(raw, str):
+        normalized = raw.strip().casefold()
+        if normalized in FALSE_SETTING_STRINGS:
+            return False
+        if normalized in TRUE_SETTING_STRINGS:
+            return True
+    return bool(raw)
 
 
 def _int_setting(django_settings: Any, key: str, default: int) -> int:
+    """Read a positive integer setting with a fallback."""
     config = _config(django_settings)
     raw = config.get(key, getattr(django_settings, key, default))
     try:
@@ -167,6 +182,7 @@ def _int_setting(django_settings: Any, key: str, default: int) -> int:
 
 
 def _manager_path(manager_class: type[Any]) -> str | None:
+    """Return an import path for manager classes that workers can resolve."""
     qualname = getattr(manager_class, "__qualname__", manager_class.__name__)
     if "<locals>" in qualname:
         return None

--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -26,6 +26,7 @@ class GraphQLPropertyWarmUpConfigurationError(ValueError):
     """Raised when warm-up is configured for an unsupported cache scope."""
 
     def __init__(self) -> None:
+        """Build the warm-up cache-scope validation error."""
         super().__init__('warm_up=True requires cache="dependency" or cache="timeout"')
 
 
@@ -34,10 +35,12 @@ class GraphQLPropertyTimeoutConfigurationError(ValueError):
 
     @classmethod
     def missing_timeout(cls) -> "GraphQLPropertyTimeoutConfigurationError":
+        """Build the error raised when timeout cache omits a timeout."""
         return cls('cache="timeout" requires timeout')
 
     @classmethod
     def unexpected_timeout(cls) -> "GraphQLPropertyTimeoutConfigurationError":
+        """Build the error raised when non-timeout caches specify a timeout."""
         return cls('timeout is only supported with cache="timeout"')
 
 
@@ -90,6 +93,7 @@ class GraphQLProperty(property):
 
         @wraps(fget)
         def resolver(instance: Any) -> Any:
+            """Resolve the property through the selected cached wrapper."""
             return self._get_cached_fget()(instance)
 
         super().__init__(resolver, doc=doc)
@@ -125,6 +129,7 @@ class GraphQLProperty(property):
         self._cached_fget = self._build_cached_fget(owner)
 
     def _build_cached_fget(self, _owner: type) -> Callable[..., Any]:
+        """Build the resolver wrapper for the configured cache scope."""
         from general_manager.cache.cache_decorator import cached
 
         selected_cache = self.cache
@@ -137,6 +142,7 @@ class GraphQLProperty(property):
         )
 
     def _get_cached_fget(self) -> Callable[..., Any]:
+        """Return the cached resolver wrapper, building it lazily if needed."""
         if self._cached_fget is None:
             if self._owner is None:
                 self._cached_fget = self._raw_fget
@@ -176,7 +182,11 @@ class GraphQLProperty(property):
 
 
 @overload
-def graph_ql_property(func: T) -> GraphQLProperty: ...
+def graph_ql_property(func: T) -> GraphQLProperty:
+    """Type overload for direct ``@graph_ql_property`` usage."""
+    ...
+
+
 @overload
 def graph_ql_property(
     *,
@@ -186,7 +196,9 @@ def graph_ql_property(
     cache: GraphQLPropertyCache = "run",
     timeout: int | None = None,
     warm_up: bool = False,
-) -> Callable[[T], GraphQLProperty]: ...
+) -> Callable[[T], GraphQLProperty]:
+    """Type overload for configured ``@graph_ql_property(...)`` usage."""
+    ...
 
 
 def graph_ql_property(
@@ -222,6 +234,7 @@ def graph_ql_property(
     """
 
     def wrapper(f: Callable[..., Any]) -> GraphQLProperty:
+        """Wrap one resolver function in a GraphQLProperty descriptor."""
         return GraphQLProperty(
             f,
             sortable=sortable,

--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Callable, Literal, TypeVar, cast, get_type_hints, overload
 
 T = TypeVar("T", bound=Callable[..., Any])
-GraphQLPropertyCache = Literal["dependency", "run", "none"]
+GraphQLPropertyCache = Literal["dependency", "run", "timeout", "none"]
 
 
 class GraphQLPropertyReturnAnnotationError(TypeError):
@@ -22,12 +22,33 @@ class GraphQLPropertyReturnAnnotationError(TypeError):
         )
 
 
+class GraphQLPropertyWarmUpConfigurationError(ValueError):
+    """Raised when warm-up is configured for an unsupported cache scope."""
+
+    def __init__(self) -> None:
+        super().__init__('warm_up=True requires cache="dependency" or cache="timeout"')
+
+
+class GraphQLPropertyTimeoutConfigurationError(ValueError):
+    """Raised when timeout cache configuration is invalid."""
+
+    @classmethod
+    def missing_timeout(cls) -> "GraphQLPropertyTimeoutConfigurationError":
+        return cls('cache="timeout" requires timeout')
+
+    @classmethod
+    def unexpected_timeout(cls) -> "GraphQLPropertyTimeoutConfigurationError":
+        return cls('timeout is only supported with cache="timeout"')
+
+
 class GraphQLProperty(property):
     """Descriptor that exposes a property with GraphQL metadata and type hints."""
 
     sortable: bool
     filterable: bool
+    warm_up: bool
     query_annotation: Any | None
+    timeout: int | None
 
     def __init__(
         self,
@@ -38,6 +59,8 @@ class GraphQLProperty(property):
         filterable: bool = False,
         query_annotation: Any | None = None,
         cache: GraphQLPropertyCache = "none",
+        timeout: int | None = None,
+        warm_up: bool = False,
     ) -> None:
         """
         Initialize the GraphQLProperty descriptor with GraphQL-specific metadata.
@@ -48,10 +71,20 @@ class GraphQLProperty(property):
             sortable (bool): Whether the property should be considered for sorting.
             filterable (bool): Whether the property should be considered for filtering.
             query_annotation (Any | None): Optional annotation to apply when querying/queryset construction.
+            cache (GraphQLPropertyCache): Cache scope for the resolver.
+            timeout (int | None): Timeout in seconds when ``cache="timeout"``.
+            warm_up (bool): Whether the property participates in proactive warm-up.
 
         Raises:
             GraphQLPropertyReturnAnnotationError: If the underlying resolver function does not declare a return type annotation.
         """
+        if warm_up and cache not in {"dependency", "timeout"}:
+            raise GraphQLPropertyWarmUpConfigurationError()
+        if cache == "timeout" and timeout is None:
+            raise GraphQLPropertyTimeoutConfigurationError.missing_timeout()
+        if timeout is not None and cache != "timeout":
+            raise GraphQLPropertyTimeoutConfigurationError.unexpected_timeout()
+
         self._raw_fget = fget
         self._cached_fget: Callable[..., Any] | None = None
 
@@ -69,6 +102,8 @@ class GraphQLProperty(property):
         self.filterable = filterable
         self.query_annotation = query_annotation
         self.cache = cache
+        self.timeout = timeout
+        self.warm_up = warm_up
 
         orig = getattr(
             fget, "__wrapped__", fget
@@ -95,6 +130,8 @@ class GraphQLProperty(property):
         selected_cache = self.cache
         if selected_cache == "none":
             return self._raw_fget
+        if selected_cache == "timeout":
+            return cached(cache="timeout", timeout=self.timeout)(self._raw_fget)
         return cached(cache=cast(Literal["dependency", "run"], selected_cache))(
             self._raw_fget
         )
@@ -147,6 +184,8 @@ def graph_ql_property(
     filterable: bool = False,
     query_annotation: Any | None = None,
     cache: GraphQLPropertyCache = "run",
+    timeout: int | None = None,
+    warm_up: bool = False,
 ) -> Callable[[T], GraphQLProperty]: ...
 
 
@@ -157,6 +196,8 @@ def graph_ql_property(
     filterable: bool = False,
     query_annotation: Any | None = None,
     cache: GraphQLPropertyCache = "run",
+    timeout: int | None = None,
+    warm_up: bool = False,
 ) -> GraphQLProperty | Callable[[T], GraphQLProperty]:
     """
     Decorate a resolver to return a cached ``GraphQLProperty`` descriptor.
@@ -170,8 +211,11 @@ def graph_ql_property(
             default and memoizes the value only within the active GraphQL request,
             calculation graph, bulk operation, or background run. ``"dependency"``
             persists the value across runs and records accessed managers so later
-            mutations can invalidate the cache entry. ``"none"`` disables caching
-            and evaluates the resolver on every access.
+            mutations can invalidate the cache entry. ``"timeout"`` persists the
+            value for ``timeout`` seconds. ``"none"`` disables caching and evaluates
+            the resolver on every access.
+        timeout (int | None): Timeout in seconds when ``cache="timeout"``.
+        warm_up (bool): Whether the property participates in proactive warm-up.
 
     Returns:
         GraphQLProperty | Callable[[Callable[..., Any]], GraphQLProperty]: Decorated property or decorator factory.
@@ -184,6 +228,8 @@ def graph_ql_property(
             query_annotation=query_annotation,
             filterable=filterable,
             cache=cache,
+            timeout=timeout,
+            warm_up=warm_up,
         )
 
     if func is None:

--- a/src/general_manager/apps.py
+++ b/src/general_manager/apps.py
@@ -103,6 +103,8 @@ def configure_search_reconcile_beat_schedule_from_settings(
 
 
 class GeneralmanagerConfig(AppConfig):
+    """Django application configuration for GeneralManager startup hooks."""
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "general_manager"
 

--- a/src/general_manager/apps.py
+++ b/src/general_manager/apps.py
@@ -44,6 +44,9 @@ from general_manager.workflow.signal_bridge import (
 from general_manager.workflow.tasks import (
     configure_workflow_beat_schedule_from_settings,
 )
+from general_manager.api.graphql_warmup_tasks import (
+    configure_graphql_warmup_beat_schedule_from_settings,
+)
 
 if TYPE_CHECKING:
     from general_manager.manager.general_manager import GeneralManager
@@ -120,6 +123,7 @@ class GeneralmanagerConfig(AppConfig):
         configure_workflow_signal_bridge_from_settings(settings)
         configure_workflow_beat_schedule_from_settings(settings)
         configure_search_reconcile_beat_schedule_from_settings(settings)
+        configure_graphql_warmup_beat_schedule_from_settings(settings)
         from general_manager.search import indexer as _search_indexer  # noqa: F401
 
         from general_manager.conf import get_setting

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import random
 import time
+from contextvars import ContextVar
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Tuple, Type, cast
 
@@ -59,6 +60,10 @@ type filter_type = Literal[
 type Dependency = Tuple[general_manager_name, filter_type, str]
 
 logger = get_logger("cache.dependency_index")
+_pending_graphql_rewarm_cache_keys: ContextVar[frozenset[str]] = ContextVar(
+    "general_manager_pending_graphql_rewarm_cache_keys",
+    default=frozenset(),
+)
 
 
 class DependencyLockTimeoutError(TimeoutError):
@@ -194,6 +199,23 @@ def end_dependency_data_change() -> None:
 def is_dependency_data_change_active() -> bool:
     """Return whether dependency-scoped cache publishing should pause."""
     return cache.get(DATA_CHANGE_LOCK_KEY) is not None
+
+
+def record_invalidated_cache_keys_for_graphql_rewarm(
+    cache_keys: Iterable[str],
+) -> None:
+    """Remember invalidated cache keys until the current data-change barrier ends."""
+    existing = _pending_graphql_rewarm_cache_keys.get()
+    _pending_graphql_rewarm_cache_keys.set(
+        existing | frozenset(dict.fromkeys(cache_keys))
+    )
+
+
+def drain_invalidated_cache_keys_for_graphql_rewarm() -> tuple[str, ...]:
+    """Return and clear invalidated cache keys pending GraphQL recipe re-warm."""
+    cache_keys = tuple(sorted(_pending_graphql_rewarm_cache_keys.get()))
+    _pending_graphql_rewarm_cache_keys.set(frozenset())
+    return cache_keys
 
 
 def acquire_lock_with_retry(operation: str) -> None:
@@ -607,7 +629,7 @@ def _generic_cache_invalidation_locked(
     manager_name: str,
     instance: GeneralManager,
     old_relevant_values: dict[str, Any],
-) -> None:
+) -> set[str]:
     """
     Invalidate cache entries affected by a change while the dependency lock is held.
 
@@ -622,6 +644,7 @@ def _generic_cache_invalidation_locked(
     invalidated_request_query_keys = _invalidate_request_query_dependencies_locked(
         idx, manager_name
     )
+    invalidated_cache_keys = set(invalidated_request_query_keys)
     for cache_key in invalidated_request_query_keys:
         logger.info(
             "invalidating request query cache key",
@@ -645,6 +668,7 @@ def _generic_cache_invalidation_locked(
         )
         cache.delete(cache_key)
         _remove_cache_keys_from_index_locked(idx, (cache_key,))
+        invalidated_cache_keys.add(cache_key)
 
     def _json_loads_val_key(val_key: Any) -> Any:
         if isinstance(val_key, str):
@@ -919,6 +943,7 @@ def _generic_cache_invalidation_locked(
                             )
                             cache.delete(ck)
                             _remove_cache_keys_from_index_locked(idx, (ck,))
+                            invalidated_cache_keys.add(ck)
                 elif lookup.startswith("__sort__"):
                     sort_lookup = lookup.removeprefix("__sort__")
                     attr_path = sort_lookup.split("__")
@@ -955,6 +980,7 @@ def _generic_cache_invalidation_locked(
                             )
                             cache.delete(ck)
                             _remove_cache_keys_from_index_locked(idx, (ck,))
+                            invalidated_cache_keys.add(ck)
                 continue
             lookup_map = cast(lookup_dependency_map, lookup_map)
             # 1) get operator and attribute path
@@ -1015,6 +1041,7 @@ def _generic_cache_invalidation_locked(
                             )
                             cache.delete(ck)
                             _remove_cache_keys_from_index_locked(idx, (ck,))
+                            invalidated_cache_keys.add(ck)
 
                 else:  # action == 'exclude'
                     # Excludes: invalidate only if matches changed
@@ -1040,13 +1067,16 @@ def _generic_cache_invalidation_locked(
                             )
                             cache.delete(ck)
                             _remove_cache_keys_from_index_locked(idx, (ck,))
+                            invalidated_cache_keys.add(ck)
+
+    return invalidated_cache_keys
 
 
 def _generic_cache_invalidation_from_shards(
     manager_name: str,
     instance: GeneralManager,
     old_relevant_values: dict[str, Any],
-) -> None:
+) -> set[str]:
     def value_for_lookup(lookup: str, *, use_old_values: bool) -> Any:
         spec = lookup_spec_from_key(lookup)
         lookup_name = "__".join(spec.attr_path)
@@ -1150,6 +1180,7 @@ def _generic_cache_invalidation_from_shards(
         return False
 
     invalidation_candidates: set[str] = set()
+    invalidated_cache_keys: set[str] = set()
 
     invalidation_candidates.update(request_query_cache_keys(manager_name))
     invalidation_candidates.update(all_records_cache_keys(manager_name))
@@ -1189,6 +1220,9 @@ def _generic_cache_invalidation_from_shards(
         )
         cache.delete(cache_key)
         remove_cache_key_from_shards(cache_key)
+        invalidated_cache_keys.add(cache_key)
+
+    return invalidated_cache_keys
 
 
 @receiver(post_data_change)
@@ -1209,6 +1243,7 @@ def generic_cache_invalidation(
         old_relevant_values (dict[str, Any]): Mapping of lookup paths (joined by "__") to their values as captured before the change; used to compare old vs. new values for invalidation decisions.
     """
     manager_name = sender.__name__
+    invalidated_cache_keys: set[str] = set()
     acquire_lock_with_retry("generic_cache_invalidation")
     try:
         if not reverse_memberships():
@@ -1216,18 +1251,26 @@ def generic_cache_invalidation(
             sections: tuple[Literal["filter", "exclude", "all", "request_query"], ...]
             sections = ("filter", "exclude", "all", "request_query")
             if any(idx.get(section) for section in sections):
-                _generic_cache_invalidation_locked(
+                invalidated_cache_keys = _generic_cache_invalidation_locked(
                     idx,
                     manager_name,
                     instance,
                     old_relevant_values,
                 )
                 set_full_index(idx)
-                return
-        _generic_cache_invalidation_from_shards(
-            manager_name,
-            instance,
-            old_relevant_values,
-        )
+            else:
+                invalidated_cache_keys = _generic_cache_invalidation_from_shards(
+                    manager_name,
+                    instance,
+                    old_relevant_values,
+                )
+        else:
+            invalidated_cache_keys = _generic_cache_invalidation_from_shards(
+                manager_name,
+                instance,
+                old_relevant_values,
+            )
     finally:
         release_lock()
+    if invalidated_cache_keys:
+        record_invalidated_cache_keys_for_graphql_rewarm(invalidated_cache_keys)

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -108,26 +108,28 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
         else:
             return result
         finally:
+            cache_keys: tuple[str, ...] = ()
             try:
-                end_dependency_data_change()
-            except Exception:
-                if primary_exc is not None:
-                    logger.exception(
-                        "Dependency data-change cleanup failed while handling "
-                        "another exception."
-                    )
-                else:
-                    raise
-            if completed:
-                cache_keys = drain_invalidated_cache_keys_for_graphql_rewarm()
-                if cache_keys:
-                    try:
-                        from general_manager.api.graphql_warmup import (
-                            enqueue_graphql_recipe_warmup,
+                try:
+                    end_dependency_data_change()
+                except Exception:
+                    if primary_exc is not None:
+                        logger.exception(
+                            "Dependency data-change cleanup failed while handling "
+                            "another exception."
                         )
+                    else:
+                        raise
+            finally:
+                cache_keys = drain_invalidated_cache_keys_for_graphql_rewarm()
+            if completed and cache_keys:
+                try:
+                    from general_manager.api.graphql_warmup import (
+                        enqueue_graphql_recipe_warmup,
+                    )
 
-                        enqueue_graphql_recipe_warmup(cache_keys)
-                    except Exception:
-                        logger.exception("GraphQL warm-up requeue failed.")
+                    enqueue_graphql_recipe_warmup(cache_keys)
+                except Exception:
+                    logger.exception("GraphQL warm-up requeue failed.")
 
     return wrapper

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -45,11 +45,13 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
         """
         from general_manager.cache.dependency_index import (
             begin_dependency_data_change,
+            drain_invalidated_cache_keys_for_graphql_rewarm,
             end_dependency_data_change,
         )
         from general_manager.cache.run_context import current_calculation_run_context
 
         primary_exc: BaseException | None = None
+        completed = False
         begin_dependency_data_change()
         context = current_calculation_run_context()
         if context is not None:
@@ -99,6 +101,7 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
                     delattr(instance_before, "_old_values")
                 except AttributeError:
                     pass
+            completed = True
         except BaseException as error:
             primary_exc = error
             raise
@@ -115,5 +118,16 @@ def data_change(func: Callable[P, R]) -> Callable[P, R]:
                     )
                 else:
                     raise
+            if completed:
+                cache_keys = drain_invalidated_cache_keys_for_graphql_rewarm()
+                if cache_keys:
+                    try:
+                        from general_manager.api.graphql_warmup import (
+                            enqueue_graphql_recipe_warmup,
+                        )
+
+                        enqueue_graphql_recipe_warmup(cache_keys)
+                    except Exception:
+                        logger.exception("GraphQL warm-up requeue failed.")
 
     return wrapper

--- a/src/general_manager/management/commands/graphql_warmup.py
+++ b/src/general_manager/management/commands/graphql_warmup.py
@@ -1,0 +1,62 @@
+"""Warm opted-in GraphQL property cache entries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.module_loading import import_string
+
+from general_manager.api.graphql import GraphQL
+from general_manager.api.graphql_warmup import warm_up_graphql_properties
+
+
+class UnknownGraphQLWarmUpManagerError(CommandError):
+    """Raised when a command manager argument cannot be resolved."""
+
+    def __init__(self, manager_name: str) -> None:
+        super().__init__(f"Unknown GraphQL manager: {manager_name}")
+
+
+class Command(BaseCommand):
+    """Run all-entry GraphQL property warm-up."""
+
+    help = "Warm opted-in GraphQL property cache entries."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--manager",
+            action="append",
+            default=None,
+            help=(
+                "Manager class name from the GraphQL registry or import path. "
+                "Can be supplied more than once."
+            ),
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        del args
+        manager_classes = self._manager_classes(options.get("manager"))
+        summary = warm_up_graphql_properties(manager_classes)
+        self.stdout.write(
+            self.style.SUCCESS(
+                "GraphQL warm-up complete: "
+                f"{summary.evaluated} evaluated, "
+                f"{summary.failed} failed, "
+                f"{summary.recipes} recipes"
+            )
+        )
+
+    def _manager_classes(self, manager_names: list[str] | None) -> list[type] | None:
+        if not manager_names:
+            return None
+        manager_classes: list[type] = []
+        for manager_name in manager_names:
+            if "." in manager_name:
+                manager_classes.append(import_string(manager_name))
+                continue
+            manager_class = GraphQL.manager_registry.get(manager_name)
+            if manager_class is None:
+                raise UnknownGraphQLWarmUpManagerError(manager_name)
+            manager_classes.append(manager_class)
+        return manager_classes

--- a/src/general_manager/management/commands/graphql_warmup.py
+++ b/src/general_manager/management/commands/graphql_warmup.py
@@ -15,7 +15,16 @@ class UnknownGraphQLWarmUpManagerError(CommandError):
     """Raised when a command manager argument cannot be resolved."""
 
     def __init__(self, manager_name: str) -> None:
+        """Build an error for an unknown GraphQL registry manager name."""
         super().__init__(f"Unknown GraphQL manager: {manager_name}")
+
+
+class InvalidGraphQLWarmUpManagerPathError(CommandError):
+    """Raised when a dotted manager import path cannot be resolved."""
+
+    def __init__(self, manager_path: str) -> None:
+        """Build an error for an invalid dotted manager import path."""
+        super().__init__(f"Invalid GraphQL manager path: {manager_path}")
 
 
 class Command(BaseCommand):
@@ -24,6 +33,7 @@ class Command(BaseCommand):
     help = "Warm opted-in GraphQL property cache entries."
 
     def add_arguments(self, parser: Any) -> None:
+        """Register command-line arguments for selecting managers."""
         parser.add_argument(
             "--manager",
             action="append",
@@ -35,6 +45,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
+        """Run warm-up for selected managers and print a summary."""
         del args
         manager_classes = self._manager_classes(options.get("manager"))
         summary = warm_up_graphql_properties(manager_classes)
@@ -48,12 +59,16 @@ class Command(BaseCommand):
         )
 
     def _manager_classes(self, manager_names: list[str] | None) -> list[type] | None:
+        """Resolve manager names or dotted import paths from command options."""
         if not manager_names:
             return None
         manager_classes: list[type] = []
         for manager_name in manager_names:
             if "." in manager_name:
-                manager_classes.append(import_string(manager_name))
+                try:
+                    manager_classes.append(import_string(manager_name))
+                except (AttributeError, ImportError, ModuleNotFoundError) as error:
+                    raise InvalidGraphQLWarmUpManagerPathError(manager_name) from error
                 continue
             manager_class = GraphQL.manager_registry.get(manager_name)
             if manager_class is None:

--- a/src/general_manager/management/commands/graphql_warmup_refresh_due.py
+++ b/src/general_manager/management/commands/graphql_warmup_refresh_due.py
@@ -1,0 +1,30 @@
+"""Refresh due timeout-backed GraphQL warm-up recipes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from general_manager.api.graphql_warmup import refresh_due_graphql_warmup_recipes
+
+
+class Command(BaseCommand):
+    """Refresh due timeout-backed GraphQL warm-up recipes."""
+
+    help = "Refresh due timeout-backed GraphQL warm-up recipes."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Maximum number of due recipes to refresh.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        del args
+        refreshed = refresh_due_graphql_warmup_recipes(limit=options.get("limit"))
+        self.stdout.write(
+            self.style.SUCCESS(f"GraphQL warm-up refreshed {refreshed} recipes.")
+        )

--- a/src/general_manager/management/commands/graphql_warmup_refresh_due.py
+++ b/src/general_manager/management/commands/graphql_warmup_refresh_due.py
@@ -15,6 +15,7 @@ class Command(BaseCommand):
     help = "Refresh due timeout-backed GraphQL warm-up recipes."
 
     def add_arguments(self, parser: Any) -> None:
+        """Register command-line arguments for limiting refresh work."""
         parser.add_argument(
             "--limit",
             type=int,
@@ -23,6 +24,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
+        """Refresh due timeout recipes and print the number refreshed."""
         del args
         refreshed = refresh_due_graphql_warmup_recipes(limit=options.get("limit"))
         self.stdout.write(

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from general_manager.cache.dependency_index import get_full_index
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.utils.testing import GeneralManagerTransactionTestCase
+from general_manager.utils.make_cache_key import make_cache_key
 from general_manager.manager import GeneralManager, Input
 from django.db.models.fields import CharField, IntegerField, DateField, DateTimeField
 from typing import ClassVar
@@ -511,6 +512,25 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
             start_date=date(2023, 12, 1),
             completion_at=timezone.make_aware(datetime(2024, 1, 20, 12, 0)),
         )
+
+    def test_dependency_invalidation_enqueues_graphql_rewarm_cache_key(self):
+        commercials = self.TestCommercials(project=self.project1)
+        prop = self.TestCommercials.Interface.get_graph_ql_properties()["budget_left"]
+        cache_key = make_cache_key(prop._get_cached_fget(), (commercials,), {})
+
+        self.assertEqual(commercials.budget_left, Measurement(800, "EUR"))
+
+        with patch(
+            "general_manager.api.graphql_warmup.enqueue_graphql_recipe_warmup",
+            return_value=True,
+        ) as enqueue:
+            self.project1.update(
+                actual_costs=Measurement(300, "EUR"),
+                ignore_permission=True,
+            )
+
+        enqueue.assert_called_once()
+        self.assertIn(cache_key, enqueue.call_args.args[0])
 
     def test_budget_left(self):
         """

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -514,6 +514,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
         )
 
     def test_dependency_invalidation_enqueues_graphql_rewarm_cache_key(self):
+        """Dependency invalidation enqueues the warmed GraphQL cache key."""
         commercials = self.TestCommercials(project=self.project1)
         prop = self.TestCommercials.Interface.get_graph_ql_properties()["budget_left"]
         cache_key = make_cache_key(prop._get_cached_fget(), (commercials,), {})

--- a/tests/unit/test_apps_utilities.py
+++ b/tests/unit/test_apps_utilities.py
@@ -126,6 +126,12 @@ class AppsUtilitiesTests(SimpleTestCase):
                                     "configure_search_reconcile_beat_schedule"
                                 ),
                             ),
+                            patch(
+                                "general_manager.apps.configure_graphql_warmup_beat_schedule_from_settings",
+                                side_effect=lambda *_args, **_kwargs: call_order.append(
+                                    "configure_graphql_warmup_beat_schedule"
+                                ),
+                            ),
                         ):
                             config.ready()
 
@@ -141,4 +147,5 @@ class AppsUtilitiesTests(SimpleTestCase):
             "configure_signal_bridge",
             "configure_beat_schedule",
             "configure_search_reconcile_beat_schedule",
+            "configure_graphql_warmup_beat_schedule",
         ]

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -42,8 +42,13 @@ from graphql import (
 
 
 class GraphQLPropertyTests(TestCase):
+    """Verify GraphQLProperty descriptor configuration."""
+
     def test_graphql_property_initialization(self):
+        """GraphQLProperty requires an annotated resolver."""
+
         def mock_getter():
+            """Unannotated resolver used to trigger validation."""
             return "test"
 
         with self.assertRaises(
@@ -53,13 +58,17 @@ class GraphQLPropertyTests(TestCase):
             GraphQLProperty(mock_getter)
 
     def test_graphql_property_with_type_hint(self):
+        """GraphQLProperty stores the resolver return annotation."""
+
         def mock_getter() -> str:
+            """Annotated resolver used to resolve the GraphQL type hint."""
             return "test"
 
         prop = GraphQLProperty(mock_getter)
         self.assertEqual(prop.graphql_type_hint, str)
 
     def test_graphql_property_cache_options_exclude_auto(self):
+        """GraphQL property cache scopes expose only user-selectable values."""
         self.assertEqual(
             set(get_args(GraphQLPropertyCache)),
             {"dependency", "run", "timeout", "none"},
@@ -69,35 +78,50 @@ class GraphQLPropertyTests(TestCase):
         )
 
     def test_graphql_property_rejects_warm_up_for_run_cache(self):
+        """Warm-up is rejected for request-run cache scope."""
+
         def getter() -> int:
+            """Return a value for warm-up validation."""
             return 1
 
         with self.assertRaisesRegex(ValueError, "warm_up=True requires"):
             GraphQLProperty(getter, cache="run", warm_up=True)
 
     def test_graphql_property_rejects_warm_up_for_none_cache(self):
+        """Warm-up is rejected when caching is disabled."""
+
         def getter() -> int:
+            """Return a value for warm-up validation."""
             return 1
 
         with self.assertRaisesRegex(ValueError, "warm_up=True requires"):
             GraphQLProperty(getter, cache="none", warm_up=True)
 
     def test_graphql_property_requires_timeout_for_timeout_cache(self):
+        """Timeout cache declarations must include a timeout value."""
+
         def getter() -> int:
+            """Return a value for timeout validation."""
             return 1
 
         with self.assertRaisesRegex(ValueError, 'cache="timeout" requires timeout'):
             GraphQLProperty(getter, cache="timeout")
 
     def test_graphql_property_rejects_timeout_for_dependency_cache(self):
+        """Non-timeout cache declarations reject timeout values."""
+
         def getter() -> int:
+            """Return a value for timeout validation."""
             return 1
 
         with self.assertRaisesRegex(ValueError, "timeout is only supported"):
             GraphQLProperty(getter, cache="dependency", timeout=60)
 
     def test_graphql_property_accepts_warm_up_for_dependency_and_timeout(self):
+        """Warm-up is accepted for dependency and timeout cache scopes."""
+
         def getter() -> int:
+            """Return a value for accepted warm-up declarations."""
             return 1
 
         dependency_prop = GraphQLProperty(getter, cache="dependency", warm_up=True)

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -61,11 +61,59 @@ class GraphQLPropertyTests(TestCase):
 
     def test_graphql_property_cache_options_exclude_auto(self):
         self.assertEqual(
-            set(get_args(GraphQLPropertyCache)), {"dependency", "run", "none"}
+            set(get_args(GraphQLPropertyCache)),
+            {"dependency", "run", "timeout", "none"},
         )
         self.assertEqual(
             signature(graph_ql_property).parameters["cache"].default, "run"
         )
+
+    def test_graphql_property_rejects_warm_up_for_run_cache(self):
+        def getter() -> int:
+            return 1
+
+        with self.assertRaisesRegex(ValueError, "warm_up=True requires"):
+            GraphQLProperty(getter, cache="run", warm_up=True)
+
+    def test_graphql_property_rejects_warm_up_for_none_cache(self):
+        def getter() -> int:
+            return 1
+
+        with self.assertRaisesRegex(ValueError, "warm_up=True requires"):
+            GraphQLProperty(getter, cache="none", warm_up=True)
+
+    def test_graphql_property_requires_timeout_for_timeout_cache(self):
+        def getter() -> int:
+            return 1
+
+        with self.assertRaisesRegex(ValueError, 'cache="timeout" requires timeout'):
+            GraphQLProperty(getter, cache="timeout")
+
+    def test_graphql_property_rejects_timeout_for_dependency_cache(self):
+        def getter() -> int:
+            return 1
+
+        with self.assertRaisesRegex(ValueError, "timeout is only supported"):
+            GraphQLProperty(getter, cache="dependency", timeout=60)
+
+    def test_graphql_property_accepts_warm_up_for_dependency_and_timeout(self):
+        def getter() -> int:
+            return 1
+
+        dependency_prop = GraphQLProperty(getter, cache="dependency", warm_up=True)
+        timeout_prop = GraphQLProperty(
+            getter,
+            cache="timeout",
+            timeout=60,
+            warm_up=True,
+        )
+
+        self.assertTrue(dependency_prop.warm_up)
+        self.assertEqual(dependency_prop.cache, "dependency")
+        self.assertIsNone(dependency_prop.timeout)
+        self.assertTrue(timeout_prop.warm_up)
+        self.assertEqual(timeout_prop.cache, "timeout")
+        self.assertEqual(timeout_prop.timeout, 60)
 
 
 class MeasurementTypeTests(TestCase):

--- a/tests/unit/test_graphql_warmup.py
+++ b/tests/unit/test_graphql_warmup.py
@@ -1,3 +1,5 @@
+"""Tests for GraphQL property warm-up execution helpers."""
+
 from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import patch
@@ -25,77 +27,107 @@ from general_manager.api.property import GraphQLProperty, graph_ql_property
 
 
 class WarmUpObject:
+    """Timeout-backed warm-up manager used by executor tests."""
+
     calls = 0
 
     def __init__(self, id: int) -> None:
+        """Store identification for recipe reconstruction."""
         self.identification = {"id": id}
         self.id = id
 
     def __str__(self) -> str:
+        """Return a deterministic representation for cache-key generation."""
         return f"WarmUpObject(**{{'id': {self.id}}})"
 
     @classmethod
     def all(cls) -> list["WarmUpObject"]:
+        """Return warm-up candidates for all-entry enumeration."""
         return [cls(1), cls(2)]
 
     @graph_ql_property(cache="timeout", timeout=300, warm_up=True)
     def score(self) -> int:
+        """Return a computed score and count evaluations."""
         type(self).calls += 1
         return self.id * 10
 
     class Interface:
+        """Expose the warmable GraphQL property for tests."""
+
         @staticmethod
         def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+            """Return GraphQL properties declared on the test manager."""
             return {"score": WarmUpObject.score}
 
 
 class DependencyWarmUpObject:
+    """Dependency-backed warm-up manager used by recipe tests."""
+
     calls = 0
 
     def __init__(self, id: int) -> None:
+        """Store identification for dependency recipe reconstruction."""
         self.identification = {"id": id}
         self.id = id
 
     @classmethod
     def all(cls) -> list["DependencyWarmUpObject"]:
+        """Return one dependency-backed warm-up candidate."""
         return [cls(1)]
 
     @graph_ql_property(cache="dependency", warm_up=True)
     def score(self) -> int:
+        """Return a dependency-backed score and count evaluations."""
         type(self).calls += 1
         return self.id * 100
 
     class Interface:
+        """Expose dependency-backed warmable properties for tests."""
+
         @staticmethod
         def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+            """Return GraphQL properties declared on the test manager."""
             return {"score": DependencyWarmUpObject.score}
 
 
 class FailingWarmUpObject:
+    """Warm-up manager whose property raises during evaluation."""
+
     def __init__(self, id: int) -> None:
+        """Store identification for failure logging."""
         self.identification = {"id": id}
         self.id = id
 
     @classmethod
     def all(cls) -> list["FailingWarmUpObject"]:
+        """Return one failing warm-up candidate."""
         return [cls(1)]
 
     @graph_ql_property(cache="timeout", timeout=300, warm_up=True)
     def score(self) -> int:
+        """Raise to exercise warm-up failure isolation."""
         raise RuntimeError("boom")
 
     class Interface:
+        """Expose the failing warmable property for tests."""
+
         @staticmethod
         def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+            """Return GraphQL properties declared on the test manager."""
             return {"score": FailingWarmUpObject.score}
 
 
 class NoInterfaceWarmUpObject:
+    """Manager-like object without a GraphQL Interface."""
+
     pass
 
 
 class GraphQLWarmUpExecutorTests(SimpleTestCase):
+    """Verify all-entry warm-up, recipe warm-up, and enqueue behavior."""
+
     def setUp(self) -> None:
+        """Reset cache state and evaluation counters before each test."""
         cache.clear()
         WarmUpObject.calls = 0
         DependencyWarmUpObject.calls = 0
@@ -104,6 +136,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
     def test_warm_up_executes_property_for_each_all_entry_and_records_recipes(
         self,
     ) -> None:
+        """Warm-up enumerates all candidates and records recipes."""
         summary = warm_up_graphql_properties([WarmUpObject])
 
         self.assertEqual(summary.evaluated, 2)
@@ -112,6 +145,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_warm_up_recipe_reconstructs_instance_and_executes_property(self) -> None:
+        """Recipe warm-up reconstructs timeout-backed manager instances."""
         warm_up_graphql_properties([WarmUpObject])
         cache_key = graphql_warmup_recipe_keys()[0]
         WarmUpObject.calls = 0
@@ -123,6 +157,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_refresh_due_timeout_recipes_updates_refresh_schedule(self) -> None:
+        """Due timeout recipes refresh once and leave the due index."""
         warm_up_graphql_properties([WarmUpObject])
         cache_key = graphql_warmup_recipe_keys()[0]
         recipe = get_graphql_warmup_recipe(cache_key)
@@ -140,6 +175,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": False})
     def test_disabled_warm_up_entry_points_skip_work(self) -> None:
+        """The global gate disables all framework-owned warm-up entry points."""
         summary = warm_up_graphql_properties([WarmUpObject])
 
         self.assertEqual(summary.evaluated, 0)
@@ -151,6 +187,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_warmable_properties_handles_missing_interface_and_filters(self) -> None:
+        """Warmable discovery skips managers and properties that do not qualify."""
         self.assertEqual(warmable_graphql_properties(NoInterfaceWarmUpObject), {})
         self.assertEqual(warmable_graphql_properties(WarmUpObject, ["missing"]), {})
 
@@ -166,6 +203,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
         }
     )
     def test_warm_up_discovers_registered_managers_when_none_are_provided(self) -> None:
+        """Warm-up uses the GraphQL registry when manager classes are omitted."""
         with patch.dict(
             GraphQL.manager_registry,
             {"WarmUpObject": WarmUpObject},
@@ -185,6 +223,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
         }
     )
     def test_warm_up_batches_and_warns_when_manager_crosses_threshold(self) -> None:
+        """Warm-up batches candidates and logs when enumeration crosses a threshold."""
         with patch("general_manager.api.graphql_warmup.logger.warning") as warning:
             summary = warm_up_graphql_properties([WarmUpObject])
 
@@ -194,25 +233,35 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_warm_up_records_no_recipe_for_local_manager_path(self) -> None:
+        """Local manager classes are evaluated but not persisted as recipes."""
+
         class LocalWarmUpObject:
+            """Local manager whose import path cannot be reconstructed."""
+
             calls = 0
 
             def __init__(self, id: int) -> None:
+                """Store identification for local warm-up."""
                 self.identification = {"id": id}
                 self.id = id
 
             @classmethod
             def all(cls) -> list["LocalWarmUpObject"]:
+                """Return one local warm-up candidate."""
                 return [cls(1)]
 
             @graph_ql_property(cache="timeout", timeout=300, warm_up=True)
             def score(self) -> int:
+                """Return a score and count local evaluations."""
                 type(self).calls += 1
                 return self.id
 
             class Interface:
+                """Expose the local warmable property for tests."""
+
                 @staticmethod
                 def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+                    """Return GraphQL properties declared on the local manager."""
                     return {"score": LocalWarmUpObject.score}
 
         summary = warm_up_graphql_properties([LocalWarmUpObject])
@@ -223,6 +272,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_warm_up_records_failures_and_continues(self) -> None:
+        """Warm-up logs property failures and continues processing."""
         with patch("general_manager.api.graphql_warmup.logger.exception") as log:
             summary = warm_up_graphql_properties([FailingWarmUpObject])
 
@@ -233,6 +283,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_warm_up_dependency_recipe_reconstructs_and_executes_property(self) -> None:
+        """Dependency recipes re-run the descriptor path when re-warmed."""
         warm_up_graphql_properties([DependencyWarmUpObject])
         cache_key = graphql_warmup_recipe_keys()[0]
         DependencyWarmUpObject.calls = 0
@@ -244,6 +295,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_warm_up_recipe_returns_false_for_missing_recipe_or_lock(self) -> None:
+        """Recipe warm-up skips missing recipes and lock contention."""
         self.assertFalse(warm_up_graphql_recipe("missing"))
 
         warm_up_graphql_properties([WarmUpObject])
@@ -256,6 +308,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_warm_up_recipe_logs_and_returns_false_for_bad_recipe(self) -> None:
+        """Recipe warm-up logs reconstruction failures and reports no work."""
         warm_up_graphql_properties([WarmUpObject])
         cache_key = graphql_warmup_recipe_keys()[0]
         recipe = get_graphql_warmup_recipe(cache_key)
@@ -275,6 +328,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
         }
     )
     def test_enqueue_recipe_warmup_respects_rewarm_setting_and_empty_keys(self) -> None:
+        """Recipe enqueueing obeys the rewarm setting and ignores empty work."""
         self.assertFalse(enqueue_graphql_recipe_warmup(["cache-key"]))
 
         with override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True}):
@@ -282,6 +336,7 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_enqueue_entry_points_delegate_to_task_dispatchers(self) -> None:
+        """Warm-up enqueue entry points delegate to task dispatch adapters."""
         with patch(
             "general_manager.api.graphql_warmup_tasks.dispatch_graphql_warmup",
             return_value=True,

--- a/tests/unit/test_graphql_warmup.py
+++ b/tests/unit/test_graphql_warmup.py
@@ -1,12 +1,17 @@
 from dataclasses import replace
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.core.cache import cache
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 
+from general_manager.api.graphql import GraphQL
 from general_manager.api.graphql_warmup import (
+    enqueue_graphql_recipe_warmup,
+    enqueue_graphql_warmup,
     refresh_due_graphql_warmup_recipes,
+    warmable_graphql_properties,
     warm_up_graphql_properties,
     warm_up_graphql_recipe,
 )
@@ -44,10 +49,56 @@ class WarmUpObject:
             return {"score": WarmUpObject.score}
 
 
+class DependencyWarmUpObject:
+    calls = 0
+
+    def __init__(self, id: int) -> None:
+        self.identification = {"id": id}
+        self.id = id
+
+    @classmethod
+    def all(cls) -> list["DependencyWarmUpObject"]:
+        return [cls(1)]
+
+    @graph_ql_property(cache="dependency", warm_up=True)
+    def score(self) -> int:
+        type(self).calls += 1
+        return self.id * 100
+
+    class Interface:
+        @staticmethod
+        def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+            return {"score": DependencyWarmUpObject.score}
+
+
+class FailingWarmUpObject:
+    def __init__(self, id: int) -> None:
+        self.identification = {"id": id}
+        self.id = id
+
+    @classmethod
+    def all(cls) -> list["FailingWarmUpObject"]:
+        return [cls(1)]
+
+    @graph_ql_property(cache="timeout", timeout=300, warm_up=True)
+    def score(self) -> int:
+        raise RuntimeError("boom")
+
+    class Interface:
+        @staticmethod
+        def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+            return {"score": FailingWarmUpObject.score}
+
+
+class NoInterfaceWarmUpObject:
+    pass
+
+
 class GraphQLWarmUpExecutorTests(SimpleTestCase):
     def setUp(self) -> None:
         cache.clear()
         WarmUpObject.calls = 0
+        DependencyWarmUpObject.calls = 0
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
     def test_warm_up_executes_property_for_each_all_entry_and_records_recipes(
@@ -86,3 +137,161 @@ class GraphQLWarmUpExecutorTests(SimpleTestCase):
         self.assertEqual(refreshed, 1)
         self.assertEqual(WarmUpObject.calls, 1)
         self.assertEqual(due_timeout_graphql_warmup_recipe_keys(), ())
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": False})
+    def test_disabled_warm_up_entry_points_skip_work(self) -> None:
+        summary = warm_up_graphql_properties([WarmUpObject])
+
+        self.assertEqual(summary.evaluated, 0)
+        self.assertEqual(WarmUpObject.calls, 0)
+        self.assertFalse(warm_up_graphql_recipe("missing"))
+        self.assertEqual(refresh_due_graphql_warmup_recipes(), 0)
+        self.assertFalse(enqueue_graphql_warmup([WarmUpObject]))
+        self.assertFalse(enqueue_graphql_recipe_warmup(["cache-key"]))
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_warmable_properties_handles_missing_interface_and_filters(self) -> None:
+        self.assertEqual(warmable_graphql_properties(NoInterfaceWarmUpObject), {})
+        self.assertEqual(warmable_graphql_properties(WarmUpObject, ["missing"]), {})
+
+        summary = warm_up_graphql_properties([WarmUpObject], property_names=["missing"])
+
+        self.assertEqual(summary.evaluated, 0)
+        self.assertEqual(WarmUpObject.calls, 0)
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_WARMUP_ENABLED": True,
+            "GRAPHQL_WARMUP_BATCH_SIZE": "invalid",
+        }
+    )
+    def test_warm_up_discovers_registered_managers_when_none_are_provided(self) -> None:
+        with patch.dict(
+            GraphQL.manager_registry,
+            {"WarmUpObject": WarmUpObject},
+            clear=True,
+        ):
+            summary = warm_up_graphql_properties()
+
+        self.assertEqual(summary.evaluated, 2)
+        self.assertEqual(WarmUpObject.calls, 2)
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_WARMUP_ENABLED": True,
+            "GRAPHQL_WARMUP_BATCH_SIZE": 1,
+            "GRAPHQL_WARMUP_WARNING_ITEMS_PER_MANAGER": 1,
+            "GRAPHQL_WARMUP_TIMEOUT_REFRESH_RATIO": "invalid",
+        }
+    )
+    def test_warm_up_batches_and_warns_when_manager_crosses_threshold(self) -> None:
+        with patch("general_manager.api.graphql_warmup.logger.warning") as warning:
+            summary = warm_up_graphql_properties([WarmUpObject])
+
+        self.assertEqual(summary.evaluated, 2)
+        self.assertEqual(summary.recipes, 2)
+        warning.assert_called_once()
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_warm_up_records_no_recipe_for_local_manager_path(self) -> None:
+        class LocalWarmUpObject:
+            calls = 0
+
+            def __init__(self, id: int) -> None:
+                self.identification = {"id": id}
+                self.id = id
+
+            @classmethod
+            def all(cls) -> list["LocalWarmUpObject"]:
+                return [cls(1)]
+
+            @graph_ql_property(cache="timeout", timeout=300, warm_up=True)
+            def score(self) -> int:
+                type(self).calls += 1
+                return self.id
+
+            class Interface:
+                @staticmethod
+                def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+                    return {"score": LocalWarmUpObject.score}
+
+        summary = warm_up_graphql_properties([LocalWarmUpObject])
+
+        self.assertEqual(summary.evaluated, 1)
+        self.assertEqual(summary.recipes, 0)
+        self.assertEqual(LocalWarmUpObject.calls, 1)
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_warm_up_records_failures_and_continues(self) -> None:
+        with patch("general_manager.api.graphql_warmup.logger.exception") as log:
+            summary = warm_up_graphql_properties([FailingWarmUpObject])
+
+        self.assertEqual(summary.evaluated, 0)
+        self.assertEqual(summary.failed, 1)
+        self.assertEqual(summary.recipes, 0)
+        log.assert_called_once()
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_warm_up_dependency_recipe_reconstructs_and_executes_property(self) -> None:
+        warm_up_graphql_properties([DependencyWarmUpObject])
+        cache_key = graphql_warmup_recipe_keys()[0]
+        DependencyWarmUpObject.calls = 0
+
+        warmed = warm_up_graphql_recipe(cache_key)
+
+        self.assertTrue(warmed)
+        self.assertEqual(DependencyWarmUpObject.calls, 1)
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_warm_up_recipe_returns_false_for_missing_recipe_or_lock(self) -> None:
+        self.assertFalse(warm_up_graphql_recipe("missing"))
+
+        warm_up_graphql_properties([WarmUpObject])
+        cache_key = graphql_warmup_recipe_keys()[0]
+        with patch(
+            "general_manager.api.graphql_warmup.acquire_graphql_warmup_recipe_lock",
+            return_value=None,
+        ):
+            self.assertFalse(warm_up_graphql_recipe(cache_key))
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_warm_up_recipe_logs_and_returns_false_for_bad_recipe(self) -> None:
+        warm_up_graphql_properties([WarmUpObject])
+        cache_key = graphql_warmup_recipe_keys()[0]
+        recipe = get_graphql_warmup_recipe(cache_key)
+        assert recipe is not None
+        register_graphql_warmup_recipe(replace(recipe, manager_path="missing.Manager"))
+
+        with patch("general_manager.api.graphql_warmup.logger.exception") as log:
+            warmed = warm_up_graphql_recipe(cache_key)
+
+        self.assertFalse(warmed)
+        log.assert_called_once()
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_WARMUP_ENABLED": True,
+            "GRAPHQL_WARMUP_REWARM_AFTER_INVALIDATION": False,
+        }
+    )
+    def test_enqueue_recipe_warmup_respects_rewarm_setting_and_empty_keys(self) -> None:
+        self.assertFalse(enqueue_graphql_recipe_warmup(["cache-key"]))
+
+        with override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True}):
+            self.assertFalse(enqueue_graphql_recipe_warmup([]))
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_enqueue_entry_points_delegate_to_task_dispatchers(self) -> None:
+        with patch(
+            "general_manager.api.graphql_warmup_tasks.dispatch_graphql_warmup",
+            return_value=True,
+        ) as dispatch_warmup:
+            self.assertTrue(enqueue_graphql_warmup([WarmUpObject]))
+        dispatch_warmup.assert_called_once_with([WarmUpObject])
+
+        with patch(
+            "general_manager.api.graphql_warmup_tasks.dispatch_graphql_recipe_warmup",
+            return_value=True,
+        ) as dispatch_recipe:
+            self.assertTrue(enqueue_graphql_recipe_warmup(["a", "a", "b"]))
+        dispatch_recipe.assert_called_once_with(("a", "b"))

--- a/tests/unit/test_graphql_warmup.py
+++ b/tests/unit/test_graphql_warmup.py
@@ -1,0 +1,88 @@
+from dataclasses import replace
+from datetime import timedelta
+
+from django.core.cache import cache
+from django.test import SimpleTestCase, override_settings
+from django.utils import timezone
+
+from general_manager.api.graphql_warmup import (
+    refresh_due_graphql_warmup_recipes,
+    warm_up_graphql_properties,
+    warm_up_graphql_recipe,
+)
+from general_manager.api.graphql_warmup_registry import (
+    due_timeout_graphql_warmup_recipe_keys,
+    get_graphql_warmup_recipe,
+    graphql_warmup_recipe_keys,
+    register_graphql_warmup_recipe,
+)
+from general_manager.api.property import GraphQLProperty, graph_ql_property
+
+
+class WarmUpObject:
+    calls = 0
+
+    def __init__(self, id: int) -> None:
+        self.identification = {"id": id}
+        self.id = id
+
+    def __str__(self) -> str:
+        return f"WarmUpObject(**{{'id': {self.id}}})"
+
+    @classmethod
+    def all(cls) -> list["WarmUpObject"]:
+        return [cls(1), cls(2)]
+
+    @graph_ql_property(cache="timeout", timeout=300, warm_up=True)
+    def score(self) -> int:
+        type(self).calls += 1
+        return self.id * 10
+
+    class Interface:
+        @staticmethod
+        def get_graph_ql_properties() -> dict[str, GraphQLProperty]:
+            return {"score": WarmUpObject.score}
+
+
+class GraphQLWarmUpExecutorTests(SimpleTestCase):
+    def setUp(self) -> None:
+        cache.clear()
+        WarmUpObject.calls = 0
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_warm_up_executes_property_for_each_all_entry_and_records_recipes(
+        self,
+    ) -> None:
+        summary = warm_up_graphql_properties([WarmUpObject])
+
+        self.assertEqual(summary.evaluated, 2)
+        self.assertEqual(WarmUpObject.calls, 2)
+        self.assertEqual(len(graphql_warmup_recipe_keys()), 2)
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_warm_up_recipe_reconstructs_instance_and_executes_property(self) -> None:
+        warm_up_graphql_properties([WarmUpObject])
+        cache_key = graphql_warmup_recipe_keys()[0]
+        WarmUpObject.calls = 0
+
+        warmed = warm_up_graphql_recipe(cache_key)
+
+        self.assertTrue(warmed)
+        self.assertEqual(WarmUpObject.calls, 1)
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_ENABLED": True})
+    def test_refresh_due_timeout_recipes_updates_refresh_schedule(self) -> None:
+        warm_up_graphql_properties([WarmUpObject])
+        cache_key = graphql_warmup_recipe_keys()[0]
+        recipe = get_graphql_warmup_recipe(cache_key)
+        assert recipe is not None
+        register_graphql_warmup_recipe(
+            replace(recipe, refresh_at=timezone.now() - timedelta(seconds=1))
+        )
+        WarmUpObject.calls = 0
+
+        refreshed = refresh_due_graphql_warmup_recipes()
+
+        self.assertEqual(refreshed, 1)
+        self.assertEqual(WarmUpObject.calls, 1)
+        self.assertEqual(due_timeout_graphql_warmup_recipe_keys(), ())

--- a/tests/unit/test_graphql_warmup_command.py
+++ b/tests/unit/test_graphql_warmup_command.py
@@ -1,0 +1,14 @@
+"""Tests for the GraphQL warm-up management command."""
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import SimpleTestCase
+
+
+class GraphQLWarmUpCommandTests(SimpleTestCase):
+    """Verify command input validation."""
+
+    def test_invalid_dotted_manager_path_raises_command_error(self) -> None:
+        """Invalid dotted manager paths are reported as CommandError."""
+        with self.assertRaisesRegex(CommandError, "Invalid GraphQL manager path"):
+            call_command("graphql_warmup", "--manager", "missing.Manager")

--- a/tests/unit/test_graphql_warmup_registry.py
+++ b/tests/unit/test_graphql_warmup_registry.py
@@ -1,3 +1,5 @@
+"""Tests for the cache-backed GraphQL warm-up recipe registry."""
+
 from datetime import UTC, datetime, timedelta
 
 from django.core.cache import cache
@@ -19,11 +21,73 @@ from general_manager.api.graphql_warmup_registry import (
 )
 
 
+class RecordingCacheBackend:
+    """Cache backend that records calls made during index updates."""
+
+    def __init__(self) -> None:
+        """Initialize in-memory state and call history."""
+        self.store: dict[str, object] = {}
+        self.events: list[tuple[str, str]] = []
+
+    def add(self, key: str, value: object, timeout: int | None = None) -> bool:
+        """Add a value only when the key is absent."""
+        del timeout
+        self.events.append(("add", key))
+        if key in self.store:
+            return False
+        self.store[key] = value
+        return True
+
+    def get(self, key: str, default: object = None) -> object:
+        """Return a stored value and record the read."""
+        self.events.append(("get", key))
+        return self.store.get(key, default)
+
+    def set(self, key: str, value: object, timeout: int | None = None) -> None:
+        """Store a value and record the write."""
+        del timeout
+        self.events.append(("set", key))
+        self.store[key] = value
+
+    def delete(self, key: str) -> None:
+        """Delete a value and record the deletion."""
+        self.events.append(("delete", key))
+        self.store.pop(key, None)
+
+
+class ReacquiredLockCacheBackend:
+    """Cache backend that simulates lock expiry and reacquisition during release."""
+
+    def __init__(self, lock: GraphQLWarmUpRecipeLock) -> None:
+        """Seed the backend with the old lock token."""
+        self.lock = lock
+        self.store = {lock.key: lock.token}
+        self.first_get = True
+        self.deleted: list[str] = []
+
+    def get(self, key: str, default: object = None) -> object:
+        """Return the old token once while replacing it with a newer token."""
+        if key == self.lock.key and self.first_get:
+            self.first_get = False
+            self.store[key] = "new-token"
+            return self.lock.token
+        return self.store.get(key, default)
+
+    def delete(self, key: str) -> None:
+        """Record lock deletion attempts."""
+        self.deleted.append(key)
+        self.store.pop(key, None)
+
+
 class GraphQLWarmUpRegistryTests(SimpleTestCase):
+    """Verify recipe persistence, indexes, and lock behavior."""
+
     def setUp(self) -> None:
+        """Clear the shared cache before each registry test."""
         cache.clear()
 
     def test_registers_and_reads_recipe_by_cache_key(self) -> None:
+        """Recipes can be registered, read back, and listed in the index."""
         recipe = GraphQLWarmUpRecipe(
             cache_key="abc",
             manager_path="tests.unit.test_graphql_warmup_registry.Manager",
@@ -40,6 +104,7 @@ class GraphQLWarmUpRegistryTests(SimpleTestCase):
         self.assertEqual(graphql_warmup_recipe_keys(), ("abc",))
 
     def test_due_timeout_recipes_filter_by_refresh_at(self) -> None:
+        """Due timeout lookup returns only recipes whose refresh time has arrived."""
         now = datetime(2026, 6, 19, tzinfo=UTC)
         due = GraphQLWarmUpRecipe(
             cache_key="due",
@@ -65,6 +130,7 @@ class GraphQLWarmUpRegistryTests(SimpleTestCase):
         self.assertEqual(due_timeout_graphql_warmup_recipe_keys(now=now), ("due",))
 
     def test_delete_removes_recipe_from_indexes(self) -> None:
+        """Deleting a recipe removes it from all registry indexes."""
         recipe = GraphQLWarmUpRecipe(
             cache_key="gone",
             manager_path="tests.unit.test_graphql_warmup_registry.Manager",
@@ -83,6 +149,7 @@ class GraphQLWarmUpRegistryTests(SimpleTestCase):
         self.assertEqual(due_timeout_graphql_warmup_recipe_keys(), ())
 
     def test_rejects_stale_recipe_versions(self) -> None:
+        """Recipes from older schema versions are ignored."""
         recipe = GraphQLWarmUpRecipe(
             cache_key="stale",
             manager_path="tests.unit.test_graphql_warmup_registry.Manager",
@@ -99,6 +166,7 @@ class GraphQLWarmUpRegistryTests(SimpleTestCase):
         self.assertIsNone(get_graphql_warmup_recipe("stale"))
 
     def test_reads_existing_recipes_for_distinct_cache_keys(self) -> None:
+        """Bulk recipe lookup deduplicates requested cache keys."""
         recipe = GraphQLWarmUpRecipe(
             cache_key="known",
             manager_path="tests.unit.test_graphql_warmup_registry.Manager",
@@ -118,6 +186,7 @@ class GraphQLWarmUpRegistryTests(SimpleTestCase):
     def test_due_timeout_recipes_prunes_stale_index_members_and_applies_limit(
         self,
     ) -> None:
+        """Due timeout lookup prunes stale index entries and honors limits."""
         now = datetime(2026, 6, 19, tzinfo=UTC)
         first = GraphQLWarmUpRecipe(
             cache_key="first",
@@ -151,6 +220,7 @@ class GraphQLWarmUpRegistryTests(SimpleTestCase):
         )
 
     def test_recipe_lock_acquire_and_release_are_token_safe(self) -> None:
+        """Recipe locks cannot be released by callers with the wrong token."""
         lock = acquire_graphql_warmup_recipe_lock("locked")
         assert lock is not None
 
@@ -165,6 +235,42 @@ class GraphQLWarmUpRegistryTests(SimpleTestCase):
         release_graphql_warmup_recipe_lock(next_lock)
 
     def test_invalid_index_payload_reads_as_empty(self) -> None:
+        """Malformed index payloads are treated as empty indexes."""
         cache.set(RECIPE_INDEX_KEY, ["not", "a", "frozenset"])
 
         self.assertEqual(graphql_warmup_recipe_keys(), ())
+
+    def test_recipe_registration_synchronizes_index_updates(self) -> None:
+        """Recipe registration acquires an index lock before read-modify-write."""
+        cache_backend = RecordingCacheBackend()
+        recipe = GraphQLWarmUpRecipe(
+            cache_key="locked-index",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 1},
+            cache="dependency",
+            timeout=None,
+            refresh_at=None,
+        )
+
+        register_graphql_warmup_recipe(recipe, cache_backend=cache_backend)
+
+        lock_adds = [
+            key
+            for event, key in cache_backend.events
+            if event == "add" and ":index:" in key
+        ]
+        self.assertGreaterEqual(len(lock_adds), 1)
+
+    def test_release_recipe_lock_does_not_delete_reacquired_lock(self) -> None:
+        """Lock release does not delete a newer token acquired after expiry."""
+        lock = GraphQLWarmUpRecipeLock(
+            "general_manager:graphql_warmup:lock:race",
+            "old-token",
+        )
+        cache_backend = ReacquiredLockCacheBackend(lock)
+
+        release_graphql_warmup_recipe_lock(lock, cache_backend=cache_backend)
+
+        self.assertEqual(cache_backend.store[lock.key], "new-token")
+        self.assertEqual(cache_backend.deleted, [])

--- a/tests/unit/test_graphql_warmup_registry.py
+++ b/tests/unit/test_graphql_warmup_registry.py
@@ -5,11 +5,17 @@ from django.test import SimpleTestCase
 
 from general_manager.api.graphql_warmup_registry import (
     GraphQLWarmUpRecipe,
+    GraphQLWarmUpRecipeLock,
+    RECIPE_INDEX_KEY,
+    TIMEOUT_RECIPE_INDEX_KEY,
+    acquire_graphql_warmup_recipe_lock,
     delete_graphql_warmup_recipe,
     due_timeout_graphql_warmup_recipe_keys,
     get_graphql_warmup_recipe,
+    get_graphql_warmup_recipes,
     graphql_warmup_recipe_keys,
     register_graphql_warmup_recipe,
+    release_graphql_warmup_recipe_lock,
 )
 
 
@@ -75,3 +81,90 @@ class GraphQLWarmUpRegistryTests(SimpleTestCase):
         self.assertIsNone(get_graphql_warmup_recipe("gone"))
         self.assertEqual(graphql_warmup_recipe_keys(), ())
         self.assertEqual(due_timeout_graphql_warmup_recipe_keys(), ())
+
+    def test_rejects_stale_recipe_versions(self) -> None:
+        recipe = GraphQLWarmUpRecipe(
+            cache_key="stale",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 1},
+            cache="dependency",
+            timeout=None,
+            refresh_at=None,
+            version=0,
+        )
+
+        register_graphql_warmup_recipe(recipe)
+
+        self.assertIsNone(get_graphql_warmup_recipe("stale"))
+
+    def test_reads_existing_recipes_for_distinct_cache_keys(self) -> None:
+        recipe = GraphQLWarmUpRecipe(
+            cache_key="known",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 1},
+            cache="dependency",
+            timeout=None,
+            refresh_at=None,
+        )
+        register_graphql_warmup_recipe(recipe)
+
+        self.assertEqual(
+            get_graphql_warmup_recipes(["known", "known", "missing"]),
+            {"known": recipe},
+        )
+
+    def test_due_timeout_recipes_prunes_stale_index_members_and_applies_limit(
+        self,
+    ) -> None:
+        now = datetime(2026, 6, 19, tzinfo=UTC)
+        first = GraphQLWarmUpRecipe(
+            cache_key="first",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 1},
+            cache="timeout",
+            timeout=300,
+            refresh_at=now - timedelta(seconds=10),
+        )
+        second = GraphQLWarmUpRecipe(
+            cache_key="second",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 2},
+            cache="timeout",
+            timeout=300,
+            refresh_at=now - timedelta(seconds=5),
+        )
+        register_graphql_warmup_recipe(first)
+        register_graphql_warmup_recipe(second)
+        cache.set(TIMEOUT_RECIPE_INDEX_KEY, frozenset(("first", "missing", "second")))
+
+        self.assertEqual(
+            due_timeout_graphql_warmup_recipe_keys(now=now, limit=1),
+            ("first",),
+        )
+        self.assertEqual(
+            cache.get(TIMEOUT_RECIPE_INDEX_KEY),
+            frozenset(("first", "second")),
+        )
+
+    def test_recipe_lock_acquire_and_release_are_token_safe(self) -> None:
+        lock = acquire_graphql_warmup_recipe_lock("locked")
+        assert lock is not None
+
+        self.assertIsNone(acquire_graphql_warmup_recipe_lock("locked"))
+        release_graphql_warmup_recipe_lock(GraphQLWarmUpRecipeLock(lock.key, "wrong"))
+        self.assertIsNone(acquire_graphql_warmup_recipe_lock("locked"))
+
+        release_graphql_warmup_recipe_lock(lock)
+        next_lock = acquire_graphql_warmup_recipe_lock("locked")
+        self.assertIsNotNone(next_lock)
+        assert next_lock is not None
+        release_graphql_warmup_recipe_lock(next_lock)
+
+    def test_invalid_index_payload_reads_as_empty(self) -> None:
+        cache.set(RECIPE_INDEX_KEY, ["not", "a", "frozenset"])
+
+        self.assertEqual(graphql_warmup_recipe_keys(), ())

--- a/tests/unit/test_graphql_warmup_registry.py
+++ b/tests/unit/test_graphql_warmup_registry.py
@@ -1,0 +1,77 @@
+from datetime import UTC, datetime, timedelta
+
+from django.core.cache import cache
+from django.test import SimpleTestCase
+
+from general_manager.api.graphql_warmup_registry import (
+    GraphQLWarmUpRecipe,
+    delete_graphql_warmup_recipe,
+    due_timeout_graphql_warmup_recipe_keys,
+    get_graphql_warmup_recipe,
+    graphql_warmup_recipe_keys,
+    register_graphql_warmup_recipe,
+)
+
+
+class GraphQLWarmUpRegistryTests(SimpleTestCase):
+    def setUp(self) -> None:
+        cache.clear()
+
+    def test_registers_and_reads_recipe_by_cache_key(self) -> None:
+        recipe = GraphQLWarmUpRecipe(
+            cache_key="abc",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 1},
+            cache="dependency",
+            timeout=None,
+            refresh_at=None,
+        )
+
+        register_graphql_warmup_recipe(recipe)
+
+        self.assertEqual(get_graphql_warmup_recipe("abc"), recipe)
+        self.assertEqual(graphql_warmup_recipe_keys(), ("abc",))
+
+    def test_due_timeout_recipes_filter_by_refresh_at(self) -> None:
+        now = datetime(2026, 6, 19, tzinfo=UTC)
+        due = GraphQLWarmUpRecipe(
+            cache_key="due",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 1},
+            cache="timeout",
+            timeout=300,
+            refresh_at=now - timedelta(seconds=1),
+        )
+        later = GraphQLWarmUpRecipe(
+            cache_key="later",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 2},
+            cache="timeout",
+            timeout=300,
+            refresh_at=now + timedelta(seconds=60),
+        )
+        register_graphql_warmup_recipe(due)
+        register_graphql_warmup_recipe(later)
+
+        self.assertEqual(due_timeout_graphql_warmup_recipe_keys(now=now), ("due",))
+
+    def test_delete_removes_recipe_from_indexes(self) -> None:
+        recipe = GraphQLWarmUpRecipe(
+            cache_key="gone",
+            manager_path="tests.unit.test_graphql_warmup_registry.Manager",
+            property_name="score",
+            identification={"id": 1},
+            cache="timeout",
+            timeout=300,
+            refresh_at=datetime(2026, 6, 19, tzinfo=UTC),
+        )
+        register_graphql_warmup_recipe(recipe)
+
+        delete_graphql_warmup_recipe("gone")
+
+        self.assertIsNone(get_graphql_warmup_recipe("gone"))
+        self.assertEqual(graphql_warmup_recipe_keys(), ())
+        self.assertEqual(due_timeout_graphql_warmup_recipe_keys(), ())

--- a/tests/unit/test_graphql_warmup_tasks.py
+++ b/tests/unit/test_graphql_warmup_tasks.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase, override_settings
+
+from general_manager.api.graphql_warmup_tasks import (
+    GRAPHQL_WARMUP_BEAT_SCHEDULE_KEY,
+    configure_graphql_warmup_beat_schedule_from_settings,
+    refresh_due_graphql_warmup_recipes_task,
+    warm_up_graphql_properties_task,
+    warm_up_graphql_recipes_task,
+)
+
+
+class GraphQLWarmUpBeatScheduleTests(SimpleTestCase):
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_WARMUP_BEAT_ENABLED": True,
+            "GRAPHQL_WARMUP_BEAT_INTERVAL_SECONDS": 13,
+        }
+    )
+    def test_configure_graphql_warmup_beat_schedule_registers_task(self) -> None:
+        fake_conf = SimpleNamespace(beat_schedule={})
+        fake_app = SimpleNamespace(conf=fake_conf)
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch("general_manager.api.graphql_warmup_tasks.current_app", fake_app),
+        ):
+            configured = configure_graphql_warmup_beat_schedule_from_settings()
+
+        self.assertTrue(configured)
+        entry = fake_conf.beat_schedule[GRAPHQL_WARMUP_BEAT_SCHEDULE_KEY]
+        self.assertEqual(
+            entry["task"],
+            "general_manager.api.graphql_warmup_tasks."
+            "refresh_due_graphql_warmup_recipes_task",
+        )
+        self.assertEqual(entry["schedule"], 13.0)
+        self.assertEqual(entry["options"], {"queue": "graphql.warmup"})
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_BEAT_ENABLED": False})
+    def test_configure_graphql_warmup_beat_schedule_skips_when_disabled(self) -> None:
+        fake_conf = SimpleNamespace(beat_schedule={})
+        fake_app = SimpleNamespace(conf=fake_conf)
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch("general_manager.api.graphql_warmup_tasks.current_app", fake_app),
+        ):
+            configured = configure_graphql_warmup_beat_schedule_from_settings()
+
+        self.assertFalse(configured)
+        self.assertEqual(fake_conf.beat_schedule, {})
+
+
+class GraphQLWarmUpTaskTests(SimpleTestCase):
+    def test_warm_up_graphql_properties_task_delegates_to_executor(self) -> None:
+        summary = SimpleNamespace(evaluated=2, failed=0, recipes=2)
+        with (
+            patch(
+                "general_manager.api.graphql_warmup_tasks.import_string",
+                return_value=object,
+            ),
+            patch(
+                "general_manager.api.graphql_warmup_tasks.warm_up_graphql_properties",
+                return_value=summary,
+            ) as warm_up,
+        ):
+            result = warm_up_graphql_properties_task(["tests.Manager"])
+
+        warm_up.assert_called_once_with([object])
+        self.assertEqual(result, {"evaluated": 2, "failed": 0, "recipes": 2})
+
+    def test_warm_up_graphql_recipes_task_isolates_recipe_failures(self) -> None:
+        with patch(
+            "general_manager.api.graphql_warmup_tasks.warm_up_graphql_recipe",
+            side_effect=[True, RuntimeError("boom"), False],
+        ):
+            warmed = warm_up_graphql_recipes_task(["a", "b", "c"])
+
+        self.assertEqual(warmed, 1)
+
+    def test_refresh_due_graphql_warmup_recipes_task_delegates_to_executor(
+        self,
+    ) -> None:
+        refresh = Mock(return_value=3)
+        with patch(
+            "general_manager.api.graphql_warmup_tasks.refresh_due_graphql_warmup_recipes",
+            refresh,
+        ):
+            refreshed = refresh_due_graphql_warmup_recipes_task(limit=10)
+
+        refresh.assert_called_once_with(limit=10)
+        self.assertEqual(refreshed, 3)

--- a/tests/unit/test_graphql_warmup_tasks.py
+++ b/tests/unit/test_graphql_warmup_tasks.py
@@ -8,6 +8,8 @@ from django.test import SimpleTestCase, override_settings
 from general_manager.api.graphql_warmup_tasks import (
     GRAPHQL_WARMUP_BEAT_SCHEDULE_KEY,
     configure_graphql_warmup_beat_schedule_from_settings,
+    dispatch_graphql_recipe_warmup,
+    dispatch_graphql_warmup,
     refresh_due_graphql_warmup_recipes_task,
     warm_up_graphql_properties_task,
     warm_up_graphql_recipes_task,
@@ -53,6 +55,40 @@ class GraphQLWarmUpBeatScheduleTests(SimpleTestCase):
         self.assertFalse(configured)
         self.assertEqual(fake_conf.beat_schedule, {})
 
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_BEAT_ENABLED": True})
+    def test_configure_graphql_warmup_beat_schedule_skips_without_celery(self) -> None:
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", False),
+            patch("general_manager.api.graphql_warmup_tasks.logger.warning") as warning,
+        ):
+            configured = configure_graphql_warmup_beat_schedule_from_settings()
+
+        self.assertFalse(configured)
+        warning.assert_called_once()
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_WARMUP_BEAT_ENABLED": True,
+            "GRAPHQL_WARMUP_BEAT_INTERVAL_SECONDS": "invalid",
+        }
+    )
+    def test_configure_graphql_warmup_beat_schedule_defaults_invalid_interval(
+        self,
+    ) -> None:
+        fake_conf = SimpleNamespace(beat_schedule=None)
+        fake_app = SimpleNamespace(conf=fake_conf)
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch("general_manager.api.graphql_warmup_tasks.current_app", fake_app),
+        ):
+            configured = configure_graphql_warmup_beat_schedule_from_settings()
+
+        self.assertTrue(configured)
+        self.assertEqual(
+            fake_conf.beat_schedule[GRAPHQL_WARMUP_BEAT_SCHEDULE_KEY]["schedule"],
+            60.0,
+        )
+
 
 class GraphQLWarmUpTaskTests(SimpleTestCase):
     def test_warm_up_graphql_properties_task_delegates_to_executor(self) -> None:
@@ -93,3 +129,87 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
 
         refresh.assert_called_once_with(limit=10)
         self.assertEqual(refreshed, 3)
+
+    def test_dispatch_graphql_warmup_skips_when_celery_unavailable(self) -> None:
+        with patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", False):
+            self.assertFalse(dispatch_graphql_warmup())
+
+    def test_dispatch_graphql_warmup_skips_unimportable_local_manager(self) -> None:
+        class LocalManager:
+            pass
+
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch(
+                "general_manager.api.graphql_warmup_tasks."
+                "warm_up_graphql_properties_task.delay"
+            ) as delay,
+        ):
+            self.assertFalse(dispatch_graphql_warmup([LocalManager]))
+
+        delay.assert_not_called()
+
+    def test_dispatch_graphql_warmup_enqueues_manager_paths(self) -> None:
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch(
+                "general_manager.api.graphql_warmup_tasks."
+                "warm_up_graphql_properties_task.delay"
+            ) as delay,
+        ):
+            dispatched = dispatch_graphql_warmup([GraphQLWarmUpTaskTests])
+
+        self.assertTrue(dispatched)
+        delay.assert_called_once_with(
+            ["tests.unit.test_graphql_warmup_tasks.GraphQLWarmUpTaskTests"]
+        )
+
+    def test_dispatch_graphql_warmup_returns_false_when_enqueue_fails(self) -> None:
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch(
+                "general_manager.api.graphql_warmup_tasks."
+                "warm_up_graphql_properties_task.delay",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("general_manager.api.graphql_warmup_tasks.logger.exception") as log,
+        ):
+            self.assertFalse(dispatch_graphql_warmup())
+
+        log.assert_called_once()
+
+    def test_dispatch_graphql_recipe_warmup_skips_without_celery_or_keys(self) -> None:
+        with patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", False):
+            self.assertFalse(dispatch_graphql_recipe_warmup(["a"]))
+
+        with patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True):
+            self.assertFalse(dispatch_graphql_recipe_warmup([]))
+
+    def test_dispatch_graphql_recipe_warmup_enqueues_distinct_keys(self) -> None:
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch(
+                "general_manager.api.graphql_warmup_tasks."
+                "warm_up_graphql_recipes_task.delay"
+            ) as delay,
+        ):
+            dispatched = dispatch_graphql_recipe_warmup(["a", "a", "b"])
+
+        self.assertTrue(dispatched)
+        delay.assert_called_once_with(["a", "b"])
+
+    def test_dispatch_graphql_recipe_warmup_returns_false_when_enqueue_fails(
+        self,
+    ) -> None:
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch(
+                "general_manager.api.graphql_warmup_tasks."
+                "warm_up_graphql_recipes_task.delay",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("general_manager.api.graphql_warmup_tasks.logger.exception") as log,
+        ):
+            self.assertFalse(dispatch_graphql_recipe_warmup(["a"]))
+
+        log.assert_called_once()

--- a/tests/unit/test_graphql_warmup_tasks.py
+++ b/tests/unit/test_graphql_warmup_tasks.py
@@ -1,3 +1,5 @@
+"""Tests for GraphQL warm-up Celery task adapters."""
+
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -17,6 +19,8 @@ from general_manager.api.graphql_warmup_tasks import (
 
 
 class GraphQLWarmUpBeatScheduleTests(SimpleTestCase):
+    """Verify optional Celery Beat schedule configuration."""
+
     @override_settings(
         GENERAL_MANAGER={
             "GRAPHQL_WARMUP_BEAT_ENABLED": True,
@@ -24,6 +28,7 @@ class GraphQLWarmUpBeatScheduleTests(SimpleTestCase):
         }
     )
     def test_configure_graphql_warmup_beat_schedule_registers_task(self) -> None:
+        """Beat configuration registers the due-timeout refresh task."""
         fake_conf = SimpleNamespace(beat_schedule={})
         fake_app = SimpleNamespace(conf=fake_conf)
         with (
@@ -44,6 +49,23 @@ class GraphQLWarmUpBeatScheduleTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_BEAT_ENABLED": False})
     def test_configure_graphql_warmup_beat_schedule_skips_when_disabled(self) -> None:
+        """Beat configuration is skipped when disabled in settings."""
+        fake_conf = SimpleNamespace(beat_schedule={})
+        fake_app = SimpleNamespace(conf=fake_conf)
+        with (
+            patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
+            patch("general_manager.api.graphql_warmup_tasks.current_app", fake_app),
+        ):
+            configured = configure_graphql_warmup_beat_schedule_from_settings()
+
+        self.assertFalse(configured)
+        self.assertEqual(fake_conf.beat_schedule, {})
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_BEAT_ENABLED": "false"})
+    def test_configure_graphql_warmup_beat_schedule_treats_false_string_as_disabled(
+        self,
+    ) -> None:
+        """String false values are parsed as disabled settings."""
         fake_conf = SimpleNamespace(beat_schedule={})
         fake_app = SimpleNamespace(conf=fake_conf)
         with (
@@ -57,6 +79,7 @@ class GraphQLWarmUpBeatScheduleTests(SimpleTestCase):
 
     @override_settings(GENERAL_MANAGER={"GRAPHQL_WARMUP_BEAT_ENABLED": True})
     def test_configure_graphql_warmup_beat_schedule_skips_without_celery(self) -> None:
+        """Beat configuration is skipped when Celery is unavailable."""
         with (
             patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", False),
             patch("general_manager.api.graphql_warmup_tasks.logger.warning") as warning,
@@ -75,6 +98,7 @@ class GraphQLWarmUpBeatScheduleTests(SimpleTestCase):
     def test_configure_graphql_warmup_beat_schedule_defaults_invalid_interval(
         self,
     ) -> None:
+        """Invalid interval settings fall back to the default schedule."""
         fake_conf = SimpleNamespace(beat_schedule=None)
         fake_app = SimpleNamespace(conf=fake_conf)
         with (
@@ -91,7 +115,10 @@ class GraphQLWarmUpBeatScheduleTests(SimpleTestCase):
 
 
 class GraphQLWarmUpTaskTests(SimpleTestCase):
+    """Verify task wrappers and dispatch helpers for GraphQL warm-up."""
+
     def test_warm_up_graphql_properties_task_delegates_to_executor(self) -> None:
+        """The all-entry task resolves paths and returns executor counts."""
         summary = SimpleNamespace(evaluated=2, failed=0, recipes=2)
         with (
             patch(
@@ -109,6 +136,7 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
         self.assertEqual(result, {"evaluated": 2, "failed": 0, "recipes": 2})
 
     def test_warm_up_graphql_recipes_task_isolates_recipe_failures(self) -> None:
+        """Recipe task failures are isolated per cache key."""
         with patch(
             "general_manager.api.graphql_warmup_tasks.warm_up_graphql_recipe",
             side_effect=[True, RuntimeError("boom"), False],
@@ -120,6 +148,7 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
     def test_refresh_due_graphql_warmup_recipes_task_delegates_to_executor(
         self,
     ) -> None:
+        """The due-refresh task delegates its limit to the executor."""
         refresh = Mock(return_value=3)
         with patch(
             "general_manager.api.graphql_warmup_tasks.refresh_due_graphql_warmup_recipes",
@@ -131,11 +160,16 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
         self.assertEqual(refreshed, 3)
 
     def test_dispatch_graphql_warmup_skips_when_celery_unavailable(self) -> None:
+        """All-entry dispatch returns false when Celery is unavailable."""
         with patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", False):
             self.assertFalse(dispatch_graphql_warmup())
 
     def test_dispatch_graphql_warmup_skips_unimportable_local_manager(self) -> None:
+        """All-entry dispatch skips manager classes without import paths."""
+
         class LocalManager:
+            """Local class that cannot be imported by a worker."""
+
             pass
 
         with (
@@ -150,6 +184,7 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
         delay.assert_not_called()
 
     def test_dispatch_graphql_warmup_enqueues_manager_paths(self) -> None:
+        """All-entry dispatch enqueues importable manager paths."""
         with (
             patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
             patch(
@@ -165,6 +200,7 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
         )
 
     def test_dispatch_graphql_warmup_returns_false_when_enqueue_fails(self) -> None:
+        """All-entry dispatch logs and returns false on enqueue failure."""
         with (
             patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
             patch(
@@ -179,6 +215,7 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
         log.assert_called_once()
 
     def test_dispatch_graphql_recipe_warmup_skips_without_celery_or_keys(self) -> None:
+        """Recipe dispatch skips missing Celery and empty work lists."""
         with patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", False):
             self.assertFalse(dispatch_graphql_recipe_warmup(["a"]))
 
@@ -186,6 +223,7 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
             self.assertFalse(dispatch_graphql_recipe_warmup([]))
 
     def test_dispatch_graphql_recipe_warmup_enqueues_distinct_keys(self) -> None:
+        """Recipe dispatch deduplicates keys before enqueueing."""
         with (
             patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
             patch(
@@ -201,6 +239,7 @@ class GraphQLWarmUpTaskTests(SimpleTestCase):
     def test_dispatch_graphql_recipe_warmup_returns_false_when_enqueue_fails(
         self,
     ) -> None:
+        """Recipe dispatch logs and returns false on enqueue failure."""
         with (
             patch("general_manager.api.graphql_warmup_tasks.CELERY_AVAILABLE", True),
             patch(

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -1,3 +1,5 @@
+"""Tests for data-change signal dispatch and dependency-cache cleanup."""
+
 from django.test import TestCase
 from django.dispatch import Signal
 from contextlib import contextmanager
@@ -18,6 +20,7 @@ def capture_signal(signal: Signal):
     calls = []
 
     def _receiver(sender, **kwargs):
+        """Record one signal emission."""
         calls.append({"sender": sender, **kwargs})
 
     signal.connect(_receiver, weak=False)
@@ -31,6 +34,7 @@ class Dummy:
     """Test helper class decorated with @data_change for create and update."""
 
     def __init__(self):
+        """Initialize a dummy instance with old-value storage."""
         # simulate existing state storage
         self._old_values = getattr(self, "_old_values", {})
         self.value = None
@@ -38,12 +42,14 @@ class Dummy:
     @classmethod
     @data_change
     def create(cls, new_value):
+        """Create a dummy instance with the provided value."""
         inst = cls()
         inst.value = new_value
         return inst
 
     @data_change
     def update(self, new_value):
+        """Update the dummy value and return the instance."""
         # store old relevant values before change
         self._old_values = getattr(self, "_old_values", {})
         self.value = new_value
@@ -51,6 +57,7 @@ class Dummy:
 
     @data_change
     def delete(self):
+        """Delete the dummy instance by returning no result."""
         return None
 
 
@@ -58,29 +65,50 @@ class InvalidatingDummy:
     """Test helper that invalidates identification during delete."""
 
     def __init__(self):
+        """Initialize the pre-delete identification."""
         self.identification = {"id": "before"}
 
     @data_change
     def delete(self):
+        """Invalidate identification while deleting the instance."""
         self.identification["id"] = "after"
         self.identification = None
         return None
 
 
 class RaisingDummy:
+    """Test helper whose update operation raises."""
+
     @data_change
     def update(self):
+        """Raise from a data-change wrapped method."""
+        raise ValueError("boom")
+
+
+class RecordingRaisingDummy:
+    """Test helper that records pending rewarm keys before raising."""
+
+    @data_change
+    def update(self):
+        """Record a pending key and raise from a wrapped method."""
+        record_invalidated_cache_keys_for_graphql_rewarm(("stale-key",))
         raise ValueError("boom")
 
 
 class ClassMethodWrappedDummy:
+    """Test helper for manually wrapping a classmethod object."""
+
     @staticmethod
     def build():
+        """Return a new helper instance."""
         return ClassMethodWrappedDummy()
 
 
 class DataChangeSignalTests(TestCase):
+    """Verify data-change signal dispatch and cleanup behavior."""
+
     def setUp(self):
+        """Isolate signal receivers for each test."""
         # Preserve existing receivers so they can be restored after the test run
         self._original_pre_receivers = list(pre_data_change.receivers)
         self._original_post_receivers = list(post_data_change.receivers)
@@ -89,6 +117,7 @@ class DataChangeSignalTests(TestCase):
         post_data_change.receivers.clear()
 
     def tearDown(self):
+        """Restore signal receivers after each test."""
         # Clean up receivers after each test
         pre_data_change.receivers.clear()
         post_data_change.receivers.clear()
@@ -97,6 +126,7 @@ class DataChangeSignalTests(TestCase):
         post_data_change.receivers[:] = self._original_post_receivers
 
     def test_create_emits_pre_and_post(self):
+        """Create operations emit pre-change and post-change signals."""
         # Capture pre and post signals
         with (
             capture_signal(pre_data_change) as pre_calls,
@@ -120,6 +150,7 @@ class DataChangeSignalTests(TestCase):
         self.assertEqual(post["old_relevant_values"], {})
 
     def test_update_emits_pre_and_post(self):
+        """Update operations emit pre-change and post-change signals."""
         inst = Dummy()
         inst._old_values = {"key": "old"}
 
@@ -145,12 +176,14 @@ class DataChangeSignalTests(TestCase):
         self.assertEqual(post["old_relevant_values"], {"key": "old"})
 
     def test_wrapper_returns_original_result(self):
+        """The data_change wrapper returns the wrapped function result."""
         inst = Dummy()
         result = inst.update("baz")
         self.assertIsInstance(result, Dummy)
         self.assertEqual(result.value, "baz")
 
     def test_delete_returning_none_sends_delete_metadata_to_post_signal(self):
+        """Delete operations returning None still send delete metadata."""
         inst = Dummy()
 
         with capture_signal(post_data_change) as post_calls:
@@ -166,6 +199,7 @@ class DataChangeSignalTests(TestCase):
         self.assertEqual(post["action"], "delete")
 
     def test_delete_identification_uses_pre_mutation_snapshot(self):
+        """Delete metadata uses the pre-mutation identification snapshot."""
         inst = InvalidatingDummy()
 
         with capture_signal(post_data_change) as post_calls:
@@ -175,15 +209,18 @@ class DataChangeSignalTests(TestCase):
         self.assertEqual(post_calls[0]["identification"], {"id": "before"})
 
     def test_rewarm_keys_enqueue_after_dependency_data_change_ends(self):
+        """Pending rewarm keys enqueue after the dependency barrier is closed."""
         barrier_states: list[bool] = []
         enqueued_keys: list[tuple[str, ...]] = []
 
         def record_rewarm_key(sender, **kwargs):
+            """Record a pending cache key during the post-change barrier."""
             del sender, kwargs
             barrier_states.append(is_dependency_data_change_active())
             record_invalidated_cache_keys_for_graphql_rewarm(("cache-key",))
 
         def enqueue_rewarm(cache_keys):
+            """Capture the keys enqueued after the barrier closes."""
             enqueued_keys.append(tuple(cache_keys))
             self.assertFalse(is_dependency_data_change_active())
             return True
@@ -199,7 +236,10 @@ class DataChangeSignalTests(TestCase):
         self.assertEqual(enqueued_keys, [("cache-key",)])
 
     def test_data_change_supports_wrapped_classmethod_object(self):
+        """The wrapper can invoke a raw classmethod object."""
+
         def create(cls):
+            """Build an instance from the provided class."""
             return cls.build()
 
         wrapped = data_change(classmethod(create))
@@ -212,16 +252,19 @@ class DataChangeSignalTests(TestCase):
         self.assertEqual(post_calls[0]["action"], "create")
 
     def test_data_change_clears_barrier_when_wrapped_function_raises(self):
+        """Failed mutations drain pending rewarm keys without enqueueing them."""
         with self.assertRaisesRegex(ValueError, "boom"):
-            RaisingDummy().update()
+            RecordingRaisingDummy().update()
 
         self.assertFalse(is_dependency_data_change_active())
         self.assertEqual(drain_invalidated_cache_keys_for_graphql_rewarm(), ())
 
     def test_cleanup_failure_is_logged_when_wrapped_function_already_failed(self):
+        """Cleanup errors are logged when another exception is already active."""
         original_end = dependency_index.end_dependency_data_change
 
         def cleanup_then_raise():
+            """Run normal cleanup, then simulate a cleanup failure."""
             original_end()
             raise RuntimeError("cleanup")
 
@@ -239,9 +282,11 @@ class DataChangeSignalTests(TestCase):
         self.assertFalse(is_dependency_data_change_active())
 
     def test_cleanup_failure_raises_when_wrapped_function_succeeded(self):
+        """Cleanup errors propagate when the wrapped function succeeded."""
         original_end = dependency_index.end_dependency_data_change
 
         def cleanup_then_raise():
+            """Run normal cleanup, then simulate a cleanup failure."""
             original_end()
             raise RuntimeError("cleanup")
 
@@ -257,7 +302,10 @@ class DataChangeSignalTests(TestCase):
         self.assertFalse(is_dependency_data_change_active())
 
     def test_rewarm_enqueue_failure_is_logged(self):
+        """Rewarm enqueue failures are logged without failing the mutation."""
+
         def record_rewarm_key(sender, **kwargs):
+            """Record one pending rewarm key from a post-change receiver."""
             del sender, kwargs
             record_invalidated_cache_keys_for_graphql_rewarm(("cache-key",))
 
@@ -274,6 +322,7 @@ class DataChangeSignalTests(TestCase):
         log.assert_called_once_with("GraphQL warm-up requeue failed.")
 
     def test_nested_dependency_data_change_keeps_outer_barrier_active(self):
+        """Nested data-change cleanup keeps the outer barrier until final exit."""
         dependency_index.begin_dependency_data_change()
         dependency_index.begin_dependency_data_change()
 

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -3,7 +3,9 @@ from django.dispatch import Signal
 from contextlib import contextmanager
 from unittest.mock import patch
 
+from general_manager.cache import dependency_index
 from general_manager.cache.dependency_index import (
+    drain_invalidated_cache_keys_for_graphql_rewarm,
     is_dependency_data_change_active,
     record_invalidated_cache_keys_for_graphql_rewarm,
 )
@@ -63,6 +65,18 @@ class InvalidatingDummy:
         self.identification["id"] = "after"
         self.identification = None
         return None
+
+
+class RaisingDummy:
+    @data_change
+    def update(self):
+        raise ValueError("boom")
+
+
+class ClassMethodWrappedDummy:
+    @staticmethod
+    def build():
+        return ClassMethodWrappedDummy()
 
 
 class DataChangeSignalTests(TestCase):
@@ -183,3 +197,88 @@ class DataChangeSignalTests(TestCase):
 
         self.assertEqual(barrier_states, [True])
         self.assertEqual(enqueued_keys, [("cache-key",)])
+
+    def test_data_change_supports_wrapped_classmethod_object(self):
+        def create(cls):
+            return cls.build()
+
+        wrapped = data_change(classmethod(create))
+
+        with capture_signal(post_data_change) as post_calls:
+            result = wrapped(ClassMethodWrappedDummy)
+
+        self.assertIsInstance(result, ClassMethodWrappedDummy)
+        self.assertIs(post_calls[0]["sender"], ClassMethodWrappedDummy)
+        self.assertEqual(post_calls[0]["action"], "create")
+
+    def test_data_change_clears_barrier_when_wrapped_function_raises(self):
+        with self.assertRaisesRegex(ValueError, "boom"):
+            RaisingDummy().update()
+
+        self.assertFalse(is_dependency_data_change_active())
+        self.assertEqual(drain_invalidated_cache_keys_for_graphql_rewarm(), ())
+
+    def test_cleanup_failure_is_logged_when_wrapped_function_already_failed(self):
+        original_end = dependency_index.end_dependency_data_change
+
+        def cleanup_then_raise():
+            original_end()
+            raise RuntimeError("cleanup")
+
+        with (
+            patch(
+                "general_manager.cache.dependency_index.end_dependency_data_change",
+                side_effect=cleanup_then_raise,
+            ),
+            patch("general_manager.cache.signals.logger.exception") as log,
+            self.assertRaisesRegex(ValueError, "boom"),
+        ):
+            RaisingDummy().update()
+
+        log.assert_called_once()
+        self.assertFalse(is_dependency_data_change_active())
+
+    def test_cleanup_failure_raises_when_wrapped_function_succeeded(self):
+        original_end = dependency_index.end_dependency_data_change
+
+        def cleanup_then_raise():
+            original_end()
+            raise RuntimeError("cleanup")
+
+        with (
+            patch(
+                "general_manager.cache.dependency_index.end_dependency_data_change",
+                side_effect=cleanup_then_raise,
+            ),
+            self.assertRaisesRegex(RuntimeError, "cleanup"),
+        ):
+            Dummy.create("warm")
+
+        self.assertFalse(is_dependency_data_change_active())
+
+    def test_rewarm_enqueue_failure_is_logged(self):
+        def record_rewarm_key(sender, **kwargs):
+            del sender, kwargs
+            record_invalidated_cache_keys_for_graphql_rewarm(("cache-key",))
+
+        post_data_change.connect(record_rewarm_key, weak=False)
+        with (
+            patch(
+                "general_manager.api.graphql_warmup.enqueue_graphql_recipe_warmup",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("general_manager.cache.signals.logger.exception") as log,
+        ):
+            Dummy.create("warm")
+
+        log.assert_called_once_with("GraphQL warm-up requeue failed.")
+
+    def test_nested_dependency_data_change_keeps_outer_barrier_active(self):
+        dependency_index.begin_dependency_data_change()
+        dependency_index.begin_dependency_data_change()
+
+        dependency_index.end_dependency_data_change()
+        self.assertTrue(is_dependency_data_change_active())
+
+        dependency_index.end_dependency_data_change()
+        self.assertFalse(is_dependency_data_change_active())

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -1,7 +1,12 @@
 from django.test import TestCase
 from django.dispatch import Signal
 from contextlib import contextmanager
+from unittest.mock import patch
 
+from general_manager.cache.dependency_index import (
+    is_dependency_data_change_active,
+    record_invalidated_cache_keys_for_graphql_rewarm,
+)
 from general_manager.cache.signals import data_change, pre_data_change, post_data_change
 
 
@@ -154,3 +159,27 @@ class DataChangeSignalTests(TestCase):
 
         self.assertEqual(len(post_calls), 1)
         self.assertEqual(post_calls[0]["identification"], {"id": "before"})
+
+    def test_rewarm_keys_enqueue_after_dependency_data_change_ends(self):
+        barrier_states: list[bool] = []
+        enqueued_keys: list[tuple[str, ...]] = []
+
+        def record_rewarm_key(sender, **kwargs):
+            del sender, kwargs
+            barrier_states.append(is_dependency_data_change_active())
+            record_invalidated_cache_keys_for_graphql_rewarm(("cache-key",))
+
+        def enqueue_rewarm(cache_keys):
+            enqueued_keys.append(tuple(cache_keys))
+            self.assertFalse(is_dependency_data_change_active())
+            return True
+
+        post_data_change.connect(record_rewarm_key, weak=False)
+        with patch(
+            "general_manager.api.graphql_warmup.enqueue_graphql_recipe_warmup",
+            side_effect=enqueue_rewarm,
+        ):
+            Dummy.create("warm")
+
+        self.assertEqual(barrier_states, [True])
+        self.assertEqual(enqueued_keys, [("cache-key",)])


### PR DESCRIPTION
## Summary

Adds opt-in GraphQL property warm-up support for dependency and timeout-scoped cached entries.

- Extends `graph_ql_property` with `warm_up=True`, `cache="timeout"`, and timeout validation.
- Adds warm-up recipe storage, execution helpers, Celery tasks, Beat scheduling integration, and management commands.
- Re-enqueues known dependency-scoped warm-up recipes after cache invalidation.
- Documents the new warm-up and timeout-cache behavior.

## Validation

- `python -m pytest -q` -> 2709 passed, 1 skipped, 1 warning, 1746 subtests passed.
- `ruff check` -> passed.
- `mypy` -> passed.
- `ruff format --check` on touched Python files -> passed.

The branch was rebased onto `origin/main` and pushed with `--force-with-lease`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GraphQL property warm-up to proactively evaluate eligible properties and register repeatable warm-up “recipes.”
  * Introduced a new **timeout** cache scope plus periodic refresh of due timeout-cached values.
  * Added management commands to warm properties and refresh due timeout recipes.
  * After dependency invalidations, queued cache re-warm entries are now created automatically.

* **Documentation**
  * Updated the cache strategy guide with timeout-based scope options and warm-up/refresh workflow steps.
  * Added a full GraphQL warm-up design specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->