### PR TITLE
[codex] Reduce GM framework cold-cache overhead

### DIFF
--- a/src/general_manager/cache/cache_tracker.py
+++ b/src/general_manager/cache/cache_tracker.py
@@ -143,6 +143,11 @@ class DependencyTracker:
             dep_set.add((class_name, operation, identifier))
 
     @staticmethod
+    def is_active() -> bool:
+        """Return whether dependency tracking is active for this execution context."""
+        return _dependency_storage.depth >= 0
+
+    @staticmethod
     def reset_thread_local_storage() -> None:
         """Clear all dependency tracking data for the current thread.
 

--- a/src/general_manager/cache/dependency_matching.py
+++ b/src/general_manager/cache/dependency_matching.py
@@ -101,6 +101,12 @@ def normalize_dependency_value(value: object) -> NormalizedDependencyValue:
 
 def serialize_normalized_value(value: object) -> str:
     """Serialize dependency values in the canonical dependency format."""
+    if isinstance(value, str):
+        return json.dumps(value)
+    if value is None or isinstance(value, (int, float, bool)):
+        return json.dumps(value)
+    if isinstance(value, date):
+        return json.dumps(value.isoformat())
     return json.dumps(normalize_dependency_value(value), sort_keys=True)
 
 

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -28,7 +28,6 @@ _active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
 ORM_BUCKET_RESULT_PREFIX = "orm_bucket_result"
 ORM_BUCKET_ROW_RESULT_PREFIX = "orm_bucket_row_result"
 BUCKET_INDEX_PREFIX = "bucket_index"
-TRUSTED_MANAGER_PREFIX = "trusted_manager"
 DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE = 1000
 logger = get_logger("cache.run_context")
 
@@ -300,15 +299,6 @@ class CalculationRunContext:
         """Discard all run-scoped ORM bucket result entries."""
         self.discard_prefix((ORM_BUCKET_RESULT_PREFIX,))
         self.discard_prefix((ORM_BUCKET_ROW_RESULT_PREFIX,))
-        self.discard_prefix((TRUSTED_MANAGER_PREFIX,))
-
-    def get_trusted_manager(self, key: Hashable) -> object:
-        """Return a run-scoped trusted manager instance, or `None` when absent."""
-        return self.get((TRUSTED_MANAGER_PREFIX, key))
-
-    def set_trusted_manager(self, key: Hashable, value: object) -> None:
-        """Store a run-scoped trusted manager instance."""
-        self.set((TRUSTED_MANAGER_PREFIX, key), value)
 
     def _bucket_index_cache_key(
         self,

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -28,6 +28,7 @@ _active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
 ORM_BUCKET_RESULT_PREFIX = "orm_bucket_result"
 ORM_BUCKET_ROW_RESULT_PREFIX = "orm_bucket_row_result"
 BUCKET_INDEX_PREFIX = "bucket_index"
+TRUSTED_MANAGER_PREFIX = "trusted_manager"
 DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE = 1000
 logger = get_logger("cache.run_context")
 
@@ -299,6 +300,15 @@ class CalculationRunContext:
         """Discard all run-scoped ORM bucket result entries."""
         self.discard_prefix((ORM_BUCKET_RESULT_PREFIX,))
         self.discard_prefix((ORM_BUCKET_ROW_RESULT_PREFIX,))
+        self.discard_prefix((TRUSTED_MANAGER_PREFIX,))
+
+    def get_trusted_manager(self, key: Hashable) -> object:
+        """Return a run-scoped trusted manager instance, or `None` when absent."""
+        return self.get((TRUSTED_MANAGER_PREFIX, key))
+
+    def set_trusted_manager(self, key: Hashable, value: object) -> None:
+        """Store a run-scoped trusted manager instance."""
+        self.set((TRUSTED_MANAGER_PREFIX, key), value)
 
     def _bucket_index_cache_key(
         self,

--- a/src/general_manager/interface/base_interface.py
+++ b/src/general_manager/interface/base_interface.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 from abc import ABC
+from collections.abc import Mapping
+from dataclasses import dataclass
 import inspect
+from types import MappingProxyType
 from typing import (
     Type,
     TYPE_CHECKING,
@@ -190,12 +193,25 @@ def _should_validate_possible_values() -> bool:
     return bool(settings.DEBUG)
 
 
+@dataclass(frozen=True, slots=True)
+class _InputParsingPlan:
+    names: tuple[str, ...]
+    name_set: frozenset[str]
+    alias_to_name: Mapping[str, str]
+    required_names: frozenset[str]
+    optional_names: frozenset[str]
+    dependency_items: tuple[tuple[str, tuple[str, ...]], ...]
+    field_state: tuple[tuple[str, int, bool, tuple[str, ...]], ...]
+
+
 class InterfaceBase(ABC):
     """Common base API for interfaces backing GeneralManager classes."""
 
     _parent_class: ClassVar[Type["GeneralManager"]]
     _interface_type: ClassVar[str]
     input_fields: ClassVar[dict[str, "Input[type[object]]"]]
+    _input_parsing_plan: ClassVar[_InputParsingPlan | None] = None
+    _input_dependency_order: ClassVar[tuple[str, ...] | None] = None
     lifecycle_capability_name: ClassVar[CapabilityName | None] = None
     _capabilities: ClassVar[frozenset[CapabilityName]] = frozenset()
     _capability_selection: ClassVar["CapabilitySelection | None"] = None
@@ -212,6 +228,8 @@ class InterfaceBase(ABC):
         This method resets per-subclass capability registries and configuration to a clean default, merges configured capability overrides into the class's capability_overrides mapping, and clears the flag that marks configured capabilities as applied. Keyword arguments are forwarded to the superclass implementation.
         """
         super().__init_subclass__(**kwargs)
+        cls._input_parsing_plan = None
+        cls._input_dependency_order = None
         cls._capabilities = frozenset()
         cls._capability_selection = None
         cls._capability_handlers = {}
@@ -564,6 +582,89 @@ class InterfaceBase(ABC):
             if callable(hook):
                 register_system_check(cls, hook)
 
