### PR TITLE
[codex] validate GraphQL search pagination values

### DIFF
--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -119,19 +119,20 @@ Results are returned as a union of manager GraphQL types:
 - `took_ms`: nullable integer field containing accumulated backend search time in milliseconds when reported.
 - `raw`: nullable JSON string field containing a list of backend-specific raw response payloads.
 
-`page` defaults to `1` and `pageSize` defaults to `10`; falsey values such as
-`0` currently fall back to those defaults. The resolver searches each selected
-manager type, instantiates managers from hit identification, then applies read
-permission filters and any required per-instance read checks before counting
-and returning results. Manager search order follows GraphQL's manager registry
-order filtered to managers with search config. When `types` is supplied,
-unknown manager class names are ignored. Malformed hit identification that
-raises `TypeError`, `ValueError`, or `KeyError` while constructing the manager
-is skipped. Invalid configured filter keys are reported as GraphQL errors.
-Backend lookup/search errors, other manager construction errors, permission
-errors, and sort comparison errors propagate. `sortBy` is not validated ahead of
-time; sorting reads each hit's `data[sortBy]` when present and otherwise sorts
-that hit as `null`/last before applying `sortDesc`.
+Omitted `page` defaults to `1` and omitted `pageSize` defaults to `10`.
+Explicit `0` or negative pagination values are rejected as GraphQL
+`BAD_USER_INPUT` errors. The resolver searches each selected manager type,
+instantiates managers from hit identification, then applies read permission
+filters and any required per-instance read checks before counting and returning
+results. Manager search order follows GraphQL's manager registry order filtered
+to managers with search config. When `types` is supplied, unknown manager class
+names are ignored. Malformed hit identification that raises `TypeError`,
+`ValueError`, or `KeyError` while constructing the manager is skipped. Invalid
+configured filter keys are reported as GraphQL errors. Backend lookup/search
+errors, other manager construction errors, permission errors, and sort
+comparison errors propagate. `sortBy` is not validated ahead of time; sorting
+reads each hit's `data[sortBy]` when present and otherwise sorts that hit as
+`null`/last before applying `sortDesc`.
 
 Note: GraphQL currently keys `types` off manager class names. If you override
 `type_label`, keep it aligned with the class name when using `types` filters.

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -69,6 +69,31 @@ GrapheneReadMapper = Callable[
 SearchResolverPayload = dict[str, object]
 SearchHitEntry = tuple[float | None, SearchHit, GeneralManager]
 SortableValue = float | datetime | str | None
+_BAD_USER_INPUT_CODE = "BAD_USER_INPUT"
+_PAGE_MUST_BE_POSITIVE = "page must be a positive integer."
+_PAGE_SIZE_MUST_BE_POSITIVE = "pageSize must be a positive integer."
+
+
+def _resolve_search_pagination(
+    page: int | None,
+    page_size: int | None,
+) -> tuple[int, int]:
+    """
+    Resolve omitted search pagination arguments and reject non-positive values.
+    """
+    current_page = 1 if page is None else page
+    limit = 10 if page_size is None else page_size
+    if current_page <= 0:
+        raise GraphQLError(
+            _PAGE_MUST_BE_POSITIVE,
+            extensions={"code": _BAD_USER_INPUT_CODE},
+        )
+    if limit <= 0:
+        raise GraphQLError(
+            _PAGE_SIZE_MUST_BE_POSITIVE,
+            extensions={"code": _BAD_USER_INPUT_CODE},
+        )
+    return current_page, limit
 
 
 # ---------------------------------------------------------------------------
@@ -803,15 +828,14 @@ def register_search_query(
         The resolver parses user filters, validates configured filter keys,
         searches each selected manager type, instantiates manager objects from
         hit identification, applies read permission filters/instance checks, and
-        returns paginated authorized manager instances. ``page`` and
-        ``page_size`` values that are ``None`` or falsey fall back to ``1`` and
-        ``10`` respectively. Backend raw payloads are collected once per backend
-        request in the ``raw`` list.
+        returns paginated authorized manager instances. Omitted ``page`` and
+        ``page_size`` values default to ``1`` and ``10`` respectively. Supplied
+        non-positive values raise a ``GraphQLError``. Backend raw payloads are
+        collected once per backend request in the ``raw`` list.
         """
         index_name = index or "global"
-        limit = page_size or 10
-        current_page = page or 1
-        offset = max(current_page - 1, 0) * limit
+        current_page, limit = _resolve_search_pagination(page, page_size)
+        offset = (current_page - 1) * limit
         parsed_filters = parse_search_filters(filters)
         if parsed_filters:
             try:

--- a/tests/unit/test_graphql_search.py
+++ b/tests/unit/test_graphql_search.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import SimpleTestCase
+from graphql import GraphQLError
 
 from general_manager.api.graphql import GraphQL
 from general_manager.apps import GeneralmanagerConfig
@@ -255,6 +256,153 @@ class GraphQLSearchTests(SimpleTestCase):
         assert len(response["results"]) == 1
         ProjectInterface.data_store.pop(3, None)
         ProjectInterface.data_store.pop(4, None)
+
+    def test_graphql_search_omitted_pagination_uses_first_page_default_size(
+        self,
+    ) -> None:
+        added_ids = range(3, 14)
+        for item_id in added_ids:
+            self.addCleanup(ProjectInterface.data_store.pop, item_id, None)
+            ProjectInterface.data_store[item_id] = {
+                "name": f"Project {item_id}",
+                "status": "public",
+            }
+        indexer = SearchIndexer(backend_registry.get_search_backend())
+        for item_id in added_ids:
+            indexer.index_instance(Project(id=item_id))
+
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        response = field.resolver(
+            None,
+            info,
+            query="",
+            index="global",
+            types=None,
+            filters=None,
+            page=None,
+            page_size=None,
+        )
+
+        assert response["total"] == 12
+        assert len(response["results"]) == 10
+
+    def test_graphql_search_positive_pagination_returns_requested_page(self) -> None:
+        added_rows = {
+            3: {"name": "Gamma", "status": "public"},
+            4: {"name": "Delta", "status": "public"},
+        }
+        for item_id, row in added_rows.items():
+            self.addCleanup(ProjectInterface.data_store.pop, item_id, None)
+            ProjectInterface.data_store[item_id] = row
+        indexer = SearchIndexer(backend_registry.get_search_backend())
+        for item_id in added_rows:
+            indexer.index_instance(Project(id=item_id))
+
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        response = field.resolver(
+            None,
+            info,
+            query="",
+            index="global",
+            types=None,
+            filters=None,
+            sort_by="name",
+            page=2,
+            page_size=2,
+        )
+
+        assert response["total"] == 3
+        assert [item.identification for item in response["results"]] == [{"id": 3}]
+
+    def test_graphql_search_rejects_zero_page(self) -> None:
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        with self.assertRaisesRegex(
+            GraphQLError,
+            "page must be a positive integer",
+        ) as ctx:
+            field.resolver(
+                None,
+                info,
+                query="",
+                index="global",
+                types=None,
+                filters=None,
+                page=0,
+                page_size=10,
+            )
+        assert ctx.exception.extensions["code"] == "BAD_USER_INPUT"
+
+    def test_graphql_search_rejects_zero_page_size(self) -> None:
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        with self.assertRaisesRegex(
+            GraphQLError,
+            "pageSize must be a positive integer",
+        ) as ctx:
+            field.resolver(
+                None,
+                info,
+                query="",
+                index="global",
+                types=None,
+                filters=None,
+                page=1,
+                page_size=0,
+            )
+        assert ctx.exception.extensions["code"] == "BAD_USER_INPUT"
+
+    def test_graphql_search_rejects_negative_page(self) -> None:
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        with self.assertRaisesRegex(
+            GraphQLError,
+            "page must be a positive integer",
+        ) as ctx:
+            field.resolver(
+                None,
+                info,
+                query="",
+                index="global",
+                types=None,
+                filters=None,
+                page=-1,
+                page_size=10,
+            )
+        assert ctx.exception.extensions["code"] == "BAD_USER_INPUT"
+
+    def test_graphql_search_rejects_negative_page_size(self) -> None:
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        with self.assertRaisesRegex(
+            GraphQLError,
+            "pageSize must be a positive integer",
+        ) as ctx:
+            field.resolver(
+                None,
+                info,
+                query="",
+                index="global",
+                types=None,
+                filters=None,
+                page=1,
+                page_size=-1,
+            )
+        assert ctx.exception.extensions["code"] == "BAD_USER_INPUT"
 
     def test_graphql_search_permission_filters_override_user_filters(self) -> None:
         field = GraphQL._query_fields["search"]


### PR DESCRIPTION
## Summary
- Fixes #302.
- Defaults only omitted `page`/`pageSize` values for global GraphQL search.
- Rejects supplied zero or negative pagination values with `BAD_USER_INPUT` GraphQL errors.
- Updates search docs to remove the falsey fallback behavior.

## Validation
- `python -m pytest tests/unit/test_graphql_search.py::GraphQLSearchTests -q`
- `python -m pytest tests/integration/test_graphql_search.py::TestGraphQLSearchIntegration::test_graphql_search_pagination -q`
- `ruff check src/general_manager/api/graphql_search.py tests/unit/test_graphql_search.py`
- `ruff format --check src/general_manager/api/graphql_search.py tests/unit/test_graphql_search.py`
- `mypy src/general_manager/api/graphql_search.py`

## Review
- Spec compliance review: passed after adding focused valid-positive pagination coverage.
- Code quality review: passed with no required fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified search pagination behavior so omitted page values use sensible defaults, while zero or negative values now return a clear input error.
  * Improved consistency in search results by applying page and page size more predictably.
* **Documentation**
  * Updated search API documentation to explain default pagination values and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->