### PR TITLE
feat: add bounded GraphQL search totals

### DIFF
--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -111,11 +111,15 @@ When GraphQL is auto-created, a global `search` query is added. It accepts:
 - `types`: optional list of manager class names to restrict results.
 - `filters`: JSON string or list of filter items.
 - `sortBy` / `sortDesc`: optional sort field and direction.
+- `totalMode`: optional total-count mode, either `exact` or `bounded`.
 - `page` / `pageSize`: pagination controls.
 
 Results are returned as a union of manager GraphQL types:
 - `results`: nullable GraphQL list field containing the authorized manager instances as the generated union type.
 - `total`: nullable integer field containing the post-permission authorized hit count, not the backend raw total.
+- `totalIsExact`: nullable boolean field. `true` means `total` is the exact
+  post-permission count; `false` means bounded mode stopped scanning before it
+  could prove no more backend hits remain, so `total` is a lower bound.
 - `took_ms`: nullable integer field containing accumulated backend search time in milliseconds when reported.
 - `raw`: nullable JSON string field containing a list of backend-specific raw response payloads.
 
@@ -134,6 +138,29 @@ comparison errors propagate. `sortBy` is not validated ahead of time; sorting
 reads each hit's `data[sortBy]` when present and otherwise sorts that hit as
 `null`/last before applying `sortDesc`.
 
+GraphQL search totals default to exact mode for backward compatibility:
+
+```python
+GENERAL_MANAGER = {
+    "GRAPHQL_SEARCH_TOTAL_MODE": "exact",
+    "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT": 1000,
+}
+```
+
+Exact mode continues scanning backend pages for each manager until it can return
+the exact authorized total, even when the requested result page is already
+filled. Set `GENERAL_MANAGER["GRAPHQL_SEARCH_TOTAL_MODE"]` to `"bounded"` to
+cap each manager's backend hit scan. The scan limit must be a positive integer
+and defaults to `1000`; the effective per-manager cap is at least the requested
+page end (`page` / `pageSize`) so the current page can still be filled where
+possible. Bounded mode returns the authorized hits found before the cap and
+sets `totalIsExact` to `false` when the resolver hits the cap before observing
+an empty or partial backend page.
+
+Clients can override the configured mode per request with `totalMode:
+"exact"` or `totalMode: "bounded"`. Invalid values are rejected as GraphQL
+user-input errors.
+
 Note: GraphQL currently keys `types` off manager class names. If you override
 `type_label`, keep it aligned with the class name when using `types` filters.
 Generated search unions also look up GraphQL object types by manager class name
