### PR TITLE
feat: add non-mutating payload m2m split

### DIFF
--- a/docs/api/interface.md
+++ b/docs/api/interface.md
@@ -229,6 +229,8 @@ interface is bound to a parent manager can raise `AttributeError`.
 
 ::: general_manager.interface.capabilities.registry.CapabilityRegistry
 
+::: general_manager.interface.capabilities.orm_utils.payload_normalizer.PayloadNormalizer
+
 `general_manager.interface.capabilities.core.utils.with_observability` is a
 public helper for wrapping capability operations with optional observability
 hooks. Its full behavior is described in the Core Observability Utility section
@@ -677,6 +679,12 @@ relation. If both `<relation>_list` and `<relation>_id_list` are present,
 iteration order decides the last canonical value stored in the many-to-many
 mapping.
 
+`split_many_to_many_non_mutating(kwargs)` returns new simple and many-to-many
+mappings without changing `kwargs`. It uses the same many-to-many alias
+recognition, canonical `<relation>_id_list` output keys, plain `_list` field
+preservation, and insertion-order collision behavior as the mutating
+`split_many_to_many()` helper.
+
 `normalize_simple_values(kwargs)` returns a new mapping. It converts
 manager-valued foreign-key/one-to-one values to identifiers and renames
 unsuffixed relation keys to `<relation>_id`; raw non-model values for those
@@ -690,8 +698,8 @@ keys exactly. It skips `None` and `models.NOT_PROVIDED`, treats strings and
 bytes as scalar one-item assignments, expands other iterables, consumes
 generators once, treats dictionaries as iterables over their keys, and resolves
 manager-like items to `identification["id"]` while preserving unrecognized
-values. Call `split_many_to_many()` first when canonical many-to-many keys are
-required.
+values. Call `split_many_to_many()` or `split_many_to_many_non_mutating()` first
+when canonical many-to-many keys are required.
 
 `SoftDeleteCapability` stores the effective soft-delete state for an interface.
 During setup it prefers `_soft_delete_default`, then

--- a/src/general_manager/interface/capabilities/orm/mutations.py
+++ b/src/general_manager/interface/capabilities/orm/mutations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from django.contrib.auth import get_user_model
 from django.db import models, transaction
@@ -10,6 +10,9 @@ from django.db.models import NOT_PROVIDED
 
 from general_manager.interface.capabilities.base import CapabilityName
 from general_manager.interface.capabilities.builtin import BaseCapability
+from general_manager.interface.capabilities.orm_utils.payload_normalizer import (
+    PayloadNormalizer,
+)
 from general_manager.interface.utils.database_interface_protocols import (
     SupportsActivation,
 )
@@ -581,10 +584,8 @@ class OrmValidationCapability(BaseCapability):
             """
             support = get_support_capability(interface_cls)
             normalizer = support.get_payload_normalizer(interface_cls)
-            payload_copy = dict(payload)
-            normalizer.validate_keys(payload_copy)
-            simple_kwargs, many_to_many_kwargs = normalizer.split_many_to_many(
-                payload_copy
+            simple_kwargs, many_to_many_kwargs = _validate_and_split_payload(
+                normalizer, payload
             )
             normalized_simple = normalizer.normalize_simple_values(simple_kwargs)
             normalized_many = normalizer.normalize_many_values(many_to_many_kwargs)
@@ -629,14 +630,39 @@ def _normalize_payload(
         )
     support = get_support_capability(interface_cls)
     normalizer = support.get_payload_normalizer(interface_cls)
-    payload_copy = dict(payload)
-    normalizer.validate_keys(payload_copy)
-    simple_kwargs, many_to_many_kwargs = normalizer.split_many_to_many(payload_copy)
+    simple_kwargs, many_to_many_kwargs = _validate_and_split_payload(
+        normalizer, payload
+    )
     normalized_simple = normalizer.normalize_simple_values(simple_kwargs)
     normalized_many = normalizer.normalize_many_values(many_to_many_kwargs)
     return dict(normalized_simple), {
         key: list(value) for key, value in normalized_many.items()
     }
+
+
+def _validate_and_split_payload(
+    normalizer: Any,
+    payload: MutationPayload,
+) -> tuple[MutationPayload, MutationPayload]:
+    """Validate and split payloads without exposing caller mappings to mutation."""
+    normalizer_payload = (
+        payload if type(normalizer) is PayloadNormalizer else dict(payload)
+    )
+    normalizer.validate_keys(normalizer_payload)
+    return _split_many_to_many_payload(normalizer, normalizer_payload)
+
+
+def _split_many_to_many_payload(
+    normalizer: Any,
+    payload: MutationPayload,
+) -> tuple[MutationPayload, MutationPayload]:
+    """Split concrete normalizer payloads without mutation; copy for custom normalizers."""
+    if type(normalizer) is PayloadNormalizer:
+        return normalizer.split_many_to_many_non_mutating(payload)
+    return cast(
+        tuple[MutationPayload, MutationPayload],
+        normalizer.split_many_to_many(payload),
+    )
 
 
 def _assign_history_actor(

--- a/src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py
+++ b/src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py
@@ -88,7 +88,7 @@ class PayloadNormalizer:
         self, kwargs: PayloadMapping
     ) -> tuple[PayloadMapping, PayloadMapping]:
         """
