### PR TITLE
[codex] skip AutoFactory build many-to-many assignment

### DIFF
--- a/docs/concepts/factories/index.md
+++ b/docs/concepts/factories/index.md
@@ -54,12 +54,15 @@ and one-to-one fields with no related factory and no existing related rows
 resolve to `None`; required relations in the same situation raise
 `MissingFactoryOrInstancesError`.
 
-Many-to-many defaults are generated after the main object is built. The helper
+Many-to-many defaults are generated after the main object is created. The helper
 creates or selects related model instances, then `AutoFactory` applies them to
-the relation. `blank=True` fields may generate an empty list, while
-`blank=False` fields request at least one related instance. If a related factory
-returns a GeneralManager instance, the helper resolves it back to the underlying
-Django row before assignment. If that manager cannot be resolved to a row,
+the saved relation for `Factory.create(...)` and `Factory.create_batch(...)`.
+`Factory.build(...)` returns unsaved model instances and skips many-to-many
+assignment, even when explicit or declared many-to-many values are supplied.
+`blank=True` fields may generate an empty list, while `blank=False` fields
+request at least one related instance. If a related factory returns a
+GeneralManager instance, the helper resolves it back to the underlying Django
+row before assignment. If that manager cannot be resolved to a row,
 `UnableToResolveManagerInstanceError` is raised.
 
 See the [Factory API reference](../../api/factory.md) for signatures.

--- a/docs/concepts/factories/performance_caching.md
+++ b/docs/concepts/factories/performance_caching.md
@@ -4,7 +4,7 @@ Factories generate many objects quickly—use them wisely to keep tests fast and
 
 ## AutoFactory shortcuts
 
-`general_manager.factory.auto_factory.AutoFactory` inspects interface metadata to populate sensible defaults. It derives values for regular fields, many-to-many relations, and handles special fields via `handle_custom_fields()`.
+`general_manager.factory.auto_factory.AutoFactory` inspects interface metadata to populate sensible defaults. It derives values for regular fields, handles special fields via `handle_custom_fields()`, and assigns many-to-many relations after saved creates. Build calls return unsaved models and do not write many-to-many relations.
 
 ```python
 class ProjectFactory(AutoFactory):
@@ -15,7 +15,7 @@ project = ProjectFactory()
 
 ## Batch creation
 
-When you need multiple objects, use `Factory.create_batch()` and wrap the call in `django.db.transaction.atomic()` to reduce database overhead. AutoFactory automatically fills many-to-many relations after creation.
+When you need multiple objects, use `Factory.create_batch()` and wrap the call in `django.db.transaction.atomic()` to reduce database overhead. AutoFactory automatically fills many-to-many relations after creation; `Factory.build()` skips those writes because the returned model is unsaved.
 
 ## Caching interactions
 

--- a/docs/howto/factory_bulk_generate.md
+++ b/docs/howto/factory_bulk_generate.md
@@ -54,7 +54,12 @@ Project.Factory.create_batch(20)
 InventoryItem.Factory.create_batch(50)
 ```
 
-Many-to-many relations are populated automatically with sensible defaults.
+`Factory.create(...)` and `Factory.create_batch(...)` save each object before
+AutoFactory assigns many-to-many relations, so explicit values and generated
+defaults can populate those relations safely. `Factory.build(...)` returns
+unsaved model instances and skips many-to-many assignment; pass scalar and
+foreign-key values to build when you need an in-memory object, then save and
+assign many-to-many relations yourself if the test needs them.
 
 ## Step 3: Customise values
 
@@ -80,14 +85,16 @@ defaults, stripped many-to-many fields from constructor kwargs, and coerced
 foreign-key/one-to-one values. Caller-supplied keyword arguments still take
 precedence over generated defaults.
 
-`Factory.create(...)` validates and saves every returned record, then wraps the
-saved models back into their `GeneralManager` class using the interface's
-identification fields. If a generated object is not a Django model instance,
-`InvalidGeneratedObjectError` is raised. If the interface has no parent manager,
-wrapping raises `MissingManagerClassError`; if an identification field cannot be
-read from the generated model, wrapping raises `MissingIdentificationFieldError`.
+`Factory.create(...)` validates and saves every returned record, assigns any
+many-to-many values after saving, then wraps the saved models back into their
+`GeneralManager` class using the interface's identification fields. If a
+generated object is not a Django model instance, `InvalidGeneratedObjectError`
+is raised. If the interface has no parent manager, wrapping raises
+`MissingManagerClassError`; if an identification field cannot be read from the
+generated model, wrapping raises `MissingIdentificationFieldError`.
 `Factory.build(...)` runs the same adjustment logic but returns unsaved model
