### PR TITLE
[codex] test readonly scalar row validation

### DIFF
--- a/tests/unit/test_read_only_interface.py
+++ b/tests/unit/test_read_only_interface.py
@@ -764,6 +764,32 @@ class SyncDataTests(SimpleTestCase):
 
         self.atomic_mock.assert_not_called()
 
+    def test_sync_rejects_scalar_row_payloads_as_readonly_data_format(self):
+        """
+        Ensure scalar rows raise the public read-only data format error.
+        """
+        malformed_payloads = [
+            [1],
+            [None],
+            ["bad"],
+            "[1]",
+        ]
+
+        for payload in malformed_payloads:
+            with self.subTest(payload=payload):
+                DummyManager._data = payload
+                self.atomic_mock.reset_mock()
+
+                with self.assertRaises(InvalidReadOnlyDataFormatError) as cm:
+                    self.capability.sync_data(
+                        DummyInterface,
+                        unique_fields={"name"},
+                        schema_validated=True,
+                    )
+
+                self.assertIs(type(cm.exception), InvalidReadOnlyDataFormatError)
+                self.atomic_mock.assert_not_called()
+
     def test_sync_falls_back_when_payload_missing_unique_field(self):
         """
         Ensure malformed payload rows still go through the existing validation path.


### PR DESCRIPTION
## Summary
- Fixes #301.
- Adds focused regression coverage for scalar rows in read-only `_data` payloads.
- Confirms malformed native list rows and JSON-list rows raise `InvalidReadOnlyDataFormatError` before transaction handling.

## Notes
- This PR is intentionally test-only. Current `main` already contains the production row-shape guard in `ReadOnlyManagementCapability.sync_data()`.

## Validation
- `python -m pytest tests/unit/test_read_only_interface.py -k "malformed_row or scalar_row or readonly_data_format" -q`
- `python -m pytest tests/unit/test_read_only_interface.py -q`
- `ruff check tests/unit/test_read_only_interface.py`
- `ruff format --check tests/unit/test_read_only_interface.py`

## Review
- Spec compliance review: passed.
- Code quality review: passed with no required fixes.