### PR TITLE
[codex] Add dataframe measurement import/export helpers

### DIFF
--- a/docs/api/dataframes.md
+++ b/docs/api/dataframes.md
@@ -1,0 +1,9 @@
+# Dataframes API
+
+`general_manager.dataframes` re-exports `expand_measurements`,
+`collapse_measurements`, `to_dataframe`, `from_dataframe`,
+`DataFrameMeasurementError`, `InvalidDataFrameMeasurementValueError`,
+`MeasurementDataFrameColumnCollisionError`,
+`MissingMeasurementDataFrameColumnError`, and `PandasNotInstalledError`.
+
+::: general_manager.dataframes.measurements

--- a/docs/howto/dataframe_measurements.md
+++ b/docs/howto/dataframe_measurements.md
@@ -1,0 +1,88 @@
+# Import and Export Measurements with Dataframes
+
+Use `general_manager.dataframes` when tabular data includes `Measurement`
+values. The helpers expand measurements into explicit value and unit columns so
+CSV, spreadsheet, and dataframe workflows do not need object-valued measurement
+columns.
+
+## Expand Measurements
+
+```python
+from general_manager.dataframes import expand_measurements
+from general_manager.measurement import Measurement
+
+rows = [
+    {"name": "Alice", "height": Measurement(180, "cm")},
+    {"name": "Bob", "height": "170 cm"},
+]
+
+expanded = expand_measurements(rows, measurement_fields={"height"})
+```
+
+`expanded` contains:
+
+```python
+from decimal import Decimal
+
+[
+    {"name": "Alice", "height_value": Decimal("180"), "height_unit": "centimeter"},
+    {"name": "Bob", "height_value": Decimal("170"), "height_unit": "centimeter"},
+]
+```
+
+Units use Pint's canonical unit names through `Measurement.unit`.
+
+## Parse Strings Intentionally
+
+Strings are parsed with `Measurement.from_string()` only when their field is
+listed in `measurement_fields`.
+
+```python
+expand_measurements(
+    [{"height": "180 cm", "age": "31"}],
+    measurement_fields={"height"},
+)
+```
+
+This expands `height` and leaves `age` unchanged. This avoids treating ordinary
+numeric strings as dimensionless measurements.
+
+## Collapse Measurement Columns
+
+```python
+from decimal import Decimal
+
+from general_manager.dataframes import collapse_measurements
+
+rows = collapse_measurements(
+    [{"height_value": Decimal("180"), "height_unit": "centimeter"}],
+    measurement_fields={"height"},
+)
+```
+
+The result is:
+
+```python
+from general_manager.measurement import Measurement
+
+[{"height": Measurement(180, "centimeter")}]
+```
+
+`collapse_measurements()` requires both `<field>_value` and `<field>_unit`
+columns for every listed measurement field. If both generated columns are null,
+the collapsed measurement is `None`.
+
+## Use Pandas When Available
+
+`to_dataframe()` imports pandas lazily. Pandas is not a GeneralManager runtime
+dependency, so projects that do not install pandas can keep using
+`expand_measurements()` and `collapse_measurements()`.
+
+```python
+from general_manager.dataframes import from_dataframe, to_dataframe
+
+df = to_dataframe(rows, measurement_fields={"height"})
+rows = from_dataframe(df, measurement_fields={"height"})
+```
+
+If pandas is not installed, `to_dataframe()` raises `PandasNotInstalledError`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
       - howto/create_project.md
       - howto/custom_user_model.md
       - howto/add_model_with_measurement.md
+      - howto/dataframe_measurements.md
       - howto/add_permission_rule.md
       - howto/permission_walkthrough.md
       - howto/expose_via_graphql.md
@@ -157,6 +158,7 @@ nav:
   - API-Reference:
       - api/core.md
       - api/measurement.md
+      - api/dataframes.md
       - api/interface.md
       - api/permission.md
       - api/graphql.md

--- a/src/general_manager/_types/dataframes.py
+++ b/src/general_manager/_types/dataframes.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Type-only imports for public API re-exports."""
+
+__all__ = [
+    "DataFrameMeasurementError",
+    "InvalidDataFrameMeasurementValueError",
+    "MeasurementDataFrameColumnCollisionError",
+    "MissingMeasurementDataFrameColumnError",
+    "PandasNotInstalledError",
+    "collapse_measurements",
+    "expand_measurements",
+    "from_dataframe",
+    "to_dataframe",
+]
+
+from general_manager.dataframes.measurements import DataFrameMeasurementError
+from general_manager.dataframes.measurements import (
+    InvalidDataFrameMeasurementValueError,
+)
+from general_manager.dataframes.measurements import (
+    MeasurementDataFrameColumnCollisionError,
+)
+from general_manager.dataframes.measurements import (
+    MissingMeasurementDataFrameColumnError,
+)
+from general_manager.dataframes.measurements import PandasNotInstalledError
+from general_manager.dataframes.measurements import collapse_measurements
+from general_manager.dataframes.measurements import expand_measurements
+from general_manager.dataframes.measurements import from_dataframe
+from general_manager.dataframes.measurements import to_dataframe

--- a/src/general_manager/dataframes/__init__.py
+++ b/src/general_manager/dataframes/__init__.py
@@ -1,0 +1,29 @@
+"""Dataframe import/export helpers for GeneralManager values."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from general_manager.public_api_registry import DATAFRAME_EXPORTS
+from general_manager.utils.public_api import build_module_dir, resolve_export
+
+__all__ = list(DATAFRAME_EXPORTS)
+
+_MODULE_MAP = DATAFRAME_EXPORTS
+
+if TYPE_CHECKING:
+    from general_manager._types.dataframes import *  # noqa: F403
+
+
+def __getattr__(name: str) -> object:
+    """Dynamically resolve dataframe helper exports."""
+    return resolve_export(
+        name,
+        module_all=__all__,
+        module_map=_MODULE_MAP,
+        module_globals=globals(),
+    )
+
+
+def __dir__() -> list[str]:
+    return build_module_dir(module_all=__all__, module_globals=globals())