+    @classmethod
+    def _get_input_parsing_plan(cls) -> _InputParsingPlan:
+        plan = cls._input_parsing_plan
+        if plan is not None:
+            if cls._input_parsing_plan_is_fresh(plan):
+                return plan
+            cls._input_dependency_order = None
+
+        names = tuple(cls.input_fields.keys())
+        field_items = tuple(cls.input_fields.items())
+        name_set = frozenset(names)
+        alias_to_name = MappingProxyType({f"{name}_id": name for name in names})
+        required_names = frozenset(
+            name for name, input_field in field_items if input_field.required
+        )
+        optional_names = name_set - required_names
+        dependency_items = tuple(
+            (name, tuple(input_field.depends_on)) for name, input_field in field_items
+        )
+        field_state = tuple(
+            (name, id(input_field), input_field.required, tuple(input_field.depends_on))
+            for name, input_field in field_items
+        )
+
+        plan = _InputParsingPlan(
+            names=names,
+            name_set=name_set,
+            alias_to_name=alias_to_name,
+            required_names=required_names,
+            optional_names=optional_names,
+            dependency_items=dependency_items,
+            field_state=field_state,
+        )
+        cls._input_parsing_plan = plan
+        return plan
+
+    @classmethod
+    def _input_parsing_plan_is_fresh(cls, plan: _InputParsingPlan) -> bool:
+        if len(cls.input_fields) != len(plan.field_state):
+            return False
+        if tuple(cls.input_fields) != plan.names:
+            return False
+        for name, input_id, required, depends_on in plan.field_state:
+            input_field = cls.input_fields.get(name)
+            if input_field is None:
+                return False
+            if id(input_field) != input_id:
+                return False
+            if input_field.required != required:
+                return False
+            if tuple(input_field.depends_on) != depends_on:
+                return False
+        return True
+
+    @classmethod
+    def _get_input_dependency_order(
+        cls,
+        plan: _InputParsingPlan,
+    ) -> tuple[tuple[str, ...], frozenset[str]]:
+        ordered_names = cls._input_dependency_order
+        if ordered_names is not None:
+            return ordered_names, frozenset()
+
+        ordered: list[str] = []
+        processed: set[str] = set()
+        while len(processed) < len(plan.names):
+            progress_made = False
+            for name, depends_on in plan.dependency_items:
+                if name in processed:
+                    continue
+                if all(dependency in processed for dependency in depends_on):
+                    ordered.append(name)
+                    processed.add(name)
+                    progress_made = True
+            if not progress_made:
+                break
+
+        ordered_names = tuple(ordered)
+        unresolved = frozenset(plan.name_set - processed)
+        if not unresolved:
+            cls._input_dependency_order = ordered_names
+        return ordered_names, unresolved
+
     def parse_input_fields_to_identification(
         self,
         *args: object,
@@ -573,10 +674,10 @@ class InterfaceBase(ABC):
         Convert positional and keyword inputs into a validated identification mapping for the interface's input fields.
 
         Positional values are assigned in `input_fields` declaration order before
-        keyword validation. A keyword named `<field>_id` is accepted only when
-        `<field>` is a declared input and the canonical field name was not
-        already supplied. Positional overflow, duplicate positional-plus-keyword
-        values, alias collisions, and unknown aliases surface as
+        keyword validation. A keyword named `<field>_id` is accepted when
+        `<field>` is a declared input; if both are supplied, the `_id` alias
+        overwrites the canonical value. Positional overflow,
+        duplicate positional-plus-keyword values, and unknown aliases surface as
         `UnexpectedInputArgumentsError` through the argument-normalization path.
 
         Parameters:
@@ -597,61 +698,42 @@ class InterfaceBase(ABC):
             InvalidInputValueError: If a provided value is not in the allowed set defined by an input's `possible_values`.
         """
         identification: dict[str, object] = {}
-        kwargs = args_to_kwargs(args, self.input_fields.keys(), kwargs)
-        # Check for extra arguments
-        extra_args = set(kwargs.keys()) - set(self.input_fields.keys())
+        plan = type(self)._get_input_parsing_plan()
+        kwargs = args_to_kwargs(args, plan.names, kwargs)
+
+        extra_args = set(kwargs) - plan.name_set
         if extra_args:
             handled: set[str] = set()
             for extra_arg in list(extra_args):
-                if extra_arg.endswith("_id"):
-                    base = extra_arg[:-3]
-                    if base in self.input_fields:
-                        kwargs[base] = kwargs.pop(extra_arg)
-                        handled.add(extra_arg)
-            # recompute remaining unknown keys after handling known *_id aliases
-            remaining = (extra_args - handled) | (
-                set(kwargs.keys()) - set(self.input_fields.keys())
-            )
+                alias = plan.alias_to_name.get(extra_arg)
+                if alias is not None:
+                    kwargs[alias] = kwargs.pop(extra_arg)
+                    handled.add(extra_arg)
+            remaining = (extra_args - handled) | (set(kwargs) - plan.name_set)
             if remaining:
                 raise UnexpectedInputArgumentsError(remaining)
 
-        for name, input_field in self.input_fields.items():
-            if name not in kwargs and not input_field.required:
+        for name in plan.optional_names:
+            if name not in kwargs:
                 kwargs[name] = None
 
-        missing_args = {
-            name
-            for name, input_field in self.input_fields.items()
-            if input_field.required and name not in kwargs
-        }
+        missing_args = plan.required_names - set(kwargs)
         if missing_args:
             raise MissingInputArgumentsError(missing_args)
 
-        # process input fields with dependencies
-        processed: set[str] = set()
-        while len(processed) < len(self.input_fields):
-            progress_made = False
-            for name, input_field in self.input_fields.items():
-                if name in processed:
-                    continue
-                depends_on = input_field.depends_on
-                if all(dep in processed for dep in depends_on):
-                    cache_context = type(self)._input_possible_values_cache_context(
-                        name
-                    )
-                    value = self.input_fields[name].cast(
-                        kwargs.get(name),
-                        identification,
-                        cache_context=cache_context,
-                    )
-                    self._process_input(name, value, identification)
-                    identification[name] = value
-                    processed.add(name)
-                    progress_made = True
-            if not progress_made:
-                # detect circular dependencies
-                unresolved = set(self.input_fields.keys()) - processed
-                raise CircularInputDependencyError(unresolved)
+        ordered_names, unresolved = type(self)._get_input_dependency_order(plan)
+        for name in ordered_names:
+            input_field = self.input_fields[name]
+            cache_context = type(self)._input_possible_values_cache_context(name)
+            value = input_field.cast(
+                kwargs.get(name),
+                identification,
+                cache_context=cache_context,
+            )
+            self._process_input(name, value, identification)
+            identification[name] = value
+        if unresolved:
+            raise CircularInputDependencyError(unresolved)
         return identification
 
     @classmethod

--- a/src/general_manager/interface/base_interface.py
+++ b/src/general_manager/interface/base_interface.py
@@ -697,7 +697,7 @@ class InterfaceBase(ABC):
             InvalidPossibleValuesTypeError: If an input's `possible_values` configuration is neither callable nor iterable.
             InvalidInputValueError: If a provided value is not in the allowed set defined by an input's `possible_values`.
         """
-        identification: dict[str, object] = {}
+        resolved_identification: dict[str, object] = {}
         plan = type(self)._get_input_parsing_plan()
         kwargs = args_to_kwargs(args, plan.names, kwargs)
 
@@ -727,13 +727,14 @@ class InterfaceBase(ABC):
             cache_context = type(self)._input_possible_values_cache_context(name)
             value = input_field.cast(
                 kwargs.get(name),
-                identification,
+                resolved_identification,
                 cache_context=cache_context,
             )
-            self._process_input(name, value, identification)
-            identification[name] = value
+            self._process_input(name, value, resolved_identification)
+            resolved_identification[name] = value
         if unresolved:
             raise CircularInputDependencyError(unresolved)
+        identification = {name: resolved_identification[name] for name in plan.names}
         return identification
 
     @classmethod

--- a/src/general_manager/interface/capabilities/core/observability.py
+++ b/src/general_manager/interface/capabilities/core/observability.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import ClassVar, Protocol
 
@@ -54,6 +55,12 @@ class LoggingObservabilityCapability(BaseCapability):
         """
         self._logger = get_logger("interface.observability")
 
+    def _debug_enabled(self) -> bool:
+        is_enabled_for = getattr(self._logger, "isEnabledFor", None)
+        if callable(is_enabled_for):
+            return bool(is_enabled_for(logging.DEBUG))
+        return True
+
     def before_operation(
         self,
         *,
@@ -64,13 +71,14 @@ class LoggingObservabilityCapability(BaseCapability):
         """
         Log the start of an interface operation with contextual metadata.
 
-        Calls ``self._logger.debug("interface operation start", context=...)``.
-        The context contains ``operation``, a string ``target`` name,
+        When debug logging is enabled, calls
+        ``self._logger.debug("interface operation start", context=...)``. The
+        context contains ``operation``, a string ``target`` name,
         ``payload_keys`` sorted from the payload keys, and selected payload
         metadata values: ``service``, ``method``, ``path``, ``status_code``,
-        ``retry_count``, and ``request_id``. Selected metadata keys are included
-        whenever they are present in the payload, including when their value is
-        ``None``.
+        ``retry_count``, and ``request_id``. Selected metadata keys are
+        included whenever they are present in the payload, including when their
+        value is ``None``.
 
         Parameters:
             operation: Operation name recorded unchanged.
@@ -80,9 +88,13 @@ class LoggingObservabilityCapability(BaseCapability):
                 metadata keys listed above.
 
         Raises:
-            Exception: Target-name lookup, payload-key sorting, payload metadata
-                lookup, and logger errors propagate unchanged.
+            Exception: Logger debug-enabled checks propagate unchanged. When
+                debug logging is enabled, target-name lookup, payload-key
+                sorting, payload metadata lookup, and logger errors propagate
+                unchanged.
         """
+        if not self._debug_enabled():
+            return
         self._logger.debug(
             "interface operation start",
             context=self._context(operation, target, payload),
@@ -99,16 +111,16 @@ class LoggingObservabilityCapability(BaseCapability):
         """
         Record the end of an interface operation.
 
-        Calls ``self._logger.debug("interface operation end", context=...)``.
-        The context starts with the same fields as ``before_operation()`` and
-        adds ``result_type`` as ``type(result).__name__``. If
-        ``result.metadata`` is a mapping, ``status_code``, ``retry_count``, and
-        ``request_id`` from that ``collections.abc.Mapping`` replace same-named
-        payload metadata values in the end-event context. Result metadata keys
-        are included whenever they are present in the mapping, including when
-        their value is ``None``. A missing ``metadata`` attribute, an
-        ``AttributeError`` raised while reading ``metadata``, or a non-mapping
-        metadata value is ignored.
+        When debug logging is enabled, calls
+        ``self._logger.debug("interface operation end", context=...)``. The
+        context starts with the same fields as ``before_operation()`` and adds
+        ``result_type`` as ``type(result).__name__``. If ``result.metadata`` is
+        a mapping, ``status_code``, ``retry_count``, and ``request_id`` from
+        that ``collections.abc.Mapping`` replace same-named payload metadata
+        values in the end-event context. Result metadata keys are included
+        whenever they are present in the mapping, including when their value is
+        ``None``. A missing ``metadata`` attribute, an ``AttributeError`` raised
+        while reading ``metadata``, or a non-mapping metadata value is ignored.
 
         Parameters:
             operation: Operation name recorded unchanged.
@@ -119,10 +131,14 @@ class LoggingObservabilityCapability(BaseCapability):
                 metadata are recorded.
 
         Raises:
-            Exception: Target-name lookup, payload-key sorting, payload metadata
-                lookup, non-``AttributeError`` result metadata lookup failures,
-                and logger errors propagate unchanged.
+            Exception: Logger debug-enabled checks propagate unchanged. When
+                debug logging is enabled, target-name lookup, payload-key
+                sorting, payload metadata lookup, non-``AttributeError`` result
+                metadata lookup failures, and logger errors propagate
+                unchanged.
         """
+        if not self._debug_enabled():
+            return
         context = self._context(operation, target, payload)
         result_metadata = getattr(result, "metadata", None)
         if isinstance(result_metadata, Mapping):

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -75,11 +75,12 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         self.__id: dict[str, object] = self._interface.identification
         self._manager_state_valid = True
         self._manager_state_reason = None
-        DependencyTracker.track(
-            self.__class__.__name__,
-            "identification",
-            serialize_dependency_identifier(self.__id),
-        )
+        if DependencyTracker.is_active():
+            DependencyTracker.track(
+                self.__class__.__name__,
+                "identification",
+                serialize_dependency_identifier(self.__id),
+            )
         logger.debug(
             "instantiated manager",
             context={
@@ -127,11 +128,12 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         manager.__id = manager._interface.identification
         manager._manager_state_valid = True
         manager._manager_state_reason = None
-        DependencyTracker.track(
-            cls.__name__,
-            "identification",
-            serialize_dependency_identifier(manager.__id),
-        )
+        if DependencyTracker.is_active():
+            DependencyTracker.track(
+                cls.__name__,
+                "identification",
+                serialize_dependency_identifier(manager.__id),
+            )
         logger.debug(
             "trusted orm manager hydrated",
             context={

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping
 from typing import TYPE_CHECKING, Iterator, Protocol, Self, Type, cast
 
 from general_manager.api.property import GraphQLProperty
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import serialize_dependency_identifier
+from general_manager.cache.run_context import current_calculation_run_context
 from general_manager.cache.signals import data_change
 from general_manager.logging import get_logger
 from general_manager.manager.meta import GeneralManagerMeta, InvalidManagerStateError
@@ -123,11 +124,34 @@ class GeneralManager(metaclass=GeneralManagerMeta):
                 return cls(pk)
             return cls(pk, search_date=search_date)
 
+        context = current_calculation_run_context()
+        cache_key: Hashable | None = None
+        if context is not None:
+            cache_key = (cls, instance.pk, search_date)
+            try:
+                cached = context.get_trusted_manager(cache_key)
+            except TypeError:
+                cache_key = None
+            else:
+                if cached is not None:
+                    cached_manager = cast(Self, cached)
+                    if DependencyTracker.is_active():
+                        DependencyTracker.track(
+                            cls.__name__,
+                            "identification",
+                            serialize_dependency_identifier(
+                                cached_manager.identification
+                            ),
+                        )
+                    return cached_manager
+
         manager = cls.__new__(cls)
         manager._interface = hydrate(instance, search_date=search_date)
         manager.__id = manager._interface.identification
         manager._manager_state_valid = True
         manager._manager_state_reason = None
+        if context is not None and cache_key is not None:
+            context.set_trusted_manager(cache_key, manager)
         if DependencyTracker.is_active():
             DependencyTracker.track(
                 cls.__name__,

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
-from collections.abc import Hashable, Mapping
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Iterator, Protocol, Self, Type, cast
 
 from general_manager.api.property import GraphQLProperty
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import serialize_dependency_identifier
-from general_manager.cache.run_context import current_calculation_run_context
 from general_manager.cache.signals import data_change
 from general_manager.logging import get_logger
 from general_manager.manager.meta import GeneralManagerMeta, InvalidManagerStateError
@@ -124,34 +123,11 @@ class GeneralManager(metaclass=GeneralManagerMeta):
                 return cls(pk)
             return cls(pk, search_date=search_date)
 
-        context = current_calculation_run_context()
-        cache_key: Hashable | None = None
-        if context is not None:
-            cache_key = (cls, instance.pk, search_date)
-            try:
-                cached = context.get_trusted_manager(cache_key)
-            except TypeError:
-                cache_key = None
-            else:
-                if cached is not None:
-                    cached_manager = cast(Self, cached)
-                    if DependencyTracker.is_active():
-                        DependencyTracker.track(
-                            cls.__name__,
-                            "identification",
-                            serialize_dependency_identifier(
-                                cached_manager.identification
-                            ),
-                        )
-                    return cached_manager
-
         manager = cls.__new__(cls)
         manager._interface = hydrate(instance, search_date=search_date)
         manager.__id = manager._interface.identification
         manager._manager_state_valid = True
         manager._manager_state_reason = None
-        if context is not None and cache_key is not None:
-            context.set_trusted_manager(cache_key, manager)
         if DependencyTracker.is_active():
             DependencyTracker.track(
                 cls.__name__,

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -127,10 +127,15 @@ class GeneralManagerMeta(type):
         ``__getattr__`` is only reached for missing names, so inherited
         ``GeneralManager`` attributes must pass through here to let declared
         fields override inherited names the same way bootstrap initialization
-        does. "Non-private" means the requested name does not start with
-        ``"_"`` and is not exactly ``"Interface"``. Probing an unknown public
-        name may call ``Interface.get_attributes()``, but it installs
-        descriptors only when the probed name is declared by the interface.
+        does. Once a manager class has completed descriptor initialization,
+        attributes already present on that class use normal type lookup without
+        rechecking initialization. Missing names and inherited public names
+        still pass through initialization so late-discovered fields keep the
+        existing override behavior. "Non-private" means the requested name does
+        not start with ``"_"`` and is not exactly ``"Interface"``. Probing an
+        unknown public name may call ``Interface.get_attributes()``, but it
+        installs descriptors only when the probed name is declared by the
+        interface.
 
         Parameters:
             attribute_name: Class attribute being read.
@@ -145,6 +150,10 @@ class GeneralManagerMeta(type):
                 ``NotImplementedError`` propagate unchanged.
         """
         if not attribute_name.startswith("_") and attribute_name != "Interface":
+            class_dict = type.__getattribute__(cls, "__dict__")
+            initialized = class_dict.get("_gm_attributes_initialized", False)
+            if initialized and attribute_name in class_dict:
+                return type.__getattribute__(cls, attribute_name)
             manager_class = cast(type["GeneralManager"], cls)
             GeneralManagerMeta.ensure_attributes_initialized(
                 manager_class, attribute_name
@@ -234,6 +243,7 @@ class GeneralManagerMeta(type):
                     GeneralManagerMeta.create_at_properties_for_attributes(
                         attributes.keys(), manager_class
                     )
+                type.__setattr__(manager_class, "_gm_attributes_initialized", True)
                 return True
 
             try:
@@ -246,6 +256,7 @@ class GeneralManagerMeta(type):
             GeneralManagerMeta.create_at_properties_for_attributes(
                 attributes.keys(), manager_class
             )
+            type.__setattr__(manager_class, "_gm_attributes_initialized", True)
             try:
                 GeneralManagerMeta.pending_attribute_initialization.remove(
                     manager_class
@@ -509,6 +520,7 @@ class GeneralManagerMeta(type):
 
         for attr_name in attributes:
             setattr(new_class, attr_name, descriptor_method(attr_name, new_class))
+        type.__setattr__(new_class, "_gm_attributes_initialized", True)
 
 
 _CAPABILITY_BUILDER: "ManifestCapabilityBuilder | None" = None

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -68,14 +68,26 @@ def _is_numeric_scalar(value: object) -> TypeGuard[NumericScalar]:
 def _unit_uses_offset_for_unit_string(unit: str) -> bool:
     """Return whether a unit string has offset conversion semantics."""
 
-    parsed_unit = ureg.parse_units(unit)
-    for unit_name, power in parsed_unit._units.items():
+    for unit_name, power in _pint_unit_components(unit):
         if power != 1:
             continue
-        converter = ureg._units[unit_name].converter
-        if getattr(converter, "offset", None) is not None:
+        if _pint_unit_component_uses_offset(unit_name):
             return True
     return False
+
+
+def _pint_unit_components(unit: str) -> tuple[tuple[str, object], ...]:
+    """Return Pint unit component names and powers for one unit expression."""
+
+    parsed_unit = ureg.parse_units(unit)
+    return tuple(parsed_unit._units.items())
+
+
+def _pint_unit_component_uses_offset(unit_name: str) -> bool:
+    """Return whether a Pint unit component has offset conversion semantics."""
+
+    converter = ureg._units[unit_name].converter
+    return getattr(converter, "offset", None) is not None
 
 
 def _unit_uses_offset(unit: str | pint.Unit | MeasurementQuantity) -> bool:

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -3,6 +3,7 @@
 # units.py
 from __future__ import annotations
 from collections.abc import Callable
+from functools import lru_cache
 from typing import TypeAlias, TypeGuard, cast
 import pint
 from decimal import Decimal, getcontext, InvalidOperation
@@ -63,12 +64,11 @@ def _is_numeric_scalar(value: object) -> TypeGuard[NumericScalar]:
     return not isinstance(value, bool) and isinstance(value, (Decimal, float, int))
 
 
-def _unit_uses_offset(unit: str | pint.Unit | MeasurementQuantity) -> bool:
-    """Return whether a Pint unit has offset conversion semantics."""
+@lru_cache(maxsize=256)
+def _unit_uses_offset_for_unit_string(unit: str) -> bool:
+    """Return whether a unit string has offset conversion semantics."""
 
-    parsed_unit = ureg.parse_units(
-        str(unit.units if isinstance(unit, PlainQuantity) else unit)
-    )
+    parsed_unit = ureg.parse_units(unit)
     for unit_name, power in parsed_unit._units.items():
         if power != 1:
             continue
@@ -76,6 +76,17 @@ def _unit_uses_offset(unit: str | pint.Unit | MeasurementQuantity) -> bool:
         if getattr(converter, "offset", None) is not None:
             return True
     return False
+
+
+def _unit_uses_offset(unit: str | pint.Unit | MeasurementQuantity) -> bool:
+    """Return whether a Pint unit has offset conversion semantics."""
+
+    unit_string = str(unit.units if isinstance(unit, PlainQuantity) else unit)
+    return _unit_uses_offset_for_unit_string(unit_string)
+
+
+_unit_uses_offset.cache_clear = _unit_uses_offset_for_unit_string.cache_clear  # type: ignore[attr-defined]
+_unit_uses_offset.cache_info = _unit_uses_offset_for_unit_string.cache_info  # type: ignore[attr-defined]
 
 
 def _quantity_as_float(quantity: MeasurementQuantity) -> PlainQuantity[float]:

--- a/tests/unit/test_base_interface.py
+++ b/tests/unit/test_base_interface.py
@@ -659,7 +659,30 @@ class InterfaceBaseTests(SimpleTestCase):
         )
         self.assertEqual(
             parsed.identification,
-            {"parent": "parent", "child": "parent:child"},
+            {"child": "parent:child", "parent": "parent"},
+        )
+
+    def test_input_parsing_plan_preserves_input_field_order_after_dependencies(
+        self,
+    ):
+        class DependentInput(DummyInput):
+            def cast(self, value, identification=None, *, cache_context=None):
+                del cache_context
+                identification = identification or {}
+                return f"{identification['parent']}:{value}"
+
+        class DependencyInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "child": DependentInput(str, depends_on=["parent"]),
+                "parent": DummyInput(str),
+            }
+
+        parsed = DependencyInterface(child="child", parent="parent")
+
+        self.assertEqual(list(parsed.identification), ["child", "parent"])
+        self.assertEqual(
+            parsed.identification,
+            {"child": "parent:child", "parent": "parent"},
         )
 
     def test_input_parsing_plan_reflects_added_required_field_after_first_parse(self):
@@ -756,7 +779,7 @@ class InterfaceBaseTests(SimpleTestCase):
         )
         self.assertEqual(
             second.identification,
-            {"parent": "parent", "child": "parent:child"},
+            {"child": "parent:child", "parent": "parent"},
         )
 
 

