### PR TITLE
[codex] reduce cold-cache framework overhead

### DIFF
--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -27,6 +27,7 @@ QueryAnnotationCallable = Callable[
     models.QuerySet[models.Model],
 ]
 MAX_RUN_SCOPED_BUCKET_RESULT_ROWS = 1000
+_QUERY_SIGNATURE_NOT_COMPUTED = object()
 
 
 class DatabaseBucketTypeMismatchError(TypeError):
@@ -251,6 +252,79 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         self._sort_keys = sort_keys
         self._sort_reverse = sort_reverse
         self._run_scoped_cacheable = run_scoped_cacheable
+        self._query_signature_cache: tuple[Hashable, ...] | None | object = (
+            _QUERY_SIGNATURE_NOT_COMPUTED
+        )
+        self._trusted_query_signature: Hashable | None = None
+
+    def _set_trusted_query_signature(self, signature: Hashable | None) -> None:
+        """Set an internal non-SQL signature for framework-built querysets."""
+        self._trusted_query_signature = signature
+        self._query_signature_cache = _QUERY_SIGNATURE_NOT_COMPUTED
+
+    def _copy_for_run_context_reuse(self) -> DatabaseBucket[GeneralManagerType]:
+        """Return an unexposed bucket copy that reuses the same trusted queryset."""
+
+        bucket = self.__class__(
+            self._data,
+            self._manager_class,
+            self.filters,
+            self.excludes,
+            search_date=self._search_date,
+            sort_keys=self._sort_keys,
+            sort_reverse=self._sort_reverse,
+            run_scoped_cacheable=self._run_scoped_cacheable,
+        )
+        bucket._set_trusted_query_signature(self._trusted_query_signature)
+        return bucket
+
+    @staticmethod
+    def _freeze_trusted_signature_payload(value: object) -> Hashable:
+        if isinstance(value, Mapping):
+            return tuple(
+                (
+                    str(key),
+                    DatabaseBucket._freeze_trusted_signature_payload(item_value),
+                )
+                for key, item_value in sorted(
+                    value.items(),
+                    key=lambda item: str(item[0]),
+                )
+            )
+        if isinstance(value, (list, tuple)):
+            return tuple(
+                DatabaseBucket._freeze_trusted_signature_payload(item) for item in value
+            )
+        if isinstance(value, (set, frozenset)):
+            return tuple(
+                sorted(
+                    (
+                        DatabaseBucket._freeze_trusted_signature_payload(item)
+                        for item in value
+                    ),
+                    key=repr,
+                )
+            )
+        if isinstance(value, models.Model):
+            return ("model", value.__class__, value.pk)
+        try:
+            hash(value)
+        except TypeError:
+            return ("serialized", serialize_dependency_identifier(value))
+        return value
+
+    def _trusted_query_signature_with(
+        self,
+        operation: str,
+        kwargs: Mapping[str, object],
+    ) -> Hashable | None:
+        if self._trusted_query_signature is None:
+            return None
+        return (
+            self._trusted_query_signature,
+            operation,
+            self._freeze_trusted_signature_payload(kwargs),
+        )
 
     def __reduce__(self) -> str | tuple[object, ...]:
         """
@@ -365,27 +439,50 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             tuple[Hashable, ...] | None: Cache key components for equivalent
             queryset results, or ``None`` when reuse should be bypassed.
         """
+        if self._query_signature_cache is not _QUERY_SIGNATURE_NOT_COMPUTED:
+            return cast(tuple[Hashable, ...] | None, self._query_signature_cache)
         if not self._run_scoped_cacheable:
+            self._query_signature_cache = None
             return None
+        if self._trusted_query_signature is not None:
+            signature = (
+                self._manager_class,
+                self._data.model,
+                self._data.db,
+                "trusted",
+                self._trusted_query_signature,
+                self._search_date,
+                self._sort_keys,
+                self._sort_reverse,
+            )
+            self._query_signature_cache = signature
+            return signature
         query = self._data.query
         if not isinstance(query, Query):
+            self._query_signature_cache = None
             return None
         if query.select_for_update:
+            self._query_signature_cache = None
             return None
         if query.combinator:
+            self._query_signature_cache = None
             return None
         if query.distinct:
+            self._query_signature_cache = None
             return None
         if getattr(self._data, "_prefetch_related_lookups", ()):
+            self._query_signature_cache = None
             return None
         deferred_loading = getattr(query, "deferred_loading", None)
         if isinstance(deferred_loading, tuple) and deferred_loading[0]:
+            self._query_signature_cache = None
             return None
         try:
             sql, params = self._data.query.sql_with_params()
         except (EmptyResultSet, FieldError, TypeError, ValueError):
+            self._query_signature_cache = None
             return None
