### PR TITLE
fix: bound calculation bucket string preview

### DIFF
--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -611,12 +611,14 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         self,
         combinations: list[Combination],
     ) -> list[GeneralManagerType]:
+        """Instantiate managers for each raw input-combination dictionary."""
         return [self._manager_class(**combo) for combo in combinations]
 
     @staticmethod
     def _manager_identifications(
         managers: list[GeneralManagerType],
     ) -> list[Combination]:
+        """Return the identification dictionaries from manager instances."""
         return [manager.identification for manager in managers]
 
     def generate_combinations(self) -> List[Combination]:

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -1,8 +1,9 @@
 """Bucket implementation that enumerates calculation interface combinations."""
 
 from __future__ import annotations
-from collections.abc import Hashable, Iterable
+from collections.abc import Hashable, Iterable, Iterator
 from types import UnionType
+from itertools import islice
 from typing import (
     Type,
     TYPE_CHECKING,
@@ -308,25 +309,86 @@ class CalculationBucket(Bucket[GeneralManagerType]):
 
     def __str__(self) -> str:
         """
-        Return a compact preview of the generated combinations.
+        Return a compact preview of generated combinations.
+
+        Cached buckets include the exact combination count. Uncached buckets avoid
+        materializing all combinations for string formatting; when more than the
+        preview limit exists, the count is reported as a lower-bound label.
 
         Returns:
             str: Human-readable summary of up to five combinations.
         """
         PRINT_MAX = 5
-        combinations = self.generate_combinations()
-        prefix = f"CalculationBucket ({len(combinations)})["
+        combinations, count_label, has_more = self._str_combinations_preview(PRINT_MAX)
+        prefix = f"CalculationBucket ({count_label})["
         main = ",".join(
-            [
-                f"{self._manager_class.__name__}(**{comb})"
-                for comb in combinations[:PRINT_MAX]
-            ]
+            [f"{self._manager_class.__name__}(**{comb})" for comb in combinations]
         )
-        sufix = "]"
-        if len(combinations) > PRINT_MAX:
-            sufix = ", ...]"
+        suffix = "]"
+        if has_more:
+            suffix = ", ...]"
 
-        return f"{prefix}{main}{sufix}"
+        return f"{prefix}{main}{suffix}"
+
+    def _str_combinations_preview(
+        self, limit: int
+    ) -> tuple[list[Combination], str, bool]:
+        """
+        Return combinations, count label, and overflow flag for ``__str__``.
+
+        Sorted or reversed buckets use normal materialization so the preview
+        reflects the final global ordering. Unsorted uncached buckets read at
+        most ``limit + 1`` matching combinations and leave ``_data`` untouched.
+        """
+        if self._data is not None:
+            return self._data[:limit], str(len(self._data)), len(self._data) > limit
+
+        if self._normalized_sort_key() is not None or self.reverse:
+            combinations = self.generate_combinations()
+            return (
+                combinations[:limit],
+                str(len(combinations)),
+                len(combinations) > limit,
+            )
+
+        from general_manager.cache.run_context import ensure_calculation_run_context
+
+        with ensure_calculation_run_context():
+            sorted_inputs = self.topological_sort_inputs()
+            sorted_filters = self._sort_filters(sorted_inputs)
+            if self._uses_static_iterator_possible_values(sorted_inputs):
+                combinations = self.generate_combinations()
+                return (
+                    combinations[:limit],
+                    str(len(combinations)),
+                    len(combinations) > limit,
+                )
+            preview_iterator = self._iter_input_combinations(
+                sorted_inputs,
+                sorted_filters["input_filters"],
+                sorted_filters["input_excludes"],
+                snapshot_iterables=False,
+            )
+            if sorted_filters["prop_filters"] or sorted_filters["prop_excludes"]:
+                preview_iterator = self._iter_prop_filtered_identifications(
+                    preview_iterator,
+                    sorted_filters["prop_filters"],
+                    sorted_filters["prop_excludes"],
+                )
+            preview = list(islice(preview_iterator, limit + 1))
+
+        has_more = len(preview) > limit
+        if has_more:
+            preview = preview[:limit]
+        count_label = f"{limit}+" if has_more else str(len(preview))
+        return preview, count_label, has_more
+
+    def _uses_static_iterator_possible_values(self, sorted_inputs: list[str]) -> bool:
+        """Return whether previewing would consume a one-shot static iterator."""
+        return any(
+            isinstance(self.input_fields[input_name].possible_values, Iterator)
+            for input_name in sorted_inputs
+        )
 
     def __repr__(self) -> str:
         """
@@ -730,22 +792,25 @@ class CalculationBucket(Bucket[GeneralManagerType]):
             raise InvalidPossibleValuesError(key_name)
         return possible_values
 
-    def _generate_input_combinations(
+    def _iter_input_combinations(
         self,
         sorted_inputs: List[str],
         filters: ParsedFilters,
         excludes: ParsedFilters,
-    ) -> List[Combination]:
+        *,
+        snapshot_iterables: bool,
+    ) -> Generator[Combination, None, None]:
         """
-        Generate all valid assignments of input fields that satisfy the provided per-field filters and exclusions.
+        Yield valid assignments of input fields satisfying filters and excludes.
 
         Parameters:
             sorted_inputs (list[str]): Input names in dependency-respecting order.
             filters (dict[str, dict]): Per-input filter definitions (may include `filter_funcs` or `filter_kwargs`).
             excludes (dict[str, dict]): Per-input exclusion definitions (may include `filter_funcs` or `filter_kwargs`).
 
-        Returns:
-            list[Combination]: Completed input-to-value mappings that meet the filters and excludes.
+        Yields:
+            Combination: Completed input-to-value mappings that meet the
+                filters and excludes.
         """
 
         def input_passes_filters(
@@ -814,8 +879,8 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                     possible_values = filter(
                         lambda x: not exclude_func(x), possible_values
                     )
-
-                possible_values = list(possible_values)
+                if snapshot_iterables:
+                    possible_values = list(possible_values)
 
             for value in possible_values:
                 if not isinstance(value, input_field.type):
@@ -824,7 +889,52 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                 yield from helper(index + 1, current_combo)
                 del current_combo[input_name]
 
-        return list(helper(0, {}))
+        yield from helper(0, {})
+
+    def _generate_input_combinations(
+        self,
+        sorted_inputs: List[str],
+        filters: ParsedFilters,
+        excludes: ParsedFilters,
+    ) -> List[Combination]:
+        """
+        Generate all valid assignments of input fields that satisfy filters.
+
+        Parameters:
+            sorted_inputs (list[str]): Input names in dependency-respecting order.
+            filters (dict[str, dict]): Per-input filter definitions.
+            excludes (dict[str, dict]): Per-input exclusion definitions.
+
+        Returns:
+            list[Combination]: Completed input-to-value mappings that meet the
+                filters and excludes.
+        """
+        return list(
+            self._iter_input_combinations(
+                sorted_inputs,
+                filters,
+                excludes,
+                snapshot_iterables=True,
+            )
+        )
+
+    def _iter_prop_filtered_identifications(
+        self,
+        combinations: Iterable[Combination],
+        prop_filters: ParsedFilters,
+        prop_excludes: ParsedFilters,
+    ) -> Generator[Combination, None, None]:
+        """
+        Lazily apply property filters and yield manager identifications.
+
+        This mirrors the property-filter materialization path used by
+        :meth:`generate_combinations`, but lets ``__str__`` stop after enough
+        matching combinations have been found.
+        """
+        for combo in combinations:
+            manager = self._manager_class(**combo)
+            if self._filter_prop_combinations([manager], prop_filters, prop_excludes):
+                yield manager.identification
 
     def _filter_prop_combinations(
         self,

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -26,6 +26,7 @@ from general_manager.bucket.base_bucket import Bucket
 from general_manager.bucket.indexing import freeze_bucket_index_value
 from general_manager.manager.input import Input, InputDomain
 from general_manager.utils.filter_parser import (
+    FilterFunction,
     ParsedFilters,
     parse_filters,
 )
@@ -46,6 +47,15 @@ class SortedFilters(TypedDict):
     input_filters: ParsedFilters
     prop_excludes: ParsedFilters
     input_excludes: ParsedFilters
+
+
+def _build_exclude_filter(exclude_func: FilterFunction) -> FilterFunction:
+    """Create a lazy predicate that keeps values an exclude does not reject."""
+
+    def includes_value(value: object) -> bool:
+        return not exclude_func(value)
+
+    return includes_value
 
 
 class InvalidCalculationInterfaceError(TypeError):
@@ -363,11 +373,12 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                     str(len(combinations)),
                     len(combinations) > limit,
                 )
+            snapshot_iterables = self._uses_dependent_possible_values(sorted_inputs)
             preview_iterator = self._iter_input_combinations(
                 sorted_inputs,
                 sorted_filters["input_filters"],
                 sorted_filters["input_excludes"],
-                snapshot_iterables=False,
+                snapshot_iterables=snapshot_iterables,
             )
             if sorted_filters["prop_filters"] or sorted_filters["prop_excludes"]:
                 preview_iterator = self._iter_prop_filtered_identifications(
@@ -387,6 +398,14 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         """Return whether previewing would consume a one-shot static iterator."""
         return any(
             isinstance(self.input_fields[input_name].possible_values, Iterator)
+            for input_name in sorted_inputs
+        )
+
+    def _uses_dependent_possible_values(self, sorted_inputs: list[str]) -> bool:
+        """Return whether previewing should snapshot values before dependencies."""
+        return any(
+            bool(self.input_fields[input_name].depends_on)
+            and self.input_fields[input_name].possible_values is not None
             for input_name in sorted_inputs
         )
 
@@ -879,7 +898,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                 exclude_funcs = field_excludes.get("filter_funcs", [])
                 for exclude_func in exclude_funcs:
                     possible_values = filter(
-                        lambda x: not exclude_func(x), possible_values
+                        _build_exclude_filter(exclude_func), possible_values
                     )
                 if snapshot_iterables:
                     possible_values = list(possible_values)

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -1,12 +1,14 @@
 # type: ignore
 from django.test import TestCase
 from datetime import date
+from types import SimpleNamespace
 from unittest.mock import patch
 from general_manager.bucket.calculation_bucket import CalculationBucket
 from general_manager.cache.run_context import current_calculation_run_context
 from general_manager.interface import CalculationInterface
 from general_manager.manager.input import DateRangeDomain, Input
 from general_manager.manager import GeneralManager
+from tests.utils.simple_manager_interface import SimpleBucket
 from typing import ClassVar
 
 
@@ -1498,3 +1500,157 @@ class TestCalculationBucketExceptions(TestCase):
         with patch.object(bucket, "filter", return_value=bucket):
             combined = bucket | manager_instance
         self.assertIsInstance(combined, CalculationBucket)
+
+
+class TestCalculationBucketCoverageEdges(TestCase):
+    def test_equality_rejects_other_types(self):
+        """CalculationBucket equality should reject non-bucket values."""
+        bucket = CalculationBucket(DummyGeneralManager)
+
+        self.assertNotEqual(bucket, object())
+
+    def test_property_transform_resolves_union_collection_and_unknown_hints(self):
+        """Property type transformation should normalize common annotation shapes."""
+        properties = {
+            "optional_number": SimpleNamespace(graphql_type_hint=int | None),
+            "names": SimpleNamespace(graphql_type_hint=list[str]),
+            "unknown": SimpleNamespace(graphql_type_hint="not-a-type"),
+        }
+
+        inputs = CalculationBucket.transform_properties_to_input_fields(
+            properties,
+            {},
+        )
+
+        self.assertEqual(inputs["optional_number"].type, int)
+        self.assertEqual(inputs["names"].type, str)
+        self.assertEqual(inputs["unknown"].type, object)
+
+    def test_bucket_index_signature_includes_sort_and_filters(self):
+        """Bucket index signatures should include plan-defining state."""
+
+        class SignatureInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "x": Input(int, possible_values=[1]),
+                "y": Input(int, possible_values=[2]),
+            }
+
+        class SignatureManager:
+            Interface = SignatureInterface
+
+        SignatureInterface._parent_class = SignatureManager
+        bucket = CalculationBucket(
+            SignatureManager,
+            {"x": 1},
+            {"y": 2},
+            sort_key=("x",),
+            reverse=True,
+        )
+
+        signature = bucket._bucket_index_source_signature()
+
+        self.assertEqual(signature[0], "calculation")
+        self.assertIs(signature[1], SignatureManager)
+        self.assertEqual(signature[-2:], (("x",), True))
+
+    def test_topological_sort_skips_already_visited_dependencies(self):
+        """Shared dependency paths should not duplicate already visited inputs."""
+
+        class SharedDependencyInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "root": Input(int, possible_values=[1]),
+                "middle": Input(int, possible_values=[2], depends_on=["root"]),
+                "leaf": Input(int, possible_values=[3], depends_on=["root", "middle"]),
+            }
+
+        class SharedDependencyManager:
+            Interface = SharedDependencyInterface
+
+        SharedDependencyInterface._parent_class = SharedDependencyManager
+        bucket = CalculationBucket(SharedDependencyManager)
+
+        self.assertEqual(
+            bucket.topological_sort_inputs(),
+            ["root", "middle", "leaf"],
+        )
+
+    def test_required_input_without_possible_values_raises(self):
+        """Required inputs without possible values should be invalid."""
+        bucket = CalculationBucket(DummyGeneralManager)
+
+        with self.assertRaises(TypeError):
+            bucket.get_possible_values("required", Input(int), {})
+
+    def test_iter_input_combinations_covers_bucket_excludes_and_type_skips(self):
+        """Input enumeration should handle bucket sources, excludes, and bad types."""
+        typed_field = Input(int, possible_values=[1, "bad", 2])
+        typed_bucket = CalculationBucket(DummyGeneralManager)
+        typed_bucket.input_fields = {"value": typed_field}
+
+        combinations = typed_bucket._generate_input_combinations(
+            ["value"],
+            {},
+            {"value": {"filter_funcs": [lambda value: value == 2]}},
+        )
+
+        self.assertEqual(combinations, [{"value": 1}])
+
+        class BucketValueInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "manager": Input(
+                    DummyGeneralManager,
+                    possible_values=SimpleBucket(DummyGeneralManager, []),
+                )
+            }
+
+        class BucketValueManager:
+            Interface = BucketValueInterface
+
+        BucketValueInterface._parent_class = BucketValueManager
+        bucket_value_bucket = CalculationBucket(BucketValueManager)
+
+        self.assertEqual(bucket_value_bucket.generate_combinations(), [])
+
+    def test_property_preview_and_terminal_helpers(self):
+        """Lazy property previews and terminal helpers should keep expected behavior."""
+
+        class ScoreInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "score": Input(int, possible_values=[1, 2, 3]),
+            }
+
+        class ScoreManager:
+            Interface = ScoreInterface
+
+            def __init__(self, **kwargs):
+                """Store the score-backed identification for helper assertions."""
+                self.identification = dict(kwargs)
+                self.score = kwargs["score"]
+
+            def __eq__(self, other):
+                """Compare helper managers by their identification payload."""
+                return (
+                    isinstance(other, ScoreManager)
+                    and self.identification == other.identification
+                )
+
+        ScoreInterface._parent_class = ScoreManager
+        bucket = CalculationBucket(ScoreManager)
+
+        preview = list(
+            bucket._iter_prop_filtered_identifications(
+                [{"score": 1}, {"score": 2}, {"score": 3}],
+                {"score": {"filter_funcs": [lambda value: value >= 2]}},
+                {"score": {"filter_funcs": [lambda value: value == 3]}},
+            )
+        )
+        self.assertEqual(preview, [{"score": 2}])
+
+        bucket._data = [{"score": 2}]
+        self.assertIn(ScoreManager(score=2), bucket)
+        self.assertEqual(bucket.get(score=2).identification, {"score": 2})
+
+        empty = bucket.none()
+        self.assertEqual(empty.generate_combinations(), [])
+        self.assertEqual(empty.filter_definitions, {})
+        self.assertEqual(empty.exclude_definitions, {})

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -1059,6 +1059,49 @@ class TestCalculationBucketAdditional(TestCase):
         )
 
     @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
+    def test_str_snapshots_iterables_before_dependencies(self, _mock_parse):
+        class StatefulValues:
+            def __init__(self):
+                self.remaining = [1, 2]
+
+            def __iter__(self):
+                while self.remaining:
+                    yield self.remaining.pop(0)
+
+        values = StatefulValues()
+
+        def dependent_values(_a):
+            values.remaining.clear()
+            return [10]
+
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "a": Input(type=int, possible_values=values),
+                "b": Input(
+                    type=int,
+                    possible_values=dependent_values,
+                    depends_on=["a"],
+                ),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        DynInterface._parent_class = DynManager
+        bucket = CalculationBucket(DynManager)
+
+        s = str(bucket)
+
+        self.assertTrue(s.startswith("CalculationBucket (2)["))
+        self.assertIn("DynManager(**{'a': 1, 'b': 10})", s)
+        self.assertIn("DynManager(**{'a': 2, 'b': 10})", s)
+        self.assertNotIn("...", s)
+        self.assertIsNone(bucket._data)
+
+    @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
     def test_str_preserves_sorted_preview_order(self, _mock_parse):
         class DynInterface(CalculationInterface):
             input_fields: ClassVar[dict] = {
@@ -1583,14 +1626,21 @@ class TestCalculationBucketCoverageEdges(TestCase):
 
     def test_iter_input_combinations_covers_bucket_excludes_and_type_skips(self):
         """Input enumeration should handle bucket sources, excludes, and bad types."""
-        typed_field = Input(int, possible_values=[1, "bad", 2])
+        typed_field = Input(int, possible_values=[1, "bad", 2, 3])
         typed_bucket = CalculationBucket(DummyGeneralManager)
         typed_bucket.input_fields = {"value": typed_field}
 
         combinations = typed_bucket._generate_input_combinations(
             ["value"],
             {},
-            {"value": {"filter_funcs": [lambda value: value == 2]}},
+            {
+                "value": {
+                    "filter_funcs": [
+                        lambda value: value == 2,
+                        lambda value: value == 3,
+                    ]
+                }
+            },
         )
 
         self.assertEqual(combinations, [{"value": 1}])

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -52,6 +52,17 @@ class DummyGeneralManager:
 DummyCalculationInterface._parent_class = DummyGeneralManager
 
 
+class CountingIterable:
+    def __init__(self, values):
+        self.values = values
+        self.yield_count = 0
+
+    def __iter__(self):
+        for value in self.values:
+            self.yield_count += 1
+            yield value
+
+
 @patch(
     "general_manager.bucket.calculation_bucket.parse_filters",
     return_value={"dummy": {"filter_kwargs": {}}},
@@ -904,6 +915,170 @@ class TestCalculationBucketAdditional(TestCase):
         s = str(bucket)
         self.assertTrue(s.startswith("CalculationBucket (5)["))
         self.assertNotIn("...", s)
+
+    @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
+    def test_str_uses_cached_combinations_with_exact_count(self, _mock_parse):
+        bucket = CalculationBucket(DummyGeneralManager)
+        bucket._data = [{"x": i} for i in range(7)]
+
+        with patch.object(
+            bucket,
+            "generate_combinations",
+            side_effect=AssertionError("str should use cached combinations directly"),
+        ):
+            s = str(bucket)
+
+        self.assertTrue(s.startswith("CalculationBucket (7)["))
+        self.assertIn("DummyGeneralManager(**{'x': 0})", s)
+        self.assertIn("...", s)
+
+    @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
+    def test_str_counts_uncached_small_preview_exactly_without_caching(
+        self, _mock_parse
+    ):
+        values = CountingIterable(range(3))
+
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "n": Input(type=int, possible_values=values),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        DynInterface._parent_class = DynManager
+        bucket = CalculationBucket(DynManager)
+
+        s = str(bucket)
+
+        self.assertTrue(s.startswith("CalculationBucket (3)["))
+        self.assertIn("DynManager(**{'n': 0})", s)
+        self.assertIn("DynManager(**{'n': 2})", s)
+        self.assertNotIn("...", s)
+        self.assertIsNone(bucket._data)
+        self.assertEqual(values.yield_count, 3)
+
+    @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
+    def test_str_bounds_uncached_large_preview_without_caching(self, _mock_parse):
+        values = CountingIterable(range(1000))
+
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "n": Input(type=int, possible_values=values),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        DynInterface._parent_class = DynManager
+        bucket = CalculationBucket(DynManager)
+
+        s = str(bucket)
+
+        self.assertTrue(s.startswith("CalculationBucket (5+)["))
+        self.assertIn("DynManager(**{'n': 0})", s)
+        self.assertIn("DynManager(**{'n': 4})", s)
+        self.assertNotIn("DynManager(**{'n': 5})", s)
+        self.assertIn("...", s)
+        self.assertIsNone(bucket._data)
+        self.assertLessEqual(values.yield_count, 6)
+
+    @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
+    def test_str_preserves_static_iterator_possible_values(self, _mock_parse):
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "n": Input(type=int, possible_values=iter(range(10))),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        DynInterface._parent_class = DynManager
+        bucket = CalculationBucket(DynManager)
+
+        s = str(bucket)
+        combinations = bucket.generate_combinations()
+
+        self.assertTrue(s.startswith("CalculationBucket (10)["))
+        self.assertEqual(combinations, [{"n": value} for value in range(10)])
+
+    @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
+    def test_generate_combinations_snapshots_iterables_before_dependencies(
+        self,
+        _mock_parse,
+    ):
+        class StatefulValues:
+            def __init__(self):
+                self.remaining = [1, 2]
+
+            def __iter__(self):
+                while self.remaining:
+                    yield self.remaining.pop(0)
+
+        values = StatefulValues()
+
+        def dependent_values(_a):
+            values.remaining.clear()
+            return [10]
+
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "a": Input(type=int, possible_values=values),
+                "b": Input(
+                    type=int,
+                    possible_values=dependent_values,
+                    depends_on=["a"],
+                ),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        DynInterface._parent_class = DynManager
+        bucket = CalculationBucket(DynManager)
+
+        combinations = bucket.generate_combinations()
+
+        self.assertEqual(
+            combinations,
+            [{"a": 1, "b": 10}, {"a": 2, "b": 10}],
+        )
+
+    @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
+    def test_str_preserves_sorted_preview_order(self, _mock_parse):
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "n": Input(type=int, possible_values=[3, 1, 2]),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        DynInterface._parent_class = DynManager
+        bucket = CalculationBucket(DynManager, sort_key="n")
+
+        s = str(bucket)
+
+        first = s.index("DynManager(**{'n': 1})")
+        second = s.index("DynManager(**{'n': 2})")
+        third = s.index("DynManager(**{'n': 3})")
+        self.assertLess(first, second)
+        self.assertLess(second, third)
 
     @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
     def test_generate_combinations_callable_returning_empty(self, _mock_parse):


### PR DESCRIPTION
## Summary
- Add a bounded `CalculationBucket.__str__` preview path for uncached unsorted buckets.
- Preserve exact formatting for cached buckets and eager generation for sorted/reversed or one-shot iterator cases.
- Keep `generate_combinations()`, iteration, indexing, `len()`, and `count()` behavior unchanged, including eager iterable snapshots for dependent inputs.

Fixes #305

## Validation
- `python -m pytest tests/unit/test_calculation_bucket.py -q` -> 58 passed
- `python -m pytest tests/unit/test_calculation_run_context.py -q` -> 28 passed
- `python -m pytest tests/unit/test_calculation_bucket.py tests/unit/test_calculation_run_context.py --cov=general_manager.bucket.calculation_bucket --cov-report=term-missing --cov-fail-under=95 -q` -> 93 passed, 99.15% coverage
- AST docstring audit for `src/general_manager/bucket/calculation_bucket.py` -> all functions/methods have docstrings
- `ruff check src/general_manager/bucket/calculation_bucket.py tests/unit/test_calculation_bucket.py`
- `ruff format --check src/general_manager/bucket/calculation_bucket.py tests/unit/test_calculation_bucket.py`
- `mypy src/general_manager/bucket/calculation_bucket.py`
- `git diff --check origin/main...HEAD`

## Review
- Subagent implementation followed TDD with initial red failures for uncached preview behavior.
- Spec/code review found iterator-safety issues; fixed with regression tests and final narrow re-review reported no issues.

## Notes
- `docs/api/core.md` intentionally remains unchanged; the source docstring carries the API contract.
- Sorted/reversed buckets still materialize eagerly by design to preserve global ordering.
- PR #309 also touches `src/general_manager/bucket/calculation_bucket.py`; this PR may need conflict resolution depending on merge order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket previews so large result sets no longer need to be fully calculated just to display a summary.
  * Made displayed counts more accurate by showing a capped preview when results exceed the visible limit.
  * Kept result ordering consistent in previews for sorted and reversed buckets.
  * Preserved existing results and behavior when buckets are generated from reusable or one-time inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->