--- a/tests/unit/test_base_interface.py
+++ b/tests/unit/test_base_interface.py
@@ -1,6 +1,11 @@
 # type: ignore
 from django.test import SimpleTestCase, override_settings
-from general_manager.interface.base_interface import InterfaceBase
+from general_manager.interface.base_interface import (
+    InterfaceBase,
+    InvalidInputTypeError,
+    MissingInputArgumentsError,
+    UnexpectedInputArgumentsError,
+)
 from general_manager.interface.capabilities.builtin import BaseCapability
 from general_manager.interface.capabilities.configuration import (
     InterfaceCapabilityConfig,
@@ -516,6 +521,243 @@ class InterfaceBaseTests(SimpleTestCase):
         # Upper bound
         inst2 = DummyInterface(a=1, b="v", gm=DummyGM({"id": 22}), vals=3, c=1)
         self.assertEqual(inst2.identification["vals"], 3)
+
+    def test_input_parsing_plan_reused_for_repeated_instances(self):
+        class CountingFields(dict):
+            keys_calls = 0
+            items_calls = 0
+
+            def keys(self):
+                self.keys_calls += 1
+                return super().keys()
+
+            def items(self):
+                self.items_calls += 1
+                return super().items()
+
+        fields = CountingFields(
+            {
+                "a": DummyInput(int),
+                "b": DummyInput(str, depends_on=["a"]),
+                "c": DummyInput(int, required=False),
+            }
+        )
+
+        class PlannedInterface(InterfaceBase):
+            input_fields = fields
+
+        first = PlannedInterface(a=1, b="x")
+        second = PlannedInterface(a=2, b="y")
+
+        self.assertEqual(first.identification, {"a": 1, "b": "x", "c": None})
+        self.assertEqual(second.identification, {"a": 2, "b": "y", "c": None})
+        self.assertEqual(fields.keys_calls, 1)
+        self.assertEqual(fields.items_calls, 1)
+
+    def test_input_parsing_plan_accepts_id_alias_and_preserves_overwrite_behavior(
+        self,
+    ):
+        class AliasInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "owner": DummyInput(DummyGM),
+                "name": DummyInput(str),
+            }
+
+        owner = DummyGM({"id": 10})
+        alias_owner = DummyGM({"id": 11})
+        parsed = AliasInterface(owner_id=owner, name="demo")
+        overwritten = AliasInterface(owner=owner, owner_id=alias_owner, name="demo")
+
+        self.assertEqual(parsed.identification, {"owner": {"id": 10}, "name": "demo"})
+        self.assertEqual(
+            overwritten.identification,
+            {"owner": {"id": 11}, "name": "demo"},
+        )
+
+    def test_input_parsing_plan_detects_circular_dependencies(self):
+        class CircularInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "a": DummyInput(int, depends_on=["b"]),
+                "b": DummyInput(int, depends_on=["a"]),
+            }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Circular dependency detected among inputs",
+        ):
+            CircularInterface(a=1, b=2)
+
+    def test_input_validation_takes_precedence_over_separate_circular_dependencies(
+        self,
+    ):
+        class MixedCircularInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "independent": DummyInput(int),
+                "a": DummyInput(int, depends_on=["b"]),
+                "b": DummyInput(int, depends_on=["a"]),
+            }
+
+        with self.assertRaises(InvalidInputTypeError):
+            MixedCircularInterface(independent="bad", a=1, b=2)
+
+    def test_input_parsing_plan_missing_args_take_precedence_over_circular_dependencies(
+        self,
+    ):
+        class CircularInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "a": DummyInput(int, depends_on=["b"]),
+                "b": DummyInput(int, depends_on=["a"]),
+            }
+
+        with self.assertRaises(MissingInputArgumentsError):
+            CircularInterface(a=1)
+
+    def test_input_parsing_plan_extra_args_take_precedence_over_circular_dependencies(
+        self,
+    ):
+        class CircularInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "a": DummyInput(int, depends_on=["b"]),
+                "b": DummyInput(int, depends_on=["a"]),
+            }
+
+        with self.assertRaises(UnexpectedInputArgumentsError):
+            CircularInterface(a=1, b=2, extra=3)
+
+    def test_input_parsing_plan_processes_dependencies_before_dependents(self):
+        events: list[tuple[str, dict[str, object]]] = []
+
+        class ObservedInput(DummyInput):
+            def __init__(self, name, dependency=None):
+                super().__init__(str, depends_on=[dependency] if dependency else None)
+                self.name = name
+                self.dependency = dependency
+
+            def cast(self, value, identification=None, *, cache_context=None):
+                del cache_context
+                identification = identification or {}
+                events.append((self.name, dict(identification)))
+                if self.dependency is None:
+                    return value
+                dependency_value = identification[self.dependency]
+                return f"{dependency_value}:{value}"
+
+        class DependencyInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "child": ObservedInput("child", dependency="parent"),
+                "parent": ObservedInput("parent"),
+            }
+
+        parsed = DependencyInterface(child="child", parent="parent")
+
+        self.assertEqual(
+            events,
+            [
+                ("parent", {}),
+                ("child", {"parent": "parent"}),
+            ],
+        )
+        self.assertEqual(
+            parsed.identification,
+            {"parent": "parent", "child": "parent:child"},
+        )
+
+    def test_input_parsing_plan_reflects_added_required_field_after_first_parse(self):
+        fields = {
+            "a": DummyInput(int),
+        }
+
+        class MutableInterface(InterfaceBase):
+            input_fields = fields
+
+        first = MutableInterface(a=1)
+        fields["b"] = DummyInput(str)
+        second = MutableInterface(a=2, b="x")
+
+        self.assertEqual(first.identification, {"a": 1})
+        self.assertEqual(second.identification, {"a": 2, "b": "x"})
+
+    def test_input_parsing_plan_reflects_field_order_mutation_after_first_parse(self):
+        a_input = DummyInput(int)
+        b_input = DummyInput(str)
+        fields = {
+            "a": a_input,
+            "b": b_input,
+        }
+
+        class MutableInterface(InterfaceBase):
+            input_fields = fields
+
+        first = MutableInterface(1, "x")
+        MutableInterface.input_fields = {
+            "b": b_input,
+            "a": a_input,
+        }
+        second = MutableInterface("y", 2)
+
+        self.assertEqual(first.identification, {"a": 1, "b": "x"})
+        self.assertEqual(second.identification, {"b": "y", "a": 2})
+
+    def test_input_parsing_plan_reflects_required_mutation_after_first_parse(self):
+        fields = {
+            "a": DummyInput(int),
+            "maybe": DummyInput(str, required=False),
+        }
+
+        class MutableInterface(InterfaceBase):
+            input_fields = fields
+
+        first = MutableInterface(a=1)
+        fields["maybe"].required = True
+
+        self.assertEqual(first.identification, {"a": 1, "maybe": None})
+        with self.assertRaises(MissingInputArgumentsError):
+            MutableInterface(a=2)
+        parsed = MutableInterface(a=2, maybe="x")
+        self.assertEqual(parsed.identification, {"a": 2, "maybe": "x"})
+
+    def test_input_parsing_plan_reflects_dependency_mutation_after_first_parse(self):
+        events: list[tuple[str, dict[str, object]]] = []
+
+        class ObservedInput(DummyInput):
+            def __init__(self, name):
+                super().__init__(str)
+                self.name = name
+
+            def cast(self, value, identification=None, *, cache_context=None):
+                del cache_context
+                identification = identification or {}
+                events.append((self.name, dict(identification)))
+                if self.depends_on:
+                    dependency_name = self.depends_on[0]
+                    return f"{identification[dependency_name]}:{value}"
+                return value
+
+        fields = {
+            "child": ObservedInput("child"),
+            "parent": ObservedInput("parent"),
+        }
+
+        class MutableInterface(InterfaceBase):
+            input_fields = fields
+
+        first = MutableInterface(child="child", parent="parent")
+        fields["child"].depends_on = ["parent"]
+        events.clear()
+        second = MutableInterface(child="child", parent="parent")
+
+        self.assertEqual(first.identification, {"child": "child", "parent": "parent"})
+        self.assertEqual(
+            events,
+            [
+                ("parent", {}),
+                ("child", {"parent": "parent"}),
+            ],
+        )
+        self.assertEqual(
+            second.identification,
+            {"parent": "parent", "child": "parent:child"},
+        )
 
 
 # ------------------------------------------------------------