-instances instead of manager wrappers.
+instances instead of manager wrappers and does not write many-to-many
+relations.
 
 `_adjustmentMethod` return values are not schema-validated before the factory uses
 them. A single dictionary produces one record. A list of dictionaries produces

--- a/src/general_manager/factory/auto_factory.py
+++ b/src/general_manager/factory/auto_factory.py
@@ -105,12 +105,12 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
 
     The factory inspects the bound ORM interface, fills missing model fields with
     generated values or declared defaults, applies many-to-many relations after
-    model construction, and wraps created objects back into GeneralManager
-    instances. Build strategy returns Django model instances; create strategy
-    returns manager wrappers. Subclasses are generated with an ORM interface that
-    provides ``handle_custom_fields()``, ``input_fields``,
-    ``format_identification()``, and ``_parent_class`` for created-object
-    wrapping.
+    saved creation, and wraps created objects back into GeneralManager instances.
+    Build strategy returns unsaved Django model instances and skips
+    many-to-many assignment; create strategy returns manager wrappers.
+    Subclasses are generated with an ORM interface that provides
+    ``handle_custom_fields()``, ``input_fields``, ``format_identification()``,
+    and ``_parent_class`` for created-object wrapping.
     """
 
     interface: type[OrmInterfaceBase[models.Model]]
@@ -127,14 +127,11 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
         caller-supplied values already present in `params` win. factory_boy then
         dispatches to `_build()` or `_create()`, where many-to-many values are
         stripped from constructor kwargs and foreign-key/one-to-one values are
-        coerced before `_adjustmentMethod` is called. After model construction,
-        this hook applies many-to-many assignments from the original `params`
-        and wraps created models into manager instances for create strategy.
-
-        Many-to-many assignment is attempted for both build and create strategy.
-        Django requires saved instances for many-to-many `.set(...)`; therefore
-        build calls with explicit or generated many-to-many values are
-        unsupported and may raise Django's unsaved-instance relation error.
+        coerced before `_adjustmentMethod` is called. Create strategy then
+        applies many-to-many assignments from the original `params` to saved
+        models and wraps them into manager instances. Build strategy returns the
+        unsaved model instance(s) without attempting many-to-many assignment,
+        even when explicit or declared many-to-many values were supplied.
 
         Parameters:
             strategy (Literal["build", "create"]): "build" returns unsaved model instance(s); "create" saves model instance(s) and returns GeneralManager wrapper(s).
@@ -202,8 +199,10 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
             for item in obj:
                 if not isinstance(item, models.Model):
                     raise InvalidGeneratedObjectError()
-                cls._handle_many_to_many_fields_after_creation(item, params)
-        else:
+            if strategy == "create":
+                for item in obj:
+                    cls._handle_many_to_many_fields_after_creation(item, params)
+        elif strategy == "create":
             cls._handle_many_to_many_fields_after_creation(obj, params)
         if strategy == "create":
             return cls._wrap_generated_objects(obj)
@@ -214,7 +213,11 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
         cls, obj: models.Model, attrs: FactoryParams
     ) -> None:
         """
-        Assign related objects to many-to-many fields after creation/building.
+        Assign related objects to many-to-many fields after saved creation.
+
+        Build strategy returns unsaved models and must skip this method because
+        Django many-to-many managers require the source instance to have a
+        primary key before `.set(...)` can be used.
 
         Parameters:
             obj (models.Model): Instance whose many-to-many relations should be populated.

--- a/tests/integration/test_auto_factory.py
+++ b/tests/integration/test_auto_factory.py
@@ -208,6 +208,44 @@ class AutoFactoryIntegrationTest(GeneralManagerTransactionTestCase):
         bucket_ids = {manager.identification["id"] for manager in options_bucket}
         self.assertSetEqual(bucket_ids, expected_option_ids)
 
