### PR TITLE
[codex] Reuse existing related factory rows

### DIFF
--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -5,17 +5,21 @@
 `AutoFactory` is the generated factory base attached to ORM-backed managers as
 `Manager.Factory`. It fills missing fields from interface metadata, strips
 many-to-many values before model construction, applies many-to-many assignments
-after build/create, and uses the interface's `input_fields` plus
+after saved creation, and uses the interface's `input_fields` plus
 `format_identification()` to wrap saved objects back into manager instances.
 `build()` returns unsaved Django model instances; `create()` validates, saves,
 and returns GeneralManager wrappers. Batch calls keep the same distinction:
 build batches return model lists and create batches return manager lists.
+Factory relation reuse and sequence counters use the interface database alias
+when one is configured, so factories query and save against the same database.
 
 The generation order is:
 
 1. `_generate()` validates `Meta.model`, asks the interface for custom-field
    metadata, and adds missing generated or declared defaults. Caller-supplied
    keyword arguments already present in the payload win over generated defaults.
+   Missing foreign-key and one-to-one values use the configured related-factory
+   mode.
 2. factory_boy dispatches to `_build()` or `_create()`.
 3. `_adjust_kwargs()` removes many-to-many values from constructor kwargs and
    coerces foreign-key/one-to-one values.
@@ -24,21 +28,42 @@ The generation order is:
    more record payloads. Otherwise the normalized kwargs are assigned directly.
 5. Create strategy calls `full_clean()` and `save()` for each record; build
    strategy only constructs unsaved model instances.
-6. `_generate()` applies many-to-many assignments from the original payload and
-   wraps create-strategy model instances into manager instances.
+6. `_generate()` applies many-to-many assignments to saved create-strategy
+   model instances, then wraps those model instances into manager instances.
 
 Call-time keyword arguments override generated defaults. Foreign-key and
 one-to-one values are normalized through the related model resolver, so callers
 may pass a Django model instance, a GeneralManager wrapper, or an identifier
-value that Django accepts. Many-to-many keyword values are removed before
-instantiation and assigned afterward. A manager/queryset/list/tuple/set is
-expanded to a list; a scalar is treated as a one-item assignment. Values that
-cannot be resolved to Django model instances are passed through to Django's
-relation manager, so normal Django validation or assignment errors surface.
-Many-to-many assignment is attempted for both `build()` and `create()`. Because
-Django requires a saved primary key for many-to-many `.set(...)`, `build()` with
-explicit or generated many-to-many values is unsupported and may raise Django's
-unsaved-instance relation error.
+value that Django accepts.
+
+Automatic relation defaults use `reuse_existing` mode unless configured
+otherwise. Foreign-key and one-to-one defaults prefer reusable existing related
+rows; one-to-one reuse excludes rows already linked through that one-to-one
+field. If no reusable row exists and the related model exposes a
+GeneralManager factory, AutoFactory creates a related row through that factory.
+Nullable relations and relations with a declared default of `None` keep their
+nullable behavior in default mode and may remain `None` even when related rows
+or factories are available. When the factory interface defines a database alias,
+existing-row lookup and one-to-one linked-row filtering use that alias.
+
+Factories can change automatic relation generation with `_related_factory_mode`
+for all generated relations or `_related_factory_modes` for individual fields.
+`"create"` forces a new related object when a related factory exists and
+bypasses nullable/default-`None` relation short-circuiting. If no related
+factory exists, nullable relations may still resolve to `None` and required
+relations raise `MissingFactoryOrInstancesError`. `"random"` restores the
+legacy foreign-key behavior that may create through the related factory or reuse
+an existing related row.
+
+Many-to-many keyword values are removed before instantiation and assigned after
+saved `create()` calls. A manager/queryset/list/tuple/set is expanded to a
+list; a scalar is treated as a one-item assignment. Values that cannot be
+resolved to Django model instances are passed through to Django's relation
+manager, so normal Django validation or assignment errors surface. Omitted
+blank many-to-many fields stay empty in default `reuse_existing` mode. A
+field-specific `_related_factory_modes = {"field_name": "create"}` entry can
+generate and assign many-to-many values after creation. `build()` returns
+unsaved model instances and skips many-to-many assignment.
 
 `Factory._adjustmentMethod`, when defined, receives the normalized keyword
 arguments and returns either one `dict[str, object]` record payload or a
@@ -62,6 +87,14 @@ class attributes are used as declared defaults only when they are present and
 not callable, `classmethod`, or `staticmethod`. A declared value of `None` is
 treated the same as no declared default by the current generation path.
 
+`AutoFactory._setup_next_sequence()` returns at least the target model's current
+row count, using `interface._get_database_alias()` when the interface provides a
+database alias. For example, if one row already exists, the first generated
+factory_boy sequence index is `1`. Override `_setup_next_sequence()` in a custom
+factory when uniqueness depends on parsing existing field values, such as
+extracting numeric suffixes from names or codes, rather than on the simple row
+count.
+
 `general_manager.factory.factories` contains lower-level generation helpers used
 by `AutoFactory`. They are importable for advanced factory customization, but
 application factory classes should prefer the exported lazy helpers below when a
@@ -75,20 +108,27 @@ fields, foreign keys, and one-to-one relations. It does not generate
 many-to-many assignment lists; if a many-to-many field is passed here it returns
 `None`, and callers should use `get_many_to_many_field_value()` for
 `ManyToManyField` values. Unsupported scalar or custom Django field classes also
-return `None`. Related fields use the related model's GeneralManager factory
-when one is registered, otherwise they select an existing related row when
-possible. Nullable fields have a small chance to return `None`; nullable
-foreign-key and one-to-one fields with no factory and no existing rows return
-`None`, while non-nullable relation fields in the same situation raise
+return `None`. Relation fields default to `relation_generation="reuse_existing"`:
+nullable/default-`None` relations may return `None`, reusable existing rows are
+preferred, and a related GeneralManager factory is used only when no reusable
+row exists. `relation_generation="create"` forces related-factory creation when
+available; `relation_generation="random"` provides legacy foreign-key behavior
+that may create or reuse. The optional `database_alias` argument scopes existing
+related-row lookup to a specific Django database alias. Nullable foreign-key and
+one-to-one fields with no factory and no existing rows return `None`, while
+non-nullable relation fields in the same situation raise
 `MissingFactoryOrInstancesError`. Missing relation metadata raises
 `MissingRelatedModelError`; non-model relation targets and non-relational scalar
 fields passed to relation helpers raise `InvalidRelatedModelTypeError`.
 
 `get_many_to_many_field_value(field)` accepts a Django `ManyToManyField` and
-returns related model instances for assignment after object creation. It creates
-new related rows through the related GeneralManager factory when available,
-mixes in existing rows when present, and raises `MissingFactoryOrInstancesError`
-when no related factory or existing rows are available. GeneralManager factory
+returns related model instances for assignment after object creation. In default
+mode it samples existing related rows when any exist; if no existing rows are
+available, it creates rows through the related GeneralManager factory when one
+is registered. `relation_generation="create"` bypasses existing rows and uses
+the related factory. The optional `database_alias` argument scopes existing-row
+sampling to that alias. The helper raises `MissingFactoryOrInstancesError` when
+no related factory or existing rows are available. GeneralManager factory
 outputs are normalized to Django model instances; if a manager output cannot be
 resolved to its model row, `UnableToResolveManagerInstanceError` is raised.
 `blank=True` fields may generate an empty list; `blank=False` fields request at

--- a/docs/concepts/factories/index.md
+++ b/docs/concepts/factories/index.md
@@ -44,25 +44,57 @@ above when a value matters.
 The automatic helpers inspect Django fields and produce values that factory_boy
 can assign later. Scalar fields usually receive factory_boy `Faker`
 declarations, short text and regex-constrained text receive lazy declarations,
-measurement fields receive lazy `Measurement` values, nullable fields may return
-`None`, and relation fields return either a model instance or a lazy declaration
-that selects an existing related row. Many-to-many fields are routed through the
-dedicated many-to-many helper after the main object is built; the scalar helper
-returns `None` if called with a many-to-many field directly. Unsupported scalar
-or custom Django field classes also fall back to `None`. Nullable foreign-key
-and one-to-one fields with no related factory and no existing related rows
-resolve to `None`; required relations in the same situation raise
-`MissingFactoryOrInstancesError`.
+measurement fields receive lazy `Measurement` values, and nullable fields may
+return `None`. Foreign-key and one-to-one fields default to reusing data that is
+already in the database: reusable existing related rows are preferred, and a
+related GeneralManager factory is used only when no reusable row exists.
+One-to-one reuse skips rows that are already linked through that one-to-one
+field. If the factory interface uses a database alias, relation reuse and
+one-to-one linked-row filtering query that alias. Nullable relations, including
+relations with a default of `None`, preserve their nullable behavior in default
+mode and may remain `None`.
+Nullable foreign-key and one-to-one fields with no related factory and no
+existing related rows resolve to `None`; required relations in the same
+situation raise `MissingFactoryOrInstancesError`.
 