--- a/tests/unit/test_cache_tracker.py
+++ b/tests/unit/test_cache_tracker.py
@@ -65,6 +65,23 @@ class TestDependencyTracker(TestCase):
                 ("TestClass", "identification", "TestIdentifier"), dependencies
             )
 
+    def test_dependency_tracker_is_active_reflects_context_depth(self):
+        """Report active tracking only while at least one context is open."""
+        DependencyTracker.reset_thread_local_storage()
+        self.assertFalse(DependencyTracker.is_active())
+
+        with DependencyTracker() as dependencies:
+            self.assertTrue(DependencyTracker.is_active())
+            DependencyTracker.track("Example", "identification", '{"id": 1}')
+
+            with DependencyTracker():
+                self.assertTrue(DependencyTracker.is_active())
+
+            self.assertTrue(DependencyTracker.is_active())
+
+        self.assertEqual(dependencies, {("Example", "identification", '{"id": 1}')})
+        self.assertFalse(DependencyTracker.is_active())
+
     def test_dependency_tracker_rejects_invalid_track_values(self):
         """Reject malformed dependency tuple values before tracking."""
         with self.assertRaises(TypeError):

--- a/tests/unit/test_dependency_matching.py
+++ b/tests/unit/test_dependency_matching.py
@@ -11,6 +11,7 @@ from general_manager.cache.dependency_matching import (
     lookup_spec_from_key,
     matches_lookup_value,
     normalize_dependency_value,
+    serialize_normalized_value,
     stable_value_hash,
 )
 from general_manager.measurement.measurement import Measurement
