### PR TITLE
[codex] fix tuple mutation return length validation

### DIFF
--- a/src/general_manager/api/mutation.py
+++ b/src/general_manager/api/mutation.py
@@ -103,6 +103,29 @@ class DuplicateMutationOutputNameError(ValueError):
         )
 
 
+class MutationTupleReturnLengthMismatchError(ValueError):
+    """Raised when a tuple-annotated mutation returns the wrong number of values."""
+
+    def __init__(
+        self,
+        function_name: str,
+        expected_count: int,
+        received_count: int,
+    ) -> None:
+        """
+        Initialize the exception indicating a tuple return length mismatch.
+
+        Parameters:
+            function_name (str): Name of the mutation function that returned values.
+            expected_count (int): Number of tuple values declared by the annotation.
+            received_count (int): Number of tuple values returned by the resolver.
+        """
+        super().__init__(
+            f"Mutation {function_name} expected {expected_count} "
+            f"tuple return values but received {received_count}."
+        )
+
+
 def _is_general_manager_type(annotation: object) -> TypeGuard[type[GeneralManager]]:
     """Return True for class annotations that subclass GeneralManager."""
     return inspect.isclass(annotation) and issubclass(annotation, GeneralManager)
@@ -389,11 +412,9 @@ def graph_ql_mutation(
             raise MissingMutationReturnAnnotationError(fn.__name__)
 
         # Unpack tuple return or single
-        out_types = (
-            list(get_args(return_ann))
-            if get_origin(return_ann) in (tuple, Tuple)
-            else [return_ann]
-        )
+        return_origin = get_origin(return_ann)
+        is_tuple_return = return_origin in (tuple, Tuple)
+        out_types = list(get_args(return_ann)) if is_tuple_return else [return_ann]
         for out in out_types:
             is_named_type = isinstance(out, TypeAliasType)
             is_type = isinstance(out, type)
@@ -436,16 +457,22 @@ def graph_ql_mutation(
                     permission.check(normalized_kwargs, info.context.user)
                 result = fn(info, **normalized_kwargs)
                 data: MutationData = {}
-                if isinstance(result, tuple):
+                if is_tuple_return:
+                    result_values = result if isinstance(result, tuple) else (result,)
+                    expected_count = len(out_types)
+                    received_count = len(result_values)
+                    if received_count != expected_count:
+                        raise MutationTupleReturnLengthMismatchError(
+                            fn.__name__,
+                            expected_count,
+                            received_count,
+                        )
                     # unpack according to outputs ordering after success
-                    for (field, _), val in zip(
-                        outputs.items(),
-                        [None, *list(result)],
-                        strict=False,  # None for success field to be set later
+                    for field, val in zip(
+                        (field for field in outputs if field != "success"),
+                        result_values,
+                        strict=True,
                     ):
-                        # skip success
-                        if field == "success":
-                            continue
                         data[field] = val
                 else:
                     only = next(k for k in outputs if k != "success")

--- a/tests/unit/test_mutation.py
+++ b/tests/unit/test_mutation.py
@@ -306,6 +306,40 @@ class MutationDecoratorTests(TestCase):
         self.assertEqual(res.bool, True)
         self.assertEqual(res.str, "Success")
 
+    def test_tuple_return_length_mismatch_too_short_raises_graphql_error(self):
+        @graph_ql_mutation()
+        def too_short(info, value: int) -> tuple[bool, str]:
+            _ = info, value
+            return (True,)  # type: ignore[return-value]
+
+        mutation = GraphQL._mutations["tooShort"]
+        Info = type("Info", (), {"context": type("Ctx", (), {"user": object()})()})
+
+        with self.assertRaises(GraphQLError) as ctx:
+            mutation.mutate(None, Info, value=1)
+
+        self.assertEqual(ctx.exception.extensions["code"], "BAD_USER_INPUT")
+        message = str(ctx.exception)
+        self.assertIn("expected 2", message)
+        self.assertIn("received 1", message)
+
+    def test_tuple_return_length_mismatch_too_long_raises_graphql_error(self):
+        @graph_ql_mutation()
+        def too_long(info, value: int) -> tuple[bool, str]:
+            _ = info, value
+            return True, "Success", "extra"  # type: ignore[return-value]
+
+        mutation = GraphQL._mutations["tooLong"]
+        Info = type("Info", (), {"context": type("Ctx", (), {"user": object()})()})
+
+        with self.assertRaises(GraphQLError) as ctx:
+            mutation.mutate(None, Info, value=1)
+
+        self.assertEqual(ctx.exception.extensions["code"], "BAD_USER_INPUT")
+        message = str(ctx.exception)
+        self.assertIn("expected 2", message)
+        self.assertIn("received 3", message)
+
     def test_mutation_execution_and_auth(self):
         class addPermission(MutationPermission):
             __mutate__: ClassVar[List[str]] = ["isAuthenticated"]


### PR DESCRIPTION
## Summary
- Fixes #300.
- Validates tuple-annotated custom GraphQL mutation resolver return length before payload assignment.
- Raises a deliberate BAD_USER_INPUT GraphQL error when tuple returns are too short or too long.

## Validation
- `python -m pytest tests/unit/test_mutation.py::MutationDecoratorTests::test_mutation_with_multiple_return_types tests/unit/test_mutation.py::MutationDecoratorTests::test_tuple_return_length_mismatch_too_short_raises_graphql_error tests/unit/test_mutation.py::MutationDecoratorTests::test_tuple_return_length_mismatch_too_long_raises_graphql_error -q`
- `python -m pytest tests/unit/test_mutation.py -q`
- `ruff check src/general_manager/api/mutation.py tests/unit/test_mutation.py`
- `ruff format --check src/general_manager/api/mutation.py tests/unit/test_mutation.py`
- `mypy src/general_manager/api/mutation.py`

## Review
- Spec compliance review: passed.
- Code quality review: passed with no required fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mutation error handling when a tuple-returning operation returns too few or too many values.
  * Validation now reports a clear user-facing error with the expected and received tuple sizes.
  * Tuple-returned mutation results are now unpacked more reliably and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->