-Many-to-many defaults are generated after the main object is created. The helper
-creates or selects related model instances, then `AutoFactory` applies them to
-the saved relation for `Factory.create(...)` and `Factory.create_batch(...)`.
-`Factory.build(...)` returns unsaved model instances and skips many-to-many
-assignment, even when explicit or declared many-to-many values are supplied.
-`blank=True` fields may generate an empty list, while `blank=False` fields
-request at least one related instance. If a related factory returns a
-GeneralManager instance, the helper resolves it back to the underlying Django
-row before assignment. If that manager cannot be resolved to a row,
+Factories can opt into different relation generation behavior on the nested
+`Factory` class:
+
+```python
+class Factory:
+    _related_factory_mode = "create"
+    _related_factory_modes = {"owner": "create"}
+```
+
+`_related_factory_mode` applies to every generated relation unless a
+field-specific `_related_factory_modes` entry overrides it. `"create"` forces a
+new related object when the related model exposes a factory, and it bypasses the
+nullable/default-`None` shortcut for that relation. `"random"` restores the
+legacy foreign-key behavior that may create a new related row or reuse an
+existing one. The default mode is `"reuse_existing"`.
+
+Many-to-many fields are handled after the main object is saved. Explicit
+many-to-many values passed to `Factory.create(...)` or
+`Factory.create_batch(...)` are assigned to the saved relation. Omitted
+`blank=True` many-to-many fields stay empty by default; use a field-specific
+`_related_factory_modes = {"members": "create"}` entry when an omitted
+many-to-many field should generate and assign related values. `Factory.build(...)`
+returns unsaved model instances and skips many-to-many assignment, even when
+explicit or declared many-to-many values are supplied. If a related factory
+returns a GeneralManager instance, the helper resolves it back to the underlying
+Django row before assignment. If that manager cannot be resolved to a row,
 `UnableToResolveManagerInstanceError` is raised.
+
+## Sequences and existing rows
+
+`AutoFactory` initializes factory_boy sequence counters from the target model's
+current row count. The count is read through the interface database alias when
+one is configured. If a table already contains one row and a factory uses
+`lazy_sequence()` or another factory_boy sequence declaration, the first
+generated sequence index is `1` rather than `0`.
+
+This is a row-count default, not a parser for existing values. Override
+`_setup_next_sequence()` on a custom factory when uniqueness requires reading
+and parsing existing names, codes, or other sequence-bearing fields.
 
 See the [Factory API reference](../../api/factory.md) for signatures.

--- a/docs/howto/factory_bulk_generate.md
+++ b/docs/howto/factory_bulk_generate.md
@@ -55,10 +55,12 @@ InventoryItem.Factory.create_batch(50)
 ```
 
 `Factory.create(...)` and `Factory.create_batch(...)` save each object before
-AutoFactory assigns many-to-many relations, so explicit values and generated
-defaults can populate those relations safely. `Factory.build(...)` returns
-unsaved model instances and skips many-to-many assignment; pass scalar and
-foreign-key values to build when you need an in-memory object, then save and
+AutoFactory assigns many-to-many relations, so explicit many-to-many values can
+populate those relations safely. Omitted `blank=True` many-to-many fields stay
+empty by default; configure field-specific create mode when an omitted
+many-to-many field should generate and assign values. `Factory.build(...)`
+returns unsaved model instances and skips many-to-many assignment; pass scalar
+and foreign-key values to build when you need an in-memory object, then save and
 assign many-to-many relations yourself if the test needs them.
 
 ## Step 3: Customise values
@@ -70,6 +72,71 @@ Project.Factory(name="Launch Project", start_date=date.today())
 ```
 
 For complex scenarios, define `@classmethod` helpers that produce pre-wired object graphs (projects with members, factories with related measurements, etc.).
+
+## Reuse or create related objects
+
+Generated foreign-key and one-to-one defaults reuse existing related rows before
+creating new ones. This keeps bulk generation from creating duplicate lookup
+data when a reusable row already exists. For factories configured with a
+database alias, reuse looks for related rows on that alias.
+
+For example, suppose each delivery manager belongs to a project:
+
+```python
+from django.db.models import CASCADE, CharField, ForeignKey
+
+from general_manager.interface import DatabaseInterface
+from general_manager.manager import GeneralManager
+
+class DeliveryManager(GeneralManager):
+    name: str
+    project: Project
+
+    class Interface(DatabaseInterface):
+        name = CharField(max_length=80)
+        project = ForeignKey(Project.Interface._model, on_delete=CASCADE)
+```
+
+If at least one `Project` row already exists, omitting `project` reuses one of
+those rows:
+
+```python
+Project.Factory.create(name="Existing Project")
+
+manager = DeliveryManager.Factory.create(name="Ava")
+```
+
+Add a field-specific related factory mode when the manager should always receive
+a newly created project instead:
+
+```python
+class DeliveryManager(GeneralManager):
+    name: str
+    project: Project
+
+    class Interface(DatabaseInterface):
+        name = CharField(max_length=80)
+        project = ForeignKey(Project.Interface._model, on_delete=CASCADE)
+
+        class Factory:
+            _related_factory_modes = {"project": "create"}
+```
+
+`_related_factory_mode = "create"` applies the same behavior to every generated
+relation on the factory. `_related_factory_mode = "random"` keeps the legacy
+foreign-key behavior that may create a new related row or reuse an existing one.
+Nullable/default-`None` relations keep their nullable behavior in default mode;
+create mode bypasses that shortcut when the related model has a factory.
+
+## Sequences with existing rows
+
+AutoFactory starts factory_boy sequence counters after the target model's
+current row count and respects the interface database alias when counting. If a
+table already has one row, the first generated sequence index is `1`.
+
+Override `_setup_next_sequence()` when a factory needs stronger uniqueness than
+a row count can provide, such as parsing the highest numeric suffix already
+present in existing names or codes.
 
 ## Use `_adjustmentMethod` for complex data creation
 