@@ -88,6 +89,48 @@ def test_normalize_dependency_value_and_hash_are_stable() -> None:
             "moment": moment,
             "opaque": ReprOnly(),
         }
+    )
+
+
+def test_primitive_dependency_serialization_matches_json_contract() -> None:
+    assert serialize_normalized_value("abc") == '"abc"'
+    assert serialize_normalized_value(3) == "3"
+    assert serialize_normalized_value(True) == "true"
+    assert serialize_normalized_value(None) == "null"
+
+
+def test_nested_dependency_serialization_remains_sorted_and_recursive() -> None:
+    value = {"b": 2, "a": [date(2026, 1, 2), {"z": "last"}]}
+
+    assert normalize_dependency_value(value) == {
+        "a": ["2026-01-02", {"z": "last"}],
+        "b": 2,
+    }
+    assert serialize_normalized_value(value) == (
+        '{"a": ["2026-01-02", {"z": "last"}], "b": 2}'
+    )
+
+
+def test_datetime_dependency_serialization_uses_isoformat() -> None:
+    assert serialize_normalized_value(datetime(2026, 1, 2, 3, 4, 5)) == (
+        '"2026-01-02T03:04:05"'
+    )
+
+
+def test_stable_value_hash_is_unchanged_for_equivalent_mapping_order() -> None:
+    assert stable_value_hash({"b": 2, "a": 1}) == stable_value_hash({"a": 1, "b": 2})
+
+
+def test_collection_dependency_serialization_remains_normalized() -> None:
+    assert serialize_normalized_value(("b", date(2026, 1, 2))) == (
+        '["b", "2026-01-02"]'
+    )
+    assert serialize_normalized_value({"b", "a"}) == '["a", "b"]'
+
+
+def test_stateful_dependency_serialization_remains_normalized() -> None:
+    assert serialize_normalized_value(Measurement(1000, "EUR")) == (
+        '{"__state__": {"magnitude": "1000", "unit": "EUR"}}'
     )
 
 

--- a/tests/unit/test_dependency_matching.py
+++ b/tests/unit/test_dependency_matching.py
@@ -112,6 +112,7 @@ def test_nested_dependency_serialization_remains_sorted_and_recursive() -> None:
 
 
 def test_datetime_dependency_serialization_uses_isoformat() -> None:
+    assert serialize_normalized_value(date(2026, 1, 2)) == '"2026-01-02"'
     assert serialize_normalized_value(datetime(2026, 1, 2, 3, 4, 5)) == (
         '"2026-01-02T03:04:05"'
     )

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -1,5 +1,4 @@
 from django.test import TestCase, override_settings