-        Separate many-to-many related entries from a kwargs mapping.
+        Mutate a kwargs mapping by moving many-to-many related entries out of it.
 
         Parameters:
             kwargs: Mapping of field lookups where keys for many-to-many relations are expected to end with `_id_list`.
@@ -105,6 +105,39 @@ class PayloadNormalizer:
             if base_key in self._many_to_many_fields:
                 many_kwargs[f"{base_key}_id_list"] = kwargs.pop(key)
         return kwargs, many_kwargs
+
+    def split_many_to_many_non_mutating(
+        self, kwargs: PayloadMapping
+    ) -> tuple[PayloadMapping, PayloadMapping]:
+        """
+        Return separated many-to-many entries without mutating the input mapping.
+
+        Parameters:
+            kwargs: Mapping of field lookups where keys for many-to-many
+                relations may use either `<relation>_list` or
+                `<relation>_id_list`.
+
+        Returns:
+            tuple: A pair `(remaining_kwargs, many_kwargs)` where both mappings
+                are new dictionaries. `remaining_kwargs` contains non-matching
+                entries from `kwargs`, and `many_kwargs` contains matching
+                many-to-many entries under canonical `<relation>_id_list` keys.
+
+        Notes:
+            This is the non-mutating counterpart to `split_many_to_many()`. If
+            both `<relation>_list` and `<relation>_id_list` are present,
+            iteration order decides the last canonical value stored in
+            `many_kwargs`.
+        """
+        remaining_kwargs: PayloadMapping = {}
+        many_kwargs: PayloadMapping = {}
+        for key, value in kwargs.items():
+            base_key = self._m2m_alias_base_key(key)
+            if base_key in self._many_to_many_fields:
+                many_kwargs[f"{base_key}_id_list"] = value
+            else:
+                remaining_kwargs[key] = value
+        return remaining_kwargs, many_kwargs
 
     def normalize_simple_values(self, kwargs: PayloadMapping) -> PayloadMapping:
         """

--- a/tests/unit/test_database_based_interface.py
+++ b/tests/unit/test_database_based_interface.py
@@ -2062,6 +2062,108 @@ def test_payload_normalizer_split_many_to_many_keeps_plain_list_field() -> None:
     assert many_kwargs == {}
 
 
+def test_payload_normalizer_split_many_to_many_non_mutating_preserves_input() -> None:
+    class NonMutatingRelatedModelA(models.Model):
+        class Meta:
+            app_label = "test_payload_non_mutating_a"
+
+    class NonMutatingModelA(models.Model):
+        name = models.CharField(max_length=32, default="")
+        tags = models.ManyToManyField(NonMutatingRelatedModelA)
+
+        class Meta:
+            app_label = "test_payload_non_mutating_a"
+
+    normalizer = PayloadNormalizer(NonMutatingModelA)
+    payload = {"name": "asset", "tags_id_list": [1, 2]}
+    original_payload = dict(payload)
+
+    simple_kwargs, many_kwargs = normalizer.split_many_to_many_non_mutating(payload)
+
+    assert payload == original_payload
+    assert simple_kwargs is not payload
+    assert simple_kwargs == {"name": "asset"}
+    assert many_kwargs == {"tags_id_list": [1, 2]}
+
+
+def test_payload_normalizer_split_many_to_many_non_mutating_normalizes_list_alias() -> (
+    None
+):
+    class NonMutatingRelatedModelB(models.Model):
+        class Meta:
+            app_label = "test_payload_non_mutating_b"
+
+    class NonMutatingModelB(models.Model):
+        name = models.CharField(max_length=32, default="")
+        tags = models.ManyToManyField(NonMutatingRelatedModelB)
+
+        class Meta:
+            app_label = "test_payload_non_mutating_b"
+
+    normalizer = PayloadNormalizer(NonMutatingModelB)
+    payload = {"name": "asset", "tags_list": [1, 2]}
+
+    simple_kwargs, many_kwargs = normalizer.split_many_to_many_non_mutating(payload)
+
+    assert payload == {"name": "asset", "tags_list": [1, 2]}
+    assert simple_kwargs == {"name": "asset"}
+    assert many_kwargs == {"tags_id_list": [1, 2]}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_many", "model_suffix"),
+    [
+        ({"tags_list": [1], "tags_id_list": [2]}, {"tags_id_list": [2]}, "a"),
+        ({"tags_id_list": [2], "tags_list": [1]}, {"tags_id_list": [1]}, "b"),
+    ],
+)
+def test_payload_normalizer_split_many_to_many_non_mutating_collision_order(
+    payload: dict[str, object],
+    expected_many: dict[str, object],
+    model_suffix: str,
+) -> None:
+    class NonMutatingRelatedModelC(models.Model):
+        class Meta:
+            app_label = f"test_payload_non_mutating_c_{model_suffix}"
+
+    class NonMutatingModelC(models.Model):
+        tags = models.ManyToManyField(NonMutatingRelatedModelC)
+
+        class Meta:
+            app_label = f"test_payload_non_mutating_c_{model_suffix}"
+
+    normalizer = PayloadNormalizer(NonMutatingModelC)
+    original_payload = dict(payload)
+
+    simple_kwargs, many_kwargs = normalizer.split_many_to_many_non_mutating(payload)
+
+    assert payload == original_payload
+    assert simple_kwargs == {}
+    assert many_kwargs == expected_many
+
+
+def test_payload_normalizer_split_many_to_many_keeps_legacy_mutation_contract() -> None:
+    class LegacyRelatedModel(models.Model):
+        class Meta:
+            app_label = "test_payload_legacy_contract"
+
+    class LegacyModel(models.Model):
+        name = models.CharField(max_length=32, default="")
+        tags = models.ManyToManyField(LegacyRelatedModel)
+
+        class Meta:
+            app_label = "test_payload_legacy_contract"
+
+    normalizer = PayloadNormalizer(LegacyModel)
+    payload = {"name": "asset", "tags_list": [1], "tags_id_list": [2]}
+
+    simple_kwargs, many_kwargs = normalizer.split_many_to_many(payload)
+
+    assert simple_kwargs is payload
+    assert payload == {"name": "asset"}
+    assert many_kwargs == {"tags_id_list": [2]}
+
+
 def test_payload_normalizer_normalize_simple_values_converts_fk_plain_id() -> None:
     class PlantModel(models.Model):
         class Meta:

--- a/tests/unit/test_orm_capabilities_comprehensive.py
+++ b/tests/unit/test_orm_capabilities_comprehensive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 import pytest
 from unittest.mock import Mock, patch
 from datetime import datetime, timedelta
@@ -14,6 +15,7 @@ from django.utils import timezone
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.interface.capabilities.orm import (
     HistoryNotSupportedError,
+    OrmDeleteCapability,
     OrmHistoryCapability,
     OrmLifecycleCapability,
     OrmMutationCapability,
@@ -23,7 +25,10 @@ from general_manager.interface.capabilities.orm import (
     OrmValidationCapability,
     SoftDeleteCapability,
 )
-from general_manager.interface.capabilities.orm.mutations import _normalize_payload
+from general_manager.interface.capabilities.orm.mutations import (
+    _assign_history_actor,
+    _normalize_payload,
+)
 from general_manager.interface.capabilities.orm.support import (
     AmbiguousReverseFilterAliasError,
     _build_reverse_filter_alias_map,
@@ -33,6 +38,10 @@ from general_manager.interface.capabilities.orm.support import (
 )
 from general_manager.interface.capabilities.orm_utils.payload_normalizer import (
     PayloadNormalizer,
+)
+from general_manager.interface.utils.errors import (
+    InvalidFieldTypeError,
+    InvalidFieldValueError,
 )
 
 
@@ -1689,6 +1698,187 @@ class TestOrmMutationCapability:
 
             assert mock_instance.name == "test"
             # Should not have set 'skipped' attribute
+
+    def test_assign_simple_attributes_wraps_assignment_errors(self):
+        """Test that assignment ValueError and TypeError are wrapped consistently."""
+        capability = OrmMutationCapability()
+        interface_cls = Mock()
+
+        class ValueRejectingInstance:
+            def __setattr__(self, key, value):
+                """Raise ValueError for the field used by this test."""
+                if key == "bad":
+                    raise ValueError("invalid")
+                super().__setattr__(key, value)
+
+        class TypeRejectingInstance:
+            def __setattr__(self, key, value):
+                """Raise TypeError for the field used by this test."""
+                if key == "bad":
+                    raise TypeError("invalid")
+                super().__setattr__(key, value)
+
+        with patch(
+            "general_manager.interface.capabilities.orm.mutations.call_with_observability",
+            side_effect=lambda *_args, **kwargs: kwargs["func"](),
+        ):
+            with pytest.raises(InvalidFieldValueError):
+                capability.assign_simple_attributes(
+                    interface_cls,
+                    ValueRejectingInstance(),
+                    {"bad": "value"},
+                )
+            with pytest.raises(InvalidFieldTypeError):
+                capability.assign_simple_attributes(
+                    interface_cls,
+                    TypeRejectingInstance(),
+                    {"bad": "value"},
+                )
+
+    def test_save_with_history_uses_database_alias(self):
+        """Test that save_with_history stores and uses the configured database alias."""
+        capability = OrmMutationCapability()
+        interface_cls = Mock()
+        instance = Mock()
+        instance.pk = 42
+        instance._state = SimpleNamespace(db=None)
+        support = Mock()
+        support.get_database_alias.return_value = "replica"
+
+        with patch(
+            "general_manager.interface.capabilities.orm.mutations.call_with_observability",
+            side_effect=lambda *_args, **kwargs: kwargs["func"](),
+        ):
+            with patch(
+                "general_manager.interface.capabilities.orm.mutations.get_support_capability",
+                return_value=support,
+            ):
+                with patch(
+                    "general_manager.interface.capabilities.orm.mutations._assign_history_actor"
+                ):
+                    with patch(
+                        "general_manager.interface.capabilities.orm.mutations.call_update_change_reason"
+                    ):
+                        with patch(
+                            "general_manager.interface.capabilities.orm.mutations.model_has_field",
+                            return_value=False,
+                        ):
+                            with patch(
+                                "general_manager.interface.capabilities.orm.mutations.transaction.atomic",
+                                return_value=nullcontext(),
+                            ):
+                                result = capability.save_with_history(
+                                    interface_cls,
+                                    instance,
+                                    creator_id=7,
+                                    history_comment="saved",
+                                )
+
+        assert result == 42
+        assert instance._state.db == "replica"
+        instance.save.assert_called_once_with(using="replica")
+
+    def test_delete_hard_deletes_with_database_alias(self):
+        """Test that hard delete records metadata and deletes via the configured alias."""
+        capability = OrmDeleteCapability()
+        interface_instance = SimpleNamespace(pk=5)
+        model_instance = Mock()
+        support = Mock()
+        manager = Mock()
+        support.get_manager.return_value = manager
+        support.get_database_alias.return_value = "archive"
+        manager.get.return_value = model_instance
+
+        with patch(
+            "general_manager.interface.capabilities.orm.mutations.call_with_observability",
+            side_effect=lambda *_args, **kwargs: kwargs["func"](),
+        ):
+            with patch(
+                "general_manager.interface.capabilities.orm.mutations.get_support_capability",
+                return_value=support,
+            ):
+                with patch(
+                    "general_manager.interface.capabilities.orm.mutations._mutation_capability_for",
+                    return_value=OrmMutationCapability(),
+                ):
+                    with patch(
+                        "general_manager.interface.capabilities.orm.mutations.is_soft_delete_enabled",
+                        return_value=False,
+                    ):
+                        with patch(
+                            "general_manager.interface.capabilities.orm.mutations._assign_history_actor"
+                        ) as assign_actor:
+                            with patch(
+                                "general_manager.interface.capabilities.orm.mutations.model_has_field",
+                                return_value=True,
+                            ):
+                                with patch(
+                                    "general_manager.interface.capabilities.orm.mutations.call_update_change_reason"
+                                ) as update_reason:
+                                    with patch(
+                                        "general_manager.interface.capabilities.orm.mutations.transaction.atomic",
+                                        return_value=nullcontext(),
+                                    ):
+                                        with patch(
+                                            "general_manager.interface.capabilities.orm.mutations.discard_orm_instance_cache"
+                                        ) as discard_cache:
+                                            result = capability.delete(
+                                                interface_instance,
+                                                creator_id=9,
+                                                history_comment="remove",
+                                            )
+
+        assert result == {"id": 5}
+        assign_actor.assert_called_once_with(
+            model_instance,
+            creator_id=9,
+            database_alias="archive",
+        )
+        assert model_instance.changed_by_id == 9
+        update_reason.assert_called_once_with(model_instance, "remove (deleted)")
+        model_instance.delete.assert_called_once_with(using="archive")
+        discard_cache.assert_called_once_with(interface_instance.__class__, 5)
+
+    def test_assign_history_actor_handles_none_and_database_alias(self):
+        """Test history actor assignment with no creator and an aliased creator lookup."""
+        instance_without_creator = SimpleNamespace()
+        with patch(
+            "general_manager.interface.capabilities.orm.mutations.model_has_field",
+            return_value=False,
+        ):
+            _assign_history_actor(
+                instance_without_creator,
+                creator_id=None,
+                database_alias=None,
+            )
+
+        assert instance_without_creator._history_user is None
+
+        instance_with_creator = SimpleNamespace()
+        user = object()
+        alias_manager = Mock()
+        alias_manager.get.return_value = user
+        manager = Mock()
+        manager.db_manager.return_value = alias_manager
+        user_model = SimpleNamespace(_default_manager=manager)
+
+        with patch(
+            "general_manager.interface.capabilities.orm.mutations.model_has_field",
+            return_value=False,
+        ):
+            with patch(
+                "general_manager.interface.capabilities.orm.mutations.get_user_model",
+                return_value=user_model,
+            ):
+                _assign_history_actor(
+                    instance_with_creator,
+                    creator_id=11,
+                    database_alias="replica",
+                )
+
+        manager.db_manager.assert_called_once_with("replica")
+        alias_manager.get.assert_called_once_with(pk=11)
+        assert instance_with_creator._history_user is user
 
 
 class TestOrmLifecycleCapability:

--- a/tests/unit/test_orm_capabilities_comprehensive.py
+++ b/tests/unit/test_orm_capabilities_comprehensive.py
@@ -23,12 +23,16 @@ from general_manager.interface.capabilities.orm import (
     OrmValidationCapability,
     SoftDeleteCapability,
 )
+from general_manager.interface.capabilities.orm.mutations import _normalize_payload
 from general_manager.interface.capabilities.orm.support import (
     AmbiguousReverseFilterAliasError,
     _build_reverse_filter_alias_map,
     _resolve_filter_segment,
     _translate_reverse_filter_aliases,
     _translate_reverse_filter_key,
+)
+from general_manager.interface.capabilities.orm_utils.payload_normalizer import (
+    PayloadNormalizer,
 )
 
 
@@ -1431,11 +1435,19 @@ class TestOrmValidationCapability:
 
         interface_cls = Mock()
 
+        payload = {"name": "test", "value": 42}
         mock_normalizer = Mock()
-        mock_normalizer.validate_keys = Mock()
-        mock_normalizer.split_many_to_many = Mock(
-            return_value=({"name": "test", "value": 42}, {"tags": [1, 2]})
-        )
+
+        def validate_keys(payload_copy):
+            payload_copy["validate_mutation"] = True
+
+        mock_normalizer.validate_keys = Mock(side_effect=validate_keys)
+
+        def split_many_to_many(payload_copy):
+            payload_copy["split_mutation"] = True
+            return {"name": "test", "value": 42}, {"tags": [1, 2]}
+
+        mock_normalizer.split_many_to_many = Mock(side_effect=split_many_to_many)
         mock_normalizer.normalize_simple_values = Mock(
             return_value={"name": "test", "value_id": 42}
         )
@@ -1452,15 +1464,149 @@ class TestOrmValidationCapability:
                 "general_manager.interface.capabilities.orm.with_observability",
                 side_effect=lambda *_args, **kwargs: kwargs["func"](),
             ):
-                result = capability.normalize_payload(
-                    interface_cls, payload={"name": "test", "value": 42}
-                )
+                result = capability.normalize_payload(interface_cls, payload=payload)
 
                 mock_normalizer.validate_keys.assert_called_once()
+                validate_payload = mock_normalizer.validate_keys.call_args.args[0]
+                assert validate_payload is not payload
+                assert validate_payload["validate_mutation"] is True
                 mock_normalizer.split_many_to_many.assert_called_once()
+                split_payload = mock_normalizer.split_many_to_many.call_args.args[0]
+                assert split_payload is not payload
+                assert split_payload == {
+                    "name": "test",
+                    "value": 42,
+                    "validate_mutation": True,
+                    "split_mutation": True,
+                }
+                assert payload == {"name": "test", "value": 42}
                 mock_normalizer.normalize_simple_values.assert_called_once()
                 mock_normalizer.normalize_many_values.assert_called_once()
                 assert result == ({"name": "test", "value_id": 42}, {"tags": [1, 2]})
+
+    def test_normalize_payload_with_concrete_normalizer_preserves_payload(self):
+        """Concrete PayloadNormalizer should split M2M payloads without caller mutation."""
+
+        class OrmValidationRelatedModel(models.Model):
+            class Meta:
+                app_label = "test_orm_validation_payload"
+
+        class OrmValidationModel(models.Model):
+            name = models.CharField(max_length=32, default="")
+            tags = models.ManyToManyField(OrmValidationRelatedModel)
+
+            class Meta:
+                app_label = "test_orm_validation_payload"
+
+        capability = OrmValidationCapability()
+        interface_cls = Mock()
+        payload = {"name": "asset", "tags_list": [1, 2]}
+        normalizer = PayloadNormalizer(OrmValidationModel)
+
+        with patch(
+            "general_manager.interface.capabilities.orm.mutations.get_support_capability"
+        ) as mock_get_support:
+            mock_support = Mock()
+            mock_support.get_payload_normalizer = Mock(return_value=normalizer)
+            mock_get_support.return_value = mock_support
+
+            with patch(
+                "general_manager.interface.capabilities.orm.with_observability",
+                side_effect=lambda *_args, **kwargs: kwargs["func"](),
+            ):
+                result = capability.normalize_payload(interface_cls, payload=payload)
+
+        assert payload == {"name": "asset", "tags_list": [1, 2]}
+        assert result == ({"name": "asset"}, {"tags_id_list": [1, 2]})
+
+    def test_normalize_payload_subclass_split_override_preserves_payload(self):
+        """PayloadNormalizer subclasses should keep split override compatibility."""
+
+        class SubclassRelatedModel(models.Model):
+            class Meta:
+                app_label = "test_orm_validation_subclass_payload"
+
+        class SubclassModel(models.Model):
+            name = models.CharField(max_length=32, default="")
+            tags = models.ManyToManyField(SubclassRelatedModel)
+
+            class Meta:
+                app_label = "test_orm_validation_subclass_payload"
+
+        class CustomPayloadNormalizer(PayloadNormalizer):
+            def split_many_to_many(self, kwargs):
+                kwargs["split_mutation"] = True
+                return (
+                    {"name": kwargs["name"], "custom": "split"},
+                    {"tags_id_list": [99]},
+                )
+
+        capability = OrmValidationCapability()
+        interface_cls = Mock()
+        payload = {"name": "asset", "tags_list": [1, 2]}
+        normalizer = CustomPayloadNormalizer(SubclassModel)
+
+        with patch(
+            "general_manager.interface.capabilities.orm.mutations.get_support_capability"
+        ) as mock_get_support:
+            mock_support = Mock()
+            mock_support.get_payload_normalizer = Mock(return_value=normalizer)
+            mock_get_support.return_value = mock_support
+
+            with patch(
+                "general_manager.interface.capabilities.orm.with_observability",
+                side_effect=lambda *_args, **kwargs: kwargs["func"](),
+            ):
+                result = capability.normalize_payload(interface_cls, payload=payload)
+
+        assert payload == {"name": "asset", "tags_list": [1, 2]}
+        assert result == (
+            {"name": "asset", "custom": "split"},
+            {"tags_id_list": [99]},
+        )
+
+    def test_normalize_payload_fallback_copies_payload_before_custom_validation(self):
+        """Fallback normalization should isolate caller payload from custom normalizers."""
+        interface_cls = Mock()
+        interface_cls.get_capability_handler.return_value = None
+        payload = {"name": "test", "value": 42}
+        mock_normalizer = Mock()
+
+        def validate_keys(payload_copy):
+            payload_copy["validate_mutation"] = True
+
+        def split_many_to_many(payload_copy):
+            payload_copy["split_mutation"] = True
+            return {"name": "test", "value": 42}, {"tags": [1, 2]}
+
+        mock_normalizer.validate_keys = Mock(side_effect=validate_keys)
+        mock_normalizer.split_many_to_many = Mock(side_effect=split_many_to_many)
+        mock_normalizer.normalize_simple_values = Mock(
+            return_value={"name": "test", "value_id": 42}
+        )
+        mock_normalizer.normalize_many_values = Mock(return_value={"tags": [1, 2]})
+
+        with patch(
+            "general_manager.interface.capabilities.orm.mutations.get_support_capability"
+        ) as mock_get_support:
+            mock_support = Mock()
+            mock_support.get_payload_normalizer = Mock(return_value=mock_normalizer)
+            mock_get_support.return_value = mock_support
+
+            result = _normalize_payload(interface_cls, payload)
+
+        validate_payload = mock_normalizer.validate_keys.call_args.args[0]
+        split_payload = mock_normalizer.split_many_to_many.call_args.args[0]
+        assert validate_payload is not payload
+        assert split_payload is validate_payload
+        assert split_payload == {
+            "name": "test",
+            "value": 42,
+            "validate_mutation": True,
+            "split_mutation": True,
+        }
+        assert payload == {"name": "test", "value": 42}
+        assert result == ({"name": "test", "value_id": 42}, {"tags": [1, 2]})
 
 
 class TestSoftDeleteCapability:


### PR DESCRIPTION
## Summary
- Add `PayloadNormalizer.split_many_to_many_non_mutating()` while preserving the legacy mutating `split_many_to_many()` contract.
- Route exact concrete `PayloadNormalizer` ORM normalization through the new non-mutating path.
- Preserve subclass/custom normalizer compatibility with copy-before-validate/split behavior.
- Expose `PayloadNormalizer` in the interface API docs and document the helper distinction.

Fixes #306

## Validation
- `python -m pytest tests/unit/test_database_based_interface.py -k "PayloadNormalizer or split_many_to_many" -q` -> 28 passed, 82 deselected
- `python -m pytest tests/unit/test_orm_capabilities_comprehensive.py::TestOrmValidationCapability -q` -> 4 passed
- `python -m pytest tests/unit/test_database_based_interface.py tests/unit/test_orm_capabilities_comprehensive.py --cov=general_manager.interface.capabilities.orm_utils.payload_normalizer --cov=general_manager.interface.capabilities.orm.mutations --cov-report=term-missing --cov-fail-under=95 -q` -> 169 passed, 99.28% coverage; one existing Django model re-registration warning
- AST docstring audit for `src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py` and `src/general_manager/interface/capabilities/orm/mutations.py` -> all functions/methods have docstrings
- `ruff format --check src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py src/general_manager/interface/capabilities/orm/mutations.py tests/unit/test_database_based_interface.py tests/unit/test_orm_capabilities_comprehensive.py`
- `ruff check src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py src/general_manager/interface/capabilities/orm/mutations.py tests/unit/test_database_based_interface.py tests/unit/test_orm_capabilities_comprehensive.py`
- `mypy src/general_manager/interface/capabilities/orm_utils/payload_normalizer.py src/general_manager/interface/capabilities/orm/mutations.py`
- `git diff --check origin/main...HEAD`

## Review
- Subagent implementation followed TDD with initial red failures for the missing helper.
- Spec review passed; code-quality review found subclass/custom-normalizer mutation gaps, which were fixed with regression tests.
- Final narrow re-review reported no issues.

## Notes
- Custom normalizer payload isolation remains a shallow `dict(payload)` copy, matching the prior copy-before-mutate contract.
- PR #310 also touches mutation-contract docs; resolve conflicts by keeping the legacy mutating docs plus this new non-mutating helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for a new ORM payload helper that splits many-to-many values without changing the original input.
  * Expanded the API reference with the payload normalizer section.

* **Bug Fixes**
  * ORM payload handling now preserves caller-provided data while normalizing relation fields.
  * Many-to-many keys are now consistently recognized and converted to canonical list-based names.

* **Documentation**
  * Clarified that the existing many-to-many splitter mutates its input, and added guidance on when to use the non-mutating option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->