+    def test_factory_build_with_many_to_many_values_returns_unsaved_model_without_assignment(
+        self,
+    ) -> None:
+        """
+        AutoFactory build returns an unsaved model and skips provided many-to-many assignments.
+        """
+        manufacturer = self.Manufacturer.create(
+            creator_id=None,
+            name="Build Manufacturer",
+            country="US",
+            ignore_permission=True,
+        )
+        option_a = self.CarOption.create(
+            creator_id=None,
+            label="Build Comfort Package",
+            ignore_permission=True,
+        )
+        option_b = self.CarOption.create(
+            creator_id=None,
+            label="Build Safety Package",
+            ignore_permission=True,
+        )
+
+        car = self.Car.Factory.build(
+            name="Built Car With Packages",
+            manufacturer=manufacturer,
+            options=[option_a, option_b],
+            changed_by=self.user,
+        )
+
+        self.assertIsInstance(car, self.Car.Interface._model)
+        self.assertIsNone(car.pk)
+        self.assertEqual(car.name, "Built Car With Packages")
+        self.assertEqual(car.manufacturer_id, manufacturer.identification["id"])
+        self.assertEqual(self.Car.Interface._model.objects.count(), 0)
+        with self.assertRaises(ValueError):
+            car.options.count()
+
     def test_factory_adjustment_method_returns_managers(self) -> None:
         """
         Factories using _adjustmentMethod should return GeneralManager instances and persist each record.

--- a/tests/unit/test_auto_factory.py
+++ b/tests/unit/test_auto_factory.py
@@ -1,7 +1,12 @@
 from django.test import TransactionTestCase
 from django.db import models, connection, connections
 from django.core.exceptions import ValidationError
-from general_manager.factory.auto_factory import AutoFactory
+from general_manager.factory.auto_factory import (
+    AutoFactory,
+    InvalidGeneratedObjectError,
+    UndefinedAdjustmentMethodError,
+)
+from types import SimpleNamespace
 from typing import Any, ClassVar, Iterable
 from unittest.mock import patch
 
@@ -235,6 +240,36 @@ class AutoFactoryTestCase(TransactionTestCase):
         self.assertEqual(DummyModel2.objects.count(), 0)
         with self.assertRaises(ValueError):
             instance.dummy_m2m.count()
+
+    def test_edge_helpers_cover_error_and_fallback_paths(self):
+        """
+        AutoFactory helper edge paths should preserve their documented fallback behavior.
+        """
+        self.assertEqual(
+            str(InvalidGeneratedObjectError()),
+            "Generated object is not a Django model instance.",
+        )
+
+        with self.assertRaises(UndefinedAdjustmentMethodError):
+            self.factory_class._AutoFactory__create_with_generate_func(
+                use_creation_method=False,
+                params={},
+            )
+
+        relation_stub = SimpleNamespace(dummy_model_id=123)
+        self.assertEqual(
+            self.factory_class2._resolve_identification_value(
+                relation_stub,
+                "dummy_model",
+            ),
+            123,
+        )
+
+        raw_value = object()
+        self.assertEqual(
+            self.factory_class2._coerce_many_to_many_values(raw_value),
+            [raw_value],
+        )
 
     def test_generate_instance_with_generate_function(self):
         """

--- a/tests/unit/test_auto_factory.py
+++ b/tests/unit/test_auto_factory.py
@@ -241,6 +241,49 @@ class AutoFactoryTestCase(TransactionTestCase):
         with self.assertRaises(ValueError):
             instance.dummy_m2m.count()
 