-from typing import ClassVar
 from general_manager.bootstrap import (
     InvalidPermissionClassError,
     check_permission_class,
@@ -17,7 +16,6 @@ from general_manager.permission.manager_based_permission import (
 )
 from unittest.mock import Mock, patch
 from general_manager.cache.cache_tracker import DependencyTracker
-from general_manager.cache.run_context import CalculationRunContext
 from general_manager.cache.signals import post_data_change, pre_data_change
 from django.contrib.auth import get_user_model
 from django.utils.crypto import get_random_string
@@ -149,30 +147,6 @@ class GeneralManagerTestCase(TestCase):
         TemporaryManager.Permission = ManagerBasedPermission  # type: ignore
         return TemporaryManager
 
-    def _temporary_trusted_orm_manager_class(self):
-        manager_class = self._temporary_manager_class()
-
-        class TrustedInterface:
-            calls: ClassVar[list[tuple[object, object | None]]] = []
-
-            def __init__(self, pk=None, search_date=None):
-                self.identification = {"id": pk}
-                self.pk = pk
-                self._search_date = search_date
-
-            @classmethod
-            def _from_trusted_orm_instance(cls, instance, *, search_date=None):
-                cls.calls.append((instance, search_date))
-                interface = cls()
-                interface.identification = {"id": instance.pk}
-                interface.pk = instance.pk
-                interface._search_date = search_date
-                interface._instance = instance
-                return interface
-
-        manager_class.Interface = TrustedInterface  # type: ignore[assignment]
-        return manager_class, TrustedInterface
-
     def test_temporary_manager_class_does_not_register_graphql_interface(self):
         pending_graphql_interfaces = list(GeneralManagerMeta.pending_graphql_interfaces)
 
@@ -257,91 +231,6 @@ class GeneralManagerTestCase(TestCase):
             ("TemporaryManager", "identification", '{"id": "trusted_id"}'),
             dependencies,
         )