@@ -145,6 +172,7 @@ Example query:
 query SearchProjects($filters: JSONString) {
   search(index: "global", query: "alpha", filters: $filters, sortBy: "name") {
     total
+    totalIsExact
     results {
       __typename
       ... on ProjectType { id name status }

--- a/docs/howto/search.md
+++ b/docs/howto/search.md
@@ -83,6 +83,7 @@ Example query:
 query SearchProjects($filters: JSONString) {
   search(index: "global", query: "alpha", filters: $filters, sortBy: "name") {
     total
+    totalIsExact
     results {
       __typename
       ... on ProjectType { id name status }
@@ -106,6 +107,51 @@ Filters can also be passed as a list of filter items:
   "filters": "[{\"field\": \"status\", \"op\": \"in\", \"values\": [\"public\", \"draft\"]}]"
 }
 ```
+
+By default, GraphQL search returns exact post-permission totals. Exact totals
+preserve existing behavior, but permission-filtered searches may need to scan
+additional backend pages after the current result page is already filled.
+
+To cap those scans per manager, enable bounded totals and choose a positive scan
+limit:
+
+```python
+GENERAL_MANAGER = {
+    **GENERAL_MANAGER,
+    "GRAPHQL_SEARCH_TOTAL_MODE": "bounded",
+    "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT": 1000,
+}
+```
+
+Bounded mode caps backend hit scans per manager. The effective cap is at least
+the requested page end (`page` / `pageSize`) so the current page can still be
+filled where possible. In bounded mode, `total` is the authorized count found
+before the cap and `totalIsExact` is `false` if the resolver hit the cap before
+observing an empty or partial backend page.
+
+Clients can override the setting per request:
+
+```graphql
+query {
+  search(
+    index: "global",
+    query: "alpha",
+    pageSize: 20,
+    totalMode: "bounded"
+  ) {
+    total
+    totalIsExact
+    results {
+      __typename
+      ... on ProjectType { id name status }
+    }
+  }
+}
+```
+
+Use `totalMode: "exact"` when a specific request needs the previous exact
+total behavior even if the deployment default is bounded. Invalid `totalMode`
+values are returned as GraphQL user-input errors.
 
 ## Step 5: Async indexing (optional)
 

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -83,6 +83,7 @@ SEARCH_TOTAL_SCAN_LIMIT_ERROR = (
 
 
 def _bad_user_input_error(message: str) -> GraphQLError:
+    """Build a GraphQL user-input error with the shared extension code."""
     return GraphQLError(message, extensions={"code": _BAD_USER_INPUT_CODE})
 
 
@@ -109,11 +110,13 @@ def _resolve_search_pagination(
 
 
 def _invalid_search_total_mode_error(setting_label: str) -> GraphQLError:
+    """Build the validation error for an invalid total-mode value."""
     message = f"{setting_label} {SEARCH_TOTAL_MODE_ERROR}"
     return _bad_user_input_error(message)
 
 
 def normalize_search_total_mode(total_mode: str | None = None) -> SearchTotalMode:
+    """Resolve and validate the requested GraphQL search total-count mode."""
     if total_mode is None:
         raw_mode = get_setting("GRAPHQL_SEARCH_TOTAL_MODE", "exact")
         setting_label = 'GENERAL_MANAGER["GRAPHQL_SEARCH_TOTAL_MODE"]'
@@ -131,6 +134,7 @@ def normalize_search_total_mode(total_mode: str | None = None) -> SearchTotalMod
 
 
 def get_graphql_search_total_scan_limit() -> int:
+    """Return the configured positive scan limit for bounded total counts."""
     raw_limit = get_setting(
         "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT",
         DEFAULT_GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT,
@@ -175,6 +179,7 @@ def sort_search_hit_entries(
         def _sort_key(
             item: SearchHitEntry,
         ) -> tuple[bool, SortableValue]:
+            """Return a null-last comparable key for an indexed search hit."""
             value = item[1].data.get(sort_by) if item[1].data else None
             normalized = normalize_search_sort_value(value)
             return (normalized is None, normalized)

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -14,6 +14,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
+    Literal,
     cast,
     get_args,
 )
@@ -23,6 +24,7 @@ from graphql import GraphQLError
 
 from django.utils import timezone
 
+from general_manager.conf import get_setting
 from general_manager.logging import get_logger
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
@@ -69,9 +71,19 @@ GrapheneReadMapper = Callable[
 SearchResolverPayload = dict[str, object]
 SearchHitEntry = tuple[float | None, SearchHit, GeneralManager]
 SortableValue = float | datetime | str | None
+SearchTotalMode = Literal["exact", "bounded"]
 _BAD_USER_INPUT_CODE = "BAD_USER_INPUT"
 _PAGE_MUST_BE_POSITIVE = "page must be a positive integer."
 _PAGE_SIZE_MUST_BE_POSITIVE = "pageSize must be a positive integer."
+DEFAULT_GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT = 1000
+SEARCH_TOTAL_MODE_ERROR = "must be one of: exact, bounded."
+SEARCH_TOTAL_SCAN_LIMIT_ERROR = (
+    "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT must be a positive integer."
+)
+
+
+def _bad_user_input_error(message: str) -> GraphQLError:
+    return GraphQLError(message, extensions={"code": _BAD_USER_INPUT_CODE})
 
 
 def _resolve_search_pagination(
@@ -94,6 +106,96 @@ def _resolve_search_pagination(
             extensions={"code": _BAD_USER_INPUT_CODE},
         )
     return current_page, limit
+
+
+def _invalid_search_total_mode_error(setting_label: str) -> GraphQLError:
+    message = f"{setting_label} {SEARCH_TOTAL_MODE_ERROR}"
+    return _bad_user_input_error(message)
+
+
+def normalize_search_total_mode(total_mode: str | None = None) -> SearchTotalMode:
+    if total_mode is None:
+        raw_mode = get_setting("GRAPHQL_SEARCH_TOTAL_MODE", "exact")
+        setting_label = 'GENERAL_MANAGER["GRAPHQL_SEARCH_TOTAL_MODE"]'
+    else:
+        raw_mode = total_mode
+        setting_label = "totalMode"
+
+    if not isinstance(raw_mode, str):
+        raise _invalid_search_total_mode_error(setting_label)
+
+    normalized = raw_mode.strip().lower()
+    if normalized not in {"exact", "bounded"}:
+        raise _invalid_search_total_mode_error(setting_label)
+    return cast(SearchTotalMode, normalized)
+
+
+def get_graphql_search_total_scan_limit() -> int:
+    raw_limit = get_setting(
+        "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT",
+        DEFAULT_GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT,
+    )
+    if not isinstance(raw_limit, int) or isinstance(raw_limit, bool) or raw_limit <= 0:
+        raise _bad_user_input_error(SEARCH_TOTAL_SCAN_LIMIT_ERROR)
+    return raw_limit
+
+
+def normalize_search_sort_value(value: object) -> SortableValue:
+    """Normalise a search sort value to a comparable type."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float, Decimal)):
+        return float(value)
+    if isinstance(value, datetime):
+        if timezone.is_naive(value):
+            return timezone.make_aware(value)
+        return value
+    if isinstance(value, date):
+        return timezone.make_aware(datetime.combine(value, datetime.min.time()))
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return value
+        if timezone.is_naive(parsed):
+            parsed = timezone.make_aware(parsed)
+        return parsed
+    return str(value)
+
+
+def sort_search_hit_entries(
+    entries: list[SearchHitEntry],
+    *,
+    sort_by: str | None,
+    sort_desc: bool,
+) -> None:
+    """Sort retained search entries using GraphQL search response semantics."""
+    if sort_by:
+
+        def _sort_key(
+            item: SearchHitEntry,
+        ) -> tuple[bool, SortableValue]:
+            value = item[1].data.get(sort_by) if item[1].data else None
+            normalized = normalize_search_sort_value(value)
+            return (normalized is None, normalized)
+
+        entries.sort(key=_sort_key, reverse=sort_desc)
+    else:
+        entries.sort(key=lambda item: item[0] or 0, reverse=True)
+
+
+def trim_search_hit_entries_to_window(
+    entries: list[SearchHitEntry],
+    *,
+    requested_count: int,
+    sort_by: str | None,
+    sort_desc: bool,
+) -> None:
+    """Keep only entries that can still appear in the requested global page."""
+    if len(entries) <= requested_count:
+        return
+    sort_search_hit_entries(entries, sort_by=sort_by, sort_desc=sort_desc)
+    del entries[requested_count:]
 
 
 # ---------------------------------------------------------------------------
@@ -343,7 +445,7 @@ def create_search_result_type(
 
     Returns:
         A ``SearchResult`` Graphene ObjectType with ``results``, ``total``,
-        ``took_ms``, and ``raw`` fields.
+        ``total_is_exact``, ``took_ms``, and ``raw`` fields.
     """
     return type(
         "SearchResult",
@@ -351,6 +453,7 @@ def create_search_result_type(
         {
             "results": graphene.List(union_type),
             "total": graphene.Int(),
+            "total_is_exact": graphene.Boolean(),
             "took_ms": graphene.Int(),
             "raw": graphene.JSONString(),
         },
@@ -767,13 +870,15 @@ def register_search_query(
 
     Manager search order follows ``manager_registry.values()`` filtered to
     managers with search configuration, unless the resolver receives ``types``;
-    unknown names in ``types`` are ignored. ``total`` in the resolver payload is
-    the post-permission authorized total, not the backend raw total. Sorting
-    uses hit ``data[sort_by]`` when available and does not validate the sort
-    field ahead of comparison. Configured filter-key validation runs on the
-    parsed top-level search filters before permission filters or relation
-    normalizers are applied; exclude-derived permission keys are not validated
-    by this search helper.
+    unknown names in ``types`` are ignored. In exact total mode, ``total`` in
+    the resolver payload is the post-permission authorized total, not the
+    backend raw total. In bounded mode, ``total`` is the authorized count found
+    before the per-manager scan cap and ``total_is_exact`` tells callers whether
+    that count is exact. Sorting uses hit ``data[sort_by]`` when available and
+    does not validate the sort field ahead of comparison. Configured filter-key
+    validation runs on the parsed top-level search filters before permission
+    filters or relation normalizers are applied; exclude-derived permission keys
+    are not validated by this search helper.
 
     Parameters:
         query_fields: Mutable dict of registered query fields; will be updated.
@@ -819,6 +924,7 @@ def register_search_query(
         filters: GraphQLSearchFilterInput = None,
         sort_by: str | None = None,
         sort_desc: bool = False,
+        total_mode: str | None = None,
         page: int | None = None,
         page_size: int | None = None,
     ) -> SearchResolverPayload:
@@ -855,10 +961,13 @@ def register_search_query(
         raw: list[object] = []
         requested_count = offset + limit
         fetch_limit = max(requested_count, limit)
-        # Tracks how many authorized hits have been appended globally so far.
-        # This enforces a single cross-manager cap on collected results while
-        # still letting the loop continue counting for an accurate ``total``.
-        global_appended_hits = 0
+        resolved_total_mode = normalize_search_total_mode(total_mode)
+        total_scan_limit = (
+            max(get_graphql_search_total_scan_limit(), requested_count)
+            if resolved_total_mode == "bounded"
+            else None
+        )
+        total_is_exact = True
 
         for manager_class in manager_classes:
             type_label = manager_class.__name__
@@ -872,17 +981,24 @@ def register_search_query(
                 parsed_filters,
                 permission_plan.filters,
             )
-            authorized_hits: list[SearchHitEntry] = []
             total_hits_for_manager = 0
             candidate_hits_for_manager = 0
-            appended_hits_for_manager = 0
             offset_cursor = 0
+            scanned_hits_for_manager = 0
+            manager_total_is_exact = True
             while True:
+                query_limit = fetch_limit
+                if total_scan_limit is not None:
+                    remaining_scan_budget = total_scan_limit - scanned_hits_for_manager
+                    if remaining_scan_budget <= 0:
+                        manager_total_is_exact = False
+                        break
+                    query_limit = min(fetch_limit, remaining_scan_budget)
                 result = backend.search(
                     index_name,
                     query,
                     filters=filter_groups,
-                    limit=fetch_limit,
+                    limit=query_limit,
                     offset=offset_cursor,
                     types=[type_label],
                     sort_by=sort_by,
@@ -896,6 +1012,7 @@ def register_search_query(
                 raw.append(result.raw)
                 if not result.hits:
                     break
+                scanned_hits_for_manager += len(result.hits)
                 offset_cursor += len(result.hits)
                 for hit in result.hits:
                     try:
@@ -918,17 +1035,24 @@ def register_search_query(
                     ):
                         continue
                     total_hits_for_manager += 1
-                    # Apply a single global cap across all managers so that
-                    # ``authorized_hits`` never grows beyond ``requested_count``
-                    # items, regardless of how many managers are searched.
-                    if global_appended_hits < requested_count:
-                        authorized_hits.append((hit.score, hit, instance))
-                        appended_hits_for_manager += 1
-                        global_appended_hits += 1
-                if len(result.hits) < fetch_limit:
+                    hits.append((hit.score, hit, instance))
+                trim_search_hit_entries_to_window(
+                    hits,
+                    requested_count=requested_count,
+                    sort_by=sort_by,
+                    sort_desc=sort_desc,
+                )
+                if len(result.hits) < query_limit:
+                    break
+                if (
+                    total_scan_limit is not None
+                    and scanned_hits_for_manager >= total_scan_limit
+                ):
+                    manager_total_is_exact = False
                     break
             total += total_hits_for_manager
-            hits.extend(authorized_hits)
+            if not manager_total_is_exact:
+                total_is_exact = False
             if permission_plan.requires_instance_check:
                 logger.info(
                     "graphql read authorization summary",
@@ -947,43 +1071,7 @@ def register_search_query(
                     },
                 )
 
-        if sort_by:
-
-            def _normalize_sort_value(value: object) -> SortableValue:
-                """Normalise a sort value to a comparable type."""
-                if value is None:
-                    return None
-                if isinstance(value, (int, float, Decimal)):
-                    return float(value)
-                if isinstance(value, datetime):
-                    if timezone.is_naive(value):
-                        return timezone.make_aware(value)
-                    return value
-                if isinstance(value, date):
-                    return timezone.make_aware(
-                        datetime.combine(value, datetime.min.time())
-                    )
-                if isinstance(value, str):
-                    try:
-                        parsed = datetime.fromisoformat(value)
-                    except ValueError:
-                        return value
-                    if timezone.is_naive(parsed):
-                        parsed = timezone.make_aware(parsed)
-                    return parsed
-                return str(value)
-
-            def _sort_key(
-                item: SearchHitEntry,
-            ) -> tuple[bool, SortableValue]:
-                """Sort key placing None-valued items last."""
-                value = item[1].data.get(sort_by) if item[1].data else None
-                normalized = _normalize_sort_value(value)
-                return (normalized is None, normalized)
-
-            hits.sort(key=_sort_key, reverse=sort_desc)
-        else:
-            hits.sort(key=lambda item: item[0] or 0, reverse=True)
+        sort_search_hit_entries(hits, sort_by=sort_by, sort_desc=sort_desc)
 
         items: list[GeneralManager] = []
         for _, _hit, instance in hits[offset : offset + limit]:
@@ -992,6 +1080,7 @@ def register_search_query(
         return {
             "results": items,
             "total": total,
+            "total_is_exact": total_is_exact,
             "took_ms": took_ms,
             "raw": raw,
         }
@@ -1004,6 +1093,7 @@ def register_search_query(
         filters=graphene.JSONString(),
         sort_by=graphene.String(),
         sort_desc=graphene.Boolean(),
+        total_mode=graphene.String(),
         page=graphene.Int(),
         page_size=graphene.Int(),
         resolver=resolver,

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -184,7 +184,13 @@ def sort_search_hit_entries(
             normalized = normalize_search_sort_value(value)
             return (normalized is None, normalized)
 
-        entries.sort(key=_sort_key, reverse=sort_desc)
+        entries.sort(key=_sort_key)
+        if sort_desc:
+            null_start = next(
+                (index for index, item in enumerate(entries) if _sort_key(item)[0]),
+                len(entries),
+            )
+            entries[:null_start] = reversed(entries[:null_start])
     else:
         entries.sort(key=lambda item: item[0] or 0, reverse=True)
 

--- a/tests/integration/test_graphql_search.py
+++ b/tests/integration/test_graphql_search.py
@@ -3,6 +3,7 @@ from typing import ClassVar
 from unittest.mock import patch
 
 from django.db.models import CASCADE, CharField, ForeignKey
+from django.test import override_settings
 from django.core.management import call_command
 
 from general_manager.interface import DatabaseInterface
@@ -13,6 +14,7 @@ from general_manager.permission.manager_based_permission import (
     ManagerBasedPermission,
 )
 from general_manager.search.backend_registry import configure_search_backend
+from general_manager.search.backend_registry import get_search_backend
 from general_manager.search.backends.dev import DevSearchBackend
 from general_manager.search.config import IndexConfig
 from general_manager.search.indexer import SearchIndexer
@@ -203,6 +205,72 @@ class TestGraphQLSearchIntegration(GeneralManagerTransactionTestCase):
         payload = response.json()["data"]["search"]
         names = [item["name"] for item in payload["results"]]
         self.assertEqual(names, ["Beta Project", "Beta Team"])
+
+    def test_graphql_search_sorted_pagination_includes_later_manager_hits(self):
+        self.Project.Factory.create(name="Zulu Project", status="public")
+        self.Project.Factory.create(name="Zzz Project", status="public")
+        self.ProjectTeam.Factory.create(name="Aardvark Team", status="public")
+        indexer = SearchIndexer(get_search_backend())
+        indexer.reindex_manager(self.Project)
+        indexer.reindex_manager(self.ProjectTeam)
+
+        query = """
+        query {
+            search(index: "global", query: "", sortBy: "name", pageSize: 2) {
+                results {
+                    __typename
+                    ... on ProjectType { name }
+                    ... on ProjectTeamType { name }
+                }
+            }
+        }
+        """
+        response = self.query(query)
+        self.assertResponseNoErrors(response)
+        payload = response.json()["data"]["search"]
+        names = [item["name"] for item in payload["results"]]
+        self.assertEqual(names, ["Aardvark Team", "Alpha Project"])
+
+    @override_settings(GENERAL_MANAGER={"GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT": 1})
+    def test_graphql_search_bounded_total_exposes_exactness_flag(self):
+        query = """
+        query {
+            search(
+                index: "global",
+                query: "",
+                types: ["ProjectTeam"],
+                pageSize: 1,
+                totalMode: "bounded"
+            ) {
+                total
+                totalIsExact
+                results {
+                    __typename
+                    ... on ProjectTeamType { name }
+                }
+            }
+        }
+        """
+        response = self.query(query)
+        self.assertResponseNoErrors(response)
+        payload = response.json()["data"]["search"]
+        self.assertEqual(payload["total"], 1)
+        self.assertFalse(payload["totalIsExact"])
+        self.assertEqual(len(payload["results"]), 1)
+
+    def test_graphql_search_invalid_total_mode_returns_bad_user_input(self):
+        query = """
+        query {
+            search(index: "global", query: "", totalMode: "fast") {
+                total
+            }
+        }
+        """
+        response = self.query(query)
+        self.assertResponseHasErrors(response)
+        error = response.json()["errors"][0]
+        self.assertIn("totalMode must be one of", error["message"])
+        self.assertEqual(error.get("extensions", {}).get("code"), "BAD_USER_INPUT")
 
     def test_graphql_search_sort_desc(self):
         query = """

--- a/tests/unit/test_graphql_search.py
+++ b/tests/unit/test_graphql_search.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from datetime import date, datetime
+from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +16,7 @@ from general_manager.apps import GeneralmanagerConfig
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.manager.input import Input
+from general_manager.measurement.measurement import Measurement
 from general_manager.permission.base_permission import BasePermission
 from general_manager.search.backends.dev import DevSearchBackend
 from general_manager.search.backend import SearchHit, SearchResult
@@ -894,3 +898,357 @@ class GraphQLSearchTests(SimpleTestCase):
         )
         names = [item.identification["id"] for item in response["results"]]
         assert names == [2, 3, 1]
+
+
+class GraphQLSearchHelperCoverageTests(SimpleTestCase):
+    def test_total_mode_and_sort_value_edge_cases(self) -> None:
+        with self.assertRaises(GraphQLError):
+            graphql_search_module.normalize_search_total_mode(object())  # type: ignore[arg-type]
+
+        assert graphql_search_module.normalize_search_sort_value(None) is None
+        assert graphql_search_module.normalize_search_sort_value(Decimal("1.5")) == 1.5
+
+        naive = datetime(2024, 1, 2, 3, 4, 5)
+        aware = graphql_search_module.normalize_search_sort_value(naive)
+        assert isinstance(aware, datetime)
+        assert aware.tzinfo is not None
+
+        date_value = graphql_search_module.normalize_search_sort_value(date(2024, 1, 2))
+        assert isinstance(date_value, datetime)
+        assert date_value.tzinfo is not None
+        assert graphql_search_module.normalize_search_sort_value(object()).startswith(
+            "<object object at"
+        )
+
+    def test_parse_filters_accepts_json_and_skips_malformed_items(self) -> None:
+        parsed = graphql_search_module.parse_search_filters(
+            '[{"field": "status", "values": ["public"]}, "bad", {"op": "exact"}]'
+        )
+
+        assert parsed == {"status__in": ["public"]}
+        assert graphql_search_module.parse_search_filters("{bad json") == {}
+
+    def test_permission_and_match_helpers_cover_empty_and_denied_paths(self) -> None:
+        assert graphql_search_module.merge_permission_filters(
+            {"status": "public"}, []
+        ) == {"status": "public"}
+
+        instance = SimpleNamespace(status="private")
+        assert not graphql_search_module.matches_filters(instance, {"status": "public"})
+
+        info = MagicMock()
+        project = Project(id=1)
+        permission_plan = SimpleNamespace(filters=[], requires_instance_check=True)
+        with patch.object(
+            graphql_search_module,
+            "get_read_permission_filter",
+            return_value=permission_plan,
+        ) as get_plan:
+            with patch.object(
+                graphql_search_module,
+                "can_read_instance",
+                return_value=False,
+            ) as can_read:
+                assert not graphql_search_module.passes_permission_filters(
+                    project,
+                    info,
+                )
+
+        get_plan.assert_called_once_with(Project, info)
+        can_read.assert_called_once_with(project, info)
+
+        denied_plan = SimpleNamespace(
+            filters=[{"filter": {"status": "public"}, "exclude": {}}],
+            requires_instance_check=False,
+        )
+        assert not graphql_search_module.passes_permission_filters(
+            instance, info, permission_plan=denied_plan
+        )
+
+    def test_search_union_empty_and_non_manager_resolution(self) -> None:
+        assert (
+            graphql_search_module.create_search_union({"Project": Project}, {}) is None
+        )
+
+        union = graphql_search_module.create_search_union(
+            {"Project": Project},
+            {"Project": MagicMock()},
+        )
+
+        assert union is not None
+        assert union.resolve_type(object(), MagicMock()) is None
+
+    def test_filter_options_cover_relation_measurement_and_relation_guards(
+        self,
+    ) -> None:
+        mapper = MagicMock(return_value=graphql_search_module.graphene.String())
+        relation_options = list(
+            graphql_search_module.get_filter_options(Project, "project", mapper)
+        )
+        assert relation_options == [("project", None)]
+
+        measurement_options = list(
+            graphql_search_module.get_filter_options(Measurement, "cost", mapper)
+        )
+        assert [name for name, _field in measurement_options] == [
+            "cost",
+            "cost__exact",
+            "cost__gt",
+            "cost__gte",
+            "cost__lt",
+            "cost__lte",
+        ]
+
+        registry: dict[str, type[graphql_search_module.graphene.InputObjectType]] = {}
+        assert (
+            graphql_search_module.get_relation_filter_option(
+                str,
+                "owner",
+                {"relation_kind": "direct"},
+                registry,
+                mapper,
+                remaining_depth=1,
+            )
+            is None
+        )
+        assert (
+            graphql_search_module.get_relation_filter_option(
+                Project,
+                "owner",
+                {"relation_kind": "unsupported"},
+                registry,
+                mapper,
+                remaining_depth=1,
+            )
+            is None
+        )
+        with patch.object(
+            graphql_search_module, "create_filter_options", return_value=None
+        ):
+            assert (
+                graphql_search_module.get_relation_filter_option(
+                    Project,
+                    "owner",
+                    {"relation_kind": "direct"},
+                    registry,
+                    mapper,
+                    remaining_depth=1,
+                )
+                is None
+            )
+
+    def test_create_filter_options_skips_unfilterable_props_and_empty_types(
+        self,
+    ) -> None:
+        class EmptyInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):
+                """Return no filterable attributes."""
+                return {}
+
+            @classmethod
+            def get_graph_ql_properties(cls):
+                """Return no filterable GraphQL properties."""
+                return {}
+
+        class EmptyManager(GeneralManager):
+            Interface = EmptyInterface
+
+        EmptyInterface._parent_class = EmptyManager
+        mapper = MagicMock(return_value=graphql_search_module.graphene.String())
+        assert (
+            graphql_search_module.create_filter_options(EmptyManager, {}, mapper)
+            is None
+        )
+
+        prop = SimpleNamespace(filterable=False, graphql_type_hint=str)
+        with patch.object(
+            Project.Interface, "get_graph_ql_properties", return_value={"x": prop}
+        ):
+            filter_type = graphql_search_module.create_filter_options(
+                Project, {}, mapper
+            )
+
+        assert filter_type is not None
+        assert "x" not in filter_type._meta.fields
+
+    def test_normalize_id_and_relation_filter_edges(self) -> None:
+        assert (
+            graphql_search_module.normalize_id_filter_value(Project, "name", "A") == "A"
+        )
+
+        class NoIdInterface(BaseTestInterface):
+            input_fields: ClassVar[dict[str, Input]] = {}
+
+        class NoIdManager(GeneralManager):
+            Interface = NoIdInterface
+
+        NoIdInterface._parent_class = NoIdManager
+        assert (
+            graphql_search_module.normalize_id_filter_value(NoIdManager, "id", "1")
+            == "1"
+        )
+        assert (
+            graphql_search_module.normalize_id_filter_value(Project, "id__in", "1")
+            == "1"
+        )
+
+        class NoAttributeInterface(BaseTestInterface):
+            input_fields: ClassVar[dict[str, Input]] = {"id": Input(int)}
+
+        class NoAttributeManager(GeneralManager):
+            Interface = NoAttributeInterface
+
+        NoAttributeInterface._parent_class = NoAttributeManager
+        assert graphql_search_module.normalize_filter_input(
+            NoAttributeManager,
+            {"status": "public"},
+        ) == {"filter": {"status": "public"}, "exclude": {}}
+
+        class LeafInterface(BaseTestInterface):
+            input_fields: ClassVar[dict[str, Input]] = {"id": Input(int)}
+
+            @classmethod
+            def get_attribute_types(cls):
+                """Return simple leaf attributes for nested relation filters."""
+                return {"id": {"type": int}, "status": {"type": str}}
+
+        class LeafManager(GeneralManager):
+            Interface = LeafInterface
+
+        LeafInterface._parent_class = LeafManager
+
+        class RelationInterface(BaseTestInterface):
+            input_fields: ClassVar[dict[str, Input]] = {"id": Input(int)}
+
+            @classmethod
+            def get_attribute_types(cls):
+                """Return direct, collection, and unsupported relation metadata."""
+                return {
+                    "owner": {
+                        "type": LeafManager,
+                        "relation_kind": "direct",
+                        "filter_lookup": "owner",
+                    },
+                    "members": {
+                        "type": LeafManager,
+                        "relation_kind": "collection",
+                        "filter_lookup": "members",
+                    },
+                    "legacy": {
+                        "type": LeafManager,
+                        "relation_kind": "legacy",
+                    },
+                    "plain_relation": {"type": LeafManager},
+                }
+
+        class RelationManager(GeneralManager):
+            Interface = RelationInterface
+
+        RelationInterface._parent_class = RelationManager
+
+        normalized = graphql_search_module.normalize_filter_input(
+            RelationManager,
+            {
+                "owner": {"status": "public", "id": "2"},
+                "members": {
+                    "any": {"status": "active"},
+                    "none": {"status": "inactive"},
+                },
+                "legacy": {"status": "ignored"},
+                "plain_relation": {"status": "plain"},
+            },
+        )
+
+        assert normalized == {
+            "filter": {
+                "owner__status": "public",
+                "owner__id": 2,
+                "members__status": "active",
+                "legacy": {"status": "ignored"},
+                "plain_relation": {"status": "plain"},
+            },
+            "exclude": {"members__status": "inactive"},
+        }
+
+    def test_register_search_query_guard_paths_and_resolver_errors(self) -> None:
+        existing_union = MagicMock()
+        existing_result = MagicMock()
+        query_fields = {"search": object()}
+
+        assert graphql_search_module.register_search_query(
+            query_fields,
+            {},
+            {},
+            existing_union,
+            existing_result,
+        ) == (existing_union, existing_result)
+
+        with patch.object(
+            graphql_search_module, "create_search_union", return_value=None
+        ):
+            assert graphql_search_module.register_search_query(
+                {},
+                {"Project": Project},
+                {"Project": MagicMock()},
+                None,
+                existing_result,
+            ) == (None, existing_result)
+
+        with patch.object(
+            graphql_search_module,
+            "validate_filter_keys",
+            side_effect=ValueError("bad filter"),
+        ):
+            query_fields = {}
+            graphql_search_module.register_search_query(
+                query_fields,
+                {"Project": Project},
+                {"Project": MagicMock()},
+                None,
+                None,
+            )
+            with self.assertRaises(GraphQLError):
+                query_fields["search"].resolver(
+                    None,
+                    MagicMock(),
+                    query="",
+                    filters={"status": "public"},
+                )
+
+    def test_resolver_logs_instantiation_failures(self) -> None:
+        query_fields = {}
+        graphql_search_module.register_search_query(
+            query_fields,
+            {"Project": Project},
+            {"Project": MagicMock()},
+            None,
+            None,
+        )
+        backend = MagicMock()
+        backend.search.side_effect = [
+            SearchResult(
+                hits=[
+                    SearchHit(
+                        id="bad",
+                        type="Project",
+                        identification={},
+                        score=1.0,
+                        data={"name": "Bad"},
+                    )
+                ],
+                total=1,
+                took_ms=1,
+                raw={},
+            ),
+            SearchResult(hits=[], total=0, took_ms=1, raw={}),
+        ]
+        info = MagicMock()
+        with patch.object(
+            graphql_search_module, "get_search_backend", return_value=backend
+        ):
+            with patch.object(graphql_search_module.logger, "debug") as debug:
+                response = query_fields["search"].resolver(None, info, query="")
+
+        assert response["results"] == []
+        debug.assert_called_once()

--- a/tests/unit/test_graphql_search.py
+++ b/tests/unit/test_graphql_search.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import ClassVar
-from unittest.mock import MagicMock
+from typing import Any, ClassVar
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import AnonymousUser
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from graphql import GraphQLError
 
+from general_manager.api import graphql_search as graphql_search_module
 from general_manager.api.graphql import GraphQL
 from general_manager.apps import GeneralmanagerConfig
 from general_manager.manager.general_manager import GeneralManager
@@ -14,6 +15,7 @@ from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.manager.input import Input
 from general_manager.permission.base_permission import BasePermission
 from general_manager.search.backends.dev import DevSearchBackend
+from general_manager.search.backend import SearchHit, SearchResult
 from general_manager.search import backend_registry
 from general_manager.search.backend_registry import configure_search_backend
 from general_manager.search.config import IndexConfig
@@ -127,6 +129,27 @@ class Project(GeneralManager):
         ]
 
 
+class CountingDevSearchBackend(DevSearchBackend):
+    def __init__(self) -> None:
+        super().__init__()
+        self.search_calls: list[dict[str, Any]] = []
+
+    def search(self, *args: Any, **kwargs: Any):
+        self.search_calls.append({"args": args, "kwargs": dict(kwargs)})
+        return super().search(*args, **kwargs)
+
+
+class BestEffortTotalSearchBackend(CountingDevSearchBackend):
+    def search(self, *args: Any, **kwargs: Any) -> SearchResult:
+        result = super().search(*args, **kwargs)
+        return SearchResult(
+            hits=result.hits,
+            total=len(result.hits),
+            took_ms=result.took_ms,
+            raw=result.raw,
+        )
+
+
 class GraphQLSearchTests(SimpleTestCase):
     def setUp(self) -> None:
         """
@@ -141,6 +164,7 @@ class GraphQLSearchTests(SimpleTestCase):
         self._orig_manager_registry = GraphQL.manager_registry
         self._orig_search_union = GraphQL._search_union
         self._orig_search_result_type = GraphQL._search_result_type
+        self._orig_project_data_store = ProjectInterface.data_store.copy()
 
         GeneralManagerMeta.all_classes = [Project]
         GeneralmanagerConfig.initialize_general_manager_classes([Project], [Project])
@@ -166,6 +190,7 @@ class GraphQLSearchTests(SimpleTestCase):
         This reverses mutations performed in setUp by restoring the previously saved search backend, GeneralManagerMeta class list and safe-class initialization, and GraphQL query/type/manager/search-related registries and caches, then delegates to the superclass tearDown.
         """
         configure_search_backend(self._orig_backend)
+        ProjectInterface.data_store = self._orig_project_data_store.copy()
         GeneralManagerMeta.all_classes = self._orig_gm_classes
         safe_classes = [
             manager_class
@@ -179,6 +204,22 @@ class GraphQLSearchTests(SimpleTestCase):
         GraphQL._search_union = self._orig_search_union
         GraphQL._search_result_type = self._orig_search_result_type
         super().tearDown()
+
+    def _configure_counting_backend_with_public_rows(
+        self,
+        public_count: int,
+        backend: CountingDevSearchBackend | None = None,
+    ) -> CountingDevSearchBackend:
+        ProjectInterface.data_store = {
+            row_id: {"name": f"Project {row_id}", "status": "public"}
+            for row_id in range(1, public_count + 1)
+        }
+        backend = backend or CountingDevSearchBackend()
+        configure_search_backend(backend)
+        indexer = SearchIndexer(backend)
+        for row_id in ProjectInterface.data_store:
+            indexer.index_instance(Project(id=row_id))
+        return backend
 
     def test_graphql_search_filters_by_permission(self) -> None:
         """
@@ -319,6 +360,285 @@ class GraphQLSearchTests(SimpleTestCase):
 
         assert response["total"] == 3
         assert [item.identification for item in response["results"]] == [{"id": 3}]
+
+    def test_graphql_search_exact_total_scans_all_matches_by_default(self) -> None:
+        backend = self._configure_counting_backend_with_public_rows(public_count=5)
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        response = field.resolver(
+            None,
+            info,
+            query="",
+            index="global",
+            types=None,
+            filters=None,
+            page=1,
+            page_size=1,
+        )
+
+        assert response["total"] == 5
+        assert response["total_is_exact"] is True
+        assert len(response["results"]) == 1
+        assert len(backend.search_calls) > 1
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_SEARCH_TOTAL_MODE": "bounded",
+            "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT": 1,
+        }
+    )
+    def test_graphql_search_bounded_total_stops_after_scan_limit(self) -> None:
+        backend = self._configure_counting_backend_with_public_rows(public_count=5)
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        response = field.resolver(
+            None,
+            info,
+            query="",
+            index="global",
+            types=None,
+            filters=None,
+            page=1,
+            page_size=1,
+        )
+
+        assert response["total"] == 1
+        assert response["total_is_exact"] is False
+        assert len(response["results"]) == 1
+        assert len(backend.search_calls) == 1
+
+    def test_graphql_search_exact_total_ignores_best_effort_backend_total(self) -> None:
+        backend = self._configure_counting_backend_with_public_rows(
+            public_count=5,
+            backend=BestEffortTotalSearchBackend(),
+        )
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        response = field.resolver(
+            None,
+            info,
+            query="",
+            index="global",
+            types=None,
+            filters=None,
+            page=1,
+            page_size=1,
+        )
+
+        assert response["total"] == 5
+        assert response["total_is_exact"] is True
+        assert len(response["results"]) == 1
+        assert len(backend.search_calls) == 6
+
+    def test_graphql_search_exact_total_trims_materialized_page_window(self) -> None:
+        self._configure_counting_backend_with_public_rows(public_count=12)
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+        trimmed_lengths: list[int] = []
+        real_trim = graphql_search_module.trim_search_hit_entries_to_window
+
+        def tracking_trim(*args: Any, **kwargs: Any) -> None:
+            real_trim(*args, **kwargs)
+            trimmed_lengths.append(len(args[0]))
+
+        with patch.object(
+            graphql_search_module,
+            "trim_search_hit_entries_to_window",
+            side_effect=tracking_trim,
+        ):
+            response = field.resolver(
+                None,
+                info,
+                query="",
+                index="global",
+                types=None,
+                filters=None,
+                page=1,
+                page_size=2,
+            )
+
+        assert response["total"] == 12
+        assert len(response["results"]) == 2
+        assert trimmed_lengths
+        assert max(trimmed_lengths) == 2
+
+    def test_search_hit_window_trims_sorted_candidates(self) -> None:
+        entries = [
+            (
+                None,
+                SearchHit(
+                    id=str(row_id),
+                    type="Project",
+                    identification={"id": row_id},
+                    data={"name": name},
+                ),
+                Project(id=row_id),
+            )
+            for row_id, name in enumerate(
+                ["Zulu Project", "Alpha Project", "Beta Project"],
+                start=1,
+            )
+        ]
+
+        graphql_search_module.trim_search_hit_entries_to_window(
+            entries,
+            requested_count=2,
+            sort_by="name",
+            sort_desc=False,
+        )
+
+        assert [entry[1].data["name"] for entry in entries] == [
+            "Alpha Project",
+            "Beta Project",
+        ]
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_SEARCH_TOTAL_MODE": "bounded",
+            "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT": 5,
+        }
+    )
+    def test_graphql_search_bounded_total_marks_best_effort_limit_inexact(
+        self,
+    ) -> None:
+        backend = self._configure_counting_backend_with_public_rows(
+            public_count=5,
+            backend=BestEffortTotalSearchBackend(),
+        )
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        response = field.resolver(
+            None,
+            info,
+            query="",
+            index="global",
+            types=None,
+            filters=None,
+            page=1,
+            page_size=1,
+        )
+
+        assert response["total"] == 5
+        assert response["total_is_exact"] is False
+        assert len(response["results"]) == 1
+        assert len(backend.search_calls) == 5
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_SEARCH_TOTAL_MODE": "bounded",
+            "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT": 5,
+        }
+    )
+    def test_graphql_search_bounded_total_is_conservative_at_scan_boundary(
+        self,
+    ) -> None:
+        backend = self._configure_counting_backend_with_public_rows(public_count=5)
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        response = field.resolver(
+            None,
+            info,
+            query="",
+            index="global",
+            types=None,
+            filters=None,
+            page=1,
+            page_size=1,
+        )
+
+        assert response["total"] == 5
+        assert response["total_is_exact"] is False
+        assert len(response["results"]) == 1
+        assert len(backend.search_calls) == 5
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_SEARCH_TOTAL_MODE": "bounded",
+            "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT": 1,
+        }
+    )
+    def test_graphql_search_total_mode_exact_overrides_bounded_setting(self) -> None:
+        backend = self._configure_counting_backend_with_public_rows(public_count=5)
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        response = field.resolver(
+            None,
+            info,
+            query="",
+            index="global",
+            types=None,
+            filters=None,
+            total_mode="exact",
+            page=1,
+            page_size=1,
+        )
+
+        assert response["total"] == 5
+        assert response["total_is_exact"] is True
+        assert len(response["results"]) == 1
+        assert len(backend.search_calls) > 1
+
+    def test_graphql_search_rejects_invalid_total_mode(self) -> None:
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        with self.assertRaisesRegex(
+            GraphQLError,
+            "totalMode must be one of",
+        ) as ctx:
+            field.resolver(
+                None,
+                info,
+                query="",
+                index="global",
+                types=None,
+                filters=None,
+                total_mode="fast",
+                page=1,
+                page_size=1,
+            )
+        assert ctx.exception.extensions["code"] == "BAD_USER_INPUT"
+
+    @override_settings(
+        GENERAL_MANAGER={
+            "GRAPHQL_SEARCH_TOTAL_MODE": "bounded",
+            "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT": 0,
+        }
+    )
+    def test_graphql_search_rejects_invalid_total_scan_limit(self) -> None:
+        field = GraphQL._query_fields["search"]
+        info = MagicMock()
+        info.context.user = AnonymousUser()
+
+        with self.assertRaisesRegex(
+            GraphQLError,
+            "GRAPHQL_SEARCH_TOTAL_SCAN_LIMIT must be a positive integer",
+        ) as ctx:
+            field.resolver(
+                None,
+                info,
+                query="",
+                index="global",
+                types=None,
+                filters=None,
+                page=1,
+                page_size=1,
+            )
+        assert ctx.exception.extensions["code"] == "BAD_USER_INPUT"
 
     def test_graphql_search_rejects_zero_page(self) -> None:
         field = GraphQL._query_fields["search"]

--- a/tests/unit/test_graphql_search.py
+++ b/tests/unit/test_graphql_search.py
@@ -503,6 +503,39 @@ class GraphQLSearchTests(SimpleTestCase):
             "Beta Project",
         ]
 
+    def test_search_hit_window_keeps_null_sort_values_last_when_descending(
+        self,
+    ) -> None:
+        entries = [
+            (
+                None,
+                SearchHit(
+                    id=str(row_id),
+                    type="Project",
+                    identification={"id": row_id},
+                    data=data,
+                ),
+                Project(id=row_id),
+            )
+            for row_id, data in [
+                (1, {"rank": 10}),
+                (2, {}),
+                (3, {"rank": 5}),
+            ]
+        ]
+
+        graphql_search_module.trim_search_hit_entries_to_window(
+            entries,
+            requested_count=2,
+            sort_by="rank",
+            sort_desc=True,
+        )
+
+        assert [entry[2].identification for entry in entries] == [
+            {"id": 1},
+            {"id": 3},
+        ]
+
     @override_settings(
         GENERAL_MANAGER={
             "GRAPHQL_SEARCH_TOTAL_MODE": "bounded",
@@ -902,8 +935,9 @@ class GraphQLSearchTests(SimpleTestCase):
 
 class GraphQLSearchHelperCoverageTests(SimpleTestCase):
     def test_total_mode_and_sort_value_edge_cases(self) -> None:
+        bad_mode: Any = object()
         with self.assertRaises(GraphQLError):
-            graphql_search_module.normalize_search_total_mode(object())  # type: ignore[arg-type]
+            graphql_search_module.normalize_search_total_mode(bad_mode)
 
         assert graphql_search_module.normalize_search_sort_value(None) is None
         assert graphql_search_module.normalize_search_sort_value(Decimal("1.5")) == 1.5
@@ -1244,6 +1278,7 @@ class GraphQLSearchHelperCoverageTests(SimpleTestCase):
             SearchResult(hits=[], total=0, took_ms=1, raw={}),
         ]
         info = MagicMock()
+        info.context.user = AnonymousUser()
         with patch.object(
             graphql_search_module, "get_search_backend", return_value=backend
         ):


### PR DESCRIPTION
## Summary
- Add configurable GraphQL search total modes with `totalMode`, `totalIsExact`, and bounded per-manager scan limits.
- Preserve exact-mode total semantics while bounding retained page candidates for sorting/pagination.
- Document exact vs bounded totals and update search tests, including best-effort backend totals and cross-manager sorted pagination.

Fixes #304

## Validation
- `python -m pytest tests/unit/test_graphql_search.py::GraphQLSearchTests -q` -> 15 passed
- `python -m pytest tests/unit/test_graphql_search.py tests/integration/test_graphql_search.py -q` -> 34 passed
- `python -m pytest tests/unit/test_graphql_search.py tests/integration/test_graphql_search.py tests/unit/test_graph_ql.py tests/unit/test_graphql_helpers.py --cov=general_manager.api.graphql_search --cov-report=term-missing --cov-fail-under=95 -q` -> 139 passed, 97.38% coverage
- AST docstring audit for `src/general_manager/api/graphql_search.py` -> all functions/methods have docstrings
- `ruff check src/general_manager/api/graphql_search.py tests/unit/test_graphql_search.py`
- `ruff format --check src/general_manager/api/graphql_search.py tests/unit/test_graphql_search.py`
- `mypy src/general_manager/api/graphql_search.py`
- `git diff --check origin/main...HEAD`

## Review
- Subagent spec/code reviews completed; final narrow re-review reported no issues.
- Residual risk: live external backend behavior, especially Meilisearch pagination edge cases, was not exercised beyond existing adapter contract/tests.

## Notes
- This branch overlaps with PR #314 in `src/general_manager/api/graphql_search.py` and `docs/concepts/search.md`; one of the search PRs may need a rebase after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GraphQL search now supports selectable total-count behavior, including exact and bounded modes, with a new field to show whether the total is precise.

* **Bug Fixes**
  * Improved search result pagination and sorting consistency across multiple sources.
  * Invalid total-count settings now return clear user-input errors.

* **Documentation**
  * Updated search docs and examples to cover the new total-count options and response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->