--- a/src/general_manager/factory/auto_factory.py
+++ b/src/general_manager/factory/auto_factory.py
@@ -1,7 +1,7 @@
 """Auto-generating factory utilities for GeneralManager models."""
 
 from __future__ import annotations
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import (
     TYPE_CHECKING,
     ClassVar,
@@ -15,6 +15,7 @@ from django.db import models
 from django.db import transaction
 from factory.django import DjangoModelFactory
 from general_manager.factory.factories import (
+    RelationGenerationMode,
     UnableToResolveManagerInstanceError,
     get_field_value,
     get_many_to_many_field_value,
@@ -115,6 +116,53 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
 
     interface: type[OrmInterfaceBase[models.Model]]
     _adjustmentMethod: ClassVar[AdjustmentMethod | None] = None
+    _related_factory_mode: ClassVar[RelationGenerationMode] = "reuse_existing"
+    _related_factory_modes: ClassVar[Mapping[str, RelationGenerationMode]] = {}
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._related_factory_modes = dict(cls._related_factory_modes)
+
+    @classmethod
+    def _setup_next_sequence(cls) -> int:
+        """Initialize factory_boy sequences after existing persisted rows."""
+        model = cls._meta.model
+        try:
+            is_model = isinstance(model, type) and issubclass(model, models.Model)
+        except TypeError:
+            is_model = False
+        if not is_model:
+            return cls._factory_boy_next_sequence()
+
+        model_cls = cast(type[models.Model], model)
+        manager = model_cls._default_manager
+        database_alias = cls._get_database_alias()
+        if database_alias:
+            manager = manager.using(database_alias)
+        try:
+            count = manager.count()
+        except Exception:  # noqa: BLE001
+            return cls._factory_boy_next_sequence()
+        return max(cls._factory_boy_next_sequence(), count)
+
+    @classmethod
+    def _factory_boy_next_sequence(cls) -> int:
+        """Call factory_boy's untyped sequence initializer with a typed boundary."""
+        setup_next_sequence = cast(Callable[[], int], super()._setup_next_sequence)
+        return setup_next_sequence()
+
+    @classmethod
+    def _get_related_factory_mode(cls, field_name: str) -> RelationGenerationMode:
+        """Return the relation generation mode configured for a model field."""
+        return cls._related_factory_modes.get(field_name, cls._related_factory_mode)
+
+    @classmethod
+    def _get_database_alias(cls) -> str | None:
+        """Return the interface database alias, when the interface defines one."""
+        if not hasattr(cls.interface, "_get_database_alias"):
+            return None
+        database_alias = cls.interface._get_database_alias()
+        return database_alias or None
 
     @classmethod
     def _generate(
@@ -158,6 +206,8 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
         if not is_model:
             raise InvalidAutoFactoryModelError
         field_name_list, to_ignore_list = cls.interface.handle_custom_fields(model)
+        supplied_field_names = set(params)
+        database_alias = cls._get_database_alias()
 
         fields = [
             field
@@ -186,6 +236,16 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
             if declared_default is not None:
                 params[field.name] = declared_default
                 continue
+            if getattr(field, "is_relation", False) and (
+                getattr(field, "many_to_one", False)
+                or getattr(field, "one_to_one", False)
+            ):
+                params[field.name] = get_field_value(
+                    field,
+                    relation_generation=cls._get_related_factory_mode(field.name),
+                    database_alias=database_alias,
+                )
+                continue
             params[field.name] = get_field_value(field)
 
         generate = cast(
@@ -201,16 +261,23 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
                     raise InvalidGeneratedObjectError()
             if strategy == "create":
                 for item in obj:
-                    cls._handle_many_to_many_fields_after_creation(item, params)
+                    cls._handle_many_to_many_fields_after_creation(
+                        item, params, supplied_field_names
+                    )
         elif strategy == "create":
-            cls._handle_many_to_many_fields_after_creation(obj, params)
+            cls._handle_many_to_many_fields_after_creation(
+                obj, params, supplied_field_names
+            )
         if strategy == "create":
             return cls._wrap_generated_objects(obj)
         return obj
 
     @classmethod
     def _handle_many_to_many_fields_after_creation(
-        cls, obj: models.Model, attrs: FactoryParams
+        cls,
+        obj: models.Model,
+        attrs: FactoryParams,
+        supplied_field_names: set[str] | None = None,
     ) -> None:
         """
         Assign related objects to many-to-many fields after saved creation.
@@ -223,11 +290,20 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
             obj (models.Model): Instance whose many-to-many relations should be populated.
             attrs: Original attributes passed to the factory.
         """
+        if supplied_field_names is None:
+            supplied_field_names = set(attrs)
         for field in obj._meta.many_to_many:
-            if field.name in attrs:
+            relation_generation = cls._get_related_factory_mode(field.name)
+            if field.name in attrs and field.name in supplied_field_names:
                 m2m_values = attrs[field.name]
+            elif relation_generation == "reuse_existing" and field.blank:
+                continue
             else:
-                m2m_values = get_many_to_many_field_value(field)
+                m2m_values = get_many_to_many_field_value(
+                    field,
+                    relation_generation=relation_generation,
+                    database_alias=cls._get_database_alias(),
+                )
             if m2m_values:
                 normalized_values = cls._coerce_many_to_many_values(m2m_values)
                 getattr(obj, field.name).set(normalized_values)
@@ -317,10 +393,10 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
         obj = model_class()
         for field, value in kwargs.items():
             setattr(obj, field, value)
+        database_alias = cls._get_database_alias()
+        if database_alias:
+            obj._state.db = database_alias
         obj.full_clean()
-        database_alias: str | None = None
-        if hasattr(cls.interface, "_get_database_alias"):
-            database_alias = cls.interface._get_database_alias()
 
         if database_alias:
             obj.save(using=database_alias)
@@ -373,9 +449,7 @@ class AutoFactory(DjangoModelFactory[modelsModel]):
 
         created_objects: list[models.Model] = []
         if use_creation_method:
-            database_alias: str | None = None
-            if hasattr(cls.interface, "_get_database_alias"):
-                database_alias = cls.interface._get_database_alias()
+            database_alias = cls._get_database_alias()
             with transaction.atomic(using=database_alias):
                 for record in records:
                     created_objects.append(cls._model_creation(model_cls, **record))

--- a/src/general_manager/factory/factories.py
+++ b/src/general_manager/factory/factories.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import string
-from typing import Protocol, cast
+from typing import Any, Literal, Protocol, cast
 
 from factory.declarations import LazyFunction
 from factory.faker import Faker
 import exrex
 from django.apps import apps
 from django.core.validators import RegexValidator
-from django.db import models
+from django.db import DatabaseError, models
 from datetime import timezone
 from decimal import Decimal
 from random import SystemRandom
@@ -24,6 +24,7 @@ _RNG = SystemRandom()
 _NO_DEFAULT = object()
 type DjangoField = models.Field[object, object]
 type RelatedFactory = Callable[[], object]
+type RelationGenerationMode = Literal["reuse_existing", "create", "random"]
 
 _LazyFunctionConstructor = cast(
     Callable[[Callable[[], object]], LazyFunction],
@@ -137,6 +138,9 @@ class UnableToResolveManagerInstanceError(ValueError):
 
 def get_field_value(
     field: DjangoField | models.ForeignObjectRel,
+    *,
+    relation_generation: RelationGenerationMode = "reuse_existing",
+    database_alias: str | None = None,
 ) -> object:
     """
     Generate a realistic sample value appropriate for the given Django model field or relation.
@@ -164,6 +168,10 @@ def get_field_value(
             relation descriptor to generate a value for. Many-to-many fields are
             accepted by the broad type shape but intentionally return `None`
             here; pass them to `get_many_to_many_field_value()` instead.
+        relation_generation: Strategy for relation fields. Defaults to reusing
+            existing related rows before creating new related rows.
+        database_alias: Optional Django database alias used when querying
+            existing related rows.
 
     Returns:
         A value suitable for assignment to the field (scalar, string, Measurement-producing LazyFunction, model instance, LazyFunction that yields a related instance, or `None`).
@@ -173,14 +181,16 @@ def get_field_value(
         MissingRelatedModelError: When a relational field does not declare a related model.
         InvalidRelatedModelTypeError: When a relational field's related value is not a Django model class.
     """
+    field_is_relation = _is_relation_field(field)
     if (
-        getattr(field, "null", False)
+        relation_generation != "create"
+        and getattr(field, "null", False)
         and getattr(field, "default", _NO_DEFAULT) is None
-        and getattr(field, "is_relation", False)
+        and field_is_relation
     ):
         return None
 
-    if field.null:
+    if relation_generation != "create" and getattr(field, "null", False):
         if _RNG.choice([True] + 9 * [False]):
             return None
 
@@ -269,39 +279,65 @@ def get_field_value(
             return _faker("text", max_nb_chars=max_length)
     elif isinstance(field, models.OneToOneField):
         related_model = get_related_model(field)
-        if hasattr(related_model, "_general_manager_class"):
-            related_factory = _get_related_factory(related_model)
-            return _ensure_model_instance(related_factory())
-        else:
-            # If no factory exists, pick a random existing instance
-            related_instances = list(related_model.objects.all())
-            if related_instances:
-                return _lazy_function(lambda: _RNG.choice(related_instances))
+        related_factory = (
+            _get_related_factory(related_model)
+            if hasattr(related_model, "_general_manager_class")
+            else None
+        )
+        if relation_generation == "create":
+            if related_factory is not None:
+                return _ensure_model_instance(related_factory())
             if field.null:
                 return None
             raise MissingFactoryOrInstancesError(related_model)
+        related_instances = _existing_related_instances(
+            field,
+            related_model,
+            database_alias=database_alias,
+        )
+        if related_instances:
+            return _lazy_existing_choice(related_instances)
+        if related_factory is not None:
+            return _ensure_model_instance(related_factory())
+        if field.null:
+            return None
+        raise MissingFactoryOrInstancesError(related_model)
     elif isinstance(field, models.ForeignKey):
         related_model = get_related_model(field)
-        # Create or get an instance of the related model
-        if hasattr(related_model, "_general_manager_class"):
-            create_a_new_instance = _RNG.choice([True, True, False])
-            if not create_a_new_instance:
-                existing_instances = list(related_model.objects.all())
-                if existing_instances:
-                    # Pick a random existing instance
-                    return _lazy_function(lambda: _RNG.choice(existing_instances))
-
-            related_factory = _get_related_factory(related_model)
-            return _ensure_model_instance(related_factory())
-
-        else:
-            # If no factory exists, pick a random existing instance
-            related_instances = list(related_model.objects.all())
-            if related_instances:
-                return _lazy_function(lambda: _RNG.choice(related_instances))
+        related_factory = (
+            _get_related_factory(related_model)
+            if hasattr(related_model, "_general_manager_class")
+            else None
+        )
+        if relation_generation == "create":
+            if related_factory is not None:
+                return _ensure_model_instance(related_factory())
             if field.null:
                 return None
             raise MissingFactoryOrInstancesError(related_model)
+        if relation_generation == "random" and related_factory is not None:
+            create_a_new_instance = _RNG.choice([True, True, False])
+            if not create_a_new_instance:
+                related_instances = _existing_related_instances(
+                    field,
+                    related_model,
+                    database_alias=database_alias,
+                )
+                if related_instances:
+                    return _lazy_existing_choice(related_instances)
+            return _ensure_model_instance(related_factory())
+        related_instances = _existing_related_instances(
+            field,
+            related_model,
+            database_alias=database_alias,
+        )
+        if related_instances:
+            return _lazy_existing_choice(related_instances)
+        if related_factory is not None:
+            return _ensure_model_instance(related_factory())
+        if field.null:
+            return None
+        raise MissingFactoryOrInstancesError(related_model)
     else:
         return None
 
@@ -372,19 +408,26 @@ def _resolve_related_model_string(
 
 def get_many_to_many_field_value(
     field: models.ManyToManyField[models.Model, models.Model],
+    *,
+    relation_generation: RelationGenerationMode = "reuse_existing",
+    database_alias: str | None = None,
 ) -> list[models.Model]:
     """
     Generate a list of related model instances suitable for assigning to a ManyToManyField.
 
     The function selects a random number of related objects (at least one when
-    the field is not blank, up to 10). It will use the related model's factory
-    to create new instances when available, prefer a mix of created and existing
-    instances if both are present, or return existing instances when no factory
-    is available. `blank=True` allows an empty result; `blank=False` requires at
-    least one related instance.
+    the field is not blank, up to 10). Default generation samples existing
+    related rows when they are available and creates through the related model's
+    factory only when no existing rows are available. Create mode bypasses
+    existing rows and uses the related factory. `blank=True` allows an empty
+    result; `blank=False` requires at least one related instance.
 
     Parameters:
         field (models.ManyToManyField): The ManyToMany field to generate values for.
+        relation_generation: Strategy for relation values. Defaults to reusing
+            existing related rows before creating new related rows.
+        database_alias: Optional Django database alias used when querying
+            existing related rows.
 
     Returns:
         list[models.Model]: A list of related model instances to assign to the field.
@@ -400,37 +443,129 @@ def get_many_to_many_field_value(
     """
     related_factory: RelatedFactory | None = None
     related_model = get_related_model(field)
-    related_instances: list[models.Model] = list(related_model.objects.all())
     if hasattr(related_model, "_general_manager_class"):
         related_factory = _get_related_factory(related_model)
 
     min_required = 0 if field.blank else 1
     number_of_instances = _RNG.randint(min_required, 10)
-    if related_factory and related_instances:
-        number_to_create = _RNG.randint(min_required, number_of_instances)
-        number_to_pick = number_of_instances - number_to_create
-        if number_to_pick > len(related_instances):
-            number_to_pick = len(related_instances)
-        existing_instances = _RNG.sample(related_instances, number_to_pick)
-        new_factory_values = [related_factory() for _ in range(number_to_create)]
-        return existing_instances + [
-            _ensure_model_instance(instance) for instance in new_factory_values
-        ]
-    elif related_factory:
-        number_to_create = number_of_instances
-        new_instances = [
-            _ensure_model_instance(related_factory()) for _ in range(number_to_create)
-        ]
-        return new_instances
-    elif related_instances:
-        number_to_create = 0
+    if relation_generation == "create":
+        if related_factory:
+            return [
+                _ensure_model_instance(related_factory())
+                for _ in range(number_of_instances)
+            ]
+        raise MissingFactoryOrInstancesError(related_model)
+
+    related_instances = _existing_related_instances(
+        field,
+        related_model,
+        database_alias=database_alias,
+    )
+    if related_instances:
         number_to_pick = number_of_instances
         if number_to_pick > len(related_instances):
             number_to_pick = len(related_instances)
-        existing_instances = _RNG.sample(related_instances, number_to_pick)
-        return existing_instances
-    else:
-        raise MissingFactoryOrInstancesError(related_model)
+        return _RNG.sample(related_instances, number_to_pick)
+    if related_factory:
+        return [
+            _ensure_model_instance(related_factory())
+            for _ in range(number_of_instances)
+        ]
+    raise MissingFactoryOrInstancesError(related_model)
+
+
+def _is_relation_field(field: object) -> bool:
+    return (
+        isinstance(field, models.OneToOneField)
+        or isinstance(field, models.ForeignKey)
+        or getattr(field, "is_relation", False) is True
+        or getattr(field, "many_to_one", False) is True
+        or getattr(field, "one_to_one", False) is True
+        or getattr(field, "many_to_many", False) is True
+    )
+
+
+def _existing_related_instances(
+    field: object,
+    related_model: type[models.Model] | None = None,
+    *,
+    database_alias: str | None = None,
+) -> list[models.Model]:
+    """Return existing related rows that are reusable for this relation field."""
+    field_obj = cast(Any, field)
+    if related_model is None:
+        related_model = cast(type[models.Model], field_obj.related_model)
+    related_instances = list(
+        _get_model_manager(related_model, database_alias=database_alias).all()
+    )
+    if not (
+        isinstance(field, models.OneToOneField)
+        or getattr(field, "one_to_one", False) is True
+    ):
+        return related_instances
+
+    model = field_obj.model
+    attname = getattr(field_obj, "attname", field_obj.name)
+    try:
+        linked_values = set(
+            _get_model_manager(
+                model,
+                prefer_base=True,
+                database_alias=database_alias,
+            )
+            .exclude(**{attname: None})
+            .values_list(attname, flat=True)
+        )
+    except DatabaseError:
+        if getattr(getattr(model, "_meta", None), "managed", True) is not False:
+            raise
+        linked_values = set()
+    return [
+        instance
+        for instance in related_instances
+        if _related_target_value(instance, getattr(field_obj, "target_field", None))
+        not in linked_values
+    ]
+
+
+def _lazy_existing_choice(instances: list[models.Model]) -> LazyFunction:
+    return _lazy_function(lambda: _RNG.choice(instances))
+
+
+def _related_target_value(instance: object, target_field: object | None) -> object:
+    if target_field is not None:
+        target_attr = getattr(
+            target_field,
+            "attname",
+            getattr(target_field, "name", None),
+        )
+        if target_attr is not None and hasattr(instance, target_attr):
+            return getattr(instance, target_attr)
+    return getattr(instance, "pk", None)
+
+
+def _get_model_manager(
+    model: object,
+    *,
+    prefer_base: bool = False,
+    database_alias: str | None = None,
+) -> Any:
+    model_obj = cast(Any, model)
+    if prefer_base:
+        base_manager = getattr(model_obj, "_base_manager", None)
+        if base_manager is not None:
+            if database_alias:
+                return base_manager.using(database_alias)
+            return base_manager
+    default_manager = getattr(model_obj, "_default_manager", None)
+    if default_manager is not None:
+        if database_alias:
+            return default_manager.using(database_alias)
+        return default_manager
+    objects_manager = model_obj.objects
+    if database_alias:
+        return objects_manager.using(database_alias)
+    return objects_manager
 
 
 def _get_related_factory(related_model: type[models.Model]) -> RelatedFactory:

--- a/tests/unit/test_auto_factory.py
+++ b/tests/unit/test_auto_factory.py
@@ -1,6 +1,10 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
 from django.test import TransactionTestCase
 from django.db import models, connection, connections
 from django.core.exceptions import ValidationError
+from factory.django import DjangoModelFactory
+from factory.declarations import LazyAttributeSequence
 from general_manager.factory.auto_factory import (
     AutoFactory,
     InvalidGeneratedObjectError,
@@ -8,7 +12,7 @@ from general_manager.factory.auto_factory import (
 )
 from types import SimpleNamespace
 from typing import Any, ClassVar, Iterable
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 class DummyInterface:
@@ -65,6 +69,20 @@ class DummyModel2(models.Model):
         app_label = "general_manager"
 
 
+class DummyModel3(models.Model):
+    """
+    A model with a one-to-one relation for AutoFactory relation reuse tests.
+    """
+
+    description = models.TextField()
+    dummy_model = models.OneToOneField(
+        DummyModel, on_delete=models.CASCADE, related_name="one_to_one_model"
+    )
+
+    class Meta:
+        app_label = "general_manager"
+
+
 class AutoFactoryTestCase(TransactionTestCase):
     databases: ClassVar[set[str]] = {"default"}
     database_alias = "factory_alias"
@@ -83,6 +101,7 @@ class AutoFactoryTestCase(TransactionTestCase):
         with connection.schema_editor() as schema:
             schema.create_model(DummyModel)
             schema.create_model(DummyModel2)
+            schema.create_model(DummyModel3)
 
     @classmethod
     def tearDownClass(cls):
@@ -92,8 +111,45 @@ class AutoFactoryTestCase(TransactionTestCase):
         super().tearDownClass()
         cls._wrap_patcher.stop()
         with connection.schema_editor() as schema:
-            schema.delete_model(DummyModel)
+            schema.delete_model(DummyModel3)
             schema.delete_model(DummyModel2)
+            schema.delete_model(DummyModel)
+
+    @contextmanager
+    def _temporary_database_alias(self, alias: str) -> Iterator[Any]:
+        original_database_config = connections.databases.get(alias)
+        had_cached_connection = hasattr(connections._connections, alias)
+        original_connection = (
+            getattr(connections._connections, alias) if had_cached_connection else None
+        )
+        if had_cached_connection:
+            delattr(connections._connections, alias)
+
+        connections.databases[alias] = {
+            **connections.databases["default"],
+            "NAME": ":memory:",
+        }
+        alias_connection = connections[alias]
+        # The alias is created only for this test, so opt it out of Django's
+        # default disallowed-database wrappers and restore prior state below.
+        for method_name, _ in self._disallowed_connection_methods:
+            method = getattr(alias_connection, method_name)
+            wrapped = getattr(method, "wrapped", None)
+            if wrapped is not None:
+                setattr(alias_connection, method_name, wrapped)
+        alias_connection.connect()
+        try:
+            yield alias_connection
+        finally:
+            alias_connection.close()
+            if hasattr(connections._connections, alias):
+                delattr(connections._connections, alias)
+            if original_database_config is None:
+                connections.databases.pop(alias, None)
+            else:
+                connections.databases[alias] = original_database_config
+            if had_cached_connection:
+                setattr(connections._connections, alias, original_connection)
 
     def setUp(self) -> None:
         """
@@ -110,6 +166,91 @@ class AutoFactoryTestCase(TransactionTestCase):
         factory_attributes["interface"] = DummyInterface
         factory_attributes["Meta"] = type("Meta", (), {"model": DummyModel2})
         self.factory_class2 = type("DummyFactory2", (AutoFactory,), factory_attributes)
+
+        factory_attributes = {}
+        factory_attributes["interface"] = DummyInterface
+        factory_attributes["Meta"] = type("Meta", (), {"model": DummyModel3})
+        self.factory_class3 = type("DummyFactory3", (AutoFactory,), factory_attributes)
+
+    def test_setup_next_sequence_uses_super_for_non_django_model(self):
+        factory_class = type(
+            "ObjectFactory",
+            (AutoFactory,),
+            {
+                "interface": DummyInterface,
+                "Meta": type("Meta", (), {"model": object}),
+            },
+        )
+
+        with patch.object(
+            DjangoModelFactory, "_setup_next_sequence", return_value=37
+        ) as setup_next_sequence:
+            next_sequence = factory_class._setup_next_sequence()
+
+        self.assertEqual(next_sequence, 37)
+        setup_next_sequence.assert_called_once_with()
+
+    def test_setup_next_sequence_counts_using_interface_database_alias(self):
+        alias = "factory_alias"
+        alias_manager = Mock()
+        alias_manager.count.return_value = 12
+        manager = Mock()
+        manager.using.return_value = alias_manager
+
+        class AliasInterface(DummyInterface):
+            @classmethod
+            def _get_database_alias(cls) -> str:
+                return alias
+
+        factory_class = type(
+            "AliasSequenceFactory",
+            (AutoFactory,),
+            {
+                "interface": AliasInterface,
+                "Meta": type("Meta", (), {"model": DummyModel}),
+            },
+        )
+
+        with (
+            patch.object(DummyModel._meta, "default_manager", manager),
+            patch.object(DjangoModelFactory, "_setup_next_sequence", return_value=3),
+        ):
+            next_sequence = factory_class._setup_next_sequence()
+
+        self.assertEqual(next_sequence, 12)
+        manager.using.assert_called_once_with(alias)
+        alias_manager.count.assert_called_once_with()
+        manager.count.assert_not_called()
+
+    def test_setup_next_sequence_returns_super_value_when_it_exceeds_count(self):
+        manager = Mock()
+        manager.count.return_value = 4
+
+        with (
+            patch.object(DummyModel._meta, "default_manager", manager),
+            patch.object(DjangoModelFactory, "_setup_next_sequence", return_value=10),
+        ):
+            next_sequence = self.factory_class._setup_next_sequence()
+
+        self.assertEqual(next_sequence, 10)
+        manager.count.assert_called_once_with()
+        manager.using.assert_not_called()
+
+    def test_setup_next_sequence_uses_super_when_count_raises(self):
+        manager = Mock()
+        manager.count.side_effect = RuntimeError("count failed")
+
+        with (
+            patch.object(DummyModel._meta, "default_manager", manager),
+            patch.object(
+                DjangoModelFactory, "_setup_next_sequence", return_value=23
+            ) as setup_next_sequence,
+        ):
+            next_sequence = self.factory_class._setup_next_sequence()
+
+        self.assertEqual(next_sequence, 23)
+        manager.count.assert_called_once_with()
+        setup_next_sequence.assert_called_once_with()
 
     def test_generate_instance(self):
         """
@@ -179,23 +320,344 @@ class AutoFactoryTestCase(TransactionTestCase):
         self.assertEqual(instance.description, "Test Description")  # type: ignore
         self.assertEqual(instance.dummy_model, dummy_model_instance)  # type: ignore
 
+    def test_generate_instance_reuses_existing_foreign_key_by_default(self):
+        existing = self.factory_class.create(name="Existing", value=1)
+        factory_calls = 0
+
+        class GMC:
+            pass
+
+        def related_factory(**_kwargs: object) -> DummyModel:
+            nonlocal factory_calls
+            factory_calls += 1
+            return self.factory_class.create(name="Created", value=2)
+
+        def deterministic_choice(values: object) -> object:
+            options = list(values)  # type: ignore[arg-type]
+            if options == [True, True, False]:
+                return True
+            return options[0]
+
+        GMC.Factory = related_factory  # type: ignore[attr-defined]
+        DummyModel._general_manager_class = GMC  # type: ignore[attr-defined]
+        try:
+            with patch(
+                "general_manager.factory.factories._RNG.choice",
+                side_effect=deterministic_choice,
+            ):
+                instance = self.factory_class2.create(description="Uses existing")
+        finally:
+            delattr(DummyModel, "_general_manager_class")
+
+        self.assertEqual(DummyModel.objects.count(), 1)
+        self.assertEqual(instance.dummy_model_id, existing.pk)
+        self.assertEqual(factory_calls, 0)
+
+    def test_generate_instance_can_force_foreign_key_creation(self):
+        existing = self.factory_class.create(name="Existing", value=1)
+        factory_calls = 0
+
+        class GMC:
+            pass
+
+        def related_factory(**_kwargs: object) -> DummyModel:
+            nonlocal factory_calls
+            factory_calls += 1
+            return self.factory_class.create(name="Created", value=2)
+
+        def deterministic_choice(values: object) -> object:
+            options = list(values)  # type: ignore[arg-type]
+            if options == [True, True, False]:
+                return False
+            return options[0]
+
+        GMC.Factory = related_factory  # type: ignore[attr-defined]
+        DummyModel._general_manager_class = GMC  # type: ignore[attr-defined]
+        self.factory_class2._related_factory_modes = {"dummy_model": "create"}
+        try:
+            with patch(
+                "general_manager.factory.factories._RNG.choice",
+                side_effect=deterministic_choice,
+            ):
+                instance = self.factory_class2.create(description="Creates related")
+        finally:
+            delattr(DummyModel, "_general_manager_class")
+            delattr(self.factory_class2, "_related_factory_modes")
+
+        self.assertEqual(DummyModel.objects.count(), 2)
+        self.assertEqual(factory_calls, 1)
+        self.assertIsNotNone(instance.dummy_model_id)
+        self.assertNotEqual(instance.dummy_model_id, existing.pk)
+
+    def test_generate_instance_reuses_foreign_key_from_interface_database_alias(
+        self,
+    ):
+        alias = self.database_alias
+
+        class AliasInterface(DummyInterface):
+            @classmethod
+            def _get_database_alias(cls) -> str:
+                return alias
+
+        factory_class = type(
+            "AliasDummyFactory2",
+            (AutoFactory,),
+            {
+                "interface": AliasInterface,
+                "Meta": type("Meta", (), {"model": DummyModel2}),
+            },
+        )
+
+        with self._temporary_database_alias(alias) as alias_connection:
+            alias_tables_created = False
+            try:
+                with alias_connection.schema_editor() as schema:
+                    schema.create_model(DummyModel)
+                    schema.create_model(DummyModel2)
+                    alias_tables_created = True
+
+                existing = DummyModel.objects.using(alias).create(
+                    name="Alias Existing",
+                    value=1,
+                )
+
+                instance = factory_class.create(description="Uses alias relation")
+
+                self.assertEqual(instance._state.db, alias)
+                self.assertEqual(instance.dummy_model_id, existing.pk)
+                self.assertEqual(DummyModel.objects.count(), 0)
+                self.assertEqual(DummyModel2.objects.using(alias).count(), 1)
+            finally:
+                if alias_tables_created:
+                    with alias_connection.schema_editor() as schema:
+                        schema.delete_model(DummyModel2)
+                        schema.delete_model(DummyModel)
+
+    def test_generate_instance_filters_one_to_one_links_on_interface_database_alias(
+        self,
+    ):
+        alias = self.database_alias
+
+        class AliasInterface(DummyInterface):
+            @classmethod
+            def _get_database_alias(cls) -> str:
+                return alias
+
+        factory_class = type(
+            "AliasDummyFactory3",
+            (AutoFactory,),
+            {
+                "interface": AliasInterface,
+                "Meta": type("Meta", (), {"model": DummyModel3}),
+            },
+        )
+
+        with self._temporary_database_alias(alias) as alias_connection:
+            alias_tables_created = False
+            try:
+                with alias_connection.schema_editor() as schema:
+                    schema.create_model(DummyModel)
+                    schema.create_model(DummyModel3)
+                    alias_tables_created = True
+
+                linked = DummyModel.objects.using(alias).create(
+                    name="Already linked",
+                    value=1,
+                )
+                available = DummyModel.objects.using(alias).create(
+                    name="Available",
+                    value=2,
+                )
+                DummyModel3.objects.using(alias).create(
+                    description="Existing link",
+                    dummy_model=linked,
+                )
+
+                instance = factory_class.create(description="Uses available relation")
+
+                self.assertEqual(instance._state.db, alias)
+                self.assertEqual(instance.dummy_model_id, available.pk)
+                self.assertEqual(DummyModel3.objects.using(alias).count(), 2)
+            finally:
+                if alias_tables_created:
+                    with alias_connection.schema_editor() as schema:
+                        schema.delete_model(DummyModel3)
+                        schema.delete_model(DummyModel)
+
+    def test_related_factory_modes_do_not_leak_between_generated_factories(self):
+        original_modes = dict(AutoFactory._related_factory_modes)
+        try:
+            factory_a = type(
+                "DummyFactory2A",
+                (AutoFactory,),
+                {
+                    "interface": DummyInterface,
+                    "Meta": type("Meta", (), {"model": DummyModel2}),
+                },
+            )
+            factory_b = type(
+                "DummyFactory2B",
+                (AutoFactory,),
+                {
+                    "interface": DummyInterface,
+                    "Meta": type("Meta", (), {"model": DummyModel2}),
+                },
+            )
+
+            factory_a._related_factory_modes["dummy_model"] = "create"
+
+            self.assertEqual(
+                factory_a._get_related_factory_mode("dummy_model"),
+                "create",
+            )
+            self.assertEqual(
+                factory_b._get_related_factory_mode("dummy_model"),
+                "reuse_existing",
+            )
+        finally:
+            AutoFactory._related_factory_modes = original_modes
+
+    def test_sequence_starts_after_existing_rows(self):
+        DummyModel.objects.create(name="Sequenced 0", value=0)
+
+        class SequencedFactory(AutoFactory):
+            interface = DummyInterface
+            name = LazyAttributeSequence(lambda _obj, n: f"Sequenced {n}")
+            value = LazyAttributeSequence(lambda _obj, n: n)
+
+            class Meta:
+                model = DummyModel
+
+        instance = SequencedFactory.create()
+
+        self.assertEqual(instance.name, "Sequenced 1")
+        self.assertEqual(instance.value, 1)
+
     def test_generate_instance_with_many_to_many(self):
         """
         Tests that the factory can create a DummyModel2 instance with ManyToMany relationships assigned to multiple DummyModel instances.
         """
         dummy_model_instance = self.factory_class.create()
         dummy_model_instance2 = self.factory_class.create()
-        self.factory_class2.create(
+        instance = self.factory_class2.create(
             description="Test Description",
             dummy_model=dummy_model_instance,
             dummy_m2m=[dummy_model_instance, dummy_model_instance2],
         )
-        instance = DummyModel2.objects.get(id=1)
         self.assertIsInstance(instance, DummyModel2)
         self.assertEqual(instance.description, "Test Description")
         self.assertEqual(instance.dummy_model, dummy_model_instance)
         self.assertIn(dummy_model_instance, instance.dummy_m2m.all())
         self.assertIn(dummy_model_instance2, instance.dummy_m2m.all())
+
+    def test_generate_instance_without_many_to_many_value_leaves_blank_m2m_empty(
+        self,
+    ):
+        dummy_model_instance = self.factory_class.create()
+        self.factory_class.create(name="Existing M2M", value=2)
+
+        with patch(
+            "general_manager.factory.factories._RNG.randint",
+            return_value=1,
+        ):
+            instance = self.factory_class2.create(
+                description="Test Description",
+                dummy_model=dummy_model_instance,
+            )
+
+        self.assertEqual(list(instance.dummy_m2m.all()), [])
+
+    def test_generate_instance_without_required_many_to_many_value_generates_relation(
+        self,
+    ):
+        dummy_model_instance = self.factory_class.create(name="FK", value=1)
+        self.factory_class.create(name="Existing M2M", value=2)
+        field = DummyModel2._meta.get_field("dummy_m2m")
+        original_blank = field.blank
+        field.blank = False
+        try:
+            with patch(
+                "general_manager.factory.factories._RNG.randint",
+                return_value=1,
+            ):
+                instance = self.factory_class2.create(
+                    description="Required M2M",
+                    dummy_model=dummy_model_instance,
+                )
+        finally:
+            field.blank = original_blank
+
+        self.assertEqual(instance.dummy_m2m.count(), 1)
+
+    def test_generate_instance_omitted_many_to_many_create_mode_assigns_created(
+        self,
+    ):
+        dummy_model_instance = self.factory_class.create(name="FK", value=1)
+        self.factory_class.create(name="Existing M2M", value=2)
+        factory_calls = 0
+
+        class GMC:
+            pass
+
+        def related_factory(**_kwargs: object) -> DummyModel:
+            nonlocal factory_calls
+            factory_calls += 1
+            return self.factory_class.create(name="Created M2M", value=3)
+
+        original_modes = dict(self.factory_class2._related_factory_modes)
+        GMC.Factory = related_factory  # type: ignore[attr-defined]
+        DummyModel._general_manager_class = GMC  # type: ignore[attr-defined]
+        self.factory_class2._related_factory_modes = {"dummy_m2m": "create"}
+        try:
+            with patch(
+                "general_manager.factory.factories._RNG.randint",
+                return_value=1,
+            ):
+                instance = self.factory_class2.create(
+                    description="Creates M2M",
+                    dummy_model=dummy_model_instance,
+                )
+        finally:
+            delattr(DummyModel, "_general_manager_class")
+            self.factory_class2._related_factory_modes = original_modes
+
+        assigned = list(instance.dummy_m2m.all())
+        self.assertEqual(factory_calls, 1)
+        self.assertEqual(len(assigned), 1)
+        self.assertEqual(assigned[0].name, "Created M2M")
+
+    def test_generate_instance_omitted_many_to_many_create_mode_with_no_params(
+        self,
+    ):
+        self.factory_class.create(name="Existing", value=1)
+        factory_calls = 0
+
+        class GMC:
+            pass
+
+        def related_factory(**_kwargs: object) -> DummyModel:
+            nonlocal factory_calls
+            factory_calls += 1
+            return self.factory_class.create(name="Created M2M", value=2)
+
+        original_modes = dict(self.factory_class2._related_factory_modes)
+        GMC.Factory = related_factory  # type: ignore[attr-defined]
+        DummyModel._general_manager_class = GMC  # type: ignore[attr-defined]
+        self.factory_class2._related_factory_modes = {"dummy_m2m": "create"}
+        try:
+            with patch(
+                "general_manager.factory.factories._RNG.randint",
+                return_value=1,
+            ):
+                instance = self.factory_class2.create()
+        finally:
+            delattr(DummyModel, "_general_manager_class")
+            self.factory_class2._related_factory_modes = original_modes
+
+        assigned = list(instance.dummy_m2m.all())
+        self.assertEqual(factory_calls, 1)
+        self.assertEqual(len(assigned), 1)
+        self.assertEqual(assigned[0].name, "Created M2M")
 
     def test_build_instance_with_many_to_many_values_skips_relation_assignment(self):
         """

--- a/tests/unit/test_factories.py
+++ b/tests/unit/test_factories.py
@@ -184,60 +184,362 @@ class TestRelationFieldValue(TestCase):
             if hasattr(M, "_general_manager_class"):
                 delattr(M, "_general_manager_class")
 
-    def test_fk_with_factory_new_instance(self):
-        # 1) _general_manager_class.Factory returns an object directly
-        dummy = DummyForeignKey(name="foo")
+    def test_fk_with_factory_prefers_existing_instances(self):
+        created = DummyForeignKey(name="created")
+        existing1 = DummyForeignKey(name="a")
+        existing2 = DummyForeignKey(name="b")
 
         class GMC:
             pass
 
-        GMC.Factory = lambda **_kwargs: dummy  # type: ignore
+        GMC.Factory = lambda **_kwargs: created  # type: ignore
         DummyForeignKey._general_manager_class = GMC  # type: ignore
-        with patch("general_manager.factory.factories._RNG.choice", return_value=True):
-            field = DummyModel._meta.get_field("dummy_fk")
-            result = get_field_value(field)
-            # In this branch we expect the factory result directly, not a LazyFunction
-            self.assertIs(result, dummy)
 
-    def test_fk_with_factory_existing_instance(self):
-        """
-        Verifies that when a related model has a factory but the random choice selects an existing instance, get_field_value returns a LazyFunction that yields one of the existing instances when evaluated.
-        The test sets up a General Manager Class (GMC) with a Factory that would create dummy1, patches the RNG to choose the "existing" branch, and patches the model manager to return [dummy1, dummy2]. It asserts the declaration is a LazyFunction and that evaluating it returns either dummy1 or dummy2.
-        """
-        dummy1 = DummyForeignKey(name="a")
-        dummy2 = DummyForeignKey(name="b")
+        def deterministic_choice(values):
+            values = list(values)
+            if values == [True, True, False]:
+                return True
+            return values[0]
+
+        with (
+            patch(
+                "general_manager.factory.factories._RNG.choice",
+                side_effect=deterministic_choice,
+            ),
+            patch.object(
+                DummyForeignKey.objects,
+                "all",
+                return_value=[existing1, existing2],
+            ),
+        ):
+            field = DummyModel._meta.get_field("dummy_fk")
+            decl = get_field_value(field)
+        self.assertIsInstance(decl, LazyFunction)
+        selected = decl.evaluate(None, None, None)  # type: ignore
+        self.assertIn(selected, (existing1, existing2))
+        self.assertIsNot(selected, created)
+
+    def test_fk_with_factory_create_mode_creates_new_instance(self):
+        created = DummyForeignKey(name="created")
         field = DummyModel._meta.get_field("dummy_fk")
 
         class GMC:
             pass
 
-        GMC.Factory = lambda **_kwargs: dummy1  # type: ignore
+        GMC.Factory = lambda **_kwargs: created  # type: ignore
+        DummyForeignKey._general_manager_class = GMC  # type: ignore
+
+        self.assertIs(
+            get_field_value(field, relation_generation="create"),
+            created,
+        )
+
+    def test_fk_with_factory_random_mode_can_create_new_instance(self):
+        created = DummyForeignKey(name="created")
+        existing = DummyForeignKey(name="existing")
+        field = DummyModel._meta.get_field("dummy_fk")
+
+        class GMC:
+            pass
+
+        GMC.Factory = lambda **_kwargs: created  # type: ignore
         DummyForeignKey._general_manager_class = GMC  # type: ignore
 
         with (
             patch(
                 "general_manager.factory.factories._RNG.choice",
-                return_value=False,
+                return_value=True,
             ),
-            patch.object(DummyForeignKey.objects, "all", return_value=[dummy1, dummy2]),
+            patch.object(DummyForeignKey.objects, "all", return_value=[existing]),
         ):
-            decl = get_field_value(field)
-            self.assertIsInstance(decl, LazyFunction)
-        inst = decl.evaluate(None, None, None)  # type: ignore
-        self.assertIn(inst, (dummy1, dummy2))
+            result = get_field_value(field, relation_generation="random")
 
-    def test_one_to_one_with_factory(self):
-        dummy = DummyForeignKey2(name="bar")
+        self.assertIs(result, created)
+
+    def test_fk_with_factory_random_mode_can_reuse_existing_instance(self):
+        created = DummyForeignKey(name="created")
+        existing = DummyForeignKey(name="existing")
+        field = DummyModel._meta.get_field("dummy_fk")
+
+        class GMC:
+            pass
+
+        GMC.Factory = lambda **_kwargs: created  # type: ignore
+        DummyForeignKey._general_manager_class = GMC  # type: ignore
+
+        def deterministic_choice(values):
+            values = list(values)
+            if values == [True, True, False]:
+                return False
+            return values[0]
+
+        with (
+            patch(
+                "general_manager.factory.factories._RNG.choice",
+                side_effect=deterministic_choice,
+            ),
+            patch.object(DummyForeignKey.objects, "all", return_value=[existing]),
+        ):
+            decl = get_field_value(field, relation_generation="random")
+
+        self.assertIsInstance(decl, LazyFunction)
+        self.assertIs(decl.evaluate(None, None, None), existing)  # type: ignore
+        self.assertIsNot(existing, created)
+
+    def test_nullable_fk_default_mode_can_return_none_with_related_available(self):
+        created = DummyForeignKey(name="created")
+        existing = DummyForeignKey(name="existing")
+        field = DummyModel._meta.get_field("dummy_fk")
+        original_null = field.null
+
+        class GMC:
+            pass
+
+        def factory(**_kwargs):
+            self.fail("default nullable relation generation should return None first")
+            return created
+
+        GMC.Factory = factory  # type: ignore
+        DummyForeignKey._general_manager_class = GMC  # type: ignore
+        field.null = True
+        try:
+            with (
+                patch(
+                    "general_manager.factory.factories._RNG.choice",
+                    return_value=True,
+                ),
+                patch.object(
+                    DummyForeignKey.objects,
+                    "all",
+                    return_value=[existing],
+                ),
+            ):
+                self.assertIsNone(get_field_value(field))
+        finally:
+            field.null = original_null
+
+    def test_nullable_one_to_one_default_mode_can_return_none_with_related_available(
+        self,
+    ):
+        created = DummyForeignKey2(name="created")
+        existing = DummyForeignKey2(id=1, name="existing")
+        field = DummyModel._meta.get_field("dummy_one_to_one")
+        original_null = field.null
 
         class GMC2:
             pass
 
-        GMC2.Factory = lambda **_kwargs: dummy  # type: ignore
+        def factory(**_kwargs):
+            self.fail("default nullable relation generation should return None first")
+            return created
+
+        GMC2.Factory = factory  # type: ignore
+        DummyForeignKey2._general_manager_class = GMC2  # type: ignore
+        field.null = True
+        try:
+            with (
+                patch(
+                    "general_manager.factory.factories._RNG.choice",
+                    return_value=True,
+                ),
+                patch.object(
+                    DummyForeignKey2.objects,
+                    "all",
+                    return_value=[existing],
+                ),
+            ):
+                self.assertIsNone(get_field_value(field))
+        finally:
+            field.null = original_null
+
+    def test_nullable_fk_default_none_create_mode_creates_new_instance(self):
+        created = DummyForeignKey(name="created")
+        field = DummyModel._meta.get_field("dummy_fk")
+        original_null = field.null
+        original_default = field.default
+
+        class GMC:
+            pass
+
+        GMC.Factory = lambda **_kwargs: created  # type: ignore
+        DummyForeignKey._general_manager_class = GMC  # type: ignore
+        field.null = True
+        field.default = None
+        try:
+            self.assertIs(
+                get_field_value(field, relation_generation="create"),
+                created,
+            )
+        finally:
+            field.null = original_null
+            field.default = original_default
+
+    def test_one_to_one_with_factory_prefers_existing_instances(self):
+        created = DummyForeignKey2(name="created")
+        existing1 = DummyForeignKey2(id=1, name="x")
+        existing2 = DummyForeignKey2(id=2, name="y")
+
+        class GMC2:
+            pass
+
+        GMC2.Factory = lambda **_kwargs: created  # type: ignore
         DummyForeignKey2._general_manager_class = GMC2  # type: ignore
 
         field = DummyModel._meta.get_field("dummy_one_to_one")
-        result = get_field_value(field)
-        self.assertIs(result, dummy)
+        with patch.object(
+            DummyForeignKey2.objects,
+            "all",
+            return_value=[existing1, existing2],
+        ):
+            decl = get_field_value(field)
+        self.assertIsInstance(decl, LazyFunction)
+        selected = decl.evaluate(None, None, None)  # type: ignore
+        self.assertIn(selected, (existing1, existing2))
+        self.assertIsNot(selected, created)
+
+    def test_one_to_one_reuse_excludes_already_linked_instances(self):
+        from general_manager.factory.factories import _existing_related_instances
+
+        available = DummyForeignKey2(id=1, name="free")
+        linked = DummyForeignKey2(id=2, name="used")
+        also_available = DummyForeignKey2(id=3, name="free2")
+        related_manager = Mock()
+        related_manager.all.return_value = [available, linked, also_available]
+        owner_manager = Mock()
+        owner_rows = owner_manager.exclude.return_value
+        owner_rows.values_list.return_value = [linked.pk]
+        owner_manager.values_list.side_effect = AssertionError(
+            "linked ids must come from the filtered owner queryset"
+        )
+        field = SimpleNamespace(
+            name="dummy_one_to_one",
+            attname="dummy_one_to_one_id",
+            one_to_one=True,
+            model=SimpleNamespace(objects=owner_manager),
+            related_model=SimpleNamespace(objects=related_manager),
+        )
+
+        result = _existing_related_instances(field)
+
+        self.assertEqual(result, [available, also_available])
+        related_manager.all.assert_called_once_with()
+        owner_manager.exclude.assert_called_once()
+        owner_rows.values_list.assert_called_once_with("dummy_one_to_one_id", flat=True)
+
+    def test_existing_related_instances_uses_default_manager_for_non_one_to_one(self):
+        from general_manager.factory.factories import _existing_related_instances
+
+        existing = [DummyForeignKey(id=1, name="available")]
+        default_manager = Mock()
+        default_manager.all.return_value = existing
+        objects_manager = Mock()
+        objects_manager.all.return_value = []
+        field = SimpleNamespace(
+            name="dummy_fk",
+            one_to_one=False,
+            related_model=SimpleNamespace(
+                _default_manager=default_manager,
+                objects=objects_manager,
+            ),
+        )
+
+        self.assertEqual(_existing_related_instances(field), existing)
+        default_manager.all.assert_called_once_with()
+        objects_manager.all.assert_not_called()
+
+    def test_existing_related_instances_uses_default_manager_for_one_to_one_owner(
+        self,
+    ):
+        from general_manager.factory.factories import _existing_related_instances
+
+        available = DummyForeignKey2(id=1, name="available")
+        linked = DummyForeignKey2(id=2, name="linked")
+        related_default_manager = Mock()
+        related_default_manager.all.return_value = [available, linked]
+        related_objects_manager = Mock()
+        related_objects_manager.all.return_value = []
+        owner_default_manager = Mock()
+        owner_rows = owner_default_manager.exclude.return_value
+        owner_rows.values_list.return_value = [linked.pk]
+        owner_objects_manager = Mock()
+        owner_objects_manager.exclude.return_value.values_list.return_value = []
+        field = SimpleNamespace(
+            name="dummy_one_to_one",
+            attname="dummy_one_to_one_id",
+            one_to_one=True,
+            model=SimpleNamespace(
+                _default_manager=owner_default_manager,
+                objects=owner_objects_manager,
+            ),
+            related_model=SimpleNamespace(
+                _default_manager=related_default_manager,
+                objects=related_objects_manager,
+            ),
+        )
+
+        self.assertEqual(_existing_related_instances(field), [available])
+        related_default_manager.all.assert_called_once_with()
+        related_objects_manager.all.assert_not_called()
+        owner_default_manager.exclude.assert_called_once()
+        owner_rows.values_list.assert_called_once_with("dummy_one_to_one_id", flat=True)
+        owner_objects_manager.exclude.assert_not_called()
+
+    def test_one_to_one_reuse_excludes_linked_to_field_value(self):
+        from general_manager.factory.factories import _existing_related_instances
+
+        available = SimpleNamespace(pk=1, code="free")
+        linked = SimpleNamespace(pk=2, code="used")
+        also_available = SimpleNamespace(pk=3, code="free2")
+        related_manager = Mock()
+        related_manager.all.return_value = [available, linked, also_available]
+        owner_manager = Mock()
+        owner_rows = owner_manager.exclude.return_value
+        owner_rows.values_list.return_value = ["used"]
+        target_field = SimpleNamespace(attname="code", name="code")
+        field = SimpleNamespace(
+            name="dummy_one_to_one",
+            attname="dummy_one_to_one_code",
+            one_to_one=True,
+            target_field=target_field,
+            model=SimpleNamespace(objects=owner_manager),
+            related_model=SimpleNamespace(objects=related_manager),
+        )
+
+        self.assertEqual(
+            _existing_related_instances(field),
+            [available, also_available],
+        )
+
+    def test_one_to_one_owner_scan_prefers_base_manager_for_linked_values(self):
+        from general_manager.factory.factories import _existing_related_instances
+
+        available = DummyForeignKey2(id=1, name="available")
+        linked = DummyForeignKey2(id=2, name="linked")
+        related_default_manager = Mock()
+        related_default_manager.all.return_value = [available, linked]
+        owner_base_manager = Mock()
+        owner_rows = owner_base_manager.exclude.return_value
+        owner_rows.values_list.return_value = [linked.pk]
+        owner_default_manager = Mock()
+        owner_default_manager.exclude.return_value.values_list.return_value = []
+        field = SimpleNamespace(
+            name="dummy_one_to_one",
+            attname="dummy_one_to_one_id",
+            one_to_one=True,
+            model=SimpleNamespace(
+                _base_manager=owner_base_manager,
+                _default_manager=owner_default_manager,
+            ),
+            related_model=SimpleNamespace(
+                _default_manager=related_default_manager,
+            ),
+        )
+
+        self.assertEqual(_existing_related_instances(field), [available])
+        related_default_manager.all.assert_called_once_with()
+        owner_base_manager.exclude.assert_called_once()
+        owner_rows.values_list.assert_called_once_with("dummy_one_to_one_id", flat=True)
+        owner_default_manager.exclude.assert_not_called()
 
     def test_fk_without_factory_with_existing_instances(self):
         # 2) No factory but existing objects → expect LazyFunction
@@ -302,25 +604,103 @@ class TestGetManyToManyFieldValue(TestCase):
         """
         dummy1 = DummyManyToMany(name="foo", id=1)
         dummy2 = DummyManyToMany(name="bar", id=2)
+        created = DummyManyToMany(name="created", id=3)
+        factory_calls = 0
 
         class GMC:
             pass
 
-        GMC.Factory = lambda **_kwargs: dummy1  # type: ignore
+        def factory(**_kwargs):
+            nonlocal factory_calls
+            factory_calls += 1
+            return created
+
+        GMC.Factory = factory  # type: ignore
         DummyManyToMany._general_manager_class = GMC  # type: ignore
 
         field = DummyModel._meta.get_field("dummy_m2m")
-        with patch.object(
-            field.related_model.objects,
-            "all",
-            return_value=[dummy1, dummy2],  # type: ignore
-        ):
-            result = get_many_to_many_field_value(field)  # type: ignore
+        original_blank = field.blank
+        field.blank = False
+        try:
+            with patch.object(
+                field.related_model.objects,
+                "all",
+                return_value=[dummy1, dummy2],  # type: ignore
+            ):
+                result = get_many_to_many_field_value(field)  # type: ignore
+        finally:
+            field.blank = original_blank
+
+        self.assertEqual(factory_calls, 0)
         self.assertIsInstance(result, list)
         self.assertTrue(
             set(result).issubset({dummy1, dummy2}),
             "Returned instances are not a subset of existing objects",
         )
+
+    def test_m2m_create_mode_uses_factory_when_existing_rows_are_available(self):
+        created = DummyManyToMany(name="created", id=2)
+        factory_calls = 0
+
+        class GMC:
+            pass
+
+        def factory(**_kwargs):
+            nonlocal factory_calls
+            factory_calls += 1
+            return created
+
+        GMC.Factory = factory  # type: ignore
+        DummyManyToMany._general_manager_class = GMC  # type: ignore
+
+        field = DummyModel._meta.get_field("dummy_m2m")
+        with (
+            patch(
+                "general_manager.factory.factories._existing_related_instances",
+                side_effect=AssertionError("create mode must not query existing rows"),
+            ) as existing_related_instances,
+            patch(
+                "general_manager.factory.factories._RNG.randint",
+                return_value=1,
+            ),
+        ):
+            result = get_many_to_many_field_value(
+                field,  # type: ignore[arg-type]
+                relation_generation="create",
+            )
+
+        self.assertEqual(factory_calls, 1)
+        existing_related_instances.assert_not_called()
+        self.assertEqual(result, [created])
+
+    def test_m2m_existing_rows_use_database_alias(self):
+        dummy1 = DummyManyToMany(name="foo", id=1)
+        dummy2 = DummyManyToMany(name="bar", id=2)
+        alias = "factory_alias"
+        alias_manager = Mock()
+        alias_manager.all.return_value = [dummy1, dummy2]
+
+        field = DummyModel._meta.get_field("dummy_m2m")
+        with (
+            patch.object(
+                field.related_model._default_manager,
+                "using",
+                return_value=alias_manager,
+            ) as using,
+            patch(
+                "general_manager.factory.factories._RNG.randint",
+                return_value=1,
+            ),
+        ):
+            result = get_many_to_many_field_value(
+                field,  # type: ignore[arg-type]
+                database_alias=alias,
+            )
+
+        using.assert_called_once_with(alias)
+        alias_manager.all.assert_called_once_with()
+        self.assertEqual(len(result), 1)
+        self.assertIn(result[0], (dummy1, dummy2))
 
     def test_m2m_with_factory(self):
         dummy1 = DummyManyToMany(name="foo", id=1)


### PR DESCRIPTION
## Summary
- Make generated foreign-key and one-to-one factory defaults prefer reusable existing related rows before creating new related objects.
- Add `_related_factory_mode` and field-specific `_related_factory_modes` for forced creation or legacy random FK behavior.
- Start factory_boy sequences after the target model row count, respecting the interface database alias.
- Keep omitted blank many-to-many fields empty by default, while preserving explicit M2M assignment and field-specific create mode.
- Document the new relation and sequence behavior, including the manager/project example.

## Validation
- `python -m pytest tests/unit/test_factories.py tests/unit/test_factory_methods.py tests/unit/test_auto_factory.py tests/docs/test_public_api_docs_coverage.py -q`
- `ruff check src/general_manager/factory/factories.py src/general_manager/factory/auto_factory.py tests/unit/test_factories.py tests/unit/test_auto_factory.py`
- `ruff format --check src/general_manager/factory/factories.py src/general_manager/factory/auto_factory.py tests/unit/test_factories.py tests/unit/test_auto_factory.py`
- `mypy src/general_manager/factory/factories.py src/general_manager/factory/auto_factory.py`

## Notes
- Relation reuse and one-to-one linked-row filtering use the factory interface database alias when configured.
- Forced related creation still relies on the related model's own factory behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Factory-generated records now better handle related fields, including reuse, creation, and random selection options.
  * Many-to-many values are handled more consistently during create vs. build operations.
  * Factory sequence values now start after existing records, improving ID generation for populated tables.

* **Bug Fixes**
  * Related objects now respect the configured database when reusing or creating values.
  * One-to-one relations avoid reusing already-linked records.
  * Nullable relations keep `None` when expected.

* **Documentation**
  * Expanded factory docs with clearer guidance on relation handling and sequence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->