-
-    def test_trusted_orm_hydration_reuses_manager_within_run_context(self):
-        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
-        row = Mock(pk="trusted_id")
-
-        with CalculationRunContext():
-            first = manager_class._from_trusted_orm_instance(row)
-            second = manager_class._from_trusted_orm_instance(row)
-
-        self.assertIs(second, first)
-        self.assertEqual(len(trusted_interface.calls), 1)
-
-    def test_trusted_orm_hydration_does_not_reuse_manager_outside_run_context(self):
-        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
-        row = Mock(pk="trusted_id")
-
-        first = manager_class._from_trusted_orm_instance(row)
-        second = manager_class._from_trusted_orm_instance(row)
-
-        self.assertIsNot(second, first)
-        self.assertEqual(len(trusted_interface.calls), 2)
-
-    def test_trusted_orm_hydration_does_not_reuse_custom_init_manager(self):
-        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
-
-        with override_settings(AUTOCREATE_GRAPHQL=False):
-
-            class CustomInitManager(manager_class):
-                init_calls = 0
-
-                def __init__(self, *args, **kwargs):
-                    type(self).init_calls += 1
-                    super().__init__(*args, **kwargs)
-
-        CustomInitManager._attributes = dict(manager_class._attributes)
-        CustomInitManager.Interface = trusted_interface  # type: ignore[assignment]
-        CustomInitManager.Permission = ManagerBasedPermission  # type: ignore[assignment]
-        row = Mock(pk="trusted_id")
-
-        with CalculationRunContext():
-            first = CustomInitManager._from_trusted_orm_instance(row)
-            second = CustomInitManager._from_trusted_orm_instance(row)
-
-        self.assertIsNot(second, first)
-        self.assertEqual(CustomInitManager.init_calls, 2)
-        self.assertEqual(trusted_interface.calls, [])
-
-    def test_trusted_orm_hydration_replays_dependency_on_run_cache_hit(self):
-        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
-        row = Mock(pk="trusted_id")
-
-        with CalculationRunContext():
-            first = manager_class._from_trusted_orm_instance(row)
-            with DependencyTracker() as dependencies:
-                second = manager_class._from_trusted_orm_instance(row)
-
-        self.assertIs(second, first)
-        self.assertEqual(len(trusted_interface.calls), 1)
-        self.assertIn(
-            ("TemporaryManager", "identification", '{"id": "trusted_id"}'),
-            dependencies,
-        )
-
-    def test_trusted_orm_hydration_bypasses_identity_map_for_unhashable_pk(self):
-        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
-        row = Mock(pk=["trusted_id"])
-
-        with CalculationRunContext():
-            first = manager_class._from_trusted_orm_instance(row)
-            second = manager_class._from_trusted_orm_instance(row)
-
-        self.assertIsNot(second, first)
-        self.assertEqual(len(trusted_interface.calls), 2)
-
-    def test_trusted_orm_hydration_clears_identity_map_with_orm_bucket_results(self):
-        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
-        row = Mock(pk="trusted_id")
-
-        with CalculationRunContext() as context:
-            first = manager_class._from_trusted_orm_instance(row)
-            context.clear_orm_bucket_results()
-            second = manager_class._from_trusted_orm_instance(row)
-
-        self.assertIsNot(second, first)
-        self.assertEqual(len(trusted_interface.calls), 2)
 
     def test_check_permission_class_defaults_to_additive_permission(self):
         """Managers without an explicit Permission should default to AdditiveManagerPermission."""

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from general_manager.bootstrap import (
     InvalidPermissionClassError,
     check_permission_class,
@@ -9,7 +9,7 @@ from general_manager.manager.general_manager import (
     TrustedOrmHydrationNotSupportedError,
     UnsupportedUnionOperandError,
 )
-from general_manager.manager.meta import InvalidManagerStateError
+from general_manager.manager.meta import GeneralManagerMeta, InvalidManagerStateError
 from general_manager.permission.manager_based_permission import (
     AdditiveManagerPermission,
     ManagerBasedPermission,
@@ -133,6 +133,27 @@ class GeneralManagerTestCase(TestCase):
         """
         post_data_change.disconnect(self.post_data_change)
         pre_data_change.disconnect(self.pre_data_change)
+
+    def _temporary_manager_class(self):
+        with override_settings(AUTOCREATE_GRAPHQL=False):
+
+            class TemporaryManager(GeneralManager):
+                pass
+
+        TemporaryManager._attributes = dict(self.manager._attributes)
+        TemporaryManager.Interface = DummyInterface  # type: ignore
+        TemporaryManager.Permission = ManagerBasedPermission  # type: ignore
+        return TemporaryManager
+
+    def test_temporary_manager_class_does_not_register_graphql_interface(self):
+        pending_graphql_interfaces = list(GeneralManagerMeta.pending_graphql_interfaces)
+
+        self._temporary_manager_class()
+
+        self.assertEqual(
+            GeneralManagerMeta.pending_graphql_interfaces,
+            pending_graphql_interfaces,
+        )
 
     @patch("general_manager.cache.cache_tracker.DependencyTracker.track")
     def test_initialization(self, mock_track):
@@ -276,6 +297,100 @@ class GeneralManagerTestCase(TestCase):
             manager,
         )
         self.assertIs(history, expected_history)
+
+    def test_initialized_manager_class_attribute_lookup_skips_attribute_initialization(
+        self,
+    ):
+        manager_class = self._temporary_manager_class()
+
+        with patch.object(DummyInterface, "get_attributes", create=True):
+            GeneralManagerMeta.ensure_attributes_initialized(manager_class)
+
+        with patch.object(
+            GeneralManagerMeta,
+            "ensure_attributes_initialized",
+            side_effect=AssertionError("should not re-enter initialization"),
+        ):
+            self.assertIs(manager_class.Permission, ManagerBasedPermission)
+
+    def test_descriptor_creation_marks_manager_initialized_for_class_lookup(self):
+        manager_class = self._temporary_manager_class()
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            manager_class._attributes.keys(),
+            manager_class,
+        )
+
+        with patch.object(
+            GeneralManagerMeta,
+            "ensure_attributes_initialized",
+            side_effect=AssertionError("should not re-enter initialization"),
+        ):
+            self.assertIs(manager_class.Permission, ManagerBasedPermission)
+
+    def test_initialized_manager_instance_descriptor_access_still_returns_value(self):
+        manager_class = self._temporary_manager_class()
+
+        with patch.object(DummyInterface, "get_attributes", create=True):
+            GeneralManagerMeta.ensure_attributes_initialized(manager_class)
+
+        instance = manager_class("dummy_id")
+
+        self.assertEqual(instance.id, "dummy_id")
+
+    def test_initialized_manager_discovers_late_added_public_field(self):
+        manager_class = self._temporary_manager_class()
+        late_attribute = "late_discovered_field"
+        had_late_attribute = late_attribute in manager_class._attributes
+        late_attribute_value = manager_class._attributes.get(late_attribute)
+
+        with (
+            patch.object(DummyInterface, "get_attributes", create=True),
+            patch.object(
+                DummyInterface,
+                "get_field_type",
+                return_value=str,
+                create=True,
+            ),
+        ):
+            GeneralManagerMeta.ensure_attributes_initialized(manager_class)
+            manager_class._attributes[late_attribute] = "late value"
+
+            try:
+                self.assertIs(getattr(manager_class, late_attribute), str)
+            finally:
+                if had_late_attribute:
+                    manager_class._attributes[late_attribute] = late_attribute_value
+                else:
+                    manager_class._attributes.pop(late_attribute, None)
+                if late_attribute in vars(manager_class):
+                    delattr(manager_class, late_attribute)
+
+    def test_initialized_manager_discovers_late_field_over_inherited_public_name(self):
+        manager_class = self._temporary_manager_class()
+        sentinel_type = type("SentinelFilterFieldType", (), {})
+        late_attribute = "filter"
+
+        with (
+            patch.object(DummyInterface, "get_attributes", create=True),
+            patch.object(
+                DummyInterface,
+                "get_field_type",
+                return_value=sentinel_type,
+                create=True,
+            ),
+        ):
+            GeneralManagerMeta.ensure_attributes_initialized(manager_class)
+            manager_class._attributes[late_attribute] = "late value"
+
+            try:
+                self.assertIs(
+                    getattr(manager_class, late_attribute),
+                    sentinel_type,
+                )
+            finally:
+                manager_class._attributes.pop(late_attribute, None)
+                if late_attribute in vars(manager_class):
+                    delattr(manager_class, late_attribute)
 
     def test_iter(self):
         # Test the __iter__ method

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -1,4 +1,5 @@
 from django.test import TestCase, override_settings
+from typing import ClassVar
 from general_manager.bootstrap import (
     InvalidPermissionClassError,
     check_permission_class,
@@ -16,6 +17,7 @@ from general_manager.permission.manager_based_permission import (
 )
 from unittest.mock import Mock, patch
 from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.cache.signals import post_data_change, pre_data_change
 from django.contrib.auth import get_user_model
 from django.utils.crypto import get_random_string
@@ -147,6 +149,30 @@ class GeneralManagerTestCase(TestCase):
         TemporaryManager.Permission = ManagerBasedPermission  # type: ignore
         return TemporaryManager
 
+    def _temporary_trusted_orm_manager_class(self):
+        manager_class = self._temporary_manager_class()
+
+        class TrustedInterface:
+            calls: ClassVar[list[tuple[object, object | None]]] = []
+
+            def __init__(self, pk=None, search_date=None):
+                self.identification = {"id": pk}
+                self.pk = pk
+                self._search_date = search_date
+
+            @classmethod
+            def _from_trusted_orm_instance(cls, instance, *, search_date=None):
+                cls.calls.append((instance, search_date))
+                interface = cls()
+                interface.identification = {"id": instance.pk}
+                interface.pk = instance.pk
+                interface._search_date = search_date
+                interface._instance = instance
+                return interface
+
+        manager_class.Interface = TrustedInterface  # type: ignore[assignment]
+        return manager_class, TrustedInterface
+
     def test_temporary_manager_class_does_not_register_graphql_interface(self):
         pending_graphql_interfaces = list(GeneralManagerMeta.pending_graphql_interfaces)
 
@@ -231,6 +257,91 @@ class GeneralManagerTestCase(TestCase):
             ("TemporaryManager", "identification", '{"id": "trusted_id"}'),
             dependencies,
         )
+
+    def test_trusted_orm_hydration_reuses_manager_within_run_context(self):
+        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
+        row = Mock(pk="trusted_id")
+
+        with CalculationRunContext():
+            first = manager_class._from_trusted_orm_instance(row)
+            second = manager_class._from_trusted_orm_instance(row)
+
+        self.assertIs(second, first)
+        self.assertEqual(len(trusted_interface.calls), 1)
+
+    def test_trusted_orm_hydration_does_not_reuse_manager_outside_run_context(self):
+        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
+        row = Mock(pk="trusted_id")
+
+        first = manager_class._from_trusted_orm_instance(row)
+        second = manager_class._from_trusted_orm_instance(row)
+
+        self.assertIsNot(second, first)
+        self.assertEqual(len(trusted_interface.calls), 2)
+
+    def test_trusted_orm_hydration_does_not_reuse_custom_init_manager(self):
+        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
+
+        with override_settings(AUTOCREATE_GRAPHQL=False):
+
+            class CustomInitManager(manager_class):
+                init_calls = 0
+
+                def __init__(self, *args, **kwargs):
+                    type(self).init_calls += 1
+                    super().__init__(*args, **kwargs)
+
+        CustomInitManager._attributes = dict(manager_class._attributes)
+        CustomInitManager.Interface = trusted_interface  # type: ignore[assignment]
+        CustomInitManager.Permission = ManagerBasedPermission  # type: ignore[assignment]
+        row = Mock(pk="trusted_id")
+
+        with CalculationRunContext():
+            first = CustomInitManager._from_trusted_orm_instance(row)
+            second = CustomInitManager._from_trusted_orm_instance(row)
+
+        self.assertIsNot(second, first)
+        self.assertEqual(CustomInitManager.init_calls, 2)
+        self.assertEqual(trusted_interface.calls, [])
+
+    def test_trusted_orm_hydration_replays_dependency_on_run_cache_hit(self):
+        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
+        row = Mock(pk="trusted_id")
+
+        with CalculationRunContext():
+            first = manager_class._from_trusted_orm_instance(row)
+            with DependencyTracker() as dependencies:
+                second = manager_class._from_trusted_orm_instance(row)
+
+        self.assertIs(second, first)
+        self.assertEqual(len(trusted_interface.calls), 1)
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "trusted_id"}'),
+            dependencies,
+        )
+
+    def test_trusted_orm_hydration_bypasses_identity_map_for_unhashable_pk(self):
+        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
+        row = Mock(pk=["trusted_id"])
+
+        with CalculationRunContext():
+            first = manager_class._from_trusted_orm_instance(row)
+            second = manager_class._from_trusted_orm_instance(row)
+
+        self.assertIsNot(second, first)
+        self.assertEqual(len(trusted_interface.calls), 2)
+
+    def test_trusted_orm_hydration_clears_identity_map_with_orm_bucket_results(self):
+        manager_class, trusted_interface = self._temporary_trusted_orm_manager_class()
+        row = Mock(pk="trusted_id")
+
+        with CalculationRunContext() as context:
+            first = manager_class._from_trusted_orm_instance(row)
+            context.clear_orm_bucket_results()
+            second = manager_class._from_trusted_orm_instance(row)
+
+        self.assertIsNot(second, first)
+        self.assertEqual(len(trusted_interface.calls), 2)
 
     def test_check_permission_class_defaults_to_additive_permission(self):
         """Managers without an explicit Permission should default to AdditiveManagerPermission."""

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -15,6 +15,7 @@ from general_manager.permission.manager_based_permission import (
     ManagerBasedPermission,
 )
 from unittest.mock import Mock, patch
+from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.signals import post_data_change, pre_data_change
 from django.contrib.auth import get_user_model
 from django.utils.crypto import get_random_string
@@ -133,6 +134,7 @@ class GeneralManagerTestCase(TestCase):
         """
         post_data_change.disconnect(self.post_data_change)
         pre_data_change.disconnect(self.pre_data_change)
+        DependencyTracker.reset_thread_local_storage()
 
     def _temporary_manager_class(self):
         with override_settings(AUTOCREATE_GRAPHQL=False):
@@ -163,11 +165,72 @@ class GeneralManagerTestCase(TestCase):
 
         Asserts that DependencyTracker.track is called with the correct arguments and that the created object is an instance of GeneralManager.
         """
-        manager = self.manager()
+        with DependencyTracker():
+            manager = self.manager()
         mock_track.assert_called_once_with(
             "GeneralManager", "identification", '{"id": "dummy_id"}'
         )
         self.assertIsInstance(manager, GeneralManager)
+
+    def test_manager_init_does_not_serialize_identifier_without_dependency_tracker(
+        self,
+    ):
+        with patch(
+            "general_manager.manager.general_manager.serialize_dependency_identifier",
+            side_effect=AssertionError("serialization should be skipped"),
+        ):
+            self.manager("dummy_id")
+
+    def test_manager_init_serializes_identifier_with_dependency_tracker(self):
+        with DependencyTracker() as dependencies:
+            self.manager("dummy_id")
+
+        self.assertIn(
+            ("GeneralManager", "identification", '{"id": "dummy_id"}'),
+            dependencies,
+        )
+
+    def test_trusted_orm_hydration_does_not_serialize_without_dependency_tracker(self):
+        manager_class = self._temporary_manager_class()
+
+        class TrustedInterface:
+            @classmethod
+            def _from_trusted_orm_instance(cls, instance, *, search_date=None):
+                interface = cls()
+                interface.identification = {"id": instance.pk}
+                return interface
+
+        manager_class.Interface = TrustedInterface  # type: ignore[assignment]
+        row = Mock(pk="trusted_id")
+
+        with patch(
+            "general_manager.manager.general_manager.serialize_dependency_identifier",
+            side_effect=AssertionError("serialization should be skipped"),
+        ):
+            manager = manager_class._from_trusted_orm_instance(row)
+
+        self.assertEqual(manager.identification, {"id": "trusted_id"})
+
+    def test_trusted_orm_hydration_serializes_identifier_with_dependency_tracker(self):
+        manager_class = self._temporary_manager_class()
+
+        class TrustedInterface:
+            @classmethod
+            def _from_trusted_orm_instance(cls, instance, *, search_date=None):
+                interface = cls()
+                interface.identification = {"id": instance.pk}
+                return interface
+
+        manager_class.Interface = TrustedInterface  # type: ignore[assignment]
+        row = Mock(pk="trusted_id")
+
+        with DependencyTracker() as dependencies:
+            manager_class._from_trusted_orm_instance(row)
+
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "trusted_id"}'),
+            dependencies,
+        )
 
     def test_check_permission_class_defaults_to_additive_permission(self):
         """Managers without an explicit Permission should default to AdditiveManagerPermission."""

--- a/tests/unit/test_logging_observability_capability.py
+++ b/tests/unit/test_logging_observability_capability.py
@@ -472,3 +472,46 @@ def test_logging_observability_omits_missing_error_status_code() -> None:
 
     context = fake_logger.error.call_args.kwargs["context"]
     assert "status_code" not in context
+
+
+def test_logging_observability_skips_context_when_debug_disabled() -> None:
+    fake_logger = mock.MagicMock()
+    fake_logger.isEnabledFor.return_value = False
+    with mock.patch(
+        "general_manager.interface.capabilities.core.observability.get_logger",
+        return_value=fake_logger,
+    ):
+        capability = LoggingObservabilityCapability()
+
+    target = object()
+    payload = {"expensive": object()}
+
+    with mock.patch.object(capability, "_context", side_effect=AssertionError):
+        capability.before_operation(operation="filter", target=target, payload=payload)
+        capability.after_operation(
+            operation="filter",
+            target=target,
+            payload=payload,
+            result=object(),
+        )
+
+    fake_logger.debug.assert_not_called()
+
+
+def test_logging_observability_still_builds_error_context() -> None:
+    fake_logger = mock.MagicMock()
+    fake_logger.isEnabledFor.return_value = False
+    with mock.patch(
+        "general_manager.interface.capabilities.core.observability.get_logger",
+        return_value=fake_logger,
+    ):
+        capability = LoggingObservabilityCapability()
+
+    capability.on_error(
+        operation="filter",
+        target=object(),
+        payload={"id": 1},
+        error=ValueError("boom"),
+    )
+
+    fake_logger.error.assert_called_once()

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -101,6 +101,12 @@ class MeasurementTestCase(TestCase):
         self.assertEqual(converted.unit, "degree_Fahrenheit")
         self.assertAlmostEqual(float(converted.magnitude), 77.0)
 
+    def test_offset_unit_from_string_conversion(self):
+        converted = Measurement.from_string("25 degC").to("degF")
+
+        self.assertEqual(converted.unit, "degree_Fahrenheit")
+        self.assertAlmostEqual(float(converted.magnitude), 77.0)
+
     def test_offset_unit_comparison(self):
         self.assertEqual(Measurement(25, "degC"), Measurement(298.15, "K"))
 

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -115,6 +115,52 @@ class MeasurementTestCase(TestCase):
         self.assertTrue(freezing_f <= freezing_c)
         self.assertTrue(freezing_f >= freezing_c)
 
+    def test_unit_uses_offset_cache_preserves_temperature_behavior(self):
+        from general_manager.measurement.measurement import _unit_uses_offset
+
+        _unit_uses_offset.cache_clear()
+
+        self.assertTrue(_unit_uses_offset("degC"))
+        first = _unit_uses_offset.cache_info()
+        self.assertTrue(_unit_uses_offset("degC"))
+        second = _unit_uses_offset.cache_info()
+
+        self.assertEqual(second.hits, first.hits + 1)
+
+    def test_unit_uses_offset_cache_preserves_pint_unit_input(self):
+        from general_manager.measurement.measurement import _unit_uses_offset
+
+        _unit_uses_offset.cache_clear()
+
+        self.assertTrue(_unit_uses_offset(ureg.degC))
+        first = _unit_uses_offset.cache_info()
+        self.assertTrue(_unit_uses_offset(ureg.degC))
+        second = _unit_uses_offset.cache_info()
+
+        self.assertEqual(second.hits, first.hits + 1)
+
+    def test_unit_uses_offset_cache_preserves_non_offset_behavior(self):
+        from general_manager.measurement.measurement import _unit_uses_offset
+
+        _unit_uses_offset.cache_clear()
+
+        self.assertFalse(_unit_uses_offset("kg"))
+        self.assertFalse(_unit_uses_offset("kg"))
+        self.assertGreaterEqual(_unit_uses_offset.cache_info().hits, 1)
+
+    def test_unit_uses_offset_cache_preserves_quantity_input(self):
+        from general_manager.measurement.measurement import _unit_uses_offset
+
+        _unit_uses_offset.cache_clear()
+        quantity = Measurement(25, "degC").quantity
+
+        self.assertTrue(_unit_uses_offset(quantity))
+        first = _unit_uses_offset.cache_info()
+        self.assertTrue(_unit_uses_offset(quantity))
+        second = _unit_uses_offset.cache_info()
+
+        self.assertEqual(second.hits, first.hits + 1)
+
     def test_addition_same_units(self):
         m1 = Measurement(1, "meter")
         m2 = Measurement(2, "meter")


### PR DESCRIPTION
## Summary

- Cache framework metadata used in hot calculation paths: interface input parsing plans, manager descriptor initialization state, primitive dependency serialization, and Pint offset-unit checks.
- Skip dependency identifier serialization when no dependency tracker is active and avoid disabled-debug observability work.
- Reverted the experimental trusted ORM manager identity map after review found stale ORM-row semantics risk.

## Performance

KnowledgeHub project revenue benchmark on `move-to-new-general-manager`, mounted against this GeneralManager branch:

- Baseline cold cProfile: `28.520s / 88.468s` GM internal time, `32.2%`.
- Final cold cProfile: `25.052s / 73.615s` GM internal time, `34.0%`.
- Revenue unchanged: `-5009896.15`.
- Calculation rows unchanged: `432`.
- Immediate hot dependency-cache run after warm-up: `0.181s`.

## Validation

- `python -m pytest tests/unit/test_base_interface.py tests/unit/test_logging_observability_capability.py tests/unit/test_general_manager.py tests/unit/test_cache_tracker.py tests/unit/test_dependency_matching.py tests/unit/test_measurement.py tests/unit/test_cache_decorator.py tests/unit/test_make_cache_key.py -q` -> `254 passed, 12 subtests passed`
- `python -m pytest tests/integration/test_database_manager.py tests/integration/test_graphql_dependency_cache_prefetch.py -q` -> `63 passed`
- `ruff check` on touched source/test files -> passed
- `mypy src/general_manager` -> passed

## Notes

The local worktree still has unstaged exploratory hot-cache changes in GraphQL permission caching, dependency-cache hit replay, and `inspect.signature()` caching. They were not staged or included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster, more reliable interface input parsing with cached planning, `_id` alias support, dependency-aware input ordering, and clearer validation for missing/unexpected inputs.
  * Added an easy way to determine whether dependency tracking is currently active.

* **Bug Fixes**
  * Reduced unnecessary dependency tracking during manager initialization and trusted-ORM hydration when tracking is inactive.
  * Improved operation observability performance by skipping debug context building when debug logging is disabled.
  * More consistent dependency value serialization and faster repeated unit offset checks.

* **Tests**
  * Expanded unit coverage for input-plan caching/aliasing/circular dependencies, dependency tracking activity, serialization contracts, logging behavior, and measurement unit offset caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->