-        return (
+        signature = (
             self._manager_class,
             self._data.model,
             self._data.db,
@@ -395,6 +492,8 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             self._sort_keys,
             self._sort_reverse,
         )
+        self._query_signature_cache = signature
+        return signature
 
     def _bucket_index_source_signature(self) -> Hashable:
         """Return a queryset signature when safe, otherwise use object identity."""
@@ -501,6 +600,38 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             return None
         return cast(tuple[models.Model, ...], cached)
 
+    def _can_cache_run_scoped_managers(self) -> bool:
+        if self._manager_class.__init__ is not GeneralManager.__init__:
+            return False
+        return callable(
+            getattr(self._manager_class.Interface, "_from_trusted_orm_instance", None)
+        )
+
+    def _get_run_scoped_managers(self) -> tuple[GeneralManagerType, ...] | None:
+        """Load or reuse manager wrappers for a trusted row snapshot."""
+        if not self._can_cache_run_scoped_managers():
+            return None
+        context = current_calculation_run_context()
+        if context is None:
+            return None
+        signature = self._query_signature()
+        if signature is None:
+            return None
+        cached = context.get_orm_bucket_managers(signature)
+        if cached is not None:
+            managers = cast(tuple[GeneralManagerType, ...], cached)
+            for manager in managers:
+                self._manager_class._track_identification_dependency(
+                    manager.identification
+                )
+            return managers
+        rows = self._get_run_scoped_rows()
+        if rows is None:
+            return None
+        managers = tuple(self._build_manager_from_instance(row) for row in rows)
+        context.set_orm_bucket_managers(signature, managers)
+        return managers
+
     @staticmethod
     def _snapshot_get_primary_key(
         kwargs: Mapping[str, LookupValue],
@@ -576,6 +707,10 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             GeneralManagerType: Manager instance for each primary key in the queryset.
         """
         self._track_effective_dependencies()
+        managers = self._get_run_scoped_managers()
+        if managers is not None:
+            yield from managers
+            return
         rows = self._get_run_scoped_rows()
         if rows is not None:
             for row in rows:
@@ -782,7 +917,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             qs = qs.filter(pk__in=ids)
 
         merged_filter = self.__merge_filter_definitions(self.filters, **kwargs)
-        return self.__class__(
+        bucket = self.__class__(
             qs,
             self._manager_class,
             merged_filter,
@@ -792,6 +927,11 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             sort_reverse=self._sort_reverse,
             run_scoped_cacheable=self._run_scoped_cacheable,
         )
+        if not annotations and not python_filters:
+            bucket._set_trusted_query_signature(
+                self._trusted_query_signature_with("filter", orm_kwargs)
+            )
+        return bucket
 
     def exclude(self, **kwargs: LookupValue) -> DatabaseBucket[GeneralManagerType]:
         """
@@ -843,7 +983,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             qs = qs.exclude(pk__in=ids)
 
         merged_exclude = self.__merge_filter_definitions(self.excludes, **kwargs)
-        return self.__class__(
+        bucket = self.__class__(
             qs,
             self._manager_class,
             self.filters,
@@ -853,6 +993,11 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             sort_reverse=self._sort_reverse,
             run_scoped_cacheable=self._run_scoped_cacheable,
         )
+        if not annotations and not python_filters:
+            bucket._set_trusted_query_signature(
+                self._trusted_query_signature_with("exclude", orm_kwargs)
+            )
+        return bucket
 
     def first(self) -> GeneralManagerType | None:
         """
@@ -932,7 +1077,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         Returns:
             DatabaseBucket[GeneralManagerType]: Bucket encapsulating `self._data.all()`.
         """
-        return self.__class__(
+        bucket = self.__class__(
             self._data.all(),
             self._manager_class,
             self.filters,
@@ -942,6 +1087,8 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             sort_reverse=self._sort_reverse,
             run_scoped_cacheable=self._run_scoped_cacheable,
         )
+        bucket._set_trusted_query_signature(self._trusted_query_signature)
+        return bucket
 
     def get(self, **kwargs: LookupValue) -> GeneralManagerType:
         """
@@ -1026,6 +1173,32 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
                 raise ValueError
             return self._build_manager_from_primary_key(primary_keys[item])
         return self._build_manager_from_instance(self._data[item])
+
+    def __bool__(self) -> bool:
+        """
+        Return whether the bucket contains at least one row without counting all rows.
+
+        Truthiness is an existence check, not a cardinality request. Reuse any
+        active run-context snapshot first, then cache a queryset ``exists()``
+        result for equivalent trusted querysets in the same calculation run.
+        """
+        self._track_effective_dependencies()
+        rows = self._peek_run_scoped_rows()
+        if rows is not None:
+            return bool(rows)
+        primary_keys = self._peek_run_scoped_primary_keys()
+        if primary_keys is not None:
+            return bool(primary_keys)
+        context = current_calculation_run_context()
+        signature = self._query_signature() if context is not None else None
+        if context is not None and signature is not None:
+            cached = context.get_orm_bucket_exists(signature)
+            if cached is not None:
+                return bool(cached)
+        exists = bool(self._data.exists())
+        if context is not None and signature is not None:
+            context.set_orm_bucket_exists(signature, exists)
+        return exists
 
     def __len__(self) -> int:
         """
@@ -1169,7 +1342,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             except (FieldError, TypeError, ValueError) as error:
                 raise QuerysetOrderingError(error) from error
 
-        return self.__class__(
+        bucket = self.__class__(
             qs,
             self._manager_class,
             self.filters,
@@ -1179,6 +1352,9 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             sort_reverse=reverse,
             run_scoped_cacheable=self._run_scoped_cacheable,
         )
+        if not annotations and not python_keys:
+            bucket._set_trusted_query_signature(self._trusted_query_signature)
+        return bucket
 
     def none(self) -> DatabaseBucket[GeneralManagerType]:
         """
@@ -1193,4 +1369,6 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         """
         own = self.all()
         own._data = own._data.none()
+        own._query_signature_cache = _QUERY_SIGNATURE_NOT_COMPUTED
+        own._trusted_query_signature = None
         return own

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -28,6 +28,8 @@ QueryAnnotationCallable = Callable[
 ]
 MAX_RUN_SCOPED_BUCKET_RESULT_ROWS = 1000
 _QUERY_SIGNATURE_NOT_COMPUTED = object()
+_FIRST_ROW_CACHE_MISS = object()
+_FIRST_ROW_CACHE_NONE = object()
 
 
 class DatabaseBucketTypeMismatchError(TypeError):
@@ -659,21 +661,33 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             return kwargs["id"]
         return None
 
+    def _can_materialize_count_snapshot(self) -> bool:
+        """Return whether count/len may populate a bounded run-scoped snapshot."""
+        context = current_calculation_run_context()
+        if context is None:
+            return False
+        query = getattr(self._data, "query", None)
+        if not isinstance(query, Query):
+            return False
+        where = getattr(query, "where", None)
+        children = getattr(where, "children", None)
+        return bool(children)
+
     def _track_effective_dependencies(self) -> None:
         """Record the bucket's effective filter/exclude state when it is evaluated."""
         manager_name = self._manager_class.__name__
         normalized_filters = self._normalize_dependency_mapping(self.filters)
         normalized_excludes = self._normalize_dependency_mapping(self.excludes)
         if self.filters:
-            DependencyTracker.track(
+            DependencyTracker._track_validated(
                 manager_name,
                 "filter",
                 serialize_dependency_identifier(normalized_filters),
             )
         else:
-            DependencyTracker.track(manager_name, "all", "")
+            DependencyTracker._track_validated(manager_name, "all", "")
         if self.excludes:
-            DependencyTracker.track(
+            DependencyTracker._track_validated(
                 manager_name,
                 "exclude",
                 serialize_dependency_identifier(normalized_excludes),
@@ -685,7 +699,7 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
                     "excludes": normalized_excludes,
                     "reverse": self._sort_reverse,
                 }
-                DependencyTracker.track(
+                DependencyTracker._track_validated(
                     manager_name,
                     "filter",
                     serialize_dependency_identifier({f"__sort__{sort_key}": payload}),
@@ -1020,7 +1034,23 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             if not primary_keys:
                 return None
             return self._build_manager_from_primary_key(primary_keys[0])
+        context = current_calculation_run_context()
+        signature = self._query_signature() if context is not None else None
+        if context is not None and signature is not None:
+            cached = context.get_orm_bucket_first_row(
+                signature,
+                _FIRST_ROW_CACHE_MISS,
+            )
+            if cached is _FIRST_ROW_CACHE_NONE:
+                return None
+            if cached is not _FIRST_ROW_CACHE_MISS:
+                return self._build_manager_from_instance(cast(models.Model, cached))
         first_element = self._data.first()
+        if context is not None and signature is not None:
+            context.set_orm_bucket_first_row(
+                signature,
+                _FIRST_ROW_CACHE_NONE if first_element is None else first_element,
+            )
         if first_element is None:
             return None
         return self._build_manager_from_instance(first_element)
@@ -1062,6 +1092,10 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             int: Number of represented rows.
         """
         self._track_effective_dependencies()
+        if self._can_materialize_count_snapshot():
+            rows = self._get_run_scoped_rows()
+            if rows is not None:
+                return len(rows)
         primary_keys = self._peek_run_scoped_primary_keys()
         if primary_keys is not None:
             return len(primary_keys)
@@ -1204,17 +1238,13 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         """
         Return the number of rows represented by the bucket.
 
-        A safe run-scoped primary-key snapshot is reused when present; otherwise
-        this delegates to the queryset count.
+        Delegates to `count()` so dependency tracking, run-scoped snapshots, and
+        queryset fallback behavior stay aligned between both cardinality paths.
 
         Returns:
             int: Number of represented rows.
         """
-        self._track_effective_dependencies()
-        primary_keys = self._peek_run_scoped_primary_keys()
-        if primary_keys is not None:
-            return len(primary_keys)
-        return int(self._data.count())
+        return self.count()
 
     def __str__(self) -> str:
         """

--- a/src/general_manager/cache/cache_tracker.py
+++ b/src/general_manager/cache/cache_tracker.py
@@ -135,12 +135,20 @@ class DependencyTracker:
             raise _InvalidDependencyTrackerValueError
         if operation not in _SUPPORTED_OPERATIONS:
             raise _InvalidDependencyTrackerOperationError(operation)
+        DependencyTracker._track_validated(class_name, operation, identifier)
+
+    @staticmethod
+    def _track_validated(
+        class_name: general_manager_name,
+        operation: filter_type,
+        identifier: str,
+    ) -> None:
+        """Record an already-validated dependency tuple in active collectors."""
         if _dependency_storage.depth < 0:
             return
-        for dep_set in _dependency_storage.dependencies[
-            : _dependency_storage.depth + 1
-        ]:
-            dep_set.add((class_name, operation, identifier))
+        dependency = (class_name, operation, identifier)
+        for dep_set in _dependency_storage.dependencies:
+            dep_set.add(dependency)
 
     @staticmethod
     def is_active() -> bool:

--- a/src/general_manager/cache/dependency_cache.py
+++ b/src/general_manager/cache/dependency_cache.py
@@ -9,7 +9,8 @@ from typing import Protocol, TypeGuard, cast
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import Dependency
 
-DEPENDENCY_CACHE_ENTRY_VERSION = 1
+LEGACY_DEPENDENCY_CACHE_ENTRY_VERSION = 1
+DEPENDENCY_CACHE_ENTRY_VERSION = 2
 _VALID_DEPENDENCY_ACTIONS = frozenset(
     {"filter", "exclude", "identification", "request_query", "all"}
 )
@@ -258,10 +259,15 @@ def _combined_payload_to_hit(
 ) -> DependencyCacheHit | None | _MissingSentinel:
     if not isinstance(payload, DependencyCacheEntry):
         return None
-    if payload.version != DEPENDENCY_CACHE_ENTRY_VERSION:
-        return _MISSING
-    dependencies = _legacy_dependency_set(payload.dependencies)
-    if dependencies is None:
+    if payload.version == LEGACY_DEPENDENCY_CACHE_ENTRY_VERSION:
+        dependencies = _legacy_dependency_set(payload.dependencies)
+        if dependencies is None:
+            return _MISSING
+    elif payload.version == DEPENDENCY_CACHE_ENTRY_VERSION:
+        if not isinstance(payload.dependencies, frozenset):
+            return _MISSING
+        dependencies = payload.dependencies
+    else:
         return _MISSING
     return DependencyCacheHit(
         value=payload.value,

--- a/src/general_manager/cache/dependency_cache.py
+++ b/src/general_manager/cache/dependency_cache.py
@@ -264,6 +264,10 @@ def _combined_payload_to_hit(
         if dependencies is None:
             return _MISSING
     elif payload.version == DEPENDENCY_CACHE_ENTRY_VERSION:
+        # Legacy entries may contain arbitrary tuple-like data, so the
+        # _legacy_dependency_set path validates each dependency. Current entries
+        # come from make_dependency_cache_entry after that same validation flow,
+        # so keep deserialization on the frozenset type-check fast path.
         if not isinstance(payload.dependencies, frozenset):
             return _MISSING
         dependencies = payload.dependencies

--- a/src/general_manager/cache/dependency_matching.py
+++ b/src/general_manager/cache/dependency_matching.py
@@ -8,6 +8,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence, Set as AbstractSet
 from dataclasses import dataclass
 from datetime import date, datetime
+from json.encoder import encode_basestring_ascii
 from typing import Literal, Protocol, cast
 
 LookupOperator = Literal[
@@ -29,6 +30,8 @@ SCAN_OPERATORS = frozenset(
 )
 SUPPORTED_LOOKUP_OPERATORS = EXACT_OPERATORS | SCAN_OPERATORS
 UNDEFINED = object()
+_SCALAR_NORMALIZATION_MISS = object()
+_SCALAR_SERIALIZATION_MISS = object()
 
 
 type NormalizedDependencyValue = (
@@ -62,6 +65,47 @@ class SupportsDependencyComparison(Protocol):
         ...
 
 
+def _normalize_scalar_dependency_value(value: object) -> object:
+    """
+    Return the scalar-only equivalent of `normalize_dependency_value`.
+
+    This avoids the slower general path for simple scalars only, and its output
+    must remain equivalent to full normalization for every value it accepts.
+    """
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return _SCALAR_NORMALIZATION_MISS
+
+
+def _serialize_scalar_dependency_value(value: object) -> str | object:
+    """
+    Serialize simple scalars without the slower generic JSON path.
+
+    Outputs must remain equivalent to full normalization followed by
+    `json.dumps(..., sort_keys=True)`. Floats are intentionally excluded so the
+    caller can preserve Python's JSON spelling for finite and non-finite values.
+    """
+
+    if isinstance(value, str):
+        return encode_basestring_ascii(value)
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if type(value) is int:
+        return str(value)
+    if isinstance(value, date):
+        return encode_basestring_ascii(value.isoformat())
+    return _SCALAR_SERIALIZATION_MISS
+
+
 @dataclass(frozen=True, slots=True)
 class LookupSpec:
     """Parsed dependency lookup path and operator."""
@@ -75,6 +119,11 @@ def normalize_dependency_value(value: object) -> NormalizedDependencyValue:
     """Return a deterministic JSON-compatible representation for dependency data."""
     if isinstance(value, Mapping):
         mapping = cast(Mapping[object, object], value)
+        if len(mapping) == 1:
+            key, val = next(iter(mapping.items()))
+            normalized_value = _normalize_scalar_dependency_value(val)
+            if normalized_value is not _SCALAR_NORMALIZATION_MISS:
+                return {str(key): cast(NormalizedDependencyValue, normalized_value)}
         return {
             str(key): normalize_dependency_value(val)
             for key, val in sorted(mapping.items(), key=lambda item: str(item[0]))
@@ -101,12 +150,24 @@ def normalize_dependency_value(value: object) -> NormalizedDependencyValue:
 
 def serialize_normalized_value(value: object) -> str:
     """Serialize dependency values in the canonical dependency format."""
-    if isinstance(value, str):
+    serialized_scalar = _serialize_scalar_dependency_value(value)
+    if serialized_scalar is not _SCALAR_SERIALIZATION_MISS:
+        return cast(str, serialized_scalar)
+    if isinstance(value, float):
         return json.dumps(value)
-    if value is None or isinstance(value, (int, float, bool)):
-        return json.dumps(value)
-    if isinstance(value, date):
-        return json.dumps(value.isoformat())
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[object, object], value)
+        if len(mapping) == 1:
+            key, val = next(iter(mapping.items()))
+            normalized_value = _normalize_scalar_dependency_value(val)
+            serialized_value = _serialize_scalar_dependency_value(normalized_value)
+            if serialized_value is not _SCALAR_SERIALIZATION_MISS:
+                return (
+                    "{"
+                    f"{encode_basestring_ascii(str(key))}: "
+                    f"{cast(str, serialized_value)}"
+                    "}"
+                )
     return json.dumps(normalize_dependency_value(value), sort_keys=True)
 
 

--- a/src/general_manager/cache/dependency_shards.py
+++ b/src/general_manager/cache/dependency_shards.py
@@ -13,6 +13,7 @@ import hashlib
 from collections.abc import Iterable, Mapping
 from collections import defaultdict
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Literal
 
 from django.core.cache import cache
@@ -377,6 +378,7 @@ def clear_legacy_dependency_index() -> set[str]:
     return cache_keys
 
 
+@lru_cache(maxsize=16384)
 def _shard_keys_for_dependency(
     manager_name: str,
     action: DependencyAction,

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -28,12 +28,16 @@ _active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
 ORM_BUCKET_RESULT_PREFIX = "orm_bucket_result"
 ORM_BUCKET_ROW_RESULT_PREFIX = "orm_bucket_row_result"
 ORM_BUCKET_MANAGER_RESULT_PREFIX = "orm_bucket_manager_result"
+ORM_BUCKET_FIRST_ROW_PREFIX = "orm_bucket_first_row"
+ORM_MODEL_ROW_INDEX_PREFIX = "orm_model_row_index"
+ORM_MODEL_RELATION_PREFETCH_PREFIX = "orm_model_relation_prefetch"
 ORM_QUERY_BUCKET_PREFIX = "orm_query_bucket"
 ORM_BUCKET_EXISTS_PREFIX = "orm_bucket_exists"
 BUCKET_INDEX_PREFIX = "bucket_index"
 TRUSTED_ORM_MANAGER_PREFIX = "trusted_orm_manager"
 DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE = 1000
 logger = get_logger("cache.run_context")
+OrmModelRowKey = tuple[Hashable, Hashable | None]
 
 
 @dataclass(frozen=True)
@@ -298,6 +302,118 @@ class CalculationRunContext:
     def set_orm_bucket_rows(self, key: Hashable, value: object) -> None:
         """Store or overwrite ORM bucket rows for the active run."""
         self.set((ORM_BUCKET_ROW_RESULT_PREFIX, key), value)
+        self._index_orm_model_rows(value)
+
+    @staticmethod
+    def _orm_model_row_key(row: object) -> OrmModelRowKey | None:
+        """Return a stable per-run key for a Django ORM row, if possible."""
+        pk = getattr(row, "pk", None)
+        try:
+            hash(pk)
+        except TypeError:
+            return None
+        state = getattr(row, "_state", None)
+        db = getattr(state, "db", None)
+        try:
+            hash(db)
+        except TypeError:
+            return None
+        return (cast(Hashable, pk), cast(Hashable | None, db))
+
+    @staticmethod
+    def _orm_model_index_classes(row: object) -> tuple[type[object], ...]:
+        """Return model classes under which an ORM row should be indexed."""
+        meta = getattr(row, "_meta", None)
+        if meta is None:
+            return ()
+        row_class = row.__class__
+        concrete_model = getattr(meta, "concrete_model", None)
+        if (
+            isinstance(concrete_model, type)
+            and issubclass(row_class, concrete_model)
+            and concrete_model is not row_class
+        ):
+            return (row_class, concrete_model)
+        return (row_class,)
+
+    def _index_orm_model_rows(self, rows: object) -> None:
+        """Index cached ORM rows by model/database/primary key for relation reuse."""
+        if not isinstance(rows, tuple):
+            return
+        for row in rows:
+            row_key = self._orm_model_row_key(row)
+            if row_key is None:
+                continue
+            for model_class in self._orm_model_index_classes(row):
+                cache_key = (ORM_MODEL_ROW_INDEX_PREFIX, model_class)
+                index = self.get(cache_key)
+                if not isinstance(index, dict):
+                    index = {}
+                    self.set(cache_key, index)
+                index[row_key] = row
+
+    def get_orm_model_row(
+        self,
+        model: type[object],
+        primary_key: Hashable,
+        database_alias: Hashable | None,
+        default: object = None,
+    ) -> object:
+        """Return an indexed ORM row by model/database/primary key, if present."""
+        index = self.get((ORM_MODEL_ROW_INDEX_PREFIX, model))
+        if not isinstance(index, dict):
+            return default
+        return index.get((primary_key, database_alias), default)
+
+    def get_orm_model_row_items(
+        self,
+        model: type[object],
+    ) -> tuple[tuple[OrmModelRowKey, object], ...]:
+        """Return indexed ORM row items for `model` in insertion order."""
+        index = self.get((ORM_MODEL_ROW_INDEX_PREFIX, model))
+        if not isinstance(index, dict):
+            return ()
+        return tuple(cast("dict[OrmModelRowKey, object]", index).items())
+
+    def get_orm_model_relation_prefetched_keys(
+        self,
+        model: type[object],
+        database_alias: Hashable | None,
+        accessor_name: str,
+    ) -> frozenset[OrmModelRowKey]:
+        """Return row keys already prefetched for one model relation."""
+        prefetched = self.get(
+            (
+                ORM_MODEL_RELATION_PREFETCH_PREFIX,
+                model,
+                database_alias,
+                accessor_name,
+            )
+        )
+        if isinstance(prefetched, frozenset):
+            return cast(frozenset[OrmModelRowKey], prefetched)
+        return frozenset()
+
+    def add_orm_model_relation_prefetched_keys(
+        self,
+        model: type[object],
+        database_alias: Hashable | None,
+        accessor_name: str,
+        row_keys: Iterable[OrmModelRowKey],
+    ) -> None:
+        """Record row keys whose relation has been prefetched in this run."""
+        cache_key = (
+            ORM_MODEL_RELATION_PREFETCH_PREFIX,
+            model,
+            database_alias,
+            accessor_name,
+        )
+        prefetched = self.get_orm_model_relation_prefetched_keys(
+            model,
+            database_alias,
+            accessor_name,
+        )
+        self.set(cache_key, prefetched | frozenset(row_keys))
 
     def get_orm_bucket_managers(self, key: Hashable) -> object:
         """Return cached ORM bucket managers for key, or `None` when absent."""
@@ -306,6 +422,18 @@ class CalculationRunContext:
     def set_orm_bucket_managers(self, key: Hashable, value: object) -> None:
         """Store or overwrite ORM bucket managers for the active run."""
         self.set((ORM_BUCKET_MANAGER_RESULT_PREFIX, key), value)
+
+    def get_orm_bucket_first_row(
+        self,
+        key: Hashable,
+        default: object = None,
+    ) -> object:
+        """Return a cached ORM first-row result, or default when absent."""
+        return self.get((ORM_BUCKET_FIRST_ROW_PREFIX, key), default)
+
+    def set_orm_bucket_first_row(self, key: Hashable, value: object) -> None:
+        """Store or overwrite an ORM first-row result for the active run."""
+        self.set((ORM_BUCKET_FIRST_ROW_PREFIX, key), value)
 
     def get_orm_query_bucket(self, key: Hashable) -> object:
         """Return a cached constructed ORM query bucket, or `None` when absent."""
@@ -328,6 +456,9 @@ class CalculationRunContext:
         self.discard_prefix((ORM_BUCKET_RESULT_PREFIX,))
         self.discard_prefix((ORM_BUCKET_ROW_RESULT_PREFIX,))
         self.discard_prefix((ORM_BUCKET_MANAGER_RESULT_PREFIX,))
+        self.discard_prefix((ORM_BUCKET_FIRST_ROW_PREFIX,))
+        self.discard_prefix((ORM_MODEL_ROW_INDEX_PREFIX,))
+        self.discard_prefix((ORM_MODEL_RELATION_PREFETCH_PREFIX,))
         self.discard_prefix((ORM_QUERY_BUCKET_PREFIX,))
         self.discard_prefix((ORM_BUCKET_EXISTS_PREFIX,))
 
@@ -365,7 +496,7 @@ class CalculationRunContext:
         from general_manager.cache.cache_tracker import DependencyTracker
 
         for class_name, operation, identifier in entry.dependencies:
-            DependencyTracker.track(class_name, operation, identifier)
+            DependencyTracker._track_validated(class_name, operation, identifier)
         return entry.value
 
     def set_bucket_index_result(

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -27,7 +27,11 @@ _active_context: ContextVar["CalculationRunContext | None"] = ContextVar(
 )
 ORM_BUCKET_RESULT_PREFIX = "orm_bucket_result"
 ORM_BUCKET_ROW_RESULT_PREFIX = "orm_bucket_row_result"
+ORM_BUCKET_MANAGER_RESULT_PREFIX = "orm_bucket_manager_result"
+ORM_QUERY_BUCKET_PREFIX = "orm_query_bucket"
+ORM_BUCKET_EXISTS_PREFIX = "orm_bucket_exists"
 BUCKET_INDEX_PREFIX = "bucket_index"
+TRUSTED_ORM_MANAGER_PREFIX = "trusted_orm_manager"
 DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE = 1000
 logger = get_logger("cache.run_context")
 
@@ -295,10 +299,37 @@ class CalculationRunContext:
         """Store or overwrite ORM bucket rows for the active run."""
         self.set((ORM_BUCKET_ROW_RESULT_PREFIX, key), value)
 
+    def get_orm_bucket_managers(self, key: Hashable) -> object:
+        """Return cached ORM bucket managers for key, or `None` when absent."""
+        return self.get((ORM_BUCKET_MANAGER_RESULT_PREFIX, key))
+
+    def set_orm_bucket_managers(self, key: Hashable, value: object) -> None:
+        """Store or overwrite ORM bucket managers for the active run."""
+        self.set((ORM_BUCKET_MANAGER_RESULT_PREFIX, key), value)
+
+    def get_orm_query_bucket(self, key: Hashable) -> object:
+        """Return a cached constructed ORM query bucket, or `None` when absent."""
+        return self.get((ORM_QUERY_BUCKET_PREFIX, key))
+
+    def set_orm_query_bucket(self, key: Hashable, value: object) -> None:
+        """Store a constructed ORM query bucket for the active run."""
+        self.set((ORM_QUERY_BUCKET_PREFIX, key), value)
+
+    def get_orm_bucket_exists(self, key: Hashable) -> object:
+        """Return cached ORM bucket existence for key, or `None` when absent."""
+        return self.get((ORM_BUCKET_EXISTS_PREFIX, key))
+
+    def set_orm_bucket_exists(self, key: Hashable, value: bool) -> None:
+        """Store an ORM bucket existence result for the active run."""
+        self.set((ORM_BUCKET_EXISTS_PREFIX, key), value)
+
     def clear_orm_bucket_results(self) -> None:
         """Discard all run-scoped ORM bucket result entries."""
         self.discard_prefix((ORM_BUCKET_RESULT_PREFIX,))
         self.discard_prefix((ORM_BUCKET_ROW_RESULT_PREFIX,))
+        self.discard_prefix((ORM_BUCKET_MANAGER_RESULT_PREFIX,))
+        self.discard_prefix((ORM_QUERY_BUCKET_PREFIX,))
+        self.discard_prefix((ORM_BUCKET_EXISTS_PREFIX,))
 
     def _bucket_index_cache_key(
         self,
@@ -358,6 +389,10 @@ class CalculationRunContext:
     def clear_bucket_indexes(self) -> None:
         """Discard all run-scoped bucket index entries."""
         self.discard_prefix((BUCKET_INDEX_PREFIX,))
+
+    def clear_trusted_orm_managers(self) -> None:
+        """Discard run-scoped manager wrappers built from trusted ORM rows."""
+        self.discard_prefix((TRUSTED_ORM_MANAGER_PREFIX,))
 
     def has(self, key: Hashable) -> bool:
         """Return whether key has a value in the active run."""

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -93,6 +93,7 @@ def data_change(
         if context is not None:
             context.clear_orm_bucket_results()
             context.clear_bucket_indexes()
+            context.clear_trusted_orm_managers()
         try:
             action = func.__name__
             if func.__name__ == "create":
@@ -117,6 +118,12 @@ def data_change(
                 result = inner(*args, **kwargs)
             else:
                 result = func(*args, **kwargs)
+
+            context = current_calculation_run_context()
+            if context is not None:
+                context.clear_orm_bucket_results()
+                context.clear_bucket_indexes()
+                context.clear_trusted_orm_managers()
 
             instance = result
             identification = getattr(instance, "identification", None)

--- a/src/general_manager/interface/base_interface.py
+++ b/src/general_manager/interface/base_interface.py
@@ -69,6 +69,10 @@ type classPostCreationMethod = Callable[
     None,
 ]
 
+_SINGLE_INPUT_VALUE_CACHE_PREFIX = "interface_single_input_value"
+_SINGLE_INPUT_VALUE_CACHE_MISS = object()
+_RUN_SCOPED_SCALAR_INPUT_TYPES = (str, int, bool)
+
 
 class AttributeTypedDict(TypedDict):
     """Describe metadata captured for each interface attribute."""
@@ -665,6 +669,37 @@ class InterfaceBase(ABC):
             cls._input_dependency_order = ordered_names
         return ordered_names, unresolved
 
+    @classmethod
+    def _single_input_run_cache_key(
+        cls,
+        name: str,
+        input_field: "Input[type[object]]",
+        value: object,
+    ) -> tuple[object, ...] | None:
+        from general_manager.manager.input import Input as ManagerInput
+
+        if type(input_field) is not ManagerInput:
+            return None
+        if input_field.type not in _RUN_SCOPED_SCALAR_INPUT_TYPES:
+            return None
+        if type(value) is not input_field.type:
+            return None
+        if input_field.is_manager:
+            return None
+        if (
+            input_field.possible_values is not None
+            or input_field.min_value is not None
+            or input_field.max_value is not None
+            or input_field.validator is not None
+            or input_field.normalizer is not None
+        ):
+            return None
+        try:
+            hash(value)
+        except TypeError:
+            return None
+        return (_SINGLE_INPUT_VALUE_CACHE_PREFIX, cls, name, id(input_field), value)
+
     def parse_input_fields_to_identification(
         self,
         *args: object,
@@ -699,6 +734,45 @@ class InterfaceBase(ABC):
         """
         resolved_identification: dict[str, object] = {}
         plan = type(self)._get_input_parsing_plan()
+        if (
+            len(args) == 1
+            and not kwargs
+            and len(plan.names) == 1
+            and plan.required_names == plan.name_set
+            and plan.dependency_items[0][1] == ()
+        ):
+            name = plan.names[0]
+            input_field = self.input_fields[name]
+            cache_key = type(self)._single_input_run_cache_key(
+                name,
+                input_field,
+                args[0],
+            )
+            context = None
+            if cache_key is not None:
+                from general_manager.cache.run_context import (
+                    current_calculation_run_context,
+                )
+
+                context = current_calculation_run_context()
+                if context is not None:
+                    cached_value = context.get(
+                        cache_key,
+                        _SINGLE_INPUT_VALUE_CACHE_MISS,
+                    )
+                    if cached_value is not _SINGLE_INPUT_VALUE_CACHE_MISS:
+                        return {name: cached_value}
+            cache_context = type(self)._input_possible_values_cache_context(name)
+            value = input_field.cast(
+                args[0],
+                resolved_identification,
+                cache_context=cache_context,
+            )
+            self._process_input(name, value, resolved_identification)
+            if context is not None and cache_key is not None:
+                context.set(cache_key, value)
+            return {name: value}
+
         kwargs = args_to_kwargs(args, plan.names, kwargs)
 
         extra_args = set(kwargs) - plan.name_set

--- a/src/general_manager/interface/capabilities/orm/support.py
+++ b/src/general_manager/interface/capabilities/orm/support.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Hashable
 from datetime import date, datetime, time, timedelta
 from functools import lru_cache
-from typing import TYPE_CHECKING, Callable, ClassVar, Type, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Type, cast
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
@@ -42,6 +43,7 @@ if TYPE_CHECKING:  # pragma: no cover
 type OrmInterfaceClass = type["OrmInterfaceBase[models.Model]"]
 type OrmInterfaceInstance = "OrmInterfaceBase[models.Model]"
 type FilterKwargs = dict[str, object]
+_PayloadNormalizerType = PayloadNormalizer
 
 
 class OrmPersistenceSupportCapability(BaseCapability):
@@ -118,7 +120,13 @@ class OrmPersistenceSupportCapability(BaseCapability):
         Returns:
             PayloadNormalizer: A normalizer instance bound to the interface's Django `models.Model`.
         """
-        return PayloadNormalizer(interface_cls._model)
+        normalizer = getattr(interface_cls, "_payload_normalizer", None)
+        if not isinstance(normalizer, _PayloadNormalizerType) or (
+            normalizer.model is not interface_cls._model
+        ):
+            normalizer = PayloadNormalizer(interface_cls._model)
+            cast(Any, interface_cls)._payload_normalizer = normalizer
+        return normalizer
 
     def get_field_descriptors(
         self, interface_cls: OrmInterfaceClass
@@ -591,6 +599,57 @@ class OrmQueryCapability(BaseCapability):
     name: ClassVar[CapabilityName] = "query"
 
     @staticmethod
+    def _is_default_history_capability(history_handler: object) -> bool:
+        handler_type = type(history_handler)
+        return (
+            handler_type.__module__
+            == "general_manager.interface.capabilities.orm.history"
+            and handler_type.__name__ == "OrmHistoryCapability"
+        )
+
+    def _trusted_query_source_signature(
+        self,
+        interface_cls: OrmInterfaceClass,
+        support: OrmPersistenceSupportCapability,
+        *,
+        include_inactive: bool,
+        search_date: datetime | None,
+        historical: bool,
+        history_handler: object | None,
+        database_alias: str | None,
+    ) -> Hashable | None:
+        if type(support) is not OrmPersistenceSupportCapability:
+            return None
+        if historical and not self._is_default_history_capability(history_handler):
+            return None
+        return (
+            "orm-query-source-v1",
+            interface_cls,
+            interface_cls._parent_class,
+            interface_cls._model,
+            database_alias,
+            include_inactive,
+            is_soft_delete_enabled(interface_cls),
+            "historical" if historical else "live",
+            search_date,
+        )
+
+    def _trusted_query_signature(
+        self,
+        source_signature: Hashable | None,
+        *,
+        exclude: bool,
+        normalized_kwargs: FilterKwargs,
+    ) -> Hashable | None:
+        if source_signature is None:
+            return None
+        return (
+            source_signature,
+            "exclude" if exclude else "filter",
+            DatabaseBucket._freeze_trusted_signature_payload(normalized_kwargs),
+        )
+
+    @staticmethod
     def _ensure_search_date_input(search_date: object) -> None:
         if not isinstance(search_date, (datetime, date)):
             raise SearchDateInputError
@@ -627,7 +686,7 @@ class OrmQueryCapability(BaseCapability):
             include_flag, normalized, search_date = self._normalize_kwargs(
                 interface_cls, kwargs
             )
-            return self._build_bucket(
+            return self._build_or_reuse_bucket(
                 interface_cls,
                 include_inactive=include_flag,
                 normalized_kwargs=normalized,
@@ -670,7 +729,7 @@ class OrmQueryCapability(BaseCapability):
             include_flag, normalized, search_date = self._normalize_kwargs(
                 interface_cls, kwargs
             )
-            return self._build_bucket(
+            return self._build_or_reuse_bucket(
                 interface_cls,
                 include_inactive=include_flag,
                 normalized_kwargs=normalized,
@@ -722,6 +781,76 @@ class OrmQueryCapability(BaseCapability):
         normalized_kwargs = normalizer.normalize_filter_kwargs(translated_payload)
         return include_inactive, normalized_kwargs, search_date
 
+    def _run_scoped_query_bucket_signature(
+        self,
+        interface_cls: OrmInterfaceClass,
+        *,
+        include_inactive: bool,
+        normalized_kwargs: FilterKwargs,
+        exclude: bool,
+        search_date: datetime | None,
+    ) -> Hashable | None:
+        support = get_support_capability(interface_cls)
+        if support.__class__ is not OrmPersistenceSupportCapability:
+            return None
+        if search_date is not None and search_date <= timezone.now() - timedelta(
+            seconds=interface_cls.historical_lookup_buffer_seconds
+        ):
+            return None
+        queryset_base = (
+            support.get_manager(interface_cls, only_active=False).all()
+            if include_inactive
+            else support.get_queryset(interface_cls)
+        )
+        source_signature = self._trusted_query_source_signature(
+            interface_cls,
+            support,
+            include_inactive=include_inactive,
+            search_date=search_date,
+            historical=False,
+            history_handler=None,
+            database_alias=queryset_base.db,
+        )
+        return self._trusted_query_signature(
+            source_signature,
+            exclude=exclude,
+            normalized_kwargs=normalized_kwargs,
+        )
+
+    def _build_or_reuse_bucket(
+        self,
+        interface_cls: OrmInterfaceClass,
+        *,
+        include_inactive: bool,
+        normalized_kwargs: FilterKwargs,
+        exclude: bool = False,
+        search_date: datetime | None = None,
+    ) -> DatabaseBucket["GeneralManager"]:
+        cache_signature = self._run_scoped_query_bucket_signature(
+            interface_cls,
+            include_inactive=include_inactive,
+            normalized_kwargs=normalized_kwargs,
+            exclude=exclude,
+            search_date=search_date,
+        )
+        context = current_calculation_run_context()
+        if context is not None and cache_signature is not None:
+            cached = context.get_orm_query_bucket(cache_signature)
+            if isinstance(cached, DatabaseBucket):
+                return cached._copy_for_run_context_reuse()
+
+        bucket = self._build_bucket(
+            interface_cls,
+            include_inactive=include_inactive,
+            normalized_kwargs=normalized_kwargs,
+            exclude=exclude,
+            search_date=search_date,
+        )
+        if context is not None and cache_signature is not None:
+            context.set_orm_query_bucket(cache_signature, bucket)
+            return bucket._copy_for_run_context_reuse()
+        return bucket
+
     def _build_bucket(
         self,
         interface_cls: OrmInterfaceClass,
@@ -745,6 +874,8 @@ class OrmQueryCapability(BaseCapability):
         """
         support = get_support_capability(interface_cls)
         queryset_base = support.get_queryset(interface_cls)
+        historical = False
+        history_handler: object | None = None
         if include_inactive:
             queryset_base = cast(
                 models.QuerySet[models.Model],
@@ -766,18 +897,36 @@ class OrmQueryCapability(BaseCapability):
                 interface_cls,
                 search_date,
             )
+            historical = True
         queryset = (
             queryset_base.exclude(**normalized_kwargs)
             if exclude
             else queryset_base.filter(**normalized_kwargs)
         )
-        return DatabaseBucket(
+        bucket = DatabaseBucket(
             queryset,
             interface_cls._parent_class,
             {} if exclude else cast("dict[str, list[object]]", dict(normalized_kwargs)),
             cast("dict[str, list[object]]", dict(normalized_kwargs)) if exclude else {},
             search_date=search_date,
         )
+        source_signature = self._trusted_query_source_signature(
+            interface_cls,
+            support,
+            include_inactive=include_inactive,
+            search_date=search_date,
+            historical=historical,
+            history_handler=history_handler,
+            database_alias=queryset.db,
+        )
+        bucket._set_trusted_query_signature(
+            self._trusted_query_signature(
+                source_signature,
+                exclude=exclude,
+                normalized_kwargs=normalized_kwargs,
+            )
+        )
+        return bucket
 
 
 class SoftDeleteCapability(BaseCapability):

--- a/src/general_manager/interface/capabilities/orm/support.py
+++ b/src/general_manager/interface/capabilities/orm/support.py
@@ -120,11 +120,14 @@ class OrmPersistenceSupportCapability(BaseCapability):
         Returns:
             PayloadNormalizer: A normalizer instance bound to the interface's Django `models.Model`.
         """
+        normalizer_cls = PayloadNormalizer
         normalizer = getattr(interface_cls, "_payload_normalizer", None)
-        if not isinstance(normalizer, _PayloadNormalizerType) or (
-            normalizer.model is not interface_cls._model
+        if (
+            not isinstance(normalizer_cls, type)
+            or not isinstance(normalizer, normalizer_cls)
+            or (normalizer.model is not interface_cls._model)
         ):
-            normalizer = PayloadNormalizer(interface_cls._model)
+            normalizer = normalizer_cls(interface_cls._model)
             cast(Any, interface_cls)._payload_normalizer = normalizer
         return normalizer
 
@@ -530,6 +533,7 @@ def _translate_reverse_filter_aliases(
     return translated
 
 
+@lru_cache(maxsize=8192)
 def _translate_reverse_filter_key(model: type[models.Model], key: str) -> str:
     """Rewrite only relation-path segments that are known reverse aliases."""
     parts = key.split("__")
@@ -826,14 +830,16 @@ class OrmQueryCapability(BaseCapability):
         exclude: bool = False,
         search_date: datetime | None = None,
     ) -> DatabaseBucket["GeneralManager"]:
-        cache_signature = self._run_scoped_query_bucket_signature(
-            interface_cls,
-            include_inactive=include_inactive,
-            normalized_kwargs=normalized_kwargs,
-            exclude=exclude,
-            search_date=search_date,
-        )
         context = current_calculation_run_context()
+        cache_signature: Hashable | None = None
+        if context is not None:
+            cache_signature = self._run_scoped_query_bucket_signature(
+                interface_cls,
+                include_inactive=include_inactive,
+                normalized_kwargs=normalized_kwargs,
+                exclude=exclude,
+                search_date=search_date,
+            )
         if context is not None and cache_signature is not None:
             cached = context.get_orm_query_bucket(cache_signature)
             if isinstance(cached, DatabaseBucket):

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -6,13 +6,14 @@ from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 import re
-from typing import TYPE_CHECKING, Callable, Iterable, Protocol, cast
+from typing import TYPE_CHECKING, Callable, Hashable, Iterable, Protocol, cast
 from uuid import UUID
 
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
+from django.db.models.query import prefetch_related_objects
 
 from general_manager.interface.base_interface import AttributeTypedDict
 from general_manager.interface.utils.errors import DuplicateFieldNameError
@@ -758,6 +759,7 @@ def _instance_attribute_accessor(field_name: str) -> DescriptorAccessor:
 
 
 _MISSING_RELATED = object()
+_MANY_RELATION_PREFETCH_CHUNK_SIZE = 1000
 
 
 def _general_manager_accessor(
@@ -767,11 +769,18 @@ def _general_manager_accessor(
     raw_id_name: str | None = None,
 ) -> DescriptorAccessor:
     """
-    Create an accessor that resolves a related object's manager instance from a OrmInterfaceBase.
+    Create an accessor that resolves a related object's manager from an interface.
+
+    When `raw_id_name` is supplied, the accessor reads the raw foreign-key value
+    first and consults Django's internal `_state.fields_cache` only to reuse an
+    already-loaded related object. Loaded related rows are hydrated through
+    `_from_trusted_orm_instance` when the manager supports it; otherwise the
+    manager is constructed from the related object's primary key.
 
     Parameters:
         field_name (str): Name of the attribute on the underlying model that holds the related object.
-        manager_class (type): Class to instantiate with the related object's primary key to obtain its manager.
+        manager_class (type): Class used to hydrate or construct the related manager.
+        raw_id_name (str | None): Optional raw foreign-key attribute name used to avoid loading the relation.
 
     Returns:
         DescriptorAccessor: A callable that, given a OrmInterfaceBase, returns the manager instance for the related object, or `None` if the related attribute is `None`.
@@ -779,10 +788,16 @@ def _general_manager_accessor(
 
     def getter(self: OrmInterfaceInstance) -> object:
         """
-        Return a manager instance bound to the related object's primary key or None.
+        Return a manager for the related object without unnecessary ORM loads.
+
+        The raw-id path avoids fetching the relation unless Django already has
+        it in `_state.fields_cache`, which is an intentional internal-Django
+        optimization point. Cached or directly loaded related objects use
+        `_from_trusted_orm_instance` when available; otherwise the manager is
+        built from the primary key.
 
         Returns:
-            The value produced by calling `manager_class` with the related object's primary key, or `None` if the related object is `None`.
+            The related manager instance, or `None` if the related object is `None`.
         """
         manager_type = cast("type[GeneralManager]", manager_class)
         if raw_id_name is not None:
@@ -868,11 +883,20 @@ def _general_manager_many_accessor(
         Returns:
             A manager or queryset containing related model instances whose foreign-key fields equal this interface instance's primary key.
         """
+        manager_cls = cast("type[GeneralManager]", general_manager_class)
         if relation_filter_name is not None:
             filter_kwargs = {relation_filter_name: self.pk}
+            prefetched_bucket = _prefetched_general_manager_many_bucket(
+                self,
+                accessor_name=accessor_name,
+                relation_filter_name=relation_filter_name,
+                manager_cls=manager_cls,
+                source_model=source_model,
+            )
+            if prefetched_bucket is not None:
+                return prefetched_bucket
         else:
             filter_kwargs = {field.name: self.pk for field in related_fields}
-        manager_cls = cast("type[GeneralManager]", general_manager_class)
         if not filter_kwargs:
             raise MissingRelatedFieldsError(
                 accessor_name=accessor_name,
@@ -882,6 +906,138 @@ def _general_manager_many_accessor(
         return manager_cls.filter(**filter_kwargs)
 
     return getter
+
+
+def _orm_row_identity(row: object) -> tuple[Hashable, Hashable | None] | None:
+    pk = getattr(row, "pk", None)
+    try:
+        hash(pk)
+    except TypeError:
+        return None
+    state = getattr(row, "_state", None)
+    database_alias = getattr(state, "db", None)
+    try:
+        hash(database_alias)
+    except TypeError:
+        return None
+    return cast(Hashable, pk), cast(Hashable | None, database_alias)
+
+
+def _can_use_prefetched_general_manager_many_bucket(
+    manager_cls: type["GeneralManager"],
+    database_alias: Hashable | None,
+) -> bool:
+    interface_cls = manager_cls.Interface
+    interface_model = getattr(interface_cls, "_model", None)
+    configured_database = getattr(interface_cls, "database", None)
+    if configured_database is not None and configured_database != database_alias:
+        return False
+    meta = getattr(interface_model, "_meta", None)
+    if bool(getattr(meta, "use_soft_delete", False)):
+        return False
+    if bool(getattr(interface_cls, "_soft_delete_default", False)):
+        return False
+    return True
+
+
+def _prefetch_relation_in_chunks(
+    rows: list[models.Model],
+    accessor_name: str,
+) -> None:
+    for index in range(0, len(rows), _MANY_RELATION_PREFETCH_CHUNK_SIZE):
+        prefetch_related_objects(
+            rows[index : index + _MANY_RELATION_PREFETCH_CHUNK_SIZE],
+            accessor_name,
+        )
+
+
+def _prefetched_general_manager_many_bucket(
+    interface_instance: OrmInterfaceInstance,
+    *,
+    accessor_name: str,
+    relation_filter_name: str,
+    manager_cls: type["GeneralManager"],
+    source_model: type[models.Model],
+) -> object | None:
+    """Return a bucket backed by a run-scoped prefetched M2M relation."""
+    source_instance = getattr(interface_instance, "_instance", None)
+    if not isinstance(source_instance, source_model):
+        return None
+    source_identity = _orm_row_identity(source_instance)
+    if source_identity is None:
+        return None
+    source_primary_key, database_alias = source_identity
+    if not _can_use_prefetched_general_manager_many_bucket(
+        manager_cls,
+        database_alias,
+    ):
+        return None
+
+    from general_manager.bucket.database_bucket import DatabaseBucket
+    from general_manager.cache.run_context import current_calculation_run_context
+
+    context = current_calculation_run_context()
+    if context is None:
+        return None
+    indexed_source_row = context.get_orm_model_row(
+        source_model,
+        source_primary_key,
+        database_alias,
+    )
+    if indexed_source_row is None:
+        return None
+
+    prefetched_keys = context.get_orm_model_relation_prefetched_keys(
+        source_model,
+        database_alias,
+        accessor_name,
+    )
+
+    def build_bucket() -> DatabaseBucket["GeneralManager"]:
+        queryset = getattr(indexed_source_row, accessor_name).all()
+        bucket = DatabaseBucket(
+            queryset,
+            manager_cls,
+            {relation_filter_name: [source_primary_key]},
+        )
+        bucket._set_trusted_query_signature(
+            (
+                "prefetched-direct-many-relation-v1",
+                source_model,
+                database_alias,
+                accessor_name,
+                relation_filter_name,
+                source_primary_key,
+            )
+        )
+        return bucket
+
+    if source_identity in prefetched_keys:
+        return build_bucket()
+
+    row_items = context.get_orm_model_row_items(source_model)
+    if not row_items:
+        return None
+
+    rows_to_prefetch: list[models.Model] = []
+    row_keys_to_prefetch = []
+    for row_key, row in row_items:
+        if row_key[1] != database_alias or row_key in prefetched_keys:
+            continue
+        if isinstance(row, source_model):
+            rows_to_prefetch.append(row)
+            row_keys_to_prefetch.append(row_key)
+
+    if rows_to_prefetch:
+        _prefetch_relation_in_chunks(rows_to_prefetch, accessor_name)
+        context.add_orm_model_relation_prefetched_keys(
+            source_model,
+            database_alias,
+            accessor_name,
+            row_keys_to_prefetch,
+        )
+
+    return build_bucket()
 
 
 def _many_to_many_relation_filter_name(

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -264,7 +264,12 @@ class _FieldDescriptorBuilder:
                 related_model, "_general_manager_class", None
             )
             if general_manager_class:
-                accessor = _general_manager_accessor(field.name, general_manager_class)
+                raw_id_name = getattr(field, "attname", f"{field.name}_id")
+                accessor = _general_manager_accessor(
+                    field.name,
+                    general_manager_class,
+                    raw_id_name=raw_id_name,
+                )
                 relation_type = cast(type[object], general_manager_class)
             else:
                 accessor = _instance_attribute_accessor(field.name)
@@ -752,8 +757,14 @@ def _instance_attribute_accessor(field_name: str) -> DescriptorAccessor:
     return getter
 
 
+_MISSING_RELATED = object()
+
+
 def _general_manager_accessor(
-    field_name: str, manager_class: type[object]
+    field_name: str,
+    manager_class: type[object],
+    *,
+    raw_id_name: str | None = None,
 ) -> DescriptorAccessor:
     """
     Create an accessor that resolves a related object's manager instance from a OrmInterfaceBase.
@@ -773,13 +784,32 @@ def _general_manager_accessor(
         Returns:
             The value produced by calling `manager_class` with the related object's primary key, or `None` if the related object is `None`.
         """
+        manager_type = cast("type[GeneralManager]", manager_class)
+        if raw_id_name is not None:
+            raw_id = getattr(self._instance, raw_id_name, None)
+            if raw_id is None:
+                return None
+            state = getattr(self._instance, "_state", None)
+            fields_cache = getattr(state, "fields_cache", {})
+            related = fields_cache.get(field_name, _MISSING_RELATED)
+            if related is _MISSING_RELATED:
+                return manager_type(raw_id)
+            if related is None:
+                return None
+            trusted_hydrate = getattr(manager_type, "_from_trusted_orm_instance", None)
+            if callable(trusted_hydrate):
+                return trusted_hydrate(related)
+            return manager_type(raw_id)
+
         try:
             related = getattr(self._instance, field_name)
         except ObjectDoesNotExist:
             return None
         if related is None:
             return None
-        manager_type = cast("type[GeneralManager]", manager_class)
+        trusted_hydrate = getattr(manager_type, "_from_trusted_orm_instance", None)
+        if callable(trusted_hydrate):
+            return trusted_hydrate(related)
         return manager_type(related.pk)
 
     return getter

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+import json
 from collections.abc import Mapping
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Iterator, Protocol, Self, Type, cast
 
 from general_manager.api.property import GraphQLProperty
@@ -48,6 +50,23 @@ if TYPE_CHECKING:
 logger = get_logger("manager.general")
 
 
+def _serialize_simple_id_identification(
+    identification: dict[str, object],
+) -> str | None:
+    if len(identification) != 1 or "id" not in identification:
+        return None
+    value = identification["id"]
+    if isinstance(value, datetime):
+        serialized_value = json.dumps(value.isoformat())
+    elif isinstance(value, date):
+        serialized_value = json.dumps(value.isoformat())
+    elif value is None or isinstance(value, (str, int, float, bool)):
+        serialized_value = json.dumps(value)
+    else:
+        return None
+    return f'{{"id": {serialized_value}}}'
+
+
 class TrustedOrmRow(Protocol):
     """Protocol for ORM rows accepted by trusted hydration."""
 
@@ -60,8 +79,24 @@ class GeneralManager(metaclass=GeneralManagerMeta):
     _attributes: dict[str, object]
     Interface: Type["InterfaceBase"]
     _old_values: dict[str, object]
+    _attribute_value_cache: dict[str, object]
     _manager_state_valid: bool
     _manager_state_reason: str | None
+
+    @classmethod
+    def _track_identification_dependency(
+        cls,
+        identification: dict[str, object],
+    ) -> None:
+        if DependencyTracker.is_active():
+            identifier = _serialize_simple_id_identification(identification)
+            if identifier is None:
+                identifier = serialize_dependency_identifier(identification)
+            DependencyTracker.track(
+                cls.__name__,
+                "identification",
+                identifier,
+            )
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         """
@@ -73,14 +108,10 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         """
         self._interface = self.Interface(*args, **kwargs)
         self.__id: dict[str, object] = self._interface.identification
+        self._attribute_value_cache = {}
         self._manager_state_valid = True
         self._manager_state_reason = None
-        if DependencyTracker.is_active():
-            DependencyTracker.track(
-                self.__class__.__name__,
-                "identification",
-                serialize_dependency_identifier(self.__id),
-            )
+        self._track_identification_dependency(self.__id)
         logger.debug(
             "instantiated manager",
             context={
@@ -123,17 +154,34 @@ class GeneralManager(metaclass=GeneralManagerMeta):
                 return cls(pk)
             return cls(pk, search_date=search_date)
 
+        from general_manager.cache.run_context import (
+            TRUSTED_ORM_MANAGER_PREFIX,
+            current_calculation_run_context,
+        )
+
+        context = current_calculation_run_context()
+        cache_key = (
+            TRUSTED_ORM_MANAGER_PREFIX,
+            cls,
+            id(instance),
+            instance.pk,
+            search_date,
+        )
+        if context is not None:
+            cached = context.get(cache_key)
+            if isinstance(cached, cls):
+                cls._track_identification_dependency(cached.identification)
+                return cached
+
         manager = cls.__new__(cls)
         manager._interface = hydrate(instance, search_date=search_date)
         manager.__id = manager._interface.identification
+        manager._attribute_value_cache = {}
         manager._manager_state_valid = True
         manager._manager_state_reason = None
-        if DependencyTracker.is_active():
-            DependencyTracker.track(
-                cls.__name__,
-                "identification",
-                serialize_dependency_identifier(manager.__id),
-            )
+        if context is not None:
+            context.set(cache_key, manager)
+        cls._track_identification_dependency(manager.__id)
         logger.debug(
             "trusted orm manager hydrated",
             context={
@@ -252,6 +300,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         ``_manager_state_reason`` is cleared.
         """
         self._interface = self.Interface(**self.__id)
+        self._attribute_value_cache = {}
         self._manager_state_valid = True
         self._manager_state_reason = None
 
@@ -264,6 +313,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         """
         self._manager_state_valid = False
         self._manager_state_reason = reason
+        self._attribute_value_cache = {}
 
     def _ensure_manager_state_valid(self, attribute_name: str | None = None) -> None:
         """

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from datetime import date, datetime
+from json.encoder import encode_basestring_ascii
 from typing import TYPE_CHECKING, Iterator, Protocol, Self, Type, cast
 
 from general_manager.api.property import GraphQLProperty
@@ -57,10 +58,20 @@ def _serialize_simple_id_identification(
         return None
     value = identification["id"]
     if isinstance(value, datetime):
-        serialized_value = json.dumps(value.isoformat())
+        serialized_value = encode_basestring_ascii(value.isoformat())
     elif isinstance(value, date):
-        serialized_value = json.dumps(value.isoformat())
-    elif value is None or isinstance(value, (str, int, float, bool)):
+        serialized_value = encode_basestring_ascii(value.isoformat())
+    elif isinstance(value, str):
+        serialized_value = encode_basestring_ascii(value)
+    elif value is True:
+        serialized_value = "true"
+    elif value is False:
+        serialized_value = "false"
+    elif value is None:
+        serialized_value = "null"
+    elif isinstance(value, int):
+        serialized_value = str(value)
+    elif isinstance(value, float):
         serialized_value = json.dumps(value)
     else:
         return None
@@ -92,7 +103,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
             identifier = _serialize_simple_id_identification(identification)
             if identifier is None:
                 identifier = serialize_dependency_identifier(identification)
-            DependencyTracker.track(
+            DependencyTracker._track_validated(
                 cls.__name__,
                 "identification",
                 identifier,
@@ -574,6 +585,18 @@ class GeneralManager(metaclass=GeneralManagerMeta):
             Mapping with managers substituted by lookup identifiers, or
             ``None`` if no substitutions occurred.
         """
+        needs_normalization = False
+        for value in kwargs.values():
+            if isinstance(value, GeneralManager):
+                needs_normalization = True
+                break
+            if isinstance(value, (list, tuple)):
+                if any(isinstance(item, GeneralManager) for item in value):
+                    needs_normalization = True
+                    break
+        if not needs_normalization:
+            return None
+
         output: dict[str, object] = {}
         changed = False
         for key, value in kwargs.items():

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -416,7 +416,7 @@ class GeneralManagerMeta(type):
         """
         Attach descriptor properties to new_class for each name in attributes.
 
-        Each generated descriptor returns the interface field type when accessed on the class and resolves the corresponding value from instance._attributes when accessed on an instance. Existing attributes with the same names are overwritten unconditionally, matching bootstrap descriptor installation. Generated descriptors implement only ``__get__``; assignment to the same name on the class replaces the descriptor, and instance assignment follows normal non-data-descriptor shadowing rules. Descriptor reads do not cache resolved values. Duplicate names are processed in order, so later duplicates overwrite earlier descriptors. Non-string names or iterables that raise during iteration propagate their original exception and may leave descriptors from earlier names installed. If called through ``ensure_attributes_initialized()``, those failures can occur after ``manager_class._attributes`` is cached and before pending-initialization removal. If the stored value is callable it is always treated as a deferred evaluator and invoked with instance._interface; expose literal callables by wrapping them in a non-callable container or by using a custom descriptor path. A missing stored key raises MissingAttributeError, but a missing ``instance._attributes`` mapping or missing ``instance._interface`` attribute raises the normal ``AttributeError``. A present but malformed ``_interface`` is passed to the callable unchanged; callable failures are wrapped in ``AttributeEvaluationError``.
+        Each generated descriptor returns the interface field type when accessed on the class and resolves the corresponding value from instance._attributes when accessed on an instance. Existing attributes with the same names are overwritten unconditionally, matching bootstrap descriptor installation. Generated descriptors implement only ``__get__``; assignment to the same name on the class replaces the descriptor, and instance assignment follows normal non-data-descriptor shadowing rules. Descriptor reads cache resolved values on the manager instance and replay dependency tracking when returning a cached manager value. Duplicate names are processed in order, so later duplicates overwrite earlier descriptors. Non-string names or iterables that raise during iteration propagate their original exception and may leave descriptors from earlier names installed. If called through ``ensure_attributes_initialized()``, those failures can occur after ``manager_class._attributes`` is cached and before pending-initialization removal. If the stored value is callable it is always treated as a deferred evaluator and invoked with instance._interface; expose literal callables by wrapping them in a non-callable container or by using a custom descriptor path. A missing stored key raises MissingAttributeError, but a missing ``instance._attributes`` mapping or missing ``instance._interface`` attribute raises the normal ``AttributeError``. A present but malformed ``_interface`` is passed to the callable unchanged; callable failures are wrapped in ``AttributeEvaluationError``.
 
         Parameters:
             attributes (Iterable[str]): Names of attributes for which descriptors will be created.
@@ -489,6 +489,25 @@ class GeneralManagerMeta(type):
                     GeneralManagerMeta.ensure_manager_is_valid(
                         instance, self._attr_name
                     )
+                    cache = getattr(instance, "_attribute_value_cache", None)
+                    if isinstance(cache, dict) and self._attr_name in cache:
+                        cached_attribute = cache[self._attr_name]
+                        track_dependency = getattr(
+                            cached_attribute.__class__,
+                            "_track_identification_dependency",
+                            None,
+                        )
+                        identification = getattr(
+                            cached_attribute,
+                            "identification",
+                            None,
+                        )
+                        if callable(track_dependency) and isinstance(
+                            identification,
+                            dict,
+                        ):
+                            track_dependency(identification)
+                        return cached_attribute
                     attribute = instance._attributes.get(self._attr_name, _nonExistent)
                     if attribute is _nonExistent:
                         logger.warning(
@@ -514,6 +533,8 @@ class GeneralManagerMeta(type):
                                 },
                             )
                             raise AttributeEvaluationError(self._attr_name, e) from e
+                    if isinstance(cache, dict):
+                        cache[self._attr_name] = attribute
                     return attribute
 
             return Descriptor(attr_name, new_class)

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -154,6 +154,13 @@ class GeneralManagerMeta(type):
             initialized = class_dict.get("_gm_attributes_initialized", False)
             if initialized and attribute_name in class_dict:
                 return type.__getattribute__(cls, attribute_name)
+            attributes = class_dict.get("_attributes")
+            if (
+                initialized
+                and isinstance(attributes, dict)
+                and attribute_name not in attributes
+            ):
+                return type.__getattribute__(cls, attribute_name)
             manager_class = cast(type["GeneralManager"], cls)
             GeneralManagerMeta.ensure_attributes_initialized(
                 manager_class, attribute_name
@@ -486,28 +493,55 @@ class GeneralManagerMeta(type):
                     """
                     if instance is None:
                         return self._class.Interface.get_field_type(self._attr_name)
-                    GeneralManagerMeta.ensure_manager_is_valid(
-                        instance, self._attr_name
-                    )
-                    cache = getattr(instance, "_attribute_value_cache", None)
-                    if isinstance(cache, dict) and self._attr_name in cache:
-                        cached_attribute = cache[self._attr_name]
-                        track_dependency = getattr(
-                            cached_attribute.__class__,
-                            "_track_identification_dependency",
-                            None,
+                    try:
+                        manager_state_valid = instance._manager_state_valid
+                    except AttributeError:
+                        manager_state_valid = True
+                    if not manager_state_valid:
+                        reason = getattr(
+                            instance,
+                            "_manager_state_reason",
+                            "manager state is invalid",
                         )
-                        identification = getattr(
-                            cached_attribute,
-                            "identification",
-                            None,
+                        raise InvalidManagerStateError(
+                            instance.__class__.__name__,
+                            reason,
+                            self._attr_name,
                         )
-                        if callable(track_dependency) and isinstance(
-                            identification,
-                            dict,
-                        ):
-                            track_dependency(identification)
-                        return cached_attribute
+                    try:
+                        cache = instance._attribute_value_cache
+                    except AttributeError:
+                        cache = None
+                    if cache is not None:
+                        try:
+                            cached_attribute = cache[self._attr_name]
+                        except (KeyError, TypeError):
+                            pass
+                        else:
+                            cached_attribute_class = cached_attribute.__class__
+                            for candidate_class in cached_attribute_class.__mro__:
+                                if (
+                                    "_track_identification_dependency"
+                                    not in candidate_class.__dict__
+                                ):
+                                    continue
+                                manager_attribute = cast(
+                                    "GeneralManager", cached_attribute
+                                )
+                                try:
+                                    identification = manager_attribute.identification
+                                except AttributeError:
+                                    break
+                                if isinstance(identification, dict):
+                                    manager_class = cast(
+                                        type["GeneralManager"],
+                                        cached_attribute_class,
+                                    )
+                                    manager_class._track_identification_dependency(
+                                        identification
+                                    )
+                                break
+                            return cached_attribute
                     attribute = instance._attributes.get(self._attr_name, _nonExistent)
                     if attribute is _nonExistent:
                         logger.warning(
@@ -533,8 +567,11 @@ class GeneralManagerMeta(type):
                                 },
                             )
                             raise AttributeEvaluationError(self._attr_name, e) from e
-                    if isinstance(cache, dict):
-                        cache[self._attr_name] = attribute
+                    if cache is not None:
+                        try:
+                            cache[self._attr_name] = attribute
+                        except TypeError:
+                            pass
                     return attribute
 
             return Descriptor(attr_name, new_class)

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -31,6 +31,13 @@ for currency in currency_units:
     ureg.define(f"{currency} = [{currency}]")
 
 
+@lru_cache(maxsize=512)
+def _parse_unit(unit: str) -> pint.Unit:
+    """Parse one Pint unit expression, reusing the immutable parsed unit."""
+
+    return ureg.parse_units(unit)
+
+
 def _format_decimal(value: Decimal) -> Decimal:
     """
     Normalise decimals so integers have no fractional component.
@@ -79,7 +86,7 @@ def _unit_uses_offset_for_unit_string(unit: str) -> bool:
 def _pint_unit_components(unit: str) -> tuple[tuple[str, object], ...]:
     """Return Pint unit component names and powers for one unit expression."""
 
-    parsed_unit = ureg.parse_units(unit)
+    parsed_unit = _parse_unit(unit)
     return tuple(parsed_unit._units.items())
 
 
@@ -129,7 +136,7 @@ def _build_quantity(value: NumericMagnitude, unit: str) -> MeasurementQuantity:
     quantity_value: QuantityMagnitude = decimal_value
     if _unit_uses_offset(unit):
         quantity_value = float(decimal_value)
-    return cast(MeasurementQuantity, ureg.Quantity(quantity_value, unit))
+    return cast(MeasurementQuantity, ureg.Quantity(quantity_value, _parse_unit(unit)))
 
 
 def _convert_quantity(
@@ -430,7 +437,25 @@ class Measurement:
                 value = Decimal(str(value))
             except (InvalidOperation, TypeError, ValueError) as error:
                 raise InvalidMeasurementInitializationError() from error
-        self.__quantity = _build_quantity(value, unit)
+        self.__set_quantity(_build_quantity(value, unit))
+
+    def __set_quantity(self, quantity: MeasurementQuantity) -> None:
+        """Store quantity and cached public scalar values for internal reads."""
+
+        self.__quantity = quantity
+        self.__magnitude = _decimal_from_magnitude(quantity.magnitude)
+        self.__unit = str(quantity.units)
+        self.__quantity_exposed = False
+
+    def __current_magnitude(self) -> Decimal:
+        if self.__quantity_exposed:
+            return _decimal_from_magnitude(self.__quantity.magnitude)
+        return self.__magnitude
+
+    def __current_unit(self) -> str:
+        if self.__quantity_exposed:
+            return str(self.__quantity.units)
+        return self.__unit
 
     def __getstate__(self) -> dict[str, str]:
         """
@@ -457,7 +482,7 @@ class Measurement:
         """
         value = Decimal(state["magnitude"])
         unit = state["unit"]
-        self.__quantity = _build_quantity(value, unit)
+        self.__set_quantity(_build_quantity(value, unit))
 
     @property
     def quantity(self) -> MeasurementQuantity:
@@ -471,6 +496,7 @@ class Measurement:
         Returns:
             PlainQuantity: Pint quantity representing the measurement value and unit.
         """
+        self.__quantity_exposed = True
         return self.__quantity
 
     @property
@@ -486,7 +512,7 @@ class Measurement:
         Returns:
             Decimal: Magnitude of the measurement in its current unit.
         """
-        return _decimal_from_magnitude(self.__quantity.magnitude)
+        return self.__current_magnitude()
 
     @property
     def unit(self) -> str:
@@ -500,7 +526,7 @@ class Measurement:
         Returns:
             str: Canonical unit string as provided by the unit registry.
         """
-        return str(self.__quantity.units)
+        return self.__current_unit()
 
     @classmethod
     def from_string(cls, value: str) -> Measurement:
@@ -701,7 +727,7 @@ class Measurement:
             # Both are currencies
             if self.unit != other.unit:
                 raise CurrencyMismatchError("Addition")
-            result_quantity = self.quantity + other.quantity
+            result_quantity = self.__quantity + other.__quantity
             if not isinstance(result_quantity, pint.Quantity):
                 raise IncompatibleUnitsError("addition")
             return Measurement(
@@ -709,11 +735,11 @@ class Measurement:
             )
         elif not self.is_currency() and not other.is_currency():
             # Both are physical units
-            if self.quantity.dimensionality != other.quantity.dimensionality:
+            if self.__quantity.dimensionality != other.__quantity.dimensionality:
                 raise IncompatibleUnitsError("addition")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
-                self.quantity,
-                other.quantity,
+                self.__quantity,
+                other.__quantity,
             )
             result_quantity = left_quantity + right_quantity
             if not isinstance(result_quantity, pint.Quantity):
@@ -749,15 +775,15 @@ class Measurement:
             # Both are currencies
             if self.unit != other.unit:
                 raise CurrencyMismatchError("Subtraction")
-            result_quantity = self.quantity - other.quantity
+            result_quantity = self.__quantity - other.__quantity
             return Measurement(Decimal(str(result_quantity.magnitude)), str(self.unit))
         elif not self.is_currency() and not other.is_currency():
             # Both are physical units
-            if self.quantity.dimensionality != other.quantity.dimensionality:
+            if self.__quantity.dimensionality != other.__quantity.dimensionality:
                 raise IncompatibleUnitsError("subtraction")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
-                self.quantity,
-                other.quantity,
+                self.__quantity,
+                other.__quantity,
             )
             result_quantity = left_quantity - right_quantity
             return Measurement(
@@ -794,8 +820,8 @@ class Measurement:
             if self.is_currency() and other.is_currency():
                 raise CurrencyScalarOperationError("Multiplication")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
-                self.quantity,
-                other.quantity,
+                self.__quantity,
+                other.__quantity,
             )
             result_quantity = left_quantity * right_quantity
             return Measurement(
@@ -805,7 +831,7 @@ class Measurement:
         elif _is_numeric_scalar(other):
             if not isinstance(other, Decimal):
                 other = Decimal(str(other))
-            quantity = self.quantity
+            quantity = self.__quantity
             scalar: QuantityMagnitude = other
             if _unit_uses_offset(quantity):
                 quantity = cast(MeasurementQuantity, _quantity_as_float(quantity))
@@ -842,8 +868,8 @@ class Measurement:
             if self.is_currency() and other.is_currency() and self.unit != other.unit:
                 raise CurrencyMismatchError("Division")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
-                self.quantity,
-                other.quantity,
+                self.__quantity,
+                other.__quantity,
             )
             result_quantity = left_quantity / right_quantity
             return Measurement(
@@ -853,7 +879,7 @@ class Measurement:
         elif _is_numeric_scalar(other):
             if not isinstance(other, Decimal):
                 other = Decimal(str(other))
-            quantity = self.quantity
+            quantity = self.__quantity
             scalar: QuantityMagnitude = other
             if _unit_uses_offset(quantity):
                 quantity = cast(MeasurementQuantity, _quantity_as_float(quantity))
@@ -934,8 +960,8 @@ class Measurement:
             raise UnsupportedComparisonError()
         try:
             self_quantity, other_quantity = _prepare_quantities_for_binary_operation(
-                self.quantity,
-                other.quantity,
+                self.__quantity,
+                other.__quantity,
             )
             other_converted = _convert_quantity(
                 other_quantity, str(self_quantity.units)
@@ -1028,7 +1054,7 @@ class Measurement:
         if _is_numeric_scalar(other):
             if not isinstance(other, Decimal):
                 other = Decimal(str(other))
-            quantity = self.quantity
+            quantity = self.__quantity
             scalar: QuantityMagnitude = other
             if _unit_uses_offset(quantity):
                 quantity = cast(MeasurementQuantity, _quantity_as_float(quantity))
@@ -1168,7 +1194,7 @@ class Measurement:
             int: Stable hash suitable for use in dictionaries and sets. Measurements
             that compare equal after unit conversion produce the same hash.
         """
-        quantity = self.quantity
+        quantity = self.__quantity
         if _unit_uses_offset(quantity):
             quantity = cast(MeasurementQuantity, _quantity_as_float(quantity))
         base_quantity = quantity.to_base_units()

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -38,6 +38,13 @@ def _parse_unit(unit: str) -> pint.Unit:
     return ureg.parse_units(unit)
 
 
+@lru_cache(maxsize=512)
+def _canonical_unit_string(unit: str) -> str:
+    """Return Pint's canonical unit string for one unit expression."""
+
+    return str(_parse_unit(unit))
+
+
 def _format_decimal(value: Decimal) -> Decimal:
     """
     Normalise decimals so integers have no fractional component.
@@ -106,6 +113,17 @@ def _unit_uses_offset(unit: str | pint.Unit | MeasurementQuantity) -> bool:
 
 _unit_uses_offset.cache_clear = _unit_uses_offset_for_unit_string.cache_clear  # type: ignore[attr-defined]
 _unit_uses_offset.cache_info = _unit_uses_offset_for_unit_string.cache_info  # type: ignore[attr-defined]
+
+
+@lru_cache(maxsize=512)
+def _scalar_arithmetic_preserves_unit(unit: str) -> bool:
+    """Return whether multiplying/dividing by a scalar keeps the canonical unit."""
+
+    if _unit_uses_offset_for_unit_string(unit):
+        return False
+    if unit == "dimensionless":
+        return True
+    return bool(_parse_unit(unit).dimensionality)
 
 
 def _quantity_as_float(quantity: MeasurementQuantity) -> PlainQuantity[float]:
@@ -437,14 +455,37 @@ class Measurement:
                 value = Decimal(str(value))
             except (InvalidOperation, TypeError, ValueError) as error:
                 raise InvalidMeasurementInitializationError() from error
-        self.__set_quantity(_build_quantity(value, unit))
+        self.__set_quantity(_build_quantity(value, unit), _canonical_unit_string(unit))
 
-    def __set_quantity(self, quantity: MeasurementQuantity) -> None:
+    @classmethod
+    def _from_canonical_parts(
+        cls,
+        value: NumericMagnitude,
+        unit: str,
+    ) -> Measurement:
+        """Build a measurement from already-canonical non-offset unit metadata."""
+
+        measurement = cls.__new__(cls)
+        decimal_value = _decimal_from_magnitude(value)
+        measurement.__quantity = cast(
+            MeasurementQuantity,
+            ureg.Quantity(decimal_value, _parse_unit(unit)),
+        )
+        measurement.__magnitude = decimal_value
+        measurement.__unit = unit
+        measurement.__quantity_exposed = False
+        return measurement
+
+    def __set_quantity(
+        self,
+        quantity: MeasurementQuantity,
+        unit: str | None = None,
+    ) -> None:
         """Store quantity and cached public scalar values for internal reads."""
 
         self.__quantity = quantity
         self.__magnitude = _decimal_from_magnitude(quantity.magnitude)
-        self.__unit = str(quantity.units)
+        self.__unit = unit if unit is not None else str(quantity.units)
         self.__quantity_exposed = False
 
     def __current_magnitude(self) -> Decimal:
@@ -482,7 +523,7 @@ class Measurement:
         """
         value = Decimal(state["magnitude"])
         unit = state["unit"]
-        self.__set_quantity(_build_quantity(value, unit))
+        self.__set_quantity(_build_quantity(value, unit), _canonical_unit_string(unit))
 
     @property
     def quantity(self) -> MeasurementQuantity:
@@ -701,7 +742,7 @@ class Measurement:
         Returns:
             bool: True if the unit matches one of the registered currency codes.
         """
-        return str(self.unit) in currency_units
+        return self.unit in currency_units
 
     def __add__(self, other: object) -> Measurement:
         """
@@ -723,6 +764,13 @@ class Measurement:
         """
         if not isinstance(other, Measurement):
             raise MeasurementOperandTypeError("Addition")
+        left_unit = self.__current_unit()
+        right_unit = other.__current_unit()
+        if left_unit == right_unit and not _unit_uses_offset_for_unit_string(left_unit):
+            return self._from_canonical_parts(
+                self.__current_magnitude() + other.__current_magnitude(),
+                left_unit,
+            )
         if self.is_currency() and other.is_currency():
             # Both are currencies
             if self.unit != other.unit:
@@ -771,6 +819,13 @@ class Measurement:
         """
         if not isinstance(other, Measurement):
             raise MeasurementOperandTypeError("Subtraction")
+        left_unit = self.__current_unit()
+        right_unit = other.__current_unit()
+        if left_unit == right_unit and not _unit_uses_offset_for_unit_string(left_unit):
+            return self._from_canonical_parts(
+                self.__current_magnitude() - other.__current_magnitude(),
+                left_unit,
+            )
         if self.is_currency() and other.is_currency():
             # Both are currencies
             if self.unit != other.unit:
@@ -831,6 +886,12 @@ class Measurement:
         elif _is_numeric_scalar(other):
             if not isinstance(other, Decimal):
                 other = Decimal(str(other))
+            unit = self.__current_unit()
+            if _scalar_arithmetic_preserves_unit(unit):
+                return self._from_canonical_parts(
+                    self.__current_magnitude() * other,
+                    unit,
+                )
             quantity = self.__quantity
             scalar: QuantityMagnitude = other
             if _unit_uses_offset(quantity):
@@ -879,6 +940,12 @@ class Measurement:
         elif _is_numeric_scalar(other):
             if not isinstance(other, Decimal):
                 other = Decimal(str(other))
+            unit = self.__current_unit()
+            if _scalar_arithmetic_preserves_unit(unit):
+                return self._from_canonical_parts(
+                    self.__current_magnitude() / other,
+                    unit,
+                )
             quantity = self.__quantity
             scalar: QuantityMagnitude = other
             if _unit_uses_offset(quantity):

--- a/src/general_manager/utils/make_cache_key.py
+++ b/src/general_manager/utils/make_cache_key.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping
 from functools import lru_cache
 import inspect
 import json
+from json.encoder import encode_basestring_ascii
 from hashlib import sha256
 
 from general_manager.utils.json_encoder import CustomJSONEncoder
@@ -13,8 +14,53 @@ type CacheKeyKwargs = Mapping[str, object]
 
 
 @lru_cache(maxsize=None)
-def _signature_for(func: Callable[..., object]) -> inspect.Signature:
+def _cached_signature_for(func: Callable[..., object]) -> inspect.Signature:
     return inspect.signature(func)
+
+
+def _signature_for(func: Callable[..., object]) -> inspect.Signature:
+    try:
+        hash(func)
+    except TypeError:
+        return inspect.signature(func)
+    return _cached_signature_for(func)
+
+
+def _simple_positional_parameter_names(
+    func: Callable[..., object],
+) -> tuple[str, ...] | None:
+    """Return parameter names for signatures where binding is pure positional zip."""
+    parameters = tuple(_signature_for(func).parameters.values())
+    for parameter in parameters:
+        if parameter.kind not in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }:
+            return None
+        if parameter.default is not inspect.Parameter.empty:
+            return None
+    return tuple(parameter.name for parameter in parameters)
+
+
+def _single_manager_arg_cache_key(
+    func: Callable[..., object],
+    parameter_name: str,
+    value: object,
+) -> str | None:
+    """Return the generic JSON-equivalent key for a single manager argument."""
+    from general_manager.manager.general_manager import GeneralManager
+
+    if not isinstance(value, GeneralManager):
+        return None
+    manager_value = f"{value.__class__.__name__}(**{value.identification})"
+    raw = (
+        '{"args": {'
+        f"{encode_basestring_ascii(parameter_name)}: "
+        f"{encode_basestring_ascii(manager_value)}"
+        f'}}, "module": {encode_basestring_ascii(func.__module__)}, '
+        f'"qualname": {encode_basestring_ascii(func.__qualname__)}}}'
+    ).encode()
+    return sha256(raw, usedforsecurity=False).hexdigest()
 
 
 def make_cache_key(
@@ -36,6 +82,25 @@ def make_cache_key(
             if payload serialization fails before `CustomJSONEncoder` can fall
             back to strings.
     """
+    if kwargs is None or len(kwargs) == 0:
+        positional_names = _simple_positional_parameter_names(func)
+        if positional_names is not None and len(positional_names) == len(args):
+            if len(args) == 1:
+                single_manager_key = _single_manager_arg_cache_key(
+                    func,
+                    positional_names[0],
+                    args[0],
+                )
+                if single_manager_key is not None:
+                    return single_manager_key
+            payload = {
+                "module": func.__module__,
+                "qualname": func.__qualname__,
+                "args": dict(zip(positional_names, args, strict=True)),
+            }
+            raw = json.dumps(payload, sort_keys=True, cls=CustomJSONEncoder).encode()
+            return sha256(raw, usedforsecurity=False).hexdigest()
+
     sig = _signature_for(func)
     kwargs_dict = {} if kwargs is None else dict(kwargs)
     bound = sig.bind_partial(*args, **kwargs_dict)

--- a/src/general_manager/utils/make_cache_key.py
+++ b/src/general_manager/utils/make_cache_key.py
@@ -1,6 +1,7 @@
 """Utilities for building deterministic cache keys from function calls."""
 
 from collections.abc import Callable, Mapping
+from functools import lru_cache
 import inspect
 import json
 from hashlib import sha256
@@ -9,6 +10,11 @@ from general_manager.utils.json_encoder import CustomJSONEncoder
 
 type CacheKeyArgs = tuple[object, ...]
 type CacheKeyKwargs = Mapping[str, object]
+
+
+@lru_cache(maxsize=None)
+def _signature_for(func: Callable[..., object]) -> inspect.Signature:
+    return inspect.signature(func)
 
 
 def make_cache_key(
@@ -30,7 +36,7 @@ def make_cache_key(
             if payload serialization fails before `CustomJSONEncoder` can fall
             back to strings.
     """
-    sig = inspect.signature(func)
+    sig = _signature_for(func)
     kwargs_dict = {} if kwargs is None else dict(kwargs)
     bound = sig.bind_partial(*args, **kwargs_dict)
     bound.apply_defaults()

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -345,6 +345,43 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(first_names, ["Alice", "Bob", "Charlie"])
         self.assertEqual(second_names, ["Alice", "Bob", "Charlie"])
 
+    def test_run_context_prefetches_cached_many_to_many_source_rows(self):
+        self.TestFamily.create(
+            creator_id=None,
+            name="Johnson Family",
+            humans=[self.test_human2],
+            ignore_permission=True,
+        )
+        families_bucket = self.TestFamily.filter(
+            name__in=["Smith Family", "Johnson Family"]
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(2):
+            families = sorted(families_bucket, key=lambda family: family.name)
+            human_names_by_family = {
+                family.name: sorted(human.name for human in family.humans_list)
+                for family in families
+            }
+
+        self.assertEqual(
+            human_names_by_family,
+            {
+                "Johnson Family": ["Bob"],
+                "Smith Family": ["Alice", "Bob"],
+            },
+        )
+
+    def test_run_context_many_to_many_accessor_falls_back_without_cached_source_row(
+        self,
+    ):
+        family_id = self.test_family.identification["id"]
+
+        with CalculationRunContext():
+            family = self.TestFamily(id=family_id)
+            human_names = sorted(human.name for human in family.humans_list)
+
+        self.assertEqual(human_names, ["Alice", "Bob"])
+
     def test_manager_field_access_reuses_resolved_attribute_value(self):
         human = self.TestHuman.filter(name="Alice").first()
         original_accessor = human._attributes["name"]

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -14,6 +14,7 @@ from general_manager.interface import DatabaseInterface, ReadOnlyInterface
 from general_manager.bucket.database_bucket import DatabaseBucket
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.cache.run_context import CalculationRunContext
+from general_manager.cache.signals import pre_data_change
 
 from general_manager.utils.testing import (
     GeneralManagerTransactionTestCase,
@@ -343,6 +344,138 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
 
         self.assertEqual(first_names, ["Alice", "Bob", "Charlie"])
         self.assertEqual(second_names, ["Alice", "Bob", "Charlie"])
+
+    def test_manager_field_access_reuses_resolved_attribute_value(self):
+        human = self.TestHuman.filter(name="Alice").first()
+        original_accessor = human._attributes["name"]
+        access_count = 0
+
+        def wrapped_accessor(interface):
+            nonlocal access_count
+            access_count += 1
+            return original_accessor(interface)
+
+        self.TestHuman._attributes["name"] = wrapped_accessor
+        self.addCleanup(
+            self.TestHuman._attributes.__setitem__, "name", original_accessor
+        )
+
+        self.assertEqual(human.name, "Alice")
+        self.assertEqual(human.name, "Alice")
+        self.assertEqual(access_count, 1)
+
+    def test_gm_created_bucket_run_cache_does_not_compile_sql_for_signature(self):
+        first_bucket = self.TestHuman.filter(name__in=["Alice", "Bob"])
+        second_bucket = self.TestHuman.filter(name__in=["Alice", "Bob"])
+
+        with (
+            patch.object(
+                first_bucket._data.query,
+                "sql_with_params",
+                side_effect=AssertionError("first bucket signature compiled SQL"),
+            ),
+            patch.object(
+                second_bucket._data.query,
+                "sql_with_params",
+                side_effect=AssertionError("second bucket signature compiled SQL"),
+            ),
+            CalculationRunContext(),
+            self.assertNumQueries(1),
+        ):
+            first_names = sorted(human.name for human in first_bucket)
+            second_names = sorted(human.name for human in second_bucket)
+
+        self.assertEqual(first_names, ["Alice", "Bob"])
+        self.assertEqual(second_names, ["Alice", "Bob"])
+
+    def test_run_context_reuses_constructed_gm_filter_bucket(self):
+        query_capability = self.TestHuman.Interface.require_capability("query")
+        original_build_bucket = query_capability._build_bucket
+
+        with (
+            CalculationRunContext(),
+            patch.object(
+                query_capability,
+                "_build_bucket",
+                wraps=original_build_bucket,
+            ) as mocked_build_bucket,
+        ):
+            first_bucket = self.TestHuman.filter(name="Alice")
+            second_bucket = self.TestHuman.filter(name="Alice")
+
+        self.assertEqual(mocked_build_bucket.call_count, 1)
+        self.assertIsNot(first_bucket, second_bucket)
+        first_bucket.filters["name"].append("mutated")
+        self.assertEqual(second_bucket.filters["name"], ["Alice"])
+
+    def test_run_context_distinguishes_recent_search_date_query_buckets(self):
+        search_date = timezone.now()
+
+        with CalculationRunContext():
+            live_bucket = self.TestHuman.filter(name="Alice")
+            dated_bucket = self.TestHuman.filter(
+                name="Alice",
+                search_date=search_date,
+            )
+
+        self.assertIsNone(live_bucket._search_date)
+        self.assertEqual(dated_bucket._search_date, search_date)
+
+    def test_pre_change_query_cache_is_cleared_after_mutation(self):
+        pre_change_names = []
+
+        def populate_pre_change_cache(sender, instance, action, **_kwargs):
+            if sender is self.TestHuman and action == "update":
+                pre_change_names.extend(
+                    human.name for human in self.TestHuman.filter(name="Alice")
+                )
+
+        pre_data_change.connect(populate_pre_change_cache, weak=False)
+        self.addCleanup(pre_data_change.disconnect, populate_pre_change_cache)
+
+        with CalculationRunContext():
+            self.test_human1.update(name="Alice Updated", ignore_permission=True)
+
+            self.assertEqual(pre_change_names, ["Alice"])
+            self.assertEqual(
+                [human.name for human in self.TestHuman.filter(name="Alice")],
+                [],
+            )
+            self.assertEqual(
+                [human.name for human in self.TestHuman.filter(name="Alice Updated")],
+                ["Alice Updated"],
+            )
+
+    def test_database_bucket_truthiness_does_not_count_rows(self):
+        bucket = self.TestHuman.filter(name="Alice")
+
+        with patch.object(
+            bucket._data,
+            "count",
+            side_effect=AssertionError("truthiness should not count rows"),
+        ):
+            self.assertTrue(bucket)
+
+    def test_orm_filter_reuses_payload_normalizer(self):
+        from general_manager.interface.capabilities.orm_utils.payload_normalizer import (
+            PayloadNormalizer,
+        )
+
+        if hasattr(self.TestHuman.Interface, "_payload_normalizer"):
+            delattr(self.TestHuman.Interface, "_payload_normalizer")
+        original_init = PayloadNormalizer.__init__
+        init_count = 0
+
+        def wrapped_init(normalizer, model):
+            nonlocal init_count
+            init_count += 1
+            original_init(normalizer, model)
+
+        with patch.object(PayloadNormalizer, "__init__", wrapped_init):
+            self.TestHuman.filter(name="Alice")
+            self.TestHuman.filter(name="Bob")
+
+        self.assertEqual(init_count, 1)
 
     def test_live_queryset_with_search_date_uses_historical_lookup(self):
         old_buffer_seconds = self.TestHuman.Interface.historical_lookup_buffer_seconds

--- a/tests/unit/test_base_interface.py
+++ b/tests/unit/test_base_interface.py
@@ -14,6 +14,7 @@ from general_manager.cache.run_context import CalculationRunContext
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.input import Input
 from typing import Callable, ClassVar, Type
+from unittest.mock import patch
 
 
 # Dummy InputField implementation for testing
@@ -553,6 +554,36 @@ class InterfaceBaseTests(SimpleTestCase):
         self.assertEqual(second.identification, {"a": 2, "b": "y", "c": None})
         self.assertEqual(fields.keys_calls, 1)
         self.assertEqual(fields.items_calls, 1)
+
+    def test_single_required_input_skips_generic_argument_mapping(self):
+        class SingleInputInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {"id": DummyInput(int)}
+
+        with patch(
+            "general_manager.interface.base_interface.args_to_kwargs",
+            side_effect=AssertionError("single input should use fast path"),
+        ):
+            instance = SingleInputInterface(7)
+
+        self.assertEqual(instance.identification, {"id": 7})
+
+    def test_single_required_input_reuses_pure_scalar_parse_inside_run_context(self):
+        class SingleInputInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {"id": Input(int)}
+
+        input_field = SingleInputInterface.input_fields["id"]
+
+        with (
+            CalculationRunContext(),
+            patch.object(input_field, "cast", wraps=input_field.cast) as cast_input,
+        ):
+            first = SingleInputInterface(7)
+            second = SingleInputInterface(7)
+
+        self.assertEqual(first.identification, {"id": 7})
+        self.assertEqual(second.identification, {"id": 7})
+        self.assertIsNot(first.identification, second.identification)
+        self.assertEqual(cast_input.call_count, 1)
 
     def test_input_parsing_plan_accepts_id_alias_and_preserves_overwrite_behavior(
         self,

--- a/tests/unit/test_cache_tracker.py
+++ b/tests/unit/test_cache_tracker.py
@@ -65,6 +65,23 @@ class TestDependencyTracker(TestCase):
                 ("TestClass", "identification", "TestIdentifier"), dependencies
             )
 
+    def test_dependency_tracker_track_validated_records_nested_dependencies(self):
+        """Internal validated tracking records to active collectors."""
+        with DependencyTracker() as outer_dependencies:
+            DependencyTracker._track_validated("Outer", "filter", "one")
+
+            with DependencyTracker() as inner_dependencies:
+                DependencyTracker._track_validated("Inner", "exclude", "two")
+
+        self.assertEqual(
+            outer_dependencies,
+            {
+                ("Outer", "filter", "one"),
+                ("Inner", "exclude", "two"),
+            },
+        )
+        self.assertEqual(inner_dependencies, {("Inner", "exclude", "two")})
+
     def test_dependency_tracker_is_active_reflects_context_depth(self):
         """Report active tracking only while at least one context is open."""
         DependencyTracker.reset_thread_local_storage()

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from types import SimpleNamespace
 
 import pytest
 
@@ -412,6 +413,49 @@ def test_clear_orm_bucket_results_clears_primary_keys_and_rows() -> None:
 
         assert ctx.get_orm_bucket_result(("query", "a")) is None
         assert ctx.get_orm_bucket_rows(("query", "a")) is None
+
+
+def test_orm_bucket_rows_index_model_rows_and_prefetch_state() -> None:
+    class Row:
+        _meta = SimpleNamespace(concrete_model=None)
+
+        def __init__(self, pk: int, database_alias: str) -> None:
+            self.pk = pk
+            self._state = SimpleNamespace(db=database_alias)
+
+    Row._meta = SimpleNamespace(concrete_model=Row)
+    row = Row(7, "default")
+
+    with CalculationRunContext() as ctx:
+        ctx.set_orm_bucket_rows(("query", "rows"), (row,))
+
+        assert ctx.get_orm_model_row(Row, 7, "default") is row
+        assert ctx.get_orm_model_row_items(Row) == (((7, "default"), row),)
+
+        ctx.add_orm_model_relation_prefetched_keys(
+            Row,
+            "default",
+            "members",
+            [(7, "default")],
+        )
+        assert ctx.get_orm_model_relation_prefetched_keys(
+            Row,
+            "default",
+            "members",
+        ) == frozenset({(7, "default")})
+
+        ctx.clear_orm_bucket_results()
+
+        assert ctx.get_orm_model_row(Row, 7, "default") is None
+        assert ctx.get_orm_model_row_items(Row) == ()
+        assert (
+            ctx.get_orm_model_relation_prefetched_keys(
+                Row,
+                "default",
+                "members",
+            )
+            == frozenset()
+        )
 
 
 def test_bucket_index_helpers_store_replay_and_clear_dependencies() -> None:

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -429,6 +429,41 @@ class DatabaseBucketTestCase(TestCase):
                 [self.u1.id, self.u2.id],
             )
 
+    def test_query_signature_reuses_compiled_sql_for_same_bucket(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+        )
+
+        with patch.object(
+            bucket._data.query,
+            "sql_with_params",
+            wraps=bucket._data.query.sql_with_params,
+        ) as sql_with_params:
+            first_signature = bucket._query_signature()
+            second_signature = bucket._query_signature()
+
+        self.assertEqual(first_signature, second_signature)
+        sql_with_params.assert_called_once()
+
+    def test_trusted_signature_payload_freezes_common_filter_values(self):
+        frozen = DatabaseBucket._freeze_trusted_signature_payload(
+            {
+                "name__in": ["alice", "bob"],
+                "is_active": True,
+                "count": 2,
+            }
+        )
+
+        self.assertEqual(
+            frozen,
+            (
+                ("count", 2),
+                ("is_active", True),
+                ("name__in", ("alice", "bob")),
+            ),
+        )
+
     def test_unordered_bucket_queries_share_loaded_rows_inside_run_context(self):
         first_bucket = DatabaseBucket(User.objects.all(), UserManager)
         second_bucket = DatabaseBucket(User.objects.all(), UserManager)
@@ -439,6 +474,32 @@ class DatabaseBucketTestCase(TestCase):
 
         self.assertEqual(second_ids, first_ids)
         self.assertEqual(sorted(first_ids), [self.u1.id, self.u2.id, self.u3.id])
+
+    def test_cached_trusted_rows_reuse_built_managers_inside_run_context(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            TrustedUserManager,
+        )
+
+        with CalculationRunContext():
+            first_managers = list(bucket)
+            with patch.object(
+                bucket,
+                "_build_manager_from_instance",
+                wraps=bucket._build_manager_from_instance,
+            ) as build_manager:
+                second_managers = list(bucket)
+
+        build_manager.assert_not_called()
+        self.assertEqual(
+            [manager.identification["id"] for manager in first_managers],
+            [self.u1.id, self.u2.id],
+        )
+        self.assertEqual(
+            [manager.identification["id"] for manager in second_managers],
+            [self.u1.id, self.u2.id],
+        )
+        self.assertIs(first_managers[0], second_managers[0])
 
     def test_equivalent_database_buckets_share_index_inside_run_context(self):
         """Share a bucket index for equivalent querysets in one run context."""

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -587,6 +587,36 @@ class DatabaseBucketTestCase(TestCase):
             self.assertEqual(bucket[1].identification["id"], self.u2.id)
             self.assertIn(self.u1, bucket)
 
+    def test_filtered_count_populates_primary_key_snapshot_for_iteration(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            UserManager,
+            {"username__in": [["alice", "bob"]]},
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            self.assertEqual(bucket.count(), 2)
+            self.assertEqual(
+                [manager.identification["id"] for manager in bucket],
+                [self.u1.id, self.u2.id],
+            )
+
+    def test_equivalent_first_reuses_row_inside_run_context(self):
+        first_bucket = DatabaseBucket(
+            User.objects.filter(username="alice").order_by("id"),
+            UserManager,
+            {"username": ["alice"]},
+        )
+        second_bucket = DatabaseBucket(
+            User.objects.filter(username="alice").order_by("id"),
+            UserManager,
+            {"username": ["alice"]},
+        )
+
+        with CalculationRunContext(), self.assertNumQueries(1):
+            self.assertEqual(first_bucket.first().identification["id"], self.u1.id)
+            self.assertEqual(second_bucket.first().identification["id"], self.u1.id)
+
     def test_primary_key_snapshot_terminal_operations_without_row_snapshot(self):
         bucket = DatabaseBucket(
             User.objects.filter(username__in=["alice", "bob"]).order_by("username"),

--- a/tests/unit/test_dependency_cache.py
+++ b/tests/unit/test_dependency_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pickle
 from collections.abc import Iterable, Mapping
 from typing import cast
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
@@ -181,6 +182,48 @@ class DependencyCacheEntryTests(SimpleTestCase):
             None,
         )
         marker = object()
+
+        self.assertIs(
+            read_dependency_cache_hit(cache_backend, "cache-a", sentinel=marker),
+            marker,
+        )
+
+    def test_current_combined_payload_reads_dependencies_without_legacy_validation(
+        self,
+    ) -> None:
+        cache_backend = PickleCache()
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+        cache_backend.set(
+            "cache-a",
+            make_dependency_cache_entry("ready", dependencies),
+            None,
+        )
+
+        with patch(
+            "general_manager.cache.dependency_cache._legacy_dependency_set",
+            side_effect=AssertionError("legacy validation should not run"),
+        ):
+            hit = read_dependency_cache_hit(cache_backend, "cache-a")
+
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+        self.assertEqual(hit.value, "ready")
+        self.assertEqual(hit.dependencies, frozenset(dependencies))
+
+    def test_legacy_combined_payload_still_rejects_malformed_dependencies(
+        self,
+    ) -> None:
+        cache_backend = PickleCache()
+        marker = object()
+        cache_backend.set(
+            "cache-a",
+            DependencyCacheEntry(
+                version=1,
+                value="legacy",
+                dependencies=frozenset({("Project", "bad-action", '{"id": 1}')}),  # type: ignore[arg-type]
+            ),
+            None,
+        )
 
         self.assertIs(
             read_dependency_cache_hit(cache_backend, "cache-a", sentinel=marker),

--- a/tests/unit/test_dependency_matching.py
+++ b/tests/unit/test_dependency_matching.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from general_manager.cache.dependency_matching import (
     EXACT_OPERATORS,
@@ -92,11 +93,52 @@ def test_normalize_dependency_value_and_hash_are_stable() -> None:
     )
 
 
+def test_single_key_scalar_dependency_mapping_skips_sorting() -> None:
+    with patch(
+        "general_manager.cache.dependency_matching.sorted",
+        side_effect=AssertionError("single-key scalar mapping does not need sorting"),
+        create=True,
+    ):
+        assert normalize_dependency_value({"id": 7}) == {"id": 7}
+
+
+def test_single_key_scalar_dependency_mapping_serialization_skips_json_dumps() -> None:
+    with (
+        patch(
+            "general_manager.cache.dependency_matching.json.dumps",
+            side_effect=AssertionError("single-key scalar mapping uses fast path"),
+        ),
+        patch(
+            "general_manager.cache.dependency_matching.sorted",
+            side_effect=AssertionError(
+                "single-key scalar mapping does not need sorting"
+            ),
+            create=True,
+        ),
+    ):
+        assert serialize_normalized_value({"id": 7}) == '{"id": 7}'
+        assert serialize_normalized_value({"day": date(2026, 1, 2)}) == (
+            '{"day": "2026-01-02"}'
+        )
+
+
 def test_primitive_dependency_serialization_matches_json_contract() -> None:
     assert serialize_normalized_value("abc") == '"abc"'
     assert serialize_normalized_value(3) == "3"
     assert serialize_normalized_value(True) == "true"
     assert serialize_normalized_value(None) == "null"
+
+
+def test_scalar_dependency_serialization_skips_json_dumps() -> None:
+    with patch(
+        "general_manager.cache.dependency_matching.json.dumps",
+        side_effect=AssertionError("scalar dependency values use fast path"),
+    ):
+        assert serialize_normalized_value("abc") == '"abc"'
+        assert serialize_normalized_value(date(2026, 1, 2)) == '"2026-01-02"'
+        assert serialize_normalized_value(3) == "3"
+        assert serialize_normalized_value(True) == "true"
+        assert serialize_normalized_value(None) == "null"
 
 
 def test_nested_dependency_serialization_remains_sorted_and_recursive() -> None:

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -8,7 +8,10 @@ from unittest import mock
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 
-from general_manager.cache.dependency_matching import stable_value_hash
+from general_manager.cache.dependency_matching import (
+    parse_dependency_identifier,
+    stable_value_hash,
+)
 from general_manager.cache.dependency_shards import (
     ALL_RECORDS_VALUE,
     DEPENDENCY_SHARD_PREFIX,
@@ -27,6 +30,7 @@ from general_manager.cache.dependency_shards import (
     request_query_shard_key,
     reverse_membership_key,
     scan_lookup_shard_key,
+    _shard_keys_for_dependency,
 )
 from general_manager.cache.dependency_index import (
     capture_old_values,
@@ -373,6 +377,36 @@ class DependencyShardKeyTests(TestCase):
         assert counting_cache.set_calls == []
         assert len(counting_cache.get_many_calls) <= 2
         assert len(counting_cache.set_many_calls) <= 2
+
+    def test_record_many_cache_dependencies_reuses_shard_plan_for_duplicates(
+        self,
+    ) -> None:
+        counting_cache = CountingShardCache()
+        dependency: Dependency = (
+            "Project",
+            "filter",
+            json.dumps({"status": "open"}),
+        )
+        entries: list[tuple[str, set[Dependency]]] = [
+            (f"cache-{index}", {dependency}) for index in range(10)
+        ]
+        cache_clear = getattr(_shard_keys_for_dependency, "cache_clear", None)
+        if callable(cache_clear):
+            cache_clear()
+
+        with (
+            mock.patch(
+                "general_manager.cache.dependency_shards.cache",
+                counting_cache,
+            ),
+            mock.patch(
+                "general_manager.cache.dependency_shards.parse_dependency_identifier",
+                wraps=parse_dependency_identifier,
+            ) as mocked_parse,
+        ):
+            record_many_cache_dependencies(entries)
+
+        assert mocked_parse.call_count == 1
 
     def test_record_many_cache_dependencies_replaces_existing_memberships_in_bulk(
         self,

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -9,6 +9,7 @@ from django.db import models
 
 from general_manager.interface.capabilities.orm_utils.field_descriptors import (
     _FieldDescriptorBuilder,
+    _general_manager_accessor,
     _general_manager_many_accessor,
     build_field_descriptors,
 )
@@ -39,6 +40,65 @@ def test_general_manager_many_accessor_uses_explicit_relation_field_name() -> No
     related_model._meta.get_field.assert_called_once_with("reviewer")
     manager_class.filter.assert_called_once_with(reviewer=42)
     assert result is filter_result
+
+
+def test_general_manager_fk_accessor_uses_trusted_hydration_for_loaded_row() -> None:
+    related = SimpleNamespace(pk=7)
+    constructor_calls: list[object] = []
+    calls: list[tuple[object, object | None]] = []
+    trusted_result = object()
+
+    class RelatedManager:
+        def __init__(self, pk: object) -> None:
+            constructor_calls.append(pk)
+
+        @classmethod
+        def _from_trusted_orm_instance(
+            cls,
+            instance: object,
+            *,
+            search_date: object | None = None,
+        ) -> object:
+            calls.append((instance, search_date))
+            return trusted_result
+
+    accessor = _general_manager_accessor("owner", RelatedManager)
+    interface_instance = SimpleNamespace(_instance=SimpleNamespace(owner=related))
+
+    assert accessor(interface_instance) is trusted_result
+    assert constructor_calls == []
+    assert calls == [(related, None)]
+
+
+def test_general_manager_fk_accessor_uses_raw_id_without_loading_relation() -> None:
+    calls: list[object] = []
+
+    class RelatedManager:
+        def __init__(self, pk: object) -> None:
+            calls.append(pk)
+
+    class SourceInstance:
+        owner_id = 7
+        _state = SimpleNamespace(fields_cache={})
+        loaded_relation = False
+
+        @property
+        def owner(self) -> object:
+            self.loaded_relation = True
+            return object()
+
+    accessor = _general_manager_accessor(
+        "owner",
+        RelatedManager,
+        raw_id_name="owner_id",
+    )
+    interface_instance = SimpleNamespace(_instance=SourceInstance())
+
+    result = accessor(interface_instance)
+
+    assert isinstance(result, RelatedManager)
+    assert calls == [7]
+    assert not interface_instance._instance.loaded_relation
 
 
 def test_build_field_descriptors_disambiguates_duplicate_reverse_relations() -> None:

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -42,6 +42,196 @@ def test_general_manager_many_accessor_uses_explicit_relation_field_name() -> No
     assert result is filter_result
 
 
+def test_general_manager_many_accessor_skips_row_scan_for_prefetched_source() -> None:
+    class PrefetchSourceModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class PrefetchRelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class RelatedManager:
+        class Interface:
+            _model = PrefetchRelatedModel
+            database = None
+            _soft_delete_default = False
+
+        @classmethod
+        def filter(cls, **_kwargs: object) -> object:
+            raise AssertionError
+
+    class RunContext:
+        def get_orm_model_row(
+            self,
+            model: type[object],
+            primary_key: object,
+            database_alias: object,
+        ) -> object:
+            assert model is PrefetchSourceModel
+            assert primary_key == 7
+            assert database_alias is None
+            return source_row
+
+        def get_orm_model_relation_prefetched_keys(
+            self,
+            model: type[object],
+            database_alias: object,
+            accessor_name: str,
+        ) -> frozenset[tuple[int, None]]:
+            assert model is PrefetchSourceModel
+            assert database_alias is None
+            assert accessor_name == "members"
+            return frozenset({(7, None)})
+
+        def get_orm_model_row_items(
+            self,
+            _model: type[object],
+        ) -> tuple[object, ...]:
+            raise AssertionError
+
+    related_queryset = Mock()
+    relation_manager = SimpleNamespace(all=Mock(return_value=related_queryset))
+    source_row = PrefetchSourceModel(id=7)
+    source_row.members = relation_manager
+    interface_instance = SimpleNamespace(_instance=source_row, pk=7)
+    accessor = _general_manager_many_accessor(
+        accessor_name="members",
+        related_model=PrefetchRelatedModel,
+        general_manager_class=RelatedManager,
+        source_model=PrefetchSourceModel,
+        relation_filter_name="sources",
+    )
+
+    with patch(
+        "general_manager.cache.run_context.current_calculation_run_context",
+        return_value=RunContext(),
+    ):
+        result = accessor(interface_instance)
+
+    assert result._data is related_queryset
+    assert result.filters == {"sources": [7]}
+    relation_manager.all.assert_called_once_with()
+
+
+def test_general_manager_many_accessor_falls_back_when_source_row_is_not_indexed() -> (
+    None
+):
+    class UnindexedPrefetchSourceModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class UnindexedPrefetchRelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class RelatedManager:
+        filter = Mock(return_value="fallback-bucket")
+
+        class Interface:
+            _model = UnindexedPrefetchRelatedModel
+            database = None
+            _soft_delete_default = False
+
+    class RunContext:
+        def get_orm_model_row(
+            self,
+            model: type[object],
+            primary_key: object,
+            database_alias: object,
+        ) -> object | None:
+            assert model is UnindexedPrefetchSourceModel
+            assert primary_key == 7
+            assert database_alias is None
+            return None
+
+    source_row = UnindexedPrefetchSourceModel(id=7)
+    interface_instance = SimpleNamespace(_instance=source_row, pk=7)
+    accessor = _general_manager_many_accessor(
+        accessor_name="members",
+        related_model=UnindexedPrefetchRelatedModel,
+        general_manager_class=RelatedManager,
+        source_model=UnindexedPrefetchSourceModel,
+        relation_filter_name="sources",
+    )
+
+    with patch(
+        "general_manager.cache.run_context.current_calculation_run_context",
+        return_value=RunContext(),
+    ):
+        result = accessor(interface_instance)
+
+    assert result == "fallback-bucket"
+    RelatedManager.filter.assert_called_once_with(sources=7)
+
+
+def test_general_manager_many_accessor_falls_back_for_soft_delete_managers() -> None:
+    class SoftDeletePrefetchSourceModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class SoftDeletePrefetchRelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class RelatedManager:
+        filter = Mock(return_value="fallback-bucket")
+
+        class Interface:
+            _model = SoftDeletePrefetchRelatedModel
+            database = None
+            _soft_delete_default = True
+
+    source_row = SoftDeletePrefetchSourceModel(id=7)
+    interface_instance = SimpleNamespace(_instance=source_row, pk=7)
+    accessor = _general_manager_many_accessor(
+        accessor_name="members",
+        related_model=SoftDeletePrefetchRelatedModel,
+        general_manager_class=RelatedManager,
+        source_model=SoftDeletePrefetchSourceModel,
+        relation_filter_name="sources",
+    )
+
+    result = accessor(interface_instance)
+
+    assert result == "fallback-bucket"
+    RelatedManager.filter.assert_called_once_with(sources=7)
+
+
+def test_general_manager_many_accessor_falls_back_for_database_mismatch() -> None:
+    class DatabasePrefetchSourceModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class DatabasePrefetchRelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class RelatedManager:
+        filter = Mock(return_value="fallback-bucket")
+
+        class Interface:
+            _model = DatabasePrefetchRelatedModel
+            database = "default"
+            _soft_delete_default = False
+
+    source_row = DatabasePrefetchSourceModel(id=7)
+    source_row._state.db = "replica"
+    interface_instance = SimpleNamespace(_instance=source_row, pk=7)
+    accessor = _general_manager_many_accessor(
+        accessor_name="members",
+        related_model=DatabasePrefetchRelatedModel,
+        general_manager_class=RelatedManager,
+        source_model=DatabasePrefetchSourceModel,
+        relation_filter_name="sources",
+    )
+
+    result = accessor(interface_instance)
+
+    assert result == "fallback-bucket"
+    RelatedManager.filter.assert_called_once_with(sources=7)
+
+
 def test_general_manager_fk_accessor_uses_trusted_hydration_for_loaded_row() -> None:
     related = SimpleNamespace(pk=7)
     constructor_calls: list[object] = []

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -16,6 +16,7 @@ from general_manager.permission.manager_based_permission import (
 )
 from unittest.mock import Mock, patch
 from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.dependency_index import serialize_dependency_identifier
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.cache.signals import post_data_change, pre_data_change
 from django.contrib.auth import get_user_model
@@ -158,18 +159,19 @@ class GeneralManagerTestCase(TestCase):
             pending_graphql_interfaces,
         )
 
-    @patch("general_manager.cache.cache_tracker.DependencyTracker.track")
-    def test_initialization(self, mock_track):
+    def test_initialization(self):
         # Test if the manager initializes correctly
         """
         Tests initialization of GeneralManager and dependency tracking.
 
-        Asserts that DependencyTracker.track is called with the correct arguments and that the created object is an instance of GeneralManager.
+        Asserts that the created object is an instance of GeneralManager and
+        its identification dependency is captured.
         """
-        with DependencyTracker():
+        with DependencyTracker() as dependencies:
             manager = self.manager()
-        mock_track.assert_called_once_with(
-            "GeneralManager", "identification", '{"id": "dummy_id"}'
+        self.assertIn(
+            ("GeneralManager", "identification", '{"id": "dummy_id"}'),
+            dependencies,
         )
         self.assertIsInstance(manager, GeneralManager)
 
@@ -205,6 +207,47 @@ class GeneralManagerTestCase(TestCase):
             ("GeneralManager", "identification", '{"id": "dummy_id"}'),
             dependencies,
         )
+
+    def test_manager_init_tracks_scalar_id_without_json_dumps(self):
+        with (
+            DependencyTracker() as dependencies,
+            patch(
+                "general_manager.manager.general_manager.json.dumps",
+                side_effect=AssertionError("scalar id should use fast serialization"),
+            ),
+        ):
+            self.manager("dummy_id")
+
+        self.assertIn(
+            ("GeneralManager", "identification", '{"id": "dummy_id"}'),
+            dependencies,
+        )
+
+    def test_manager_init_tracks_non_ascii_scalar_id_like_generic_serializer(self):
+        class NonAsciiInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        manager_class = self._temporary_manager_class()
+        manager_class.Interface = NonAsciiInterface
+        expected_identifier = serialize_dependency_identifier({"id": "M\u00fcller"})
+
+        with DependencyTracker() as dependencies:
+            manager_class("M\u00fcller")
+
+        self.assertIn(
+            (manager_class.__name__, "identification", expected_identifier),
+            dependencies,
+        )
+
+    def test_parse_identification_skips_item_scan_for_scalar_values(self):
+        class ScalarOnlyPayload(dict):
+            def items(self):  # type: ignore[override]
+                raise AssertionError
+
+        parse_identification = GeneralManager._GeneralManager__parse_identification
+
+        self.assertIsNone(parse_identification(ScalarOnlyPayload({"id": 7})))
 
     def test_trusted_orm_hydration_does_not_serialize_without_dependency_tracker(self):
         manager_class = self._temporary_manager_class()
@@ -263,9 +306,10 @@ class GeneralManagerTestCase(TestCase):
         manager_class.Interface = TrustedInterface  # type: ignore[assignment]
         row = Mock(pk="trusted_id")
 
-        with CalculationRunContext(), DependencyTracker() as dependencies:
+        with CalculationRunContext():
             first = manager_class._from_trusted_orm_instance(row)
-            second = manager_class._from_trusted_orm_instance(row)
+            with DependencyTracker() as dependencies:
+                second = manager_class._from_trusted_orm_instance(row)
 
         self.assertIs(first, second)
         self.assertEqual(hydration_calls, [(row, None)])
@@ -441,6 +485,35 @@ class GeneralManagerTestCase(TestCase):
         instance = manager_class("dummy_id")
 
         self.assertEqual(instance.id, "dummy_id")
+
+    def test_cached_descriptor_read_skips_generic_getattr_lookup(self):
+        manager_class = self._temporary_manager_class()
+
+        with patch.object(DummyInterface, "get_attributes", create=True):
+            GeneralManagerMeta.ensure_attributes_initialized(manager_class)
+
+        instance = manager_class("dummy_id")
+        self.assertEqual(instance.id, "dummy_id")
+
+        with patch(
+            "general_manager.manager.meta.getattr",
+            side_effect=AssertionError("cached descriptor read should be direct"),
+            create=True,
+        ):
+            self.assertEqual(instance.id, "dummy_id")
+
+    def test_initialized_manager_inherited_method_skips_attribute_initialization(self):
+        manager_class = self._temporary_manager_class()
+
+        with patch.object(DummyInterface, "get_attributes", create=True):
+            GeneralManagerMeta.ensure_attributes_initialized(manager_class)
+
+        with patch.object(
+            GeneralManagerMeta,
+            "ensure_attributes_initialized",
+            side_effect=AssertionError("inherited method should not reinitialize"),
+        ):
+            self.assertTrue(callable(manager_class.filter))
 
     def test_initialized_manager_discovers_late_added_public_field(self):
         manager_class = self._temporary_manager_class()
@@ -684,6 +757,19 @@ class GeneralManagerTestCase(TestCase):
             result = manager_obj.delete(creator_id=1)
             mock_delete.assert_called_once_with(creator_id=1, history_comment=None)
             self.assertIsNone(result)
+
+    def test_valid_manager_descriptor_read_skips_validity_helper(self):
+        manager_class = self._temporary_manager_class()
+        with patch.object(DummyInterface, "get_attributes", create=True):
+            GeneralManagerMeta.ensure_attributes_initialized(manager_class)
+        manager_obj = manager_class("dummy_id")
+
+        with patch.object(
+            GeneralManagerMeta,
+            "ensure_manager_is_valid",
+            side_effect=AssertionError("valid descriptor reads should be inline"),
+        ):
+            self.assertEqual(manager_obj.id, "dummy_id")
 
     def test_invalidated_manager_state_raises_dedicated_error(self):
         manager_obj = self.manager()

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -16,6 +16,7 @@ from general_manager.permission.manager_based_permission import (
 )
 from unittest.mock import Mock, patch
 from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.run_context import CalculationRunContext
 from general_manager.cache.signals import post_data_change, pre_data_change
 from django.contrib.auth import get_user_model
 from django.utils.crypto import get_random_string
@@ -190,6 +191,21 @@ class GeneralManagerTestCase(TestCase):
             dependencies,
         )
 
+    def test_manager_init_tracks_scalar_id_without_generic_serializer(self):
+        with (
+            DependencyTracker() as dependencies,
+            patch(
+                "general_manager.manager.general_manager.serialize_dependency_identifier",
+                side_effect=AssertionError("generic serialization should be skipped"),
+            ),
+        ):
+            self.manager("dummy_id")
+
+        self.assertIn(
+            ("GeneralManager", "identification", '{"id": "dummy_id"}'),
+            dependencies,
+        )
+
     def test_trusted_orm_hydration_does_not_serialize_without_dependency_tracker(self):
         manager_class = self._temporary_manager_class()
 
@@ -227,6 +243,32 @@ class GeneralManagerTestCase(TestCase):
         with DependencyTracker() as dependencies:
             manager_class._from_trusted_orm_instance(row)
 
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "trusted_id"}'),
+            dependencies,
+        )
+
+    def test_trusted_orm_hydration_reuses_loaded_row_inside_run_context(self):
+        manager_class = self._temporary_manager_class()
+        hydration_calls = []
+
+        class TrustedInterface:
+            @classmethod
+            def _from_trusted_orm_instance(cls, instance, *, search_date=None):
+                hydration_calls.append((instance, search_date))
+                interface = cls()
+                interface.identification = {"id": instance.pk}
+                return interface
+
+        manager_class.Interface = TrustedInterface  # type: ignore[assignment]
+        row = Mock(pk="trusted_id")
+
+        with CalculationRunContext(), DependencyTracker() as dependencies:
+            first = manager_class._from_trusted_orm_instance(row)
+            second = manager_class._from_trusted_orm_instance(row)
+
+        self.assertIs(first, second)
+        self.assertEqual(hydration_calls, [(row, None)])
         self.assertIn(
             ("TemporaryManager", "identification", '{"id": "trusted_id"}'),
             dependencies,

--- a/tests/unit/test_make_cache_key.py
+++ b/tests/unit/test_make_cache_key.py
@@ -49,6 +49,115 @@ class TestMakeCacheKey(SimpleTestCase):
 
         signature.assert_called_once_with(sample_function)
 
+    def test_make_cache_key_skips_binding_for_simple_positional_call(self):
+        def sample_function(manager):
+            return manager
+
+        args = ("manager-id",)
+        payload = {
+            "module": sample_function.__module__,
+            "qualname": sample_function.__qualname__,
+            "args": {"manager": "manager-id"},
+        }
+        raw = json.dumps(payload, sort_keys=True, cls=CustomJSONEncoder).encode()
+        expected = hashlib.sha256(raw, usedforsecurity=False).hexdigest()
+
+        with patch.object(
+            inspect.Signature,
+            "bind_partial",
+            side_effect=AssertionError("simple call should not bind"),
+        ):
+            result = make_cache_key(sample_function, args, {})
+
+        self.assertEqual(result, expected)
+
+    def test_make_cache_key_supports_unhashable_callable_instances(self):
+        class CallableWithoutHash:
+            __hash__ = None  # type: ignore[assignment]
+
+            def __init__(self) -> None:
+                self.__module__ = __name__
+                self.__qualname__ = "CallableWithoutHash"
+
+            def __eq__(self, other):
+                return isinstance(other, CallableWithoutHash)
+
+            def __call__(self, value):
+                return value
+
+        callable_instance = CallableWithoutHash()
+        payload = {
+            "module": callable_instance.__module__,
+            "qualname": callable_instance.__qualname__,
+            "args": {"value": 7},
+        }
+        raw = json.dumps(payload, sort_keys=True, cls=CustomJSONEncoder).encode()
+        expected = hashlib.sha256(raw, usedforsecurity=False).hexdigest()
+
+        result = make_cache_key(callable_instance, (7,), {})
+
+        self.assertEqual(result, expected)
+
+    def test_make_cache_key_fast_path_for_single_manager_arg_matches_generic_key(self):
+        from general_manager.manager.general_manager import GeneralManager
+
+        class CacheKeyInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        class CacheKeyManager(GeneralManager):
+            pass
+
+        CacheKeyManager.Interface = CacheKeyInterface
+
+        def sample_function(manager):
+            return manager
+
+        manager = CacheKeyManager(7)
+        payload = {
+            "module": sample_function.__module__,
+            "qualname": sample_function.__qualname__,
+            "args": {"manager": manager},
+        }
+        raw = json.dumps(payload, sort_keys=True, cls=CustomJSONEncoder).encode()
+        expected = hashlib.sha256(raw, usedforsecurity=False).hexdigest()
+
+        with patch(
+            "general_manager.utils.make_cache_key.json.dumps",
+            side_effect=AssertionError("single manager fast path should not dump"),
+        ):
+            result = make_cache_key(sample_function, (manager,), {})
+
+        self.assertEqual(result, expected)
+
+    def test_make_cache_key_fast_path_for_non_ascii_manager_arg_matches_generic_key(
+        self,
+    ):
+        from general_manager.manager.general_manager import GeneralManager
+
+        class CacheKeyInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        class CacheKeyManager(GeneralManager):
+            pass
+
+        CacheKeyManager.Interface = CacheKeyInterface
+
+        def sample_function(manager):
+            return manager
+
+        manager = CacheKeyManager("M\u00fcller")
+        payload = {
+            "module": sample_function.__module__,
+            "qualname": sample_function.__qualname__,
+            "args": {"manager": manager},
+        }
+        raw = json.dumps(payload, sort_keys=True, cls=CustomJSONEncoder).encode()
+        expected = hashlib.sha256(raw, usedforsecurity=False).hexdigest()
+
+        self.assertEqual(make_cache_key(sample_function, (manager,), {}), expected)
+
     def test_make_cache_key_with_different_args(self):
         """
         Tests that different positional arguments produce different cache keys for the same function.

--- a/tests/unit/test_make_cache_key.py
+++ b/tests/unit/test_make_cache_key.py
@@ -36,6 +36,19 @@ class TestMakeCacheKey(SimpleTestCase):
         result2 = make_cache_key(sample_function, args, kwargs)
         self.assertEqual(result, result2)
 
+    def test_make_cache_key_reuses_signature_for_same_function(self):
+        def sample_function(x, y=1):
+            return x + y
+
+        with patch(
+            "general_manager.utils.make_cache_key.inspect.signature",
+            wraps=inspect.signature,
+        ) as signature:
+            make_cache_key(sample_function, (1,), None)
+            make_cache_key(sample_function, (2,), None)
+
+        signature.assert_called_once_with(sample_function)
+
     def test_make_cache_key_with_different_args(self):
         """
         Tests that different positional arguments produce different cache keys for the same function.

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -252,6 +252,25 @@ class MeasurementTestCase(TestCase):
         result = m1 * 3
         self.assertEqual(str(result), "6 meter")
 
+    def test_scalar_arithmetic_reuses_canonical_unit_without_rebuilding(self):
+        from unittest.mock import patch
+
+        from general_manager.measurement import measurement as measurement_module
+
+        measurement = Measurement(Decimal("12"), "meter")
+
+        with patch.object(
+            measurement_module,
+            "_build_quantity",
+            wraps=measurement_module._build_quantity,
+        ) as mocked:
+            multiplied = measurement * Decimal("2")
+            divided = measurement / Decimal("3")
+
+        self.assertEqual(str(multiplied), "24 meter")
+        self.assertEqual(str(divided), "4 meter")
+        mocked.assert_not_called()
+
     def test_multiplication_different_units(self):
         m1 = Measurement(2, "meter")
         m2 = Measurement(3, "second")
@@ -286,6 +305,26 @@ class MeasurementTestCase(TestCase):
         m2 = Measurement(1, "meter")
         result = m1 - m2
         self.assertEqual(str(result), "1 meter")
+
+    def test_same_unit_add_sub_reuses_canonical_unit_without_rebuilding(self):
+        from unittest.mock import patch
+
+        from general_manager.measurement import measurement as measurement_module
+
+        left = Measurement(Decimal("2"), "meter")
+        right = Measurement(Decimal("1.5"), "meter")
+
+        with patch.object(
+            measurement_module,
+            "_build_quantity",
+            wraps=measurement_module._build_quantity,
+        ) as mocked:
+            added = left + right
+            subtracted = left - right
+
+        self.assertEqual(str(added), "3.5 meter")
+        self.assertEqual(str(subtracted), "0.5 meter")
+        mocked.assert_not_called()
 
     def test_random_measurements(self):
         """

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -122,8 +122,12 @@ class MeasurementTestCase(TestCase):
         self.assertTrue(freezing_f >= freezing_c)
 
     def test_unit_uses_offset_cache_preserves_temperature_behavior(self):
-        from general_manager.measurement.measurement import _unit_uses_offset
+        from general_manager.measurement.measurement import (
+            _parse_unit,
+            _unit_uses_offset,
+        )
 
+        _parse_unit.cache_clear()
         _unit_uses_offset.cache_clear()
 
         self.assertTrue(_unit_uses_offset("degC"))
@@ -153,6 +157,35 @@ class MeasurementTestCase(TestCase):
         self.assertFalse(_unit_uses_offset("kg"))
         self.assertFalse(_unit_uses_offset("kg"))
         self.assertGreaterEqual(_unit_uses_offset.cache_info().hits, 1)
+
+    def test_repeated_measurements_reuse_parsed_unit(self):
+        from unittest.mock import patch
+
+        from general_manager.measurement.measurement import (
+            _parse_unit,
+            _unit_uses_offset,
+        )
+
+        _parse_unit.cache_clear()
+        _unit_uses_offset.cache_clear()
+
+        with patch.object(ureg, "parse_units", wraps=ureg.parse_units) as mocked:
+            Measurement(1, "kg")
+            Measurement(2, "kg")
+
+        self.assertEqual(mocked.call_count, 1)
+
+    def test_measurement_reuses_canonical_values_until_quantity_is_exposed(self):
+        measurement = Measurement(Decimal("1.2300"), "kg / m ** 3")
+
+        self.assertIs(measurement.unit, measurement.unit)
+        self.assertIs(measurement.magnitude, measurement.magnitude)
+
+        exposed_quantity = measurement.quantity
+        exposed_quantity.ito("g / cm ** 3")
+
+        self.assertEqual(measurement.unit, "gram / centimeter ** 3")
+        self.assertNotEqual(measurement.magnitude, Decimal("1.23"))
 
     def test_unit_uses_offset_cache_preserves_quantity_input(self):
         from general_manager.measurement.measurement import _unit_uses_offset

--- a/tests/unit/test_orm_capabilities_comprehensive.py
+++ b/tests/unit/test_orm_capabilities_comprehensive.py
@@ -1130,6 +1130,48 @@ class TestOrmQueryCapability:
 
         assert translated == "unresolvedaliastargetrequestfeasibility__missing__gte"
 
+    def test_translate_reverse_filter_key_caches_repeated_model_key_pairs(
+        self,
+    ) -> None:
+        class CachedFilterTranslationModel(models.Model):
+            status = models.IntegerField(default=0)
+
+            class Meta:
+                app_label = "orm_capability_tests"
+
+        cache_clear = getattr(_translate_reverse_filter_key, "cache_clear", None)
+        if callable(cache_clear):
+            cache_clear()
+
+        status_field = CachedFilterTranslationModel._meta.get_field("status")
+        try:
+            with patch(
+                "general_manager.interface.capabilities.orm.support._resolve_filter_segment",
+                return_value=("status", status_field),
+            ) as resolve_segment:
+                assert (
+                    _translate_reverse_filter_key(
+                        CachedFilterTranslationModel,
+                        "status__gte",
+                    )
+                    == "status__gte"
+                )
+                assert (
+                    _translate_reverse_filter_key(
+                        CachedFilterTranslationModel,
+                        "status__gte",
+                    )
+                    == "status__gte"
+                )
+
+            resolve_segment.assert_called_once_with(
+                CachedFilterTranslationModel,
+                "status",
+            )
+        finally:
+            if callable(cache_clear):
+                cache_clear()
+
     def test_translate_reverse_filter_key_preserves_remaining_parts_after_relation_without_related_model(
         self,
     ) -> None:
@@ -1231,6 +1273,42 @@ class TestOrmQueryCapability:
                         search_date=None,
                     )
                     assert result is mock_bucket.return_value
+
+    def test_build_or_reuse_bucket_skips_signature_without_run_context(self):
+        capability = OrmQueryCapability()
+        interface_cls = Mock()
+        built_bucket = Mock()
+
+        with (
+            patch(
+                "general_manager.interface.capabilities.orm.support.current_calculation_run_context",
+                return_value=None,
+            ),
+            patch.object(
+                capability,
+                "_run_scoped_query_bucket_signature",
+                side_effect=AssertionError("signature only needed inside run context"),
+            ),
+            patch.object(
+                capability,
+                "_build_bucket",
+                return_value=built_bucket,
+            ) as build_bucket,
+        ):
+            result = capability._build_or_reuse_bucket(
+                interface_cls,
+                include_inactive=False,
+                normalized_kwargs={"name": "test"},
+            )
+
+        assert result is built_bucket
+        build_bucket.assert_called_once_with(
+            interface_cls,
+            include_inactive=False,
+            normalized_kwargs={"name": "test"},
+            exclude=False,
+            search_date=None,
+        )
 
     def test_exclude_returns_database_bucket(self):
         """Test that exclude returns a DatabaseBucket with exclusion."""


### PR DESCRIPTION
## Summary

- reduce cold-cache framework overhead for dependency-cached calculation paths
- add run-context reuse for trusted ORM buckets, bucket managers, query buckets, and existence checks
- add faster dependency-cache payload handling, dependency shard planning, scalar dependency serialization, cache-key signature caching, descriptor caching, FK raw-id accessors, and measurement/unit caching
- harden JSON-equivalent fast paths for non-ASCII scalar manager IDs, single-manager cache keys, and unhashable callable cache-key inputs
- add regression coverage for cache payloads, bucket reuse, FK accessors, measurement caching, dependency shards, run-context mutation invalidation, recent search-date query buckets, many-to-many prefetch fallback paths, run-context query-bucket cold paths, callable cache-key fallbacks, and related edge cases

## Performance

KnowledgeHub revenue benchmark, prefix `KH-REV-CTX-0630`, 1 project, 12 derivatives, 36 months, 432 rows:

- cold cProfile calculation elapsed: `97.821s -> 31.698s` (`3.09x` faster)
- 10-run non-profile New-GM cold mean: `12.019s`
- 10-run old BE cold mean: `49.738s`; New-GM cold mean is about `4.14x` faster in that runner
- hot New-GM 10-run mean: `0.1283s`

Note: the old BE and New-GM benchmark runners still report different grand totals, so the old/new timing comparison is a runtime comparison of the current benchmark implementations, not a parity assertion.

## Validation

- `python3 -m pytest tests/unit/test_make_cache_key.py::TestMakeCacheKey::test_make_cache_key_supports_unhashable_callable_instances -q`: `1 passed in 0.04s`
- `python3 -m pytest tests/unit/test_make_cache_key.py -q`: `27 passed, 7 subtests passed in 0.05s`
- `ruff check src/general_manager/utils/make_cache_key.py tests/unit/test_make_cache_key.py`: passed
- `ruff format --check src/general_manager/utils/make_cache_key.py tests/unit/test_make_cache_key.py`: passed
- `mypy src/general_manager/utils/make_cache_key.py`: passed
- `mkdocs build --strict`: passed
- `python3 -m pytest --cov=general_manager --cov-report=xml:coverage.xml`: `3910 passed, 1 skipped, 1 warning in 98.97s`
- `pre-commit run --all-files`: ruff lint, ruff format, EOF/whitespace/line endings/merge-conflict/debug checks, and full strict mypy all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced run-scoped caching for ORM query buckets, trusted hydration, and per-run result reuse (including first-row, exists, count, and relationship prefetch bucketing).
  * Improved cache determinism and performance for dependency matching/serialization, cache key generation, and single-field input parsing.
  * Measurement parsing/arithmetic now reuses canonical unit/magnitude computations more efficiently.
* **Bug Fixes**
  * Fixed cases where repeated access could trigger extra SQL compilation, redundant evaluation, or incorrect run-context cache behavior.
  * Updated cache invalidation so data-change events also clear trusted ORM manager reuse.
* **Tests**
  * Added extensive integration and unit coverage for the new caching and normalization behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->