+    def test_build_list_with_many_to_many_values_skips_relation_assignment(self):
+        """
+        Build list results skip many-to-many assignment for every unsaved model.
+        """
+        dummy_model_instance = self.factory_class.create()
+        dummy_model_instance2 = self.factory_class.create()
+
+        def custom_generate_function(**kwargs: Any) -> list[dict[str, Any]]:
+            """
+            Return multiple DummyModel2 payloads without many-to-many records.
+            """
+            return [
+                {
+                    "description": f"{kwargs['description']} {index}",
+                    "dummy_model": kwargs["dummy_model"],
+                }
+                for index in range(2)
+            ]
+
+        self.factory_class2._adjustmentMethod = custom_generate_function
+
+        with patch.object(
+            self.factory_class2,
+            "_coerce_many_to_many_values",
+            side_effect=AssertionError("build list should not process dummy_m2m"),
+        ):
+            instances = self.factory_class2.build(
+                description="Generated Description",
+                dummy_model=dummy_model_instance,
+                dummy_m2m=[dummy_model_instance, dummy_model_instance2],
+            )
+
+        self.assertIsInstance(instances, list)
+        self.assertEqual(len(instances), 2)
+        self.assertEqual(DummyModel2.objects.count(), 0)
+        for index, instance in enumerate(instances):
+            self.assertIsInstance(instance, DummyModel2)
+            self.assertIsNone(instance.pk)
+            self.assertEqual(instance.description, f"Generated Description {index}")
+            self.assertEqual(instance.dummy_model, dummy_model_instance)
+            with self.assertRaises(ValueError):
+                instance.dummy_m2m.count()
+
     def test_edge_helpers_cover_error_and_fallback_paths(self):
         """
         AutoFactory helper edge paths should preserve their documented fallback behavior.

--- a/tests/unit/test_auto_factory.py
+++ b/tests/unit/test_auto_factory.py
@@ -192,6 +192,50 @@ class AutoFactoryTestCase(TransactionTestCase):
         self.assertIn(dummy_model_instance, instance.dummy_m2m.all())
         self.assertIn(dummy_model_instance2, instance.dummy_m2m.all())
 
+    def test_build_instance_with_many_to_many_values_skips_relation_assignment(self):
+        """
+        Build returns an unsaved model without assigning provided many-to-many values.
+        """
+        dummy_model_instance = self.factory_class.create()
+        dummy_model_instance2 = self.factory_class.create()
+
+        instance = self.factory_class2.build(
+            description="Test Description",
+            dummy_model=dummy_model_instance,
+            dummy_m2m=[dummy_model_instance, dummy_model_instance2],
+        )
+
+        self.assertIsInstance(instance, DummyModel2)
+        self.assertIsNone(instance.pk)
+        self.assertEqual(instance.description, "Test Description")
+        self.assertEqual(instance.dummy_model, dummy_model_instance)
+        self.assertEqual(DummyModel2.objects.count(), 0)
+        with self.assertRaises(ValueError):
+            instance.dummy_m2m.count()
+
+    def test_build_instance_without_many_to_many_values_skips_generated_relation_assignment(
+        self,
+    ):
+        """
+        Build does not assign default many-to-many values for unsaved models.
+        """
+        dummy_model_instance = self.factory_class.create()
+        available_related = self.factory_class.create()
+        self.factory_class2.dummy_m2m = [available_related]
+
+        instance = self.factory_class2.build(
+            description="Test Description",
+            dummy_model=dummy_model_instance,
+        )
+
+        self.assertIsInstance(instance, DummyModel2)
+        self.assertIsNone(instance.pk)
+        self.assertEqual(instance.description, "Test Description")
+        self.assertEqual(instance.dummy_model, dummy_model_instance)
+        self.assertEqual(DummyModel2.objects.count(), 0)
+        with self.assertRaises(ValueError):
+            instance.dummy_m2m.count()
+
     def test_generate_instance_with_generate_function(self):
         """
         Test that the factory can generate and persist multiple instances using a custom generate function that returns a list of dictionaries.


### PR DESCRIPTION
## Summary
- Fixes #303.
- Skips many-to-many relation assignment for `AutoFactory.build()` so unsaved model instances can be built with explicit or declared M2M values present.
- Preserves `AutoFactory.create()` many-to-many assignment and manager wrapping behavior.
- Updates factory docs to distinguish create/create_batch relation assignment from build behavior.

## Validation
- `python -m pytest tests/unit/test_auto_factory.py::AutoFactoryTestCase::test_build_list_with_many_to_many_values_skips_relation_assignment -q` -> 1 passed
- `python -m pytest tests/unit/test_auto_factory.py::AutoFactoryTestCase::test_build_instance_with_many_to_many_values_skips_relation_assignment tests/unit/test_auto_factory.py::AutoFactoryTestCase::test_build_instance_without_many_to_many_values_skips_generated_relation_assignment tests/integration/test_auto_factory.py::AutoFactoryIntegrationTest::test_factory_build_with_many_to_many_values_returns_unsaved_model_without_assignment tests/integration/test_auto_factory.py::AutoFactoryIntegrationTest::test_factory_populates_many_to_many_relations -q`
- `python -m pytest tests/unit/test_auto_factory.py tests/integration/test_auto_factory.py -q`
- `python -m pytest tests/unit/test_auto_factory.py tests/integration/test_auto_factory.py --cov=general_manager.factory.auto_factory --cov-report=term-missing --cov-fail-under=95 -q` -> 43 passed, 95.54% coverage
- AST docstring audit for `src/general_manager/factory/auto_factory.py` -> all functions/methods have docstrings
- `ruff check src/general_manager/factory/auto_factory.py tests/unit/test_auto_factory.py`
- `ruff format --check src/general_manager/factory/auto_factory.py tests/unit/test_auto_factory.py`
- `mypy src/general_manager/factory/auto_factory.py`

## Review
- Spec compliance review: passed.
- Code quality review: passed with no required fixes.
- CodeRabbit list-build many-to-many coverage finding: verified still valid and fixed with a focused regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified and aligned many-to-many behavior across factory actions: saved creations assign relations, while builds now return unsaved objects without many-to-many assignment.
  * Improved error handling and documented clearer behavior when relation data cannot be resolved.

* **Documentation**
  * Updated factory guides and performance notes to explain when many-to-many values are applied and how batch creation differs from build mode.

* **Tests**
  * Added and expanded coverage for build/create behavior, unsaved instances, and related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->