--- a/src/general_manager/dataframes/measurements.py
+++ b/src/general_manager/dataframes/measurements.py
@@ -57,7 +57,9 @@ def expand_measurements(
     """Expand Measurement values in mapping-like rows into value/unit columns."""
 
     copied_rows = [dict(row) for row in rows]
-    explicit_fields = _ordered_unique(measurement_fields or ())
+    explicit_fields = _ordered_unique(
+        () if measurement_fields is None else measurement_fields
+    )
     inferred_fields = _infer_measurement_fields(copied_rows)
     expanded_fields = _ordered_unique((*explicit_fields, *inferred_fields))
     if not expanded_fields:

--- a/src/general_manager/dataframes/measurements.py
+++ b/src/general_manager/dataframes/measurements.py
@@ -6,6 +6,8 @@ from collections.abc import Iterable, Mapping
 from decimal import Decimal, InvalidOperation
 import math
 
+import pint
+
 from general_manager.measurement import Measurement
 
 Row = Mapping[str, object]
@@ -43,11 +45,17 @@ class InvalidDataFrameMeasurementValueError(DataFrameMeasurementError):
 
 
 class MeasurementDataFrameColumnCollisionError(DataFrameMeasurementError):
-    """Raised when generated measurement columns would overwrite row data."""
+    """Raised when measurement expansion or collapse would overwrite row data."""
 
-    def __init__(self, field: str, generated_field: str) -> None:
+    def __init__(
+        self,
+        field: str,
+        generated_field: str,
+        *,
+        operation: str = "Expanding",
+    ) -> None:
         super().__init__(
-            "Expanding measurement field "
+            f"{operation} measurement field "
             f"{field!r} would overwrite existing column {generated_field!r}."
         )
 
@@ -204,6 +212,12 @@ def _collapse_row(
             raise MissingMeasurementDataFrameColumnError(value_field)
         if unit_field not in row:
             raise MissingMeasurementDataFrameColumnError(unit_field)
+        if field in row:
+            raise MeasurementDataFrameColumnCollisionError(
+                field,
+                field,
+                operation="Collapsing",
+            )
 
     collapsed_row: MutableRow = {}
     for column, value in row.items():
@@ -268,7 +282,18 @@ def _build_collapsed_measurement(
             field,
             value_type=type(value).__name__,
         ) from error
-    return Measurement(magnitude, unit)
+    try:
+        return Measurement(magnitude, unit)
+    except pint.errors.PintError as error:
+        raise InvalidDataFrameMeasurementValueError(
+            field,
+            value_type=type(unit).__name__,
+        ) from error
+    except (TypeError, ValueError) as error:
+        raise InvalidDataFrameMeasurementValueError(
+            field,
+            value_type=type(value).__name__,
+        ) from error
 
 
 def _is_null_measurement_value(value: object) -> bool:

--- a/src/general_manager/dataframes/measurements.py
+++ b/src/general_manager/dataframes/measurements.py
@@ -16,7 +16,6 @@ Row = Mapping[str, object]
 MutableRow = dict[str, object]
 
 __all__ = [
-    "DataFrameLike",
     "DataFrameMeasurementError",
     "InvalidDataFrameMeasurementValueError",
     "MeasurementDataFrameColumnCollisionError",

--- a/src/general_manager/dataframes/measurements.py
+++ b/src/general_manager/dataframes/measurements.py
@@ -165,8 +165,8 @@ def to_dataframe(
 ) -> Any:
     """Expand measurement values and build a pandas DataFrame."""
 
-    pandas = _import_pandas()
     expanded_rows = expand_measurements(rows, measurement_fields=measurement_fields)
+    pandas = _import_pandas()
     return pandas.DataFrame(expanded_rows, **dataframe_kwargs)
 
 

--- a/src/general_manager/dataframes/measurements.py
+++ b/src/general_manager/dataframes/measurements.py
@@ -1,0 +1,176 @@
+"""Helpers for expanding row-level Measurement values into dataframe columns."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+import math
+
+from general_manager.measurement import Measurement
+
+Row = Mapping[str, object]
+MutableRow = dict[str, object]
+
+__all__ = [
+    "DataFrameMeasurementError",
+    "InvalidDataFrameMeasurementValueError",
+    "MeasurementDataFrameColumnCollisionError",
+    "expand_measurements",
+]
+
+
+class DataFrameMeasurementError(ValueError):
+    """Base error for dataframe measurement expansion failures."""
+
+
+class InvalidDataFrameMeasurementValueError(DataFrameMeasurementError):
+    """Raised when a configured measurement field contains an invalid value."""
+
+    def __init__(
+        self,
+        field: str,
+        *,
+        value_type: str | None = None,
+        allows_strings: bool = False,
+    ) -> None:
+        expected = "Measurement values or nulls"
+        if allows_strings:
+            expected = "Measurement values, parseable measurement strings, or nulls"
+        details = f"; got {value_type}" if value_type else ""
+        super().__init__(f"Field {field!r} must contain {expected}{details}.")
+
+
+class MeasurementDataFrameColumnCollisionError(DataFrameMeasurementError):
+    """Raised when generated measurement columns would overwrite row data."""
+
+    def __init__(self, field: str, generated_field: str) -> None:
+        super().__init__(
+            "Expanding measurement field "
+            f"{field!r} would overwrite existing column {generated_field!r}."
+        )
+
+
+def expand_measurements(
+    rows: Iterable[Row],
+    *,
+    measurement_fields: Iterable[str] | None = None,
+) -> list[MutableRow]:
+    """Expand Measurement values in mapping-like rows into value/unit columns."""
+
+    copied_rows = [dict(row) for row in rows]
+    explicit_fields = _ordered_unique(measurement_fields or ())
+    inferred_fields = _infer_measurement_fields(copied_rows)
+    expanded_fields = _ordered_unique((*explicit_fields, *inferred_fields))
+    if not expanded_fields:
+        return copied_rows
+
+    _check_generated_column_collisions(copied_rows, expanded_fields)
+    explicit_field_names = set(explicit_fields)
+    expanded_field_names = set(expanded_fields)
+    return [
+        _expand_row(
+            row,
+            expanded_fields=expanded_fields,
+            expanded_field_names=expanded_field_names,
+            explicit_field_names=explicit_field_names,
+        )
+        for row in copied_rows
+    ]
+
+
+def _ordered_unique(fields: Iterable[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered_fields: list[str] = []
+    for field in fields:
+        if field in seen:
+            continue
+        seen.add(field)
+        ordered_fields.append(field)
+    return tuple(ordered_fields)
+
+
+def _infer_measurement_fields(rows: Iterable[Row]) -> tuple[str, ...]:
+    return _ordered_unique(
+        field
+        for row in rows
+        for field, value in row.items()
+        if isinstance(value, Measurement)
+    )
+
+
+def _check_generated_column_collisions(
+    rows: Iterable[Row], measurement_fields: Iterable[str]
+) -> None:
+    for field in measurement_fields:
+        generated_fields = _generated_field_names(field)
+        for row in rows:
+            for generated_field in generated_fields:
+                if generated_field in row and generated_field != field:
+                    raise MeasurementDataFrameColumnCollisionError(
+                        field, generated_field
+                    )
+
+
+def _generated_field_names(field: str) -> tuple[str, str]:
+    return (f"{field}_value", f"{field}_unit")
+
+
+def _expand_row(
+    row: Row,
+    *,
+    expanded_fields: tuple[str, ...],
+    expanded_field_names: set[str],
+    explicit_field_names: set[str],
+) -> MutableRow:
+    expanded_row: MutableRow = {}
+    seen_measurement_fields: set[str] = set()
+
+    for field, value in row.items():
+        if field not in expanded_field_names:
+            expanded_row[field] = value
+            continue
+
+        seen_measurement_fields.add(field)
+        value_field, unit_field = _generated_field_names(field)
+        measurement = _coerce_measurement_value(
+            field,
+            value,
+            explicit_field_names=explicit_field_names,
+        )
+        expanded_row[value_field] = (
+            measurement.magnitude if measurement is not None else None
+        )
+        expanded_row[unit_field] = measurement.unit if measurement is not None else None
+
+    for field in expanded_fields:
+        if field in seen_measurement_fields:
+            continue
+        value_field, unit_field = _generated_field_names(field)
+        expanded_row[value_field] = None
+        expanded_row[unit_field] = None
+
+    return expanded_row
+
+
+def _coerce_measurement_value(
+    field: str,
+    value: object,
+    *,
+    explicit_field_names: set[str],
+) -> Measurement | None:
+    if _is_null_measurement_value(value):
+        return None
+    if isinstance(value, Measurement):
+        return value
+    if isinstance(value, str) and field in explicit_field_names:
+        try:
+            return Measurement.from_string(value)
+        except ValueError as error:
+            raise InvalidDataFrameMeasurementValueError(
+                field, allows_strings=True
+            ) from error
+
+    raise InvalidDataFrameMeasurementValueError(field, value_type=type(value).__name__)
+
+
+def _is_null_measurement_value(value: object) -> bool:
+    return value is None or (isinstance(value, float) and math.isnan(value))

--- a/src/general_manager/dataframes/measurements.py
+++ b/src/general_manager/dataframes/measurements.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from decimal import Decimal, InvalidOperation
 import math
 
 from general_manager.measurement import Measurement
@@ -14,6 +15,8 @@ __all__ = [
     "DataFrameMeasurementError",
     "InvalidDataFrameMeasurementValueError",
     "MeasurementDataFrameColumnCollisionError",
+    "MissingMeasurementDataFrameColumnError",
+    "collapse_measurements",
     "expand_measurements",
 ]
 
@@ -49,6 +52,15 @@ class MeasurementDataFrameColumnCollisionError(DataFrameMeasurementError):
         )
 
 
+class MissingMeasurementDataFrameColumnError(DataFrameMeasurementError):
+    """Raised when a generated measurement column is required but absent."""
+
+    def __init__(self, column: str) -> None:
+        super().__init__(
+            f"Collapsing measurement dataframe rows requires column {column!r}."
+        )
+
+
 def expand_measurements(
     rows: Iterable[Row],
     *,
@@ -76,6 +88,32 @@ def expand_measurements(
             explicit_field_names=explicit_field_names,
         )
         for row in copied_rows
+    ]
+
+
+def collapse_measurements(
+    rows: Iterable[Row],
+    *,
+    measurement_fields: Iterable[str],
+) -> list[MutableRow]:
+    """Collapse value/unit dataframe columns back into Measurement values."""
+
+    collapsed_fields = _ordered_unique(measurement_fields)
+    value_columns: dict[str, str] = {}
+    unit_columns: set[str] = set()
+    for field in collapsed_fields:
+        value_field, unit_field = _generated_field_names(field)
+        value_columns[value_field] = field
+        unit_columns.add(unit_field)
+
+    return [
+        _collapse_row(
+            dict(row),
+            collapsed_fields=collapsed_fields,
+            value_columns=value_columns,
+            unit_columns=unit_columns,
+        )
+        for row in rows
     ]
 
 
@@ -153,6 +191,38 @@ def _expand_row(
     return expanded_row
 
 
+def _collapse_row(
+    row: MutableRow,
+    *,
+    collapsed_fields: tuple[str, ...],
+    value_columns: Mapping[str, str],
+    unit_columns: set[str],
+) -> MutableRow:
+    for field in collapsed_fields:
+        value_field, unit_field = _generated_field_names(field)
+        if value_field not in row:
+            raise MissingMeasurementDataFrameColumnError(value_field)
+        if unit_field not in row:
+            raise MissingMeasurementDataFrameColumnError(unit_field)
+
+    collapsed_row: MutableRow = {}
+    for column, value in row.items():
+        if column in value_columns:
+            field = value_columns[column]
+            _value_field, unit_field = _generated_field_names(field)
+            collapsed_row[field] = _build_collapsed_measurement(
+                field,
+                value,
+                row[unit_field],
+            )
+            continue
+        if column in unit_columns:
+            continue
+        collapsed_row[column] = value
+
+    return collapsed_row
+
+
 def _coerce_measurement_value(
     field: str,
     value: object,
@@ -172,6 +242,33 @@ def _coerce_measurement_value(
             ) from error
 
     raise InvalidDataFrameMeasurementValueError(field, value_type=type(value).__name__)
+
+
+def _build_collapsed_measurement(
+    field: str,
+    value: object,
+    unit: object,
+) -> Measurement | None:
+    value_is_null = _is_null_measurement_value(value)
+    unit_is_null = _is_null_measurement_value(unit)
+    if value_is_null and unit_is_null:
+        return None
+    if value_is_null or unit_is_null:
+        raise InvalidDataFrameMeasurementValueError(field)
+    if not isinstance(unit, str):
+        raise InvalidDataFrameMeasurementValueError(
+            field,
+            value_type=type(unit).__name__,
+        )
+
+    try:
+        magnitude = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as error:
+        raise InvalidDataFrameMeasurementValueError(
+            field,
+            value_type=type(value).__name__,
+        ) from error
+    return Measurement(magnitude, unit)
 
 
 def _is_null_measurement_value(value: object) -> bool:

--- a/src/general_manager/dataframes/measurements.py
+++ b/src/general_manager/dataframes/measurements.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from decimal import Decimal, InvalidOperation
+import importlib
 import math
+from typing import Any, Protocol
 
 import pint
 
@@ -14,17 +16,47 @@ Row = Mapping[str, object]
 MutableRow = dict[str, object]
 
 __all__ = [
+    "DataFrameLike",
     "DataFrameMeasurementError",
     "InvalidDataFrameMeasurementValueError",
     "MeasurementDataFrameColumnCollisionError",
     "MissingMeasurementDataFrameColumnError",
+    "PandasNotInstalledError",
     "collapse_measurements",
     "expand_measurements",
+    "from_dataframe",
+    "to_dataframe",
 ]
+
+
+class DataFrameLike(Protocol):
+    """Minimal dataframe interface needed to collapse measurement columns."""
+
+    def to_dict(self, orient: str = "dict") -> Any:
+        """Return dataframe rows as dictionaries."""
 
 
 class DataFrameMeasurementError(ValueError):
     """Base error for dataframe measurement expansion failures."""
+
+
+class PandasNotInstalledError(ImportError):
+    """Raised when pandas-specific dataframe helpers are used without pandas."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "pandas is required to create dataframes; install pandas to use "
+            "to_dataframe()."
+        )
+
+
+class _InvalidDataFrameRecordsError(TypeError):
+    """Raised when dataframe records are not list[Mapping[str, object]]."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "dataframe.to_dict(orient='records') must return a list of mapping rows."
+        )
 
 
 class InvalidDataFrameMeasurementValueError(DataFrameMeasurementError):
@@ -123,6 +155,48 @@ def collapse_measurements(
         )
         for row in rows
     ]
+
+
+def to_dataframe(
+    rows: Iterable[Row],
+    *,
+    measurement_fields: Iterable[str] | None = None,
+    **dataframe_kwargs: object,
+) -> Any:
+    """Expand measurement values and build a pandas DataFrame."""
+
+    pandas = _import_pandas()
+    expanded_rows = expand_measurements(rows, measurement_fields=measurement_fields)
+    return pandas.DataFrame(expanded_rows, **dataframe_kwargs)
+
+
+def from_dataframe(
+    dataframe: DataFrameLike,
+    *,
+    measurement_fields: Iterable[str],
+) -> list[MutableRow]:
+    """Collapse measurement value/unit columns from a dataframe-like object."""
+
+    records = dataframe.to_dict(orient="records")
+    if not isinstance(records, list):
+        raise _InvalidDataFrameRecordsError
+
+    row_records: list[Row] = []
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise _InvalidDataFrameRecordsError
+        row_records.append(record)
+
+    return collapse_measurements(row_records, measurement_fields=measurement_fields)
+
+
+def _import_pandas() -> Any:
+    try:
+        return importlib.import_module("pandas")
+    except ModuleNotFoundError as error:
+        if error.name != "pandas":
+            raise
+        raise PandasNotInstalledError from error
 
 
 def _ordered_unique(fields: Iterable[str]) -> tuple[str, ...]:

--- a/src/general_manager/dataframes/measurements.py
+++ b/src/general_manager/dataframes/measurements.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Mapping
 from decimal import Decimal, InvalidOperation
 import importlib
 import math
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 import pint
 
@@ -370,4 +370,29 @@ def _build_collapsed_measurement(
 
 
 def _is_null_measurement_value(value: object) -> bool:
-    return value is None or (isinstance(value, float) and math.isnan(value))
+    if value is None:
+        return True
+    if _is_nan_like(value):
+        return True
+    return _is_pandas_null_sentinel(value)
+
+
+def _is_nan_like(value: object) -> bool:
+    try:
+        if math.isnan(cast(Any, value)):
+            return True
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        return bool(value != value)
+    except (TypeError, ValueError):
+        return False
+
+
+def _is_pandas_null_sentinel(value: object) -> bool:
+    value_type = type(value)
+    return value_type.__name__ in {
+        "NAType",
+        "NaTType",
+    } and value_type.__module__.startswith("pandas.")

--- a/src/general_manager/public_api_registry.py
+++ b/src/general_manager/public_api_registry.py
@@ -163,6 +163,40 @@ MEASUREMENT_EXPORTS: LazyExportMap = {
 }
 
 
+DATAFRAME_EXPORTS: LazyExportMap = {
+    "DataFrameMeasurementError": (
+        "general_manager.dataframes.measurements",
+        "DataFrameMeasurementError",
+    ),
+    "InvalidDataFrameMeasurementValueError": (
+        "general_manager.dataframes.measurements",
+        "InvalidDataFrameMeasurementValueError",
+    ),
+    "MeasurementDataFrameColumnCollisionError": (
+        "general_manager.dataframes.measurements",
+        "MeasurementDataFrameColumnCollisionError",
+    ),
+    "MissingMeasurementDataFrameColumnError": (
+        "general_manager.dataframes.measurements",
+        "MissingMeasurementDataFrameColumnError",
+    ),
+    "PandasNotInstalledError": (
+        "general_manager.dataframes.measurements",
+        "PandasNotInstalledError",
+    ),
+    "collapse_measurements": (
+        "general_manager.dataframes.measurements",
+        "collapse_measurements",
+    ),
+    "expand_measurements": (
+        "general_manager.dataframes.measurements",
+        "expand_measurements",
+    ),
+    "from_dataframe": ("general_manager.dataframes.measurements", "from_dataframe"),
+    "to_dataframe": ("general_manager.dataframes.measurements", "to_dataframe"),
+}
+
+
 UTILS_EXPORTS: LazyExportMap = {
     "none_to_zero": ("general_manager.utils.none_to_zero", "none_to_zero"),
     "args_to_kwargs": ("general_manager.utils.args_to_kwargs", "args_to_kwargs"),
@@ -541,6 +575,7 @@ EXPORT_REGISTRY: Mapping[str, LazyExportMap] = {
     "general_manager.api": API_EXPORTS,
     "general_manager.factory": FACTORY_EXPORTS,
     "general_manager.measurement": MEASUREMENT_EXPORTS,
+    "general_manager.dataframes": DATAFRAME_EXPORTS,
     "general_manager.utils": UTILS_EXPORTS,
     "general_manager.permission": PERMISSION_EXPORTS,
     "general_manager.interface": INTERFACE_EXPORTS,

--- a/tests/snapshots/public_api_exports.json
+++ b/tests/snapshots/public_api_exports.json
@@ -247,6 +247,44 @@
       "serialize_dependency_identifier"
     ]
   },
+  "general_manager.dataframes": {
+    "DataFrameMeasurementError": [
+      "general_manager.dataframes.measurements",
+      "DataFrameMeasurementError"
+    ],
+    "InvalidDataFrameMeasurementValueError": [
+      "general_manager.dataframes.measurements",
+      "InvalidDataFrameMeasurementValueError"
+    ],
+    "MeasurementDataFrameColumnCollisionError": [
+      "general_manager.dataframes.measurements",
+      "MeasurementDataFrameColumnCollisionError"
+    ],
+    "MissingMeasurementDataFrameColumnError": [
+      "general_manager.dataframes.measurements",
+      "MissingMeasurementDataFrameColumnError"
+    ],
+    "PandasNotInstalledError": [
+      "general_manager.dataframes.measurements",
+      "PandasNotInstalledError"
+    ],
+    "collapse_measurements": [
+      "general_manager.dataframes.measurements",
+      "collapse_measurements"
+    ],
+    "expand_measurements": [
+      "general_manager.dataframes.measurements",
+      "expand_measurements"
+    ],
+    "from_dataframe": [
+      "general_manager.dataframes.measurements",
+      "from_dataframe"
+    ],
+    "to_dataframe": [
+      "general_manager.dataframes.measurements",
+      "to_dataframe"
+    ]
+  },
   "general_manager.factory": {
     "AutoFactory": [
       "general_manager.factory.auto_factory",

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -63,7 +63,7 @@ def test_expand_measurements_does_not_parse_unconfigured_strings() -> None:
 
 
 def test_expand_measurements_rejects_mixed_inferred_measurement_values() -> None:
-    rows = [
+    rows: list[dict[str, object]] = [
         {"name": "Alice", "height": Measurement(180, "cm")},
         {"name": "Bob", "height": "170 cm"},
     ]
@@ -76,7 +76,7 @@ def test_expand_measurements_rejects_mixed_inferred_measurement_values() -> None
 
 
 def test_expand_measurements_expands_nulls_for_measurement_fields() -> None:
-    rows = [
+    rows: list[dict[str, object]] = [
         {"name": "Alice", "height": Measurement(180, "cm")},
         {"name": "Bob", "height": None},
         {"name": "Cara"},

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -80,6 +80,7 @@ def test_expand_measurements_expands_nulls_for_measurement_fields() -> None:
         {"name": "Alice", "height": Measurement(180, "cm")},
         {"name": "Bob", "height": None},
         {"name": "Cara"},
+        {"name": "Dana", "height": float("nan")},
     ]
 
     assert expand_measurements(rows) == [
@@ -90,6 +91,7 @@ def test_expand_measurements_expands_nulls_for_measurement_fields() -> None:
         },
         {"name": "Bob", "height_value": None, "height_unit": None},
         {"name": "Cara", "height_value": None, "height_unit": None},
+        {"name": "Dana", "height_value": None, "height_unit": None},
     ]
 
 

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import numpy as np
 
 import general_manager.dataframes.measurements as dataframe_measurements
 from general_manager.dataframes.measurements import (
@@ -356,6 +357,38 @@ def test_from_dataframe_collapses_records() -> None:
 
     assert from_dataframe(dataframe, measurement_fields={"height"}) == [
         {"height": Measurement(180, "centimeter")}
+    ]
+
+
+def test_from_dataframe_collapses_numpy_null_measurement_columns() -> None:
+    dataframe = FakeDataFrame(
+        [
+            {"height_value": np.float64("nan"), "height_unit": np.float64("nan")},
+            {
+                "height_value": np.datetime64("NaT"),
+                "height_unit": np.datetime64("NaT"),
+            },
+        ]
+    )
+
+    assert from_dataframe(dataframe, measurement_fields={"height"}) == [
+        {"height": None},
+        {"height": None},
+    ]
+
+
+def test_from_dataframe_collapses_pandas_null_measurement_columns() -> None:
+    pandas: Any = pytest.importorskip("pandas")
+    dataframe = FakeDataFrame(
+        [
+            {"height_value": pandas.NA, "height_unit": pandas.NA},
+            {"height_value": pandas.NaT, "height_unit": pandas.NaT},
+        ]
+    )
+
+    assert from_dataframe(dataframe, measurement_fields={"height"}) == [
+        {"height": None},
+        {"height": None},
     ]
 
 

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from general_manager.dataframes.measurements import (
+    InvalidDataFrameMeasurementValueError,
+    MeasurementDataFrameColumnCollisionError,
+    expand_measurements,
+)
+from general_manager.measurement import Measurement
+
+
+def test_expand_measurements_splits_measurement_objects() -> None:
+    rows = [
+        {"name": "Alice", "height": Measurement(180, "cm"), "age": 31},
+        {"name": "Bob", "height": Measurement(170, "cm"), "age": 29},
+    ]
+
+    assert expand_measurements(rows) == [
+        {
+            "name": "Alice",
+            "height_value": Decimal("180"),
+            "height_unit": "centimeter",
+            "age": 31,
+        },
+        {
+            "name": "Bob",
+            "height_value": Decimal("170"),
+            "height_unit": "centimeter",
+            "age": 29,
+        },
+    ]
+
+
+def test_expand_measurements_parses_configured_measurement_strings() -> None:
+    rows = [
+        {"name": "Alice", "height": "180 cm"},
+        {"name": "Bob", "height": "1.7 m"},
+    ]
+
+    assert expand_measurements(rows, measurement_fields={"height"}) == [
+        {
+            "name": "Alice",
+            "height_value": Decimal("180"),
+            "height_unit": "centimeter",
+        },
+        {
+            "name": "Bob",
+            "height_value": Decimal("1.7"),
+            "height_unit": "meter",
+        },
+    ]
+
+
+def test_expand_measurements_does_not_parse_unconfigured_strings() -> None:
+    rows = [{"name": "Alice", "height": "180 cm", "age": "31"}]
+
+    assert expand_measurements(rows) == [
+        {"name": "Alice", "height": "180 cm", "age": "31"}
+    ]
+
+
+def test_expand_measurements_rejects_mixed_inferred_measurement_values() -> None:
+    rows = [
+        {"name": "Alice", "height": Measurement(180, "cm")},
+        {"name": "Bob", "height": "170 cm"},
+    ]
+
+    with pytest.raises(InvalidDataFrameMeasurementValueError) as exc_info:
+        expand_measurements(rows)
+
+    assert "height" in str(exc_info.value)
+    assert "Measurement" in str(exc_info.value)
+
+
+def test_expand_measurements_expands_nulls_for_measurement_fields() -> None:
+    rows = [
+        {"name": "Alice", "height": Measurement(180, "cm")},
+        {"name": "Bob", "height": None},
+        {"name": "Cara"},
+    ]
+
+    assert expand_measurements(rows) == [
+        {
+            "name": "Alice",
+            "height_value": Decimal("180"),
+            "height_unit": "centimeter",
+        },
+        {"name": "Bob", "height_value": None, "height_unit": None},
+        {"name": "Cara", "height_value": None, "height_unit": None},
+    ]
+
+
+def test_expand_measurements_rejects_generated_column_collisions() -> None:
+    rows = [
+        {
+            "name": "Alice",
+            "height": Measurement(180, "cm"),
+            "height_value": 180,
+        }
+    ]
+
+    with pytest.raises(MeasurementDataFrameColumnCollisionError) as exc_info:
+        expand_measurements(rows)
+
+    assert "height_value" in str(exc_info.value)

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+import general_manager.dataframes.measurements as dataframe_measurements
 from general_manager.dataframes.measurements import (
     InvalidDataFrameMeasurementValueError,
     MeasurementDataFrameColumnCollisionError,
@@ -46,6 +47,10 @@ def test_dataframe_helpers_are_available_from_public_module() -> None:
 
     assert public_expand_measurements is expand_measurements
     assert public_collapse_measurements is collapse_measurements
+
+
+def test_dataframe_protocol_stays_internal() -> None:
+    assert "DataFrameLike" not in dataframe_measurements.__all__
 
 
 def test_expand_measurements_splits_measurement_objects() -> None:

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -291,6 +291,31 @@ def test_to_dataframe_uses_lazy_pandas_import(
     assert dataframe.kwargs == {"index": ["row-1"]}
 
 
+def test_to_dataframe_expands_before_importing_pandas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    imported_modules: list[str] = []
+
+    def fake_import_module(module_name: str) -> Any:
+        imported_modules.append(module_name)
+        raise AssertionError
+
+    monkeypatch.setattr(
+        "general_manager.dataframes.measurements.importlib.import_module",
+        fake_import_module,
+    )
+
+    with pytest.raises(InvalidDataFrameMeasurementValueError):
+        to_dataframe(
+            [
+                {"height": Measurement(180, "cm")},
+                {"height": "170 cm"},
+            ]
+        )
+
+    assert imported_modules == []
+
+
 def test_to_dataframe_reports_missing_pandas(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -9,10 +11,23 @@ from general_manager.dataframes.measurements import (
     InvalidDataFrameMeasurementValueError,
     MeasurementDataFrameColumnCollisionError,
     MissingMeasurementDataFrameColumnError,
+    PandasNotInstalledError,
     collapse_measurements,
     expand_measurements,
+    from_dataframe,
+    to_dataframe,
 )
 from general_manager.measurement import Measurement
+
+
+class FakeDataFrame:
+    def __init__(self, rows: list[dict[str, object]], **kwargs: object) -> None:
+        self.rows = rows
+        self.kwargs = kwargs
+
+    def to_dict(self, orient: str = "dict") -> list[dict[str, object]]:
+        assert orient == "records"
+        return self.rows
 
 
 class TruthinessDisabledIterable:
@@ -246,3 +261,79 @@ def test_collapse_measurements_requires_value_and_unit_columns() -> None:
         collapse_measurements(rows, measurement_fields={"height"})
 
     assert "height_unit" in str(exc_info.value)
+
+
+def test_to_dataframe_uses_lazy_pandas_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    imported_modules: list[str] = []
+
+    def fake_import_module(module_name: str) -> Any:
+        imported_modules.append(module_name)
+        return SimpleNamespace(DataFrame=FakeDataFrame)
+
+    monkeypatch.setattr(
+        "general_manager.dataframes.measurements.importlib.import_module",
+        fake_import_module,
+    )
+
+    dataframe = to_dataframe(
+        [{"height": Measurement(180, "cm")}],
+        measurement_fields={"height"},
+        index=["row-1"],
+    )
+
+    assert imported_modules == ["pandas"]
+    assert isinstance(dataframe, FakeDataFrame)
+    assert dataframe.rows == [
+        {"height_value": Decimal("180"), "height_unit": "centimeter"}
+    ]
+    assert dataframe.kwargs == {"index": ["row-1"]}
+
+
+def test_to_dataframe_reports_missing_pandas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_import_module(module_name: str) -> Any:
+        assert module_name == "pandas"
+        raise ModuleNotFoundError(name="pandas")
+
+    monkeypatch.setattr(
+        "general_manager.dataframes.measurements.importlib.import_module",
+        fake_import_module,
+    )
+
+    with pytest.raises(PandasNotInstalledError) as exc_info:
+        to_dataframe([{"height": Measurement(180, "cm")}])
+
+    assert "pandas" in str(exc_info.value)
+
+
+def test_from_dataframe_collapses_records() -> None:
+    dataframe = FakeDataFrame(
+        [{"height_value": Decimal("180"), "height_unit": "centimeter"}]
+    )
+
+    assert from_dataframe(dataframe, measurement_fields={"height"}) == [
+        {"height": Measurement(180, "centimeter")}
+    ]
+
+
+def test_from_dataframe_rejects_non_list_records() -> None:
+    class TupleRecordsDataFrame:
+        def to_dict(self, orient: str = "dict") -> tuple[dict[str, object], ...]:
+            assert orient == "records"
+            return ({"height_value": Decimal("180"), "height_unit": "centimeter"},)
+
+    with pytest.raises(TypeError, match="list"):
+        from_dataframe(TupleRecordsDataFrame(), measurement_fields={"height"})
+
+
+def test_from_dataframe_rejects_non_mapping_records() -> None:
+    class NonMappingRecordsDataFrame:
+        def to_dict(self, orient: str = "dict") -> list[object]:
+            assert orient == "records"
+            return [object()]
+
+    with pytest.raises(TypeError, match="mapping"):
+        from_dataframe(NonMappingRecordsDataFrame(), measurement_fields={"height"})

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -38,6 +38,16 @@ class TruthinessDisabledIterable:
         raise TypeError
 
 
+def test_dataframe_helpers_are_available_from_public_module() -> None:
+    from general_manager.dataframes import (
+        collapse_measurements as public_collapse_measurements,
+        expand_measurements as public_expand_measurements,
+    )
+
+    assert public_expand_measurements is expand_measurements
+    assert public_collapse_measurements is collapse_measurements
+
+
 def test_expand_measurements_splits_measurement_objects() -> None:
     rows = [
         {"name": "Alice", "height": Measurement(180, "cm"), "age": 31},

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -158,6 +158,22 @@ def test_collapse_measurements_rebuilds_measurement_objects() -> None:
     assert "height_unit" in rows[0]
 
 
+def test_collapse_measurements_rejects_existing_target_field_collision() -> None:
+    rows: list[dict[str, object]] = [
+        {
+            "name": "Alice",
+            "height": "raw",
+            "height_value": Decimal("180"),
+            "height_unit": "centimeter",
+        }
+    ]
+
+    with pytest.raises(MeasurementDataFrameColumnCollisionError) as exc_info:
+        collapse_measurements(rows, measurement_fields={"height"})
+
+    assert "height" in str(exc_info.value)
+
+
 def test_collapse_measurements_restores_null_measurements() -> None:
     rows: list[dict[str, object]] = [
         {
@@ -199,6 +215,21 @@ def test_collapse_measurements_rejects_non_string_units() -> None:
             "name": "Alice",
             "height_value": Decimal("180"),
             "height_unit": 1,
+        }
+    ]
+
+    with pytest.raises(InvalidDataFrameMeasurementValueError) as exc_info:
+        collapse_measurements(rows, measurement_fields={"height"})
+
+    assert "height" in str(exc_info.value)
+
+
+def test_collapse_measurements_rejects_invalid_unit_strings() -> None:
+    rows = [
+        {
+            "name": "Alice",
+            "height_value": Decimal("180"),
+            "height_unit": "not_a_real_unit",
         }
     ]
 

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from decimal import Decimal
 
 import pytest
@@ -10,6 +11,14 @@ from general_manager.dataframes.measurements import (
     expand_measurements,
 )
 from general_manager.measurement import Measurement
+
+
+class TruthinessDisabledIterable:
+    def __iter__(self) -> Iterator[str]:
+        return iter(["height"])
+
+    def __bool__(self) -> bool:
+        raise TypeError
 
 
 def test_expand_measurements_splits_measurement_objects() -> None:
@@ -52,6 +61,14 @@ def test_expand_measurements_parses_configured_measurement_strings() -> None:
             "height_unit": "meter",
         },
     ]
+
+
+def test_expand_measurements_accepts_truthiness_disabled_field_iterable() -> None:
+    rows = [{"height": "180 cm"}]
+
+    assert expand_measurements(
+        rows, measurement_fields=TruthinessDisabledIterable()
+    ) == [{"height_value": Decimal("180"), "height_unit": "centimeter"}]
 
 
 def test_expand_measurements_does_not_parse_unconfigured_strings() -> None:

--- a/tests/unit/test_dataframe_measurements.py
+++ b/tests/unit/test_dataframe_measurements.py
@@ -8,6 +8,8 @@ import pytest
 from general_manager.dataframes.measurements import (
     InvalidDataFrameMeasurementValueError,
     MeasurementDataFrameColumnCollisionError,
+    MissingMeasurementDataFrameColumnError,
+    collapse_measurements,
     expand_measurements,
 )
 from general_manager.measurement import Measurement
@@ -125,3 +127,91 @@ def test_expand_measurements_rejects_generated_column_collisions() -> None:
         expand_measurements(rows)
 
     assert "height_value" in str(exc_info.value)
+
+
+def test_collapse_measurements_rebuilds_measurement_objects() -> None:
+    rows = [
+        {
+            "name": "Alice",
+            "height_value": Decimal("180"),
+            "height_unit": "centimeter",
+            "age": 31,
+        },
+        {
+            "name": "Bob",
+            "height_value": Decimal("1.7"),
+            "height_unit": "meter",
+            "age": 29,
+        },
+    ]
+
+    collapsed = collapse_measurements(rows, measurement_fields={"height"})
+
+    assert list(collapsed[0]) == ["name", "height", "age"]
+    assert collapsed[0]["name"] == "Alice"
+    assert collapsed[0]["height"] == Measurement(180, "centimeter")
+    assert collapsed[0]["age"] == 31
+    assert collapsed[1]["name"] == "Bob"
+    assert collapsed[1]["height"] == Measurement("1.7", "meter")
+    assert collapsed[1]["age"] == 29
+    assert "height_value" in rows[0]
+    assert "height_unit" in rows[0]
+
+
+def test_collapse_measurements_restores_null_measurements() -> None:
+    rows: list[dict[str, object]] = [
+        {
+            "name": "Alice",
+            "height_value": None,
+            "height_unit": None,
+        },
+        {
+            "name": "Bob",
+            "height_value": float("nan"),
+            "height_unit": float("nan"),
+        },
+    ]
+
+    assert collapse_measurements(rows, measurement_fields={"height"}) == [
+        {"name": "Alice", "height": None},
+        {"name": "Bob", "height": None},
+    ]
+
+
+def test_collapse_measurements_rejects_partial_null_measurements() -> None:
+    rows = [
+        {
+            "name": "Alice",
+            "height_value": Decimal("180"),
+            "height_unit": None,
+        }
+    ]
+
+    with pytest.raises(InvalidDataFrameMeasurementValueError) as exc_info:
+        collapse_measurements(rows, measurement_fields={"height"})
+
+    assert "height" in str(exc_info.value)
+
+
+def test_collapse_measurements_rejects_non_string_units() -> None:
+    rows = [
+        {
+            "name": "Alice",
+            "height_value": Decimal("180"),
+            "height_unit": 1,
+        }
+    ]
+
+    with pytest.raises(InvalidDataFrameMeasurementValueError) as exc_info:
+        collapse_measurements(rows, measurement_fields={"height"})
+
+    assert "height" in str(exc_info.value)
+
+
+def test_collapse_measurements_requires_value_and_unit_columns() -> None:
+    rows = [{"name": "Alice", "height_value": Decimal("180")}]
+
+    with pytest.raises(MissingMeasurementDataFrameColumnError) as exc_info:
+        collapse_measurements(rows, measurement_fields={"height"})
+
+    assert "height_unit" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Add `general_manager.dataframes` helpers to expand `Measurement` values into `<field>_value` / `<field>_unit` row data and collapse those columns back into `Measurement` objects.
- Add optional lazy pandas wrappers via `to_dataframe()` and `from_dataframe()` without making pandas a runtime dependency.
- Register the public API, generated type exports, documentation, and mkdocs navigation.

## Behavior

- `Measurement` objects expand using `measurement.magnitude` and Pint canonical `measurement.unit`.
- Strings are parsed through `Measurement.from_string()` only for explicitly configured measurement fields.
- Null values are supported, generated-column collisions are rejected, and invalid collapse values use dataframe measurement errors.

## Validation

- `PYTHONPATH=src python -m pytest tests/unit/test_dataframe_measurements.py tests/unit/test_public_api_init_modules.py tests/docs/test_public_api_docs_coverage.py -q` -> 262 passed
- `ruff check src/general_manager/dataframes tests/unit/test_dataframe_measurements.py src/general_manager/public_api_registry.py`
- `ruff format --check src/general_manager/dataframes tests/unit/test_dataframe_measurements.py`
- `mypy src/general_manager/dataframes src/general_manager/public_api_registry.py tests/unit/test_dataframe_measurements.py`
- `mkdocs build --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dataframe helpers for working with measurement values, including expanding them into columns and collapsing them back.
  * Added support for converting to and from dataframe-compatible formats, with clearer behavior when the optional dataframe library is unavailable.

* **Documentation**
  * Added an API reference page for dataframe utilities.
  * Added a how-to guide with examples for using measurement values in dataframe workflows.

* **Tests**
  * Added coverage for measurement conversion behavior, error handling, and optional dataframe-library loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->