### PR TITLE
[codex] Reduce dependency-cache framework overhead

### DIFF
--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -142,7 +142,10 @@ class GraphQLProperty(property):
         @wraps(fget)
         def resolver(instance: object) -> object:
             """Resolve the property through the selected cached wrapper."""
-            return self._get_cached_fget()(instance)
+            cached_fget = self._cached_fget
+            if cached_fget is None:
+                cached_fget = self._get_cached_fget()
+            return cached_fget(instance)
 
         super().__init__(resolver, doc=doc)
         self.is_graphql_resolver = True

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -608,6 +608,11 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
     def _can_cache_run_scoped_managers(self) -> bool:
         if self._manager_class.__init__ is not GeneralManager.__init__:
             return False
+        if not type.__getattribute__(
+            self._manager_class,
+            "_gm_uses_default_identification_dependency_active",
+        ):
+            return False
         return callable(
             getattr(self._manager_class.Interface, "_from_trusted_orm_instance", None)
         )

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -11,7 +11,10 @@ from django.db.models.sql.query import Query
 
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.cache.cache_tracker import DependencyTracker
-from general_manager.cache.dependency_index import serialize_dependency_identifier
+from general_manager.cache.dependency_index import (
+    Dependency,
+    serialize_dependency_identifier,
+)
 from general_manager.cache.run_context import current_calculation_run_context
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.utils.filter_parser import create_filter_function
@@ -609,6 +612,20 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
             getattr(self._manager_class.Interface, "_from_trusted_orm_instance", None)
         )
 
+    def _manager_identification_dependencies(
+        self,
+        managers: tuple[GeneralManagerType, ...],
+    ) -> frozenset[Dependency]:
+        manager_name = type.__getattribute__(self._manager_class, "__name__")
+        return frozenset(
+            (
+                manager_name,
+                "identification",
+                serialize_dependency_identifier(manager.identification),
+            )
+            for manager in managers
+        )
+
     def _get_run_scoped_managers(self) -> tuple[GeneralManagerType, ...] | None:
         """Load or reuse manager wrappers for a trusted row snapshot."""
         if not self._can_cache_run_scoped_managers():
@@ -622,16 +639,24 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         cached = context.get_orm_bucket_managers(signature)
         if cached is not None:
             managers = cast(tuple[GeneralManagerType, ...], cached)
-            for manager in managers:
-                self._manager_class._track_identification_dependency(
-                    manager.identification
-                )
+            dependencies = context.get_orm_bucket_manager_dependencies(signature)
+            if dependencies is not None:
+                DependencyTracker._track_many_validated(dependencies)
+            else:
+                for manager in managers:
+                    self._manager_class._track_identification_dependency(
+                        manager.identification
+                    )
             return managers
         rows = self._get_run_scoped_rows()
         if rows is None:
             return None
         managers = tuple(self._build_manager_from_instance(row) for row in rows)
-        context.set_orm_bucket_managers(signature, managers)
+        context.set_orm_bucket_managers(
+            signature,
+            managers,
+            self._manager_identification_dependencies(managers),
+        )
         return managers
 
     @staticmethod
@@ -675,9 +700,18 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
 
     def _track_effective_dependencies(self) -> None:
         """Record the bucket's effective filter/exclude state when it is evaluated."""
-        manager_name = self._manager_class.__name__
-        normalized_filters = self._normalize_dependency_mapping(self.filters)
-        normalized_excludes = self._normalize_dependency_mapping(self.excludes)
+        manager_name = type.__getattribute__(self._manager_class, "__name__")
+        needs_sort_payload = bool(self._sort_keys)
+        normalized_filters = (
+            self._normalize_dependency_mapping(self.filters)
+            if self.filters or needs_sort_payload
+            else {}
+        )
+        normalized_excludes = (
+            self._normalize_dependency_mapping(self.excludes)
+            if self.excludes or needs_sort_payload
+            else {}
+        )
         if self.filters:
             DependencyTracker._track_validated(
                 manager_name,

--- a/src/general_manager/cache/cache_decorator.py
+++ b/src/general_manager/cache/cache_decorator.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable, Iterable
 from functools import wraps
+from hashlib import sha256
 from typing import (
     Literal,
     Protocol,
@@ -15,6 +16,16 @@ from django.core.cache import cache as django_cache
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_cache import (
     DependencyCacheHit,
+    dependency_cache_prefetch_bundle_key,
+    dependency_cache_prefetch_segment_bundle_key,
+    dependency_cache_prefetch_segment_index_key,
+    dependency_cache_prefetch_segment_value_bundle_key,
+    dependency_cache_prefetch_value_bundle_key,
+    read_many_dependency_cache_hits,
+    read_many_dependency_cache_prefetch_bundle_hits,
+    read_many_dependency_cache_prefetch_bundle_values,
+    read_dependency_cache_prefetch_bundle_hits,
+    read_dependency_cache_prefetch_bundle_values,
     read_dependency_cache_hit,
     replay_dependency_cache_hit,
 )
@@ -63,6 +74,10 @@ FuncT = TypeVar("FuncT", bound=Callable[..., object])
 CacheScope = Literal["dependency", "run", "timeout", "none"]
 
 _SENTINEL = object()
+_RUN_CACHE_MISS = object()
+_DEPENDENCY_CACHE_PREFETCH_MANIFEST_PREFIX = "dependency_cache_prefetch_manifest"
+_DEPENDENCY_CACHE_PREFETCH_ATTEMPT_PREFIX = "dependency_cache_prefetch_attempt"
+_DEPENDENCY_CACHE_PREFETCH_VALUE_PREFIX = "dependency_cache_prefetch_value"
 logger = get_logger("cache.decorator")
 
 
@@ -169,7 +184,130 @@ def cached(
     if timeout is not None and cache != "timeout":
         raise CacheTimeoutConfigurationError.unexpected_timeout()
 
+    def dependency_cache_prefetch_manifest_key(
+        decorated_func: Callable[..., object],
+    ) -> str:
+        raw = f"{decorated_func.__module__}:{decorated_func.__qualname__}".encode()
+        digest = sha256(raw, usedforsecurity=False).hexdigest()
+        return f"{_DEPENDENCY_CACHE_PREFETCH_MANIFEST_PREFIX}:{digest}"
+
+    def prefetch_dependency_cache_manifest(
+        context: object,
+        manifest_key: str,
+    ) -> None:
+        if not callable(getattr(cache_backend, "get_many", None)):
+            return
+        if not all(
+            hasattr(context, attr)
+            for attr in (
+                "get",
+                "set",
+                "set_dependency_cache_hits",
+            )
+        ):
+            return
+        attempt_key = (
+            _DEPENDENCY_CACHE_PREFETCH_ATTEMPT_PREFIX,
+            id(cache_backend),
+            manifest_key,
+        )
+        if context.get(attempt_key, False):  # type: ignore[attr-defined]
+            return
+        context.set(attempt_key, True)  # type: ignore[attr-defined]
+
+        segment_tokens = cache_backend.get(
+            dependency_cache_prefetch_segment_index_key(manifest_key),
+            (),
+        )
+        if isinstance(segment_tokens, (tuple, list, frozenset, set)):
+            valid_segment_tokens = tuple(
+                token for token in segment_tokens if isinstance(token, str)
+            )
+        else:
+            valid_segment_tokens = ()
+
+        if not DependencyTracker.is_active():
+            if valid_segment_tokens:
+                segment_value_keys = tuple(
+                    dependency_cache_prefetch_segment_value_bundle_key(
+                        manifest_key,
+                        segment_token,
+                    )
+                    for segment_token in valid_segment_tokens
+                )
+                segment_values = read_many_dependency_cache_prefetch_bundle_values(
+                    cache_backend,
+                    segment_value_keys,
+                )
+                if segment_values:
+                    for cache_key, value in segment_values.items():
+                        context.set(  # type: ignore[attr-defined]
+                            (
+                                _DEPENDENCY_CACHE_PREFETCH_VALUE_PREFIX,
+                                id(cache_backend),
+                                cache_key,
+                            ),
+                            value,
+                        )
+                    return
+
+            bundle_values = read_dependency_cache_prefetch_bundle_values(
+                cache_backend,
+                dependency_cache_prefetch_value_bundle_key(manifest_key),
+            )
+            if bundle_values:
+                for cache_key, value in bundle_values.items():
+                    context.set(  # type: ignore[attr-defined]
+                        (
+                            _DEPENDENCY_CACHE_PREFETCH_VALUE_PREFIX,
+                            id(cache_backend),
+                            cache_key,
+                        ),
+                        value,
+                    )
+                return
+
+        if valid_segment_tokens:
+            segment_bundle_keys = tuple(
+                dependency_cache_prefetch_segment_bundle_key(
+                    manifest_key,
+                    segment_token,
+                )
+                for segment_token in valid_segment_tokens
+            )
+            segment_hits = read_many_dependency_cache_prefetch_bundle_hits(
+                cache_backend,
+                segment_bundle_keys,
+            )
+            if segment_hits:
+                context.set_dependency_cache_hits(segment_hits)  # type: ignore[attr-defined]
+                return
+
+        bundle_hits = read_dependency_cache_prefetch_bundle_hits(
+            cache_backend,
+            dependency_cache_prefetch_bundle_key(manifest_key),
+        )
+        if bundle_hits:
+            context.set_dependency_cache_hits(bundle_hits)  # type: ignore[attr-defined]
+            return
+
+        manifest = cache_backend.get(manifest_key, ())
+        if not isinstance(manifest, (tuple, list, frozenset, set)):
+            return
+        cache_keys = tuple(key for key in manifest if isinstance(key, str))
+        if not cache_keys:
+            return
+        hits = read_many_dependency_cache_hits(cache_backend, cache_keys)
+        if hits:
+            context.set_dependency_cache_hits(hits)  # type: ignore[attr-defined]
+
     def decorator(decorated_func: FuncT) -> FuncT:
+        prefetch_manifest_key = (
+            dependency_cache_prefetch_manifest_key(decorated_func)
+            if cache == "dependency"
+            else None
+        )
+
         @wraps(decorated_func)
         def wrapper(*args: object, **kwargs: object) -> object:
             if cache == "none":
@@ -177,11 +315,21 @@ def cached(
 
             if cache == "run":
                 key = make_cache_key(decorated_func, args, kwargs)
+                active_context = current_calculation_run_context()
+                if active_context is not None:
+                    cached_run_value = active_context.get(key, _RUN_CACHE_MISS)
+                    if cached_run_value is not _RUN_CACHE_MISS:
+                        return cached_run_value
+                    result = decorated_func(*args, **kwargs)
+                    active_context.set(key, result)
+                    return result
                 with ensure_calculation_run_context() as context:
-                    return context.get_or_set(
-                        key,
-                        lambda: decorated_func(*args, **kwargs),
-                    )
+                    cached_run_value = context.get(key, _RUN_CACHE_MISS)
+                    if cached_run_value is not _RUN_CACHE_MISS:
+                        return cached_run_value
+                    result = decorated_func(*args, **kwargs)
+                    context.set(key, result)
+                    return result
 
             key = make_cache_key(decorated_func, args, kwargs)
 
@@ -223,8 +371,23 @@ def cached(
                 )
                 return hit.value
 
+            def prefetched_value_from_context(context: object) -> object:
+                if DependencyTracker.is_active():
+                    return _SENTINEL
+                return context.get(  # type: ignore[attr-defined]
+                    (
+                        _DEPENDENCY_CACHE_PREFETCH_VALUE_PREFIX,
+                        id(cache_backend),
+                        key,
+                    ),
+                    _SENTINEL,
+                )
+
             prefetch_context = current_calculation_run_context()
             if prefetch_context is not None:
+                prefetched_value = prefetched_value_from_context(prefetch_context)
+                if prefetched_value is not _SENTINEL:
+                    return prefetched_value
                 prefetched_hit = prefetch_context.get_dependency_cache_hit(
                     key, _SENTINEL
                 )
@@ -233,6 +396,22 @@ def cached(
                         prefetched_hit,
                         "cache hit from dependency prefetch",
                     )
+                if prefetch_manifest_key is not None:
+                    prefetch_dependency_cache_manifest(
+                        prefetch_context,
+                        prefetch_manifest_key,
+                    )
+                    prefetched_value = prefetched_value_from_context(prefetch_context)
+                    if prefetched_value is not _SENTINEL:
+                        return prefetched_value
+                    prefetched_hit = prefetch_context.get_dependency_cache_hit(
+                        key, _SENTINEL
+                    )
+                    if isinstance(prefetched_hit, DependencyCacheHit):
+                        return return_cached_hit(
+                            prefetched_hit,
+                            "cache hit from dependency prefetch manifest",
+                        )
 
             cached_hit = read_dependency_cache_hit(
                 cache_backend,
@@ -288,6 +467,10 @@ def cached(
                             timeout=timeout,
                             started_generation=started_generation,
                             lease=lease,
+                            dependencies_trusted=DependencyTracker._dependencies_are_tracker_captured(
+                                dependencies
+                            ),
+                            prefetch_manifest_key=prefetch_manifest_key,
                         )
                     )
                     lease_transferred_to_context = True
@@ -305,6 +488,7 @@ def cached(
                                 if record_fn is record_dependencies
                                 else record_many
                             ),
+                            prefetch_manifest_key=prefetch_manifest_key,
                         )
                     except CachePublishAborted:
                         logger.debug(

--- a/src/general_manager/cache/cache_tracker.py
+++ b/src/general_manager/cache/cache_tracker.py
@@ -1,5 +1,6 @@
 """Context manager utilities for tracking cache dependencies per thread."""
 
+from collections.abc import Collection, Iterable
 import threading
 from types import TracebackType
 
@@ -30,18 +31,32 @@ class _InvalidDependencyTrackerOperationError(ValueError):
         super().__init__(f"Unsupported dependency tracker operation: {operation!r}")
 
 
+class _TrackedDependencySet(set[Dependency]):
+    """Dependency set returned by DependencyTracker for framework-captured deps."""
+
+
 class _DependencyStorage(threading.local):
     """Thread-local dependency tracking stack."""
 
     def __init__(self) -> None:
         """Initialize an inactive dependency stack for one thread."""
-        self.dependencies: list[set[Dependency]] = []
+        self.dependencies: list[_TrackedDependencySet] = []
         self.depth = -1
+        self.stack_version = 0
+        self.last_dependency: Dependency | None = None
+        self.last_dependency_stack_version = -1
+        self.seen_dependencies: set[Dependency] = set()
+        self.seen_dependencies_stack_version = -1
 
     def reset(self) -> None:
         """Clear all active dependency scopes for the current thread."""
         self.dependencies.clear()
         self.depth = -1
+        self.stack_version += 1
+        self.last_dependency = None
+        self.last_dependency_stack_version = -1
+        self.seen_dependencies.clear()
+        self.seen_dependencies_stack_version = -1
 
 
 _dependency_storage = _DependencyStorage()
@@ -69,7 +84,8 @@ class DependencyTracker:
             thread-local storage does not mutate sets that were already returned.
         """
         _dependency_storage.depth += 1
-        _dependency_storage.dependencies.append(set())
+        _dependency_storage.dependencies.append(_TrackedDependencySet())
+        _dependency_storage.stack_version += 1
         return _dependency_storage.dependencies[_dependency_storage.depth]
 
     def __exit__(
@@ -98,6 +114,9 @@ class DependencyTracker:
             return
         _dependency_storage.dependencies.pop()
         _dependency_storage.depth -= 1
+        _dependency_storage.stack_version += 1
+        _dependency_storage.last_dependency = None
+        _dependency_storage.last_dependency_stack_version = -1
 
     @staticmethod
     def track(
@@ -144,11 +163,50 @@ class DependencyTracker:
         identifier: str,
     ) -> None:
         """Record an already-validated dependency tuple in active collectors."""
+        storage = _dependency_storage
+        if storage.depth < 0:
+            return
+        if storage.last_dependency_stack_version == storage.stack_version:
+            last_dependency = storage.last_dependency
+            if (
+                last_dependency is not None
+                and last_dependency[0] == class_name
+                and last_dependency[1] == operation
+                and last_dependency[2] == identifier
+            ):
+                return
+        dependency = (class_name, operation, identifier)
+        if storage.seen_dependencies_stack_version != storage.stack_version:
+            storage.seen_dependencies.clear()
+            storage.seen_dependencies_stack_version = storage.stack_version
+        elif dependency in storage.seen_dependencies:
+            return
+        if storage.depth == 0:
+            storage.dependencies[0].add(dependency)
+        else:
+            for dep_set in storage.dependencies:
+                dep_set.add(dependency)
+        storage.last_dependency = dependency
+        storage.last_dependency_stack_version = storage.stack_version
+        storage.seen_dependencies.add(dependency)
+
+    @staticmethod
+    def _track_many_validated(dependencies: Iterable[Dependency]) -> None:
+        """Record already-validated dependency tuples in active collectors."""
         if _dependency_storage.depth < 0:
             return
-        dependency = (class_name, operation, identifier)
+        reusable_dependencies: Collection[Dependency]
+        if isinstance(dependencies, Collection):
+            reusable_dependencies = dependencies
+        else:
+            reusable_dependencies = tuple(dependencies)
         for dep_set in _dependency_storage.dependencies:
-            dep_set.add(dependency)
+            dep_set.update(reusable_dependencies)
+
+    @staticmethod
+    def _dependencies_are_tracker_captured(dependencies: object) -> bool:
+        """Return whether dependencies came from this tracker implementation."""
+        return isinstance(dependencies, _TrackedDependencySet)
 
     @staticmethod
     def is_active() -> bool:

--- a/src/general_manager/cache/dependency_cache.py
+++ b/src/general_manager/cache/dependency_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from hashlib import sha256
 from typing import Protocol, TypeGuard, cast
 
 from general_manager.cache.cache_tracker import DependencyTracker
@@ -11,6 +12,9 @@ from general_manager.cache.dependency_index import Dependency
 
 LEGACY_DEPENDENCY_CACHE_ENTRY_VERSION = 1
 DEPENDENCY_CACHE_ENTRY_VERSION = 2
+TRUSTED_DEPENDENCY_CACHE_ENTRY_VERSION = 3
+DEPENDENCY_CACHE_PREFETCH_BUNDLE_VERSION = 1
+DEPENDENCY_CACHE_PREFETCH_VALUE_BUNDLE_VERSION = 1
 _VALID_DEPENDENCY_ACTIONS = frozenset(
     {"filter", "exclude", "identification", "request_query", "all"}
 )
@@ -39,6 +43,84 @@ class DependencyCacheEntry:
     value: object
     dependencies: frozenset[Dependency]
 
+    def __reduce__(
+        self,
+    ) -> tuple[
+        object,
+        tuple[int, object, frozenset[Dependency]],
+    ]:
+        """Pickle entries through constructor args instead of slot state."""
+        return (
+            _rebuild_dependency_cache_entry,
+            (self.version, self.value, self.dependencies),
+        )
+
+
+def _rebuild_dependency_cache_entry(
+    version: int,
+    value: object,
+    dependencies: frozenset[Dependency],
+) -> DependencyCacheEntry:
+    return DependencyCacheEntry(
+        version=version,
+        value=value,
+        dependencies=dependencies,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyCachePrefetchBundle:
+    """Private payload containing multiple dependency-cache entries."""
+
+    version: int
+    entries: Mapping[str, DependencyCacheEntry]
+
+    def __reduce__(
+        self,
+    ) -> tuple[
+        object,
+        tuple[int, dict[str, DependencyCacheEntry]],
+    ]:
+        """Pickle bundles through constructor args instead of slot state."""
+        return (
+            _rebuild_dependency_cache_prefetch_bundle,
+            (self.version, dict(self.entries)),
+        )
+
+
+def _rebuild_dependency_cache_prefetch_bundle(
+    version: int,
+    entries: dict[str, DependencyCacheEntry],
+) -> DependencyCachePrefetchBundle:
+    return DependencyCachePrefetchBundle(version=version, entries=entries)
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyCachePrefetchValueBundle:
+    """Private payload containing values for inactive dependency tracking."""
+
+    version: int
+    values: Mapping[str, object]
+
+    def __reduce__(
+        self,
+    ) -> tuple[
+        object,
+        tuple[int, dict[str, object]],
+    ]:
+        """Pickle value bundles through constructor args instead of slot state."""
+        return (
+            _rebuild_dependency_cache_prefetch_value_bundle,
+            (self.version, dict(self.values)),
+        )
+
+
+def _rebuild_dependency_cache_prefetch_value_bundle(
+    version: int,
+    values: dict[str, object],
+) -> DependencyCachePrefetchValueBundle:
+    return DependencyCachePrefetchValueBundle(version=version, values=values)
+
 
 @dataclass(frozen=True, slots=True)
 class DependencyCacheHit:
@@ -50,6 +132,10 @@ class DependencyCacheHit:
 
     value: object
     dependencies: frozenset[Dependency]
+
+
+class _TrustedDependencyCacheHit(DependencyCacheHit):
+    """Cache hit whose dependencies were captured by DependencyTracker."""
 
 
 class DependencyCacheBackend(Protocol):
@@ -87,21 +173,185 @@ class DependencyCacheSetManyBackend(DependencyCacheBackend, Protocol):
 def make_dependency_cache_entry(
     value: object,
     dependencies: Iterable[Dependency],
+    *,
+    trusted_dependencies: bool | None = None,
 ) -> DependencyCacheEntry:
     """Build the current persisted dependency-cache payload.
 
     Args:
         value: Cached function result to persist.
         dependencies: Dependencies captured while computing the value.
+        trusted_dependencies: Whether dependencies are known to come from
+            `DependencyTracker`. When omitted, tracker-captured sets are
+            detected automatically.
 
     Returns:
         A versioned `DependencyCacheEntry` with dependencies frozen.
     """
+    if trusted_dependencies is None:
+        trusted_dependencies = DependencyTracker._dependencies_are_tracker_captured(
+            dependencies
+        )
     return DependencyCacheEntry(
-        version=DEPENDENCY_CACHE_ENTRY_VERSION,
+        version=(
+            TRUSTED_DEPENDENCY_CACHE_ENTRY_VERSION
+            if trusted_dependencies
+            else DEPENDENCY_CACHE_ENTRY_VERSION
+        ),
         value=value,
         dependencies=frozenset(dependencies),
     )
+
+
+def dependency_cache_prefetch_bundle_key(manifest_key: str) -> str:
+    """Return the private bundle key paired with a prefetch manifest key."""
+    return f"{manifest_key}:bundle"
+
+
+def dependency_cache_prefetch_value_bundle_key(manifest_key: str) -> str:
+    """Return the private value-bundle key paired with a prefetch manifest key."""
+    return f"{manifest_key}:values"
+
+
+def dependency_cache_prefetch_segment_index_key(manifest_key: str) -> str:
+    """Return the private segment-index key paired with a prefetch manifest."""
+    return f"{manifest_key}:segments"
+
+
+def dependency_cache_prefetch_segment_token(cache_keys: Iterable[str]) -> str:
+    """Return a stable token for one prefetch segment's ordered cache keys."""
+    digest = sha256(usedforsecurity=False)
+    for cache_key in cache_keys:
+        encoded_key = cache_key.encode()
+        digest.update(len(encoded_key).to_bytes(8, "big"))
+        digest.update(encoded_key)
+    return digest.hexdigest()
+
+
+def dependency_cache_prefetch_segment_bundle_key(
+    manifest_key: str,
+    segment_token: str,
+) -> str:
+    """Return the private full bundle key for one prefetch segment."""
+    return f"{manifest_key}:segment:{segment_token}:bundle"
+
+
+def dependency_cache_prefetch_segment_value_bundle_key(
+    manifest_key: str,
+    segment_token: str,
+) -> str:
+    """Return the private value bundle key for one prefetch segment."""
+    return f"{manifest_key}:segment:{segment_token}:values"
+
+
+def make_dependency_cache_prefetch_bundle(
+    entries: Mapping[str, DependencyCacheEntry],
+) -> DependencyCachePrefetchBundle:
+    """Build a private prefetch bundle from dependency-cache entry payloads."""
+    return DependencyCachePrefetchBundle(
+        version=DEPENDENCY_CACHE_PREFETCH_BUNDLE_VERSION,
+        entries=dict(entries),
+    )
+
+
+def make_dependency_cache_prefetch_value_bundle(
+    entries: Mapping[str, DependencyCacheEntry],
+) -> DependencyCachePrefetchValueBundle:
+    """Build a private value-only bundle from dependency-cache entries."""
+    return DependencyCachePrefetchValueBundle(
+        version=DEPENDENCY_CACHE_PREFETCH_VALUE_BUNDLE_VERSION,
+        values={cache_key: entry.value for cache_key, entry in entries.items()},
+    )
+
+
+def read_dependency_cache_prefetch_bundle_hits(
+    cache_backend: DependencyCacheBackend,
+    bundle_key: str,
+) -> dict[str, DependencyCacheHit]:
+    """Read dependency-cache hits from one private prefetch bundle payload."""
+    entries = read_dependency_cache_prefetch_bundle_entries(cache_backend, bundle_key)
+    if not entries:
+        return {}
+
+    hits: dict[str, DependencyCacheHit] = {}
+    for cache_key, entry in entries.items():
+        hit = _combined_payload_to_hit(entry)
+        if isinstance(hit, DependencyCacheHit):
+            hits[cache_key] = hit
+    return hits
+
+
+def read_dependency_cache_prefetch_bundle_entries(
+    cache_backend: DependencyCacheBackend,
+    bundle_key: str,
+) -> dict[str, DependencyCacheEntry]:
+    """Read raw dependency-cache entries from one private prefetch bundle."""
+    payload = cache_backend.get(bundle_key, _MISSING)
+    if not isinstance(payload, DependencyCachePrefetchBundle):
+        return {}
+    if payload.version != DEPENDENCY_CACHE_PREFETCH_BUNDLE_VERSION:
+        return {}
+    return {
+        cache_key: entry
+        for cache_key, entry in payload.entries.items()
+        if isinstance(cache_key, str) and isinstance(entry, DependencyCacheEntry)
+    }
+
+
+def read_dependency_cache_prefetch_bundle_values(
+    cache_backend: DependencyCacheBackend,
+    value_bundle_key: str,
+) -> dict[str, object]:
+    """Read value-only dependency-cache hits from one private bundle payload."""
+    payload = cache_backend.get(value_bundle_key, _MISSING)
+    if not isinstance(payload, DependencyCachePrefetchValueBundle):
+        return {}
+    if payload.version != DEPENDENCY_CACHE_PREFETCH_VALUE_BUNDLE_VERSION:
+        return {}
+    return {
+        cache_key: value
+        for cache_key, value in payload.values.items()
+        if isinstance(cache_key, str)
+    }
+
+
+def read_many_dependency_cache_prefetch_bundle_hits(
+    cache_backend: DependencyCacheBackend,
+    bundle_keys: Iterable[str],
+) -> dict[str, DependencyCacheHit]:
+    """Read dependency-cache hits from multiple private prefetch bundles."""
+    payloads = _get_many_or_loop(cache_backend, tuple(dict.fromkeys(bundle_keys)))
+    hits: dict[str, DependencyCacheHit] = {}
+    for payload in payloads.values():
+        if not isinstance(payload, DependencyCachePrefetchBundle):
+            continue
+        if payload.version != DEPENDENCY_CACHE_PREFETCH_BUNDLE_VERSION:
+            continue
+        for cache_key, entry in payload.entries.items():
+            if not isinstance(cache_key, str):
+                continue
+            hit = _combined_payload_to_hit(entry)
+            if isinstance(hit, DependencyCacheHit):
+                hits[cache_key] = hit
+    return hits
+
+
+def read_many_dependency_cache_prefetch_bundle_values(
+    cache_backend: DependencyCacheBackend,
+    value_bundle_keys: Iterable[str],
+) -> dict[str, object]:
+    """Read values from multiple private prefetch value bundles."""
+    payloads = _get_many_or_loop(cache_backend, tuple(dict.fromkeys(value_bundle_keys)))
+    values: dict[str, object] = {}
+    for payload in payloads.values():
+        if not isinstance(payload, DependencyCachePrefetchValueBundle):
+            continue
+        if payload.version != DEPENDENCY_CACHE_PREFETCH_VALUE_BUNDLE_VERSION:
+            continue
+        for cache_key, value in payload.values.items():
+            if isinstance(cache_key, str):
+                values[cache_key] = value
+    return values
 
 
 def read_dependency_cache_hit(
@@ -223,6 +473,9 @@ def replay_dependency_cache_hit(hit: DependencyCacheHit) -> None:
         ValueError: Propagated from `DependencyTracker.track()` if a dependency
             tuple uses an unsupported operation.
     """
+    if isinstance(hit, _TrustedDependencyCacheHit):
+        DependencyTracker._track_many_validated(hit.dependencies)
+        return
     for class_name, operation, identifier in hit.dependencies:
         DependencyTracker.track(class_name, operation, identifier)
 
@@ -264,16 +517,23 @@ def _combined_payload_to_hit(
         if dependencies is None:
             return _MISSING
     elif payload.version == DEPENDENCY_CACHE_ENTRY_VERSION:
-        # Legacy entries may contain arbitrary tuple-like data, so the
-        # _legacy_dependency_set path validates each dependency. Current entries
-        # come from make_dependency_cache_entry after that same validation flow,
-        # so keep deserialization on the frozenset type-check fast path.
+        # Version 2 entries are structurally checked here and still validate
+        # each dependency during replay.
         if not isinstance(payload.dependencies, frozenset):
             return _MISSING
         dependencies = payload.dependencies
+        hit_type = DependencyCacheHit
+    elif payload.version == TRUSTED_DEPENDENCY_CACHE_ENTRY_VERSION:
+        # Version 3 entries are written only for dependency sets captured by
+        # DependencyTracker, so replay can bulk-merge them without per-tuple
+        # validation.
+        if not isinstance(payload.dependencies, frozenset):
+            return _MISSING
+        dependencies = payload.dependencies
+        hit_type = _TrustedDependencyCacheHit
     else:
         return _MISSING
-    return DependencyCacheHit(
+    return hit_type(
         value=payload.value,
         dependencies=dependencies,
     )
@@ -283,6 +543,22 @@ def _supports_get_many(
     cache_backend: DependencyCacheBackend,
 ) -> TypeGuard[DependencyCacheGetManyBackend]:
     return callable(getattr(cache_backend, "get_many", None))
+
+
+def _get_many_or_loop(
+    cache_backend: DependencyCacheBackend,
+    keys: tuple[str, ...],
+) -> Mapping[str, object]:
+    if not keys:
+        return {}
+    if _supports_get_many(cache_backend):
+        return cache_backend.get_many(keys)
+    values: dict[str, object] = {}
+    for key in keys:
+        value = cache_backend.get(key, _MISSING)
+        if value is not _MISSING:
+            values[key] = value
+    return values
 
 
 def _read_many_without_get_many(

--- a/src/general_manager/cache/dependency_cache.py
+++ b/src/general_manager/cache/dependency_cache.py
@@ -290,6 +290,8 @@ def read_dependency_cache_prefetch_bundle_entries(
         return {}
     if payload.version != DEPENDENCY_CACHE_PREFETCH_BUNDLE_VERSION:
         return {}
+    if not isinstance(payload.entries, Mapping):
+        return {}
     return {
         cache_key: entry
         for cache_key, entry in payload.entries.items()
@@ -306,6 +308,8 @@ def read_dependency_cache_prefetch_bundle_values(
     if not isinstance(payload, DependencyCachePrefetchValueBundle):
         return {}
     if payload.version != DEPENDENCY_CACHE_PREFETCH_VALUE_BUNDLE_VERSION:
+        return {}
+    if not isinstance(payload.values, Mapping):
         return {}
     return {
         cache_key: value
@@ -325,6 +329,8 @@ def read_many_dependency_cache_prefetch_bundle_hits(
         if not isinstance(payload, DependencyCachePrefetchBundle):
             continue
         if payload.version != DEPENDENCY_CACHE_PREFETCH_BUNDLE_VERSION:
+            continue
+        if not isinstance(payload.entries, Mapping):
             continue
         for cache_key, entry in payload.entries.items():
             if not isinstance(cache_key, str):
@@ -346,6 +352,8 @@ def read_many_dependency_cache_prefetch_bundle_values(
         if not isinstance(payload, DependencyCachePrefetchValueBundle):
             continue
         if payload.version != DEPENDENCY_CACHE_PREFETCH_VALUE_BUNDLE_VERSION:
+            continue
+        if not isinstance(payload.values, Mapping):
             continue
         for cache_key, value in payload.values.items():
             if isinstance(cache_key, str):

--- a/src/general_manager/cache/dependency_cache.py
+++ b/src/general_manager/cache/dependency_cache.py
@@ -10,7 +10,6 @@ from typing import Protocol, TypeGuard, cast
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import Dependency
 
-LEGACY_DEPENDENCY_CACHE_ENTRY_VERSION = 1
 DEPENDENCY_CACHE_ENTRY_VERSION = 2
 TRUSTED_DEPENDENCY_CACHE_ENTRY_VERSION = 3
 DEPENDENCY_CACHE_PREFETCH_BUNDLE_VERSION = 1
@@ -512,11 +511,7 @@ def _combined_payload_to_hit(
 ) -> DependencyCacheHit | None | _MissingSentinel:
     if not isinstance(payload, DependencyCacheEntry):
         return None
-    if payload.version == LEGACY_DEPENDENCY_CACHE_ENTRY_VERSION:
-        dependencies = _legacy_dependency_set(payload.dependencies)
-        if dependencies is None:
-            return _MISSING
-    elif payload.version == DEPENDENCY_CACHE_ENTRY_VERSION:
+    if payload.version == DEPENDENCY_CACHE_ENTRY_VERSION:
         # Version 2 entries are structurally checked here and still validate
         # each dependency during replay.
         if not isinstance(payload.dependencies, frozenset):

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -1334,15 +1334,15 @@ def _generic_cache_invalidation_from_shards(
     invalidation_candidates.update(all_records_cache_keys(manager_name))
     identification = getattr(instance, "identification", None)
     if identification:
-        invalidation_candidates.update(
-            candidate_cache_keys_for_lookup(
-                manager_name,
-                "filter",
-                "identification",
-                old_value=serialize_dependency_identifier(identification),
-                new_value=serialize_dependency_identifier(identification),
-            )
-        )
+        for cache_key in candidate_cache_keys_for_lookup(
+            manager_name,
+            "filter",
+            "identification",
+            old_value=serialize_dependency_identifier(identification),
+            new_value=serialize_dependency_identifier(identification),
+        ):
+            if candidate_should_invalidate(cache_key, "identification", None):
+                invalidation_candidates.add(cache_key)
 
     for lookup in tracked_lookup_names(manager_name):
         old_value = old_relevant_values.get(lookup)

--- a/src/general_manager/cache/dependency_matching.py
+++ b/src/general_manager/cache/dependency_matching.py
@@ -108,6 +108,8 @@ def _serialize_scalar_dependency_value(value: object) -> str | object:
 
 
 def _serialize_simple_dependency_value(value: object) -> str | object:
+    """Serialize only values matching the full encoder, else return the miss sentinel."""
+
     normalized_value = _normalize_scalar_dependency_value(value)
     if normalized_value is not _SCALAR_NORMALIZATION_MISS:
         serialized_value = _serialize_scalar_dependency_value(normalized_value)
@@ -123,6 +125,8 @@ def _serialize_simple_dependency_value(value: object) -> str | object:
 def _serialize_simple_dependency_mapping(
     value: Mapping[object, object],
 ) -> str | object:
+    """Serialize mappings or return `_MAPPING_SERIALIZATION_MISS` on ambiguity."""
+
     if not value:
         return "{}"
     if len(value) == 1:

--- a/src/general_manager/cache/dependency_matching.py
+++ b/src/general_manager/cache/dependency_matching.py
@@ -32,6 +32,7 @@ SUPPORTED_LOOKUP_OPERATORS = EXACT_OPERATORS | SCAN_OPERATORS
 UNDEFINED = object()
 _SCALAR_NORMALIZATION_MISS = object()
 _SCALAR_SERIALIZATION_MISS = object()
+_MAPPING_SERIALIZATION_MISS = object()
 
 
 type NormalizedDependencyValue = (
@@ -106,6 +107,71 @@ def _serialize_scalar_dependency_value(value: object) -> str | object:
     return _SCALAR_SERIALIZATION_MISS
 
 
+def _serialize_simple_dependency_value(value: object) -> str | object:
+    normalized_value = _normalize_scalar_dependency_value(value)
+    if normalized_value is not _SCALAR_NORMALIZATION_MISS:
+        serialized_value = _serialize_scalar_dependency_value(normalized_value)
+        if serialized_value is not _SCALAR_SERIALIZATION_MISS:
+            return serialized_value
+        if isinstance(normalized_value, float):
+            return json.dumps(normalized_value)
+    if isinstance(value, Mapping):
+        return _serialize_simple_dependency_mapping(value)
+    return _MAPPING_SERIALIZATION_MISS
+
+
+def _serialize_simple_dependency_mapping(
+    value: Mapping[object, object],
+) -> str | object:
+    if not value:
+        return "{}"
+    if len(value) == 1:
+        raw_key, raw_value = next(iter(value.items()))
+        serialized_value = _serialize_simple_dependency_value(raw_value)
+        if serialized_value is _MAPPING_SERIALIZATION_MISS:
+            return _MAPPING_SERIALIZATION_MISS
+        return (
+            "{"
+            f"{encode_basestring_ascii(str(raw_key))}: {cast(str, serialized_value)}"
+            "}"
+        )
+    if len(value) == 2:
+        iterator = iter(value.items())
+        first_key, first_value = next(iterator)
+        second_key, second_value = next(iterator)
+        first_key_str = str(first_key)
+        second_key_str = str(second_key)
+        if first_key_str == second_key_str:
+            return _MAPPING_SERIALIZATION_MISS
+        if first_key_str < second_key_str:
+            first_serialized = _serialize_simple_dependency_value(first_value)
+            if first_serialized is _MAPPING_SERIALIZATION_MISS:
+                return _MAPPING_SERIALIZATION_MISS
+            second_serialized = _serialize_simple_dependency_value(second_value)
+            if second_serialized is _MAPPING_SERIALIZATION_MISS:
+                return _MAPPING_SERIALIZATION_MISS
+            return (
+                "{"
+                f"{encode_basestring_ascii(first_key_str)}: "
+                f"{cast(str, first_serialized)}, "
+                f"{encode_basestring_ascii(second_key_str)}: "
+                f"{cast(str, second_serialized)}"
+                "}"
+            )
+    parts: list[str] = []
+    seen_keys: set[str] = set()
+    for raw_key, raw_value in sorted(value.items(), key=lambda item: str(item[0])):
+        key = str(raw_key)
+        if key in seen_keys:
+            return _MAPPING_SERIALIZATION_MISS
+        seen_keys.add(key)
+        serialized_value = _serialize_simple_dependency_value(raw_value)
+        if serialized_value is _MAPPING_SERIALIZATION_MISS:
+            return _MAPPING_SERIALIZATION_MISS
+        parts.append(f"{encode_basestring_ascii(key)}: {cast(str, serialized_value)}")
+    return "{" + ", ".join(parts) + "}"
+
+
 @dataclass(frozen=True, slots=True)
 class LookupSpec:
     """Parsed dependency lookup path and operator."""
@@ -157,17 +223,9 @@ def serialize_normalized_value(value: object) -> str:
         return json.dumps(value)
     if isinstance(value, Mapping):
         mapping = cast(Mapping[object, object], value)
-        if len(mapping) == 1:
-            key, val = next(iter(mapping.items()))
-            normalized_value = _normalize_scalar_dependency_value(val)
-            serialized_value = _serialize_scalar_dependency_value(normalized_value)
-            if serialized_value is not _SCALAR_SERIALIZATION_MISS:
-                return (
-                    "{"
-                    f"{encode_basestring_ascii(str(key))}: "
-                    f"{cast(str, serialized_value)}"
-                    "}"
-                )
+        serialized_mapping = _serialize_simple_dependency_mapping(mapping)
+        if serialized_mapping is not _MAPPING_SERIALIZATION_MISS:
+            return cast(str, serialized_mapping)
     return json.dumps(normalize_dependency_value(value), sort_keys=True)
 
 

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -11,10 +11,18 @@ from typing import TypeGuard
 
 from django.core.cache import cache as coordination_cache
 
+from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_cache import (
     DependencyCacheBackend,
+    DependencyCacheEntry,
     DependencyCacheHit,
     DependencyCacheSetManyBackend,
+    dependency_cache_prefetch_segment_bundle_key,
+    dependency_cache_prefetch_segment_index_key,
+    dependency_cache_prefetch_segment_token,
+    dependency_cache_prefetch_segment_value_bundle_key,
+    make_dependency_cache_prefetch_bundle,
+    make_dependency_cache_prefetch_value_bundle,
     make_dependency_cache_entry,
     read_dependency_cache_hit,
 )
@@ -72,6 +80,8 @@ class PendingDependencyCachePublication:
     timeout: int | None
     started_generation: int
     lease: CacheComputeLease
+    dependencies_trusted: bool = False
+    prefetch_manifest_key: str | None = None
 
 
 RecordManyDependenciesFn = Callable[[Iterable[tuple[str, Iterable[Dependency]]]], None]
@@ -81,6 +91,10 @@ COMPUTE_LOCK_TIMEOUT = LOCK_TIMEOUT
 WAIT_INITIAL_DELAY = 0.01
 WAIT_MAX_DELAY = 0.2
 _WAIT_MISS = object()
+_CALCULATION_IDENTITY_MANAGER_NAMES_CACHE: tuple[tuple[int, ...], frozenset[str]] = (
+    (),
+    frozenset(),
+)
 
 
 def _compute_lock_key(cache_key: str) -> str:
@@ -179,6 +193,90 @@ def _supports_set_many(
     return callable(getattr(cache_backend, "set_many", None))
 
 
+def _calculation_identity_manager_names() -> frozenset[str]:
+    from general_manager.interface.interfaces.calculation import CalculationInterface
+    from general_manager.manager.meta import GeneralManagerMeta
+
+    global _CALCULATION_IDENTITY_MANAGER_NAMES_CACHE
+
+    manager_classes = tuple(GeneralManagerMeta.all_classes)
+    fingerprint = tuple(id(manager_class) for manager_class in manager_classes)
+    cached_fingerprint, cached_names = _CALCULATION_IDENTITY_MANAGER_NAMES_CACHE
+    if fingerprint == cached_fingerprint:
+        return cached_names
+
+    names = frozenset(
+        manager_class.__name__
+        for manager_class in manager_classes
+        if isinstance(getattr(manager_class, "Interface", None), type)
+        and issubclass(manager_class.Interface, CalculationInterface)
+    )
+    _CALCULATION_IDENTITY_MANAGER_NAMES_CACHE = (fingerprint, names)
+    return names
+
+
+def _metadata_dependency_set(
+    dependencies: Iterable[Dependency],
+    calculation_manager_names: frozenset[str] | None = None,
+) -> set[Dependency]:
+    dependency_set = set(dependencies)
+    if not dependency_set:
+        return dependency_set
+
+    if calculation_manager_names is None:
+        calculation_manager_names = _calculation_identity_manager_names()
+    if not calculation_manager_names:
+        return dependency_set
+
+    return {
+        dependency
+        for dependency in dependency_set
+        if not (
+            dependency[1] == "identification"
+            and dependency[0] in calculation_manager_names
+        )
+    }
+
+
+def _segment_tokens(payload: object) -> tuple[str, ...]:
+    if not isinstance(payload, (tuple, list, frozenset, set)):
+        return ()
+    return tuple(token for token in payload if isinstance(token, str))
+
+
+def _set_prefetch_segment_entries(
+    cache_backend: DependencyCacheBackend,
+    timeout: int | None,
+    manifest_key: str,
+    bundle_entries: dict[str, DependencyCacheEntry],
+) -> None:
+    if not bundle_entries:
+        return
+    ordered_cache_keys = tuple(bundle_entries)
+    segment_token = dependency_cache_prefetch_segment_token(ordered_cache_keys)
+    segment_index_key = dependency_cache_prefetch_segment_index_key(manifest_key)
+    segment_tokens = _segment_tokens(cache_backend.get(segment_index_key, ()))
+    if segment_token not in segment_tokens:
+        cache_backend.set(
+            segment_index_key,
+            (*segment_tokens, segment_token),
+            timeout,
+        )
+    cache_backend.set(
+        dependency_cache_prefetch_segment_bundle_key(manifest_key, segment_token),
+        make_dependency_cache_prefetch_bundle(bundle_entries),
+        timeout,
+    )
+    cache_backend.set(
+        dependency_cache_prefetch_segment_value_bundle_key(
+            manifest_key,
+            segment_token,
+        ),
+        make_dependency_cache_prefetch_value_bundle(bundle_entries),
+        timeout,
+    )
+
+
 def _set_dependency_cache_entries(
     entries: Iterable[PendingDependencyCachePublication],
 ) -> None:
@@ -196,6 +294,7 @@ def _set_dependency_cache_entries(
             entry.cache_key: make_dependency_cache_entry(
                 entry.result,
                 entry.dependencies,
+                trusted_dependencies=entry.dependencies_trusted,
             )
             for entry in group_entries
         }
@@ -204,9 +303,60 @@ def _set_dependency_cache_entries(
             for key in failed_keys:
                 if key in payloads:
                     cache_backend.set(key, payloads[key], timeout)
-            continue
-        for key, payload in payloads.items():
-            cache_backend.set(key, payload, timeout)
+        else:
+            for key, payload in payloads.items():
+                cache_backend.set(key, payload, timeout)
+
+        manifest_payloads: dict[str, list[str]] = defaultdict(list)
+        for entry in group_entries:
+            if entry.prefetch_manifest_key is not None:
+                manifest_payloads[entry.prefetch_manifest_key].append(entry.cache_key)
+        for manifest_key, cache_keys in manifest_payloads.items():
+            ordered_cache_keys = tuple(dict.fromkeys(cache_keys))
+            bundle_payloads = {
+                cache_key: payloads[cache_key]
+                for cache_key in ordered_cache_keys
+                if cache_key in payloads
+            }
+            cache_backend.set(manifest_key, tuple(bundle_payloads), timeout)
+            _set_prefetch_segment_entries(
+                cache_backend,
+                timeout,
+                manifest_key,
+                bundle_payloads,
+            )
+
+
+def _prefetch_bundle_dependency_entries_from_metadata(
+    grouped_dependencies: dict[str, set[Dependency]],
+    grouped_cache_keys: dict[str, list[str]],
+) -> tuple[tuple[str, set[Dependency]], ...]:
+    return tuple(
+        bundle_entry
+        for manifest_key, dependencies in grouped_dependencies.items()
+        for segment_token in (
+            dependency_cache_prefetch_segment_token(
+                tuple(dict.fromkeys(grouped_cache_keys[manifest_key]))
+            ),
+        )
+        for bundle_entry in (
+            (
+                dependency_cache_prefetch_segment_bundle_key(
+                    manifest_key,
+                    segment_token,
+                ),
+                dependencies,
+            ),
+            (
+                dependency_cache_prefetch_segment_value_bundle_key(
+                    manifest_key,
+                    segment_token,
+                ),
+                dependencies,
+            ),
+        )
+        if dependencies
+    )
 
 
 def publish_dependency_cache_entries(
@@ -250,11 +400,32 @@ def publish_dependency_cache_entries(
         if not publishable_entries:
             return
 
-        record_many_cache_dependencies(
-            (entry.cache_key, entry.dependencies)
-            for entry in publishable_entries
-            if entry.dependencies
+        calculation_manager_names = _calculation_identity_manager_names()
+        dependency_entries: list[tuple[str, Iterable[Dependency]]] = []
+        prefetch_dependencies: dict[str, set[Dependency]] = defaultdict(set)
+        prefetch_cache_keys: dict[str, list[str]] = defaultdict(list)
+        for entry in publishable_entries:
+            if entry.dependencies:
+                metadata_dependencies = _metadata_dependency_set(
+                    entry.dependencies,
+                    calculation_manager_names,
+                )
+                if metadata_dependencies:
+                    dependency_entries.append((entry.cache_key, metadata_dependencies))
+                    if entry.prefetch_manifest_key is not None:
+                        prefetch_dependencies[entry.prefetch_manifest_key].update(
+                            metadata_dependencies
+                        )
+                        prefetch_cache_keys[entry.prefetch_manifest_key].append(
+                            entry.cache_key
+                        )
+        dependency_entries.extend(
+            _prefetch_bundle_dependency_entries_from_metadata(
+                prefetch_dependencies,
+                prefetch_cache_keys,
+            )
         )
+        record_many_cache_dependencies(dependency_entries)
 
         _ensure_publish_current(current_generation)
         _set_dependency_cache_entries(publishable_entries)
@@ -271,6 +442,7 @@ def publish_dependency_cache_entry(
     timeout: int | None,
     started_generation: int,
     record_many_fn: RecordManyDependenciesFn | None = None,
+    prefetch_manifest_key: str | None = None,
 ) -> None:
     """Publish dependency metadata and value only if the computation is current.
 
@@ -296,6 +468,9 @@ def publish_dependency_cache_entry(
         Exception: Lock, dependency-index, custom recorder, and cache backend
             errors propagate.
     """
+    dependencies_trusted = DependencyTracker._dependencies_are_tracker_captured(
+        dependencies
+    )
     dependency_set = set(dependencies)
 
     acquire_lock_with_retry("publish_dependency_cache_entry")
@@ -307,14 +482,51 @@ def publish_dependency_cache_entry(
                 record_many_fn([(cache_key, dependency_set)])
             _ensure_publish_current(started_generation)
         else:
-            if dependency_set:
-                record_many_cache_dependencies([(cache_key, dependency_set)])
+            metadata_dependencies = _metadata_dependency_set(dependency_set)
+            dependency_entries = (
+                [(cache_key, metadata_dependencies)] if metadata_dependencies else []
+            )
+            if prefetch_manifest_key is not None and metadata_dependencies:
+                segment_token = dependency_cache_prefetch_segment_token((cache_key,))
+                dependency_entries.extend(
+                    [
+                        (
+                            dependency_cache_prefetch_segment_bundle_key(
+                                prefetch_manifest_key,
+                                segment_token,
+                            ),
+                            metadata_dependencies,
+                        ),
+                        (
+                            dependency_cache_prefetch_segment_value_bundle_key(
+                                prefetch_manifest_key,
+                                segment_token,
+                            ),
+                            metadata_dependencies,
+                        ),
+                    ]
+                )
+            record_many_cache_dependencies(dependency_entries)
             _ensure_publish_current(started_generation)
 
-        cache_backend.set(
-            cache_key,
-            make_dependency_cache_entry(result, dependency_set),
-            timeout,
+        payload = make_dependency_cache_entry(
+            result,
+            dependency_set,
+            trusted_dependencies=dependencies_trusted,
         )
+        prefetch_bundle_entries = {cache_key: payload}
+
+        cache_backend.set(cache_key, payload, timeout)
+        if prefetch_manifest_key is not None:
+            if record_many_fn is None:
+                cache_backend.set(prefetch_manifest_key, (cache_key,), timeout)
+                _set_prefetch_segment_entries(
+                    cache_backend,
+                    timeout,
+                    prefetch_manifest_key,
+                    prefetch_bundle_entries,
+                )
+            else:
+                cache_backend.set(prefetch_manifest_key, (cache_key,), timeout)
     finally:
         release_lock()

--- a/src/general_manager/cache/dependency_shards.py
+++ b/src/general_manager/cache/dependency_shards.py
@@ -691,38 +691,22 @@ def candidate_cache_keys_for_lookup(
             Runtime callers are expected to honor this typed contract; the
             helper does not perform additional action validation.
         lookup: Changed lookup attribute path.
-        old_value: Optional previous value for exact-match shard candidates.
-            The sentinel `VALUE_NOT_PROVIDED` suppresses the exact old-value
-            lookup. `None` is a real dependency value and is hashed.
-        new_value: Optional current value for exact-match shard candidates. The
-            sentinel `VALUE_NOT_PROVIDED` suppresses the exact new-value lookup.
-            Serialization errors propagate from `stable_value_hash()`.
+        old_value: Deprecated compatibility parameter; exact-value shards are
+            no longer queried.
+        new_value: Deprecated compatibility parameter; exact-value shards are
+            no longer queried.
 
     Returns:
-        Cache keys from exact, scan, composite, and all-records shards that may
+        Cache keys from scan, composite, and all-records shards that may
         need runtime dependency evaluation. Scan shards are queried for every
         operator in `SCAN_OPERATORS` using both `{lookup}__{operator}` and the
-        normalized base lookup name. Exact old/new values are looked up only in
-        equality (`"eq"`) shards for the base lookup name returned by
-        `lookup_spec_from_key()`, which treats a supported operator suffix such
-        as `status__gte` as lookup path `status` plus operator `gte`.
+        normalized base lookup name returned by `lookup_spec_from_key()`, which
+        treats a supported operator suffix such as `status__gte` as lookup path
+        `status` plus operator `gte`.
     """
+    del old_value, new_value
     candidates = set()
     candidate_lookup = _lookup_name_for_candidate(lookup)
-
-    for value in (old_value, new_value):
-        if value is not VALUE_NOT_PROVIDED:
-            candidates.update(
-                cache_set_members(
-                    exact_lookup_shard_key(
-                        manager_name,
-                        action,
-                        candidate_lookup,
-                        "eq",
-                        value,
-                    )
-                )
-            )
 
     for operator in SCAN_OPERATORS:
         scan_lookup = f"{candidate_lookup}__{operator}"

--- a/src/general_manager/cache/dependency_shards.py
+++ b/src/general_manager/cache/dependency_shards.py
@@ -257,14 +257,22 @@ def _cache_member_set(value: object) -> set[str]:
 
 
 def _cache_set_add_many(additions: Mapping[str, set[str]]) -> None:
-    pending = {key: set(members) for key, members in additions.items() if members}
+    pending = {
+        key: members if type(members) is set else set(members)
+        for key, members in additions.items()
+        if members
+    }
     if not pending:
         return
 
     existing_sets = _cache_get_many(pending)
     payloads: dict[str, set[str]] = {}
     for key, members in pending.items():
-        current = _cache_member_set(existing_sets.get(key, set()))
+        existing = existing_sets.get(key)
+        if existing is None:
+            payloads[key] = members
+            continue
+        current = _cache_member_set(existing)
         current.update(members)
         payloads[key] = current
     _cache_set_many(payloads)
@@ -411,13 +419,7 @@ def _shard_keys_for_dependency(
 
     if action == "identification":
         shard_keys.add(
-            exact_lookup_shard_key(
-                manager_name,
-                "filter",
-                "identification",
-                "eq",
-                identifier,
-            )
+            composite_lookup_shard_key(manager_name, "filter", "identification")
         )
         simple_dependencies.add((manager_name, action, identifier))
         return _DependencyShardPlan(
@@ -494,13 +496,13 @@ def _shard_keys_for_dependency(
             frozenset(lookup_registrations),
         )
 
-    lookup, value = next(iter(params.items()))
+    lookup, _value = next(iter(params.items()))
     spec = lookup_spec_from_key(str(lookup))
     candidate_lookup = "__".join(spec.attr_path)
     lookup_registrations.add((manager_name, action, candidate_lookup))
     if spec.operator == "eq":
         shard_keys.add(
-            exact_lookup_shard_key(manager_name, action, spec.lookup, "eq", value)
+            composite_lookup_shard_key(manager_name, action, candidate_lookup)
         )
     else:
         shard_keys.add(
@@ -518,6 +520,7 @@ def _shard_keys_for_dependency(
 def _reverse_membership_for_dependencies(
     cache_key: str,
     dependency_set: set[Dependency],
+    plan_cache: dict[Dependency, _DependencyShardPlan] | None = None,
 ) -> tuple[ReverseDependencyMembership, set[tuple[str, str, str]]]:
     shard_keys: set[str] = set()
     composites: set[CompositeDependency] = set()
@@ -525,7 +528,15 @@ def _reverse_membership_for_dependencies(
     lookup_registrations: set[tuple[str, str, str]] = set()
 
     for manager_name, action, identifier in dependency_set:
-        plan = _shard_keys_for_dependency(manager_name, action, identifier)
+        dependency = (manager_name, action, identifier)
+        if plan_cache is None:
+            plan = _shard_keys_for_dependency(manager_name, action, identifier)
+        else:
+            try:
+                plan = plan_cache[dependency]
+            except KeyError:
+                plan = _shard_keys_for_dependency(manager_name, action, identifier)
+                plan_cache[dependency] = plan
         shard_keys.update(plan.shard_keys)
         composites.update(plan.composite_dependencies)
         simple_dependencies.update(plan.simple_dependencies)
@@ -592,7 +603,11 @@ def record_many_cache_dependencies(
     for cache_key, dependencies in entries:
         dependency_set = set(dependencies)
         if dependency_set:
-            normalized.setdefault(cache_key, set()).update(dependency_set)
+            existing_dependencies = normalized.get(cache_key)
+            if existing_dependencies is None:
+                normalized[cache_key] = dependency_set
+            else:
+                existing_dependencies.update(dependency_set)
     if not normalized:
         return
 
@@ -614,11 +629,13 @@ def record_many_cache_dependencies(
 
     set_additions: dict[str, set[str]] = defaultdict(set)
     reverse_payloads: dict[str, ReverseDependencyMembership] = {}
+    plan_cache: dict[Dependency, _DependencyShardPlan] = {}
 
     for cache_key, dependency_set in normalized.items():
         reverse, lookup_registrations = _reverse_membership_for_dependencies(
             cache_key,
             dependency_set,
+            plan_cache,
         )
         for shard_key in reverse.shard_keys:
             set_additions[shard_key].add(cache_key)

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -31,6 +31,7 @@ ORM_BUCKET_MANAGER_RESULT_PREFIX = "orm_bucket_manager_result"
 ORM_BUCKET_FIRST_ROW_PREFIX = "orm_bucket_first_row"
 ORM_MODEL_ROW_INDEX_PREFIX = "orm_model_row_index"
 ORM_MODEL_RELATION_PREFETCH_PREFIX = "orm_model_relation_prefetch"
+ORM_RELATION_MANAGER_PREFIX = "orm_relation_manager"
 ORM_QUERY_BUCKET_PREFIX = "orm_query_bucket"
 ORM_BUCKET_EXISTS_PREFIX = "orm_bucket_exists"
 BUCKET_INDEX_PREFIX = "bucket_index"
@@ -43,6 +44,14 @@ OrmModelRowKey = tuple[Hashable, Hashable | None]
 @dataclass(frozen=True)
 class BucketIndexRunCacheEntry:
     """Run-cache payload for a bucket index plus dependencies to replay on hits."""
+
+    value: object
+    dependencies: frozenset["Dependency"]
+
+
+@dataclass(frozen=True)
+class OrmBucketManagersRunCacheEntry:
+    """Run-cache payload for cached ORM managers plus dependencies to replay."""
 
     value: object
     dependencies: frozenset["Dependency"]
@@ -147,9 +156,12 @@ class CalculationRunContext:
         synchronous callable; coroutine objects are stored as ordinary return
         values if a loader returns one.
         """
-        if key not in self._values:
-            self._values[key] = loader()
-        return cast(T, self._values[key])
+        try:
+            return cast(T, self._values[key])
+        except KeyError:
+            value = loader()
+            self._values[key] = value
+            return value
 
     def get(self, key: Hashable, default: object = None) -> object:
         """Return the stored value for key, or default when key is absent."""
@@ -415,13 +427,48 @@ class CalculationRunContext:
         )
         self.set(cache_key, prefetched | frozenset(row_keys))
 
+    def get_orm_relation_manager(self, key: Hashable) -> object:
+        """Return a cached relation manager for key, or `None` when absent."""
+        return self.get((ORM_RELATION_MANAGER_PREFIX, key))
+
+    def set_orm_relation_manager(self, key: Hashable, value: object) -> None:
+        """Store a manager created by a generated ORM relation accessor."""
+        self.set((ORM_RELATION_MANAGER_PREFIX, key), value)
+
     def get_orm_bucket_managers(self, key: Hashable) -> object:
         """Return cached ORM bucket managers for key, or `None` when absent."""
-        return self.get((ORM_BUCKET_MANAGER_RESULT_PREFIX, key))
+        entry = self.get((ORM_BUCKET_MANAGER_RESULT_PREFIX, key))
+        if isinstance(entry, OrmBucketManagersRunCacheEntry):
+            return entry.value
+        return entry
 
-    def set_orm_bucket_managers(self, key: Hashable, value: object) -> None:
+    def get_orm_bucket_manager_dependencies(
+        self,
+        key: Hashable,
+    ) -> frozenset["Dependency"] | None:
+        """Return cached ORM manager dependencies for key, when available."""
+        entry = self.get((ORM_BUCKET_MANAGER_RESULT_PREFIX, key))
+        if isinstance(entry, OrmBucketManagersRunCacheEntry):
+            return entry.dependencies
+        return None
+
+    def set_orm_bucket_managers(
+        self,
+        key: Hashable,
+        value: object,
+        dependencies: Iterable["Dependency"] | None = None,
+    ) -> None:
         """Store or overwrite ORM bucket managers for the active run."""
-        self.set((ORM_BUCKET_MANAGER_RESULT_PREFIX, key), value)
+        if dependencies is None:
+            self.set((ORM_BUCKET_MANAGER_RESULT_PREFIX, key), value)
+            return
+        self.set(
+            (ORM_BUCKET_MANAGER_RESULT_PREFIX, key),
+            OrmBucketManagersRunCacheEntry(
+                value=value,
+                dependencies=frozenset(dependencies),
+            ),
+        )
 
     def get_orm_bucket_first_row(
         self,
@@ -459,6 +506,7 @@ class CalculationRunContext:
         self.discard_prefix((ORM_BUCKET_FIRST_ROW_PREFIX,))
         self.discard_prefix((ORM_MODEL_ROW_INDEX_PREFIX,))
         self.discard_prefix((ORM_MODEL_RELATION_PREFETCH_PREFIX,))
+        self.discard_prefix((ORM_RELATION_MANAGER_PREFIX,))
         self.discard_prefix((ORM_QUERY_BUCKET_PREFIX,))
         self.discard_prefix((ORM_BUCKET_EXISTS_PREFIX,))
 

--- a/src/general_manager/interface/base_interface.py
+++ b/src/general_manager/interface/base_interface.py
@@ -18,8 +18,11 @@ from typing import (
     cast,
 )
 from django.conf import settings
+from django.core.signals import setting_changed
 from django.db.models import Model
+from django.dispatch import receiver
 
+from general_manager.conf import get_setting
 from general_manager.utils.args_to_kwargs import args_to_kwargs
 from general_manager.api.property import GraphQLProperty
 from general_manager.interface.capabilities.base import Capability, CapabilityName
@@ -71,7 +74,9 @@ type classPostCreationMethod = Callable[
 
 _SINGLE_INPUT_VALUE_CACHE_PREFIX = "interface_single_input_value"
 _SINGLE_INPUT_VALUE_CACHE_MISS = object()
+_OBSERVABILITY_HOOK_MISSING = object()
 _RUN_SCOPED_SCALAR_INPUT_TYPES = (str, int, bool)
+_FORMATLESS_IDENTIFICATION_VALUE_TYPES = {str, int, float, bool, type(None)}
 
 
 class AttributeTypedDict(TypedDict):
@@ -181,30 +186,62 @@ class InvalidInputConstraintError(ValueError):
         super().__init__(f"Invalid value for {name}: {detail}.")
 
 
+_VALIDATE_POSSIBLE_VALUES_CACHE: bool | None = None
+
+
+@receiver(setting_changed)
+def _clear_possible_values_validation_cache(
+    *,
+    setting: str,
+    **_kwargs: object,
+) -> None:
+    if setting in {
+        "DEBUG",
+        "GENERAL_MANAGER",
+        "GENERAL_MANAGER_VALIDATE_INPUT_VALUES",
+        "VALIDATE_INPUT_VALUES",
+    }:
+        global _VALIDATE_POSSIBLE_VALUES_CACHE
+        _VALIDATE_POSSIBLE_VALUES_CACHE = None
+
+
 def _should_validate_possible_values() -> bool:
     """Return whether ``possible_values`` membership should be enforced."""
-    from general_manager.conf import get_setting
+    global _VALIDATE_POSSIBLE_VALUES_CACHE
+    if _VALIDATE_POSSIBLE_VALUES_CACHE is not None:
+        return _VALIDATE_POSSIBLE_VALUES_CACHE
 
     value = get_setting("VALIDATE_INPUT_VALUES")
     if value is None:
-        return bool(settings.DEBUG)
+        result = bool(settings.DEBUG)
+        _VALIDATE_POSSIBLE_VALUES_CACHE = result
+        return result
     if isinstance(value, bool):
+        _VALIDATE_POSSIBLE_VALUES_CACHE = value
         return value
     if isinstance(value, str):
-        return value.strip().lower() in {"true", "1", "yes", "on"}
+        result = value.strip().lower() in {"true", "1", "yes", "on"}
+        _VALIDATE_POSSIBLE_VALUES_CACHE = result
+        return result
     if isinstance(value, int):
-        return value != 0
-    return bool(settings.DEBUG)
+        result = value != 0
+        _VALIDATE_POSSIBLE_VALUES_CACHE = result
+        return result
+    result = bool(settings.DEBUG)
+    _VALIDATE_POSSIBLE_VALUES_CACHE = result
+    return result
 
 
 @dataclass(frozen=True, slots=True)
 class _InputParsingPlan:
     names: tuple[str, ...]
     name_set: frozenset[str]
+    field_by_name: Mapping[str, "Input[type[object]]"]
     alias_to_name: Mapping[str, str]
     required_names: frozenset[str]
     optional_names: frozenset[str]
     dependency_items: tuple[tuple[str, tuple[str, ...]], ...]
+    has_dependencies: bool
     field_state: tuple[tuple[str, int, bool, tuple[str, ...]], ...]
 
 
@@ -257,6 +294,11 @@ class InterfaceBase(ABC):
             **kwargs: Named identification values matching the interface's input field names.
         """
         identification = self.parse_input_fields_to_identification(*args, **kwargs)
+        if len(identification) == 1:
+            value = next(iter(identification.values()))
+            if value.__class__ in _FORMATLESS_IDENTIFICATION_VALUE_TYPES:
+                self.identification = identification
+                return
         self.identification = self.format_identification(identification)
 
     @classmethod
@@ -292,6 +334,11 @@ class InterfaceBase(ABC):
         Returns:
             Capability | None: The capability handler registered for `name`, or `None` if no handler is bound.
         """
+        if (
+            cls._capability_selection is not None
+            and cls._configured_capabilities_applied
+        ):
+            return cls._capability_handlers.get(name)
         cls._ensure_capabilities_initialized()
         return cls._capability_handlers.get(name)
 
@@ -597,6 +644,7 @@ class InterfaceBase(ABC):
         names = tuple(cls.input_fields.keys())
         field_items = tuple(cls.input_fields.items())
         name_set = frozenset(names)
+        field_by_name = MappingProxyType(dict(field_items))
         alias_to_name = MappingProxyType({f"{name}_id": name for name in names})
         required_names = frozenset(
             name for name, input_field in field_items if input_field.required
@@ -613,10 +661,12 @@ class InterfaceBase(ABC):
         plan = _InputParsingPlan(
             names=names,
             name_set=name_set,
+            field_by_name=field_by_name,
             alias_to_name=alias_to_name,
             required_names=required_names,
             optional_names=optional_names,
             dependency_items=dependency_items,
+            has_dependencies=any(depends_on for _name, depends_on in dependency_items),
             field_state=field_state,
         )
         cls._input_parsing_plan = plan
@@ -624,6 +674,18 @@ class InterfaceBase(ABC):
 
     @classmethod
     def _input_parsing_plan_is_fresh(cls, plan: _InputParsingPlan) -> bool:
+        if len(plan.field_state) == 1:
+            if len(cls.input_fields) != 1:
+                return False
+            name, input_id, required, depends_on = plan.field_state[0]
+            input_field = cls.input_fields.get(name)
+            if input_field is None:
+                return False
+            return (
+                id(input_field) == input_id
+                and input_field.required == required
+                and tuple(input_field.depends_on) == depends_on
+            )
         if len(cls.input_fields) != len(plan.field_state):
             return False
         if tuple(cls.input_fields) != plan.names:
@@ -735,43 +797,88 @@ class InterfaceBase(ABC):
         resolved_identification: dict[str, object] = {}
         plan = type(self)._get_input_parsing_plan()
         if (
-            len(args) == 1
-            and not kwargs
-            and len(plan.names) == 1
+            len(plan.names) == 1
             and plan.required_names == plan.name_set
             and plan.dependency_items[0][1] == ()
         ):
             name = plan.names[0]
-            input_field = self.input_fields[name]
-            cache_key = type(self)._single_input_run_cache_key(
-                name,
-                input_field,
-                args[0],
-            )
-            context = None
-            if cache_key is not None:
-                from general_manager.cache.run_context import (
-                    current_calculation_run_context,
+            raw_value: object = None
+            has_single_value = False
+            if len(args) == 1 and not kwargs:
+                raw_value = args[0]
+                has_single_value = True
+            elif not args and len(kwargs) == 1 and name in kwargs:
+                raw_value = kwargs[name]
+                has_single_value = True
+            if has_single_value:
+                input_field = plan.field_by_name[name]
+                cache_key = type(self)._single_input_run_cache_key(
+                    name,
+                    input_field,
+                    raw_value,
                 )
-
-                context = current_calculation_run_context()
-                if context is not None:
-                    cached_value = context.get(
-                        cache_key,
-                        _SINGLE_INPUT_VALUE_CACHE_MISS,
+                context = None
+                if cache_key is not None:
+                    from general_manager.cache.run_context import (
+                        current_calculation_run_context,
                     )
-                    if cached_value is not _SINGLE_INPUT_VALUE_CACHE_MISS:
-                        return {name: cached_value}
-            cache_context = type(self)._input_possible_values_cache_context(name)
-            value = input_field.cast(
-                args[0],
-                resolved_identification,
-                cache_context=cache_context,
-            )
-            self._process_input(name, value, resolved_identification)
-            if context is not None and cache_key is not None:
-                context.set(cache_key, value)
-            return {name: value}
+
+                    context = current_calculation_run_context()
+                    if context is not None:
+                        cached_value = context.get(
+                            cache_key,
+                            _SINGLE_INPUT_VALUE_CACHE_MISS,
+                        )
+                        if cached_value is not _SINGLE_INPUT_VALUE_CACHE_MISS:
+                            return {name: cached_value}
+                cache_context = type(self)._input_possible_values_cache_context(name)
+                value = input_field.cast(
+                    raw_value,
+                    resolved_identification,
+                    cache_context=cache_context,
+                )
+                self._process_input_field(
+                    name,
+                    input_field,
+                    value,
+                    resolved_identification,
+                    cache_context=cache_context,
+                )
+                if context is not None and cache_key is not None:
+                    context.set(cache_key, value)
+                return {name: value}
+
+        if not args:
+            kwarg_names = kwargs.keys()
+            if kwarg_names <= plan.name_set and plan.required_names <= kwarg_names:
+                if plan.has_dependencies:
+                    ordered_names, unresolved = type(self)._get_input_dependency_order(
+                        plan
+                    )
+                else:
+                    ordered_names = plan.names
+                    unresolved = frozenset()
+                for name in ordered_names:
+                    input_field = plan.field_by_name[name]
+                    cache_context = type(self)._input_possible_values_cache_context(
+                        name
+                    )
+                    value = input_field.cast(
+                        kwargs.get(name),
+                        resolved_identification,
+                        cache_context=cache_context,
+                    )
+                    self._process_input_field(
+                        name,
+                        input_field,
+                        value,
+                        resolved_identification,
+                        cache_context=cache_context,
+                    )
+                    resolved_identification[name] = value
+                if unresolved:
+                    raise CircularInputDependencyError(unresolved)
+                return {name: resolved_identification[name] for name in plan.names}
 
         kwargs = args_to_kwargs(args, plan.names, kwargs)
 
@@ -797,14 +904,20 @@ class InterfaceBase(ABC):
 
         ordered_names, unresolved = type(self)._get_input_dependency_order(plan)
         for name in ordered_names:
-            input_field = self.input_fields[name]
+            input_field = plan.field_by_name[name]
             cache_context = type(self)._input_possible_values_cache_context(name)
             value = input_field.cast(
                 kwargs.get(name),
                 resolved_identification,
                 cache_context=cache_context,
             )
-            self._process_input(name, value, resolved_identification)
+            self._process_input_field(
+                name,
+                input_field,
+                value,
+                resolved_identification,
+                cache_context=cache_context,
+            )
             resolved_identification[name] = value
         if unresolved:
             raise CircularInputDependencyError(unresolved)
@@ -876,30 +989,56 @@ class InterfaceBase(ABC):
             InvalidInputValueError: If possible-value validation is enabled and `value` is not contained in the evaluated `possible_values`.
         """
         input_field = self.input_fields[name]
+        cache_context = type(self)._input_possible_values_cache_context(name)
+        self._process_input_field(
+            name,
+            input_field,
+            value,
+            identification,
+            cache_context=cache_context,
+        )
+
+    def _process_input_field(
+        self,
+        name: str,
+        input_field: "Input[type[object]]",
+        value: object,
+        identification: dict[str, object],
+        *,
+        cache_context: tuple[type[object], str] | None,
+    ) -> None:
+        """Validate a value against an already-resolved input field."""
         if value is None:
             if input_field.required:
                 raise InvalidInputTypeError(name, type(value), input_field.type)
             return
         if not isinstance(value, input_field.type):
             raise InvalidInputTypeError(name, type(value), input_field.type)
-        if not input_field.validate_bounds(value):
+        if (
+            input_field.min_value is not None or input_field.max_value is not None
+        ) and not input_field.validate_bounds(value):
             raise InvalidInputConstraintError(
                 name,
                 f"{value} is outside the allowed range"
                 f" [{input_field.min_value}, {input_field.max_value}]",
             )
-        if not input_field.validate_with_callable(value, identification):
+        if input_field.validator is not None and not input_field.validate_with_callable(
+            value,
+            identification,
+        ):
             raise InvalidInputConstraintError(
                 name,
                 f"{value} did not satisfy the configured validator",
             )
 
+        if input_field.possible_values is None:
+            return
         if not _should_validate_possible_values():
             return
 
         allowed_values = input_field.resolve_possible_values(
             identification,
-            cache_context=type(self)._input_possible_values_cache_context(name),
+            cache_context=cache_context,
         )
         if allowed_values is None:
             return
@@ -1242,8 +1381,16 @@ class InterfaceBase(ABC):
             after a successful `func`, that exception is propagated instead of
             the result.
         """
-        if observer is not None and hasattr(observer, "before_operation"):
-            observer.before_operation(
+        if observer is not None:
+            before_operation = getattr(
+                observer,
+                "before_operation",
+                _OBSERVABILITY_HOOK_MISSING,
+            )
+        else:
+            before_operation = _OBSERVABILITY_HOOK_MISSING
+        if before_operation is not _OBSERVABILITY_HOOK_MISSING:
+            cast(Callable[..., None], before_operation)(
                 operation=operation,
                 target=target,
                 payload=payload,
@@ -1251,16 +1398,32 @@ class InterfaceBase(ABC):
         try:
             result = func()
         except Exception as error:
-            if observer is not None and hasattr(observer, "on_error"):
-                observer.on_error(
+            if observer is not None:
+                on_error = getattr(
+                    observer,
+                    "on_error",
+                    _OBSERVABILITY_HOOK_MISSING,
+                )
+            else:
+                on_error = _OBSERVABILITY_HOOK_MISSING
+            if on_error is not _OBSERVABILITY_HOOK_MISSING:
+                cast(Callable[..., None], on_error)(
                     operation=operation,
                     target=target,
                     payload=payload,
                     error=error,
                 )
             raise
-        if observer is not None and hasattr(observer, "after_operation"):
-            observer.after_operation(
+        if observer is not None:
+            after_operation = getattr(
+                observer,
+                "after_operation",
+                _OBSERVABILITY_HOOK_MISSING,
+            )
+        else:
+            after_operation = _OBSERVABILITY_HOOK_MISSING
+        if after_operation is not _OBSERVABILITY_HOOK_MISSING:
+            cast(Callable[..., None], after_operation)(
                 operation=operation,
                 target=target,
                 payload=payload,

--- a/src/general_manager/interface/capabilities/calculation/lifecycle.py
+++ b/src/general_manager/interface/capabilities/calculation/lifecycle.py
@@ -6,8 +6,6 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, ClassVar
 
 from general_manager.bucket.calculation_bucket import CalculationBucket
-from general_manager.cache.cache_tracker import DependencyTracker
-from general_manager.cache.dependency_index import serialize_dependency_identifier
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.input import Input
 
@@ -23,11 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def _track_cached_manager(value: object) -> None:
     if isinstance(value, GeneralManager):
-        DependencyTracker.track(
-            value.__class__.__name__,
-            "identification",
-            serialize_dependency_identifier(value.identification),
-        )
+        value.__class__._track_identification_dependency(value.identification)
 
 
 class CalculationReadCapability(BaseCapability):

--- a/src/general_manager/interface/capabilities/core/utils.py
+++ b/src/general_manager/interface/capabilities/core/utils.py
@@ -44,17 +44,6 @@ class ObservabilityCapability(Protocol):
     ) -> None: ...
 
 
-class ObservabilityTarget(Protocol):
-    """
-    Structural target shape consumed internally by :func:`with_observability`.
-
-    The protocol is not exported from this module. The wrapper requests only the
-    ``"observability"`` capability name.
-    """
-
-    def get_capability_handler(self, name: str) -> object | None: ...
-
-
 def with_observability(
     target: object,
     *,
@@ -103,9 +92,7 @@ def with_observability(
     get_handler = getattr(target, "get_capability_handler", None)
     if get_handler is None:
         return func()
-    capability = cast(ObservabilityTarget, target).get_capability_handler(
-        "observability"
-    )
+    capability = get_handler("observability")
     if capability is None:
         return func()
     observed = cast(ObservabilityCapability, capability)

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -15,6 +15,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models.query import prefetch_related_objects
 
+from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.interface.base_interface import AttributeTypedDict
 from general_manager.interface.utils.errors import DuplicateFieldNameError
 from general_manager.measurement.measurement import Measurement
@@ -785,6 +786,33 @@ def _general_manager_accessor(
     Returns:
         DescriptorAccessor: A callable that, given a OrmInterfaceBase, returns the manager instance for the related object, or `None` if the related attribute is `None`.
     """
+    manager_type = cast("type[GeneralManager]", manager_class)
+
+    def raw_id_manager(raw_id: object, database_alias: object) -> object:
+        from general_manager.cache.run_context import current_calculation_run_context
+
+        context = current_calculation_run_context()
+        if context is None:
+            return manager_type(raw_id)
+
+        cache_key = (manager_type, raw_id, database_alias)
+        try:
+            cached = context.get_orm_relation_manager(cast(Hashable, cache_key))
+        except TypeError:
+            return manager_type(raw_id)
+        if isinstance(cached, manager_type):
+            track_own = getattr(
+                cached,
+                "_track_own_identification_dependency_active",
+                None,
+            )
+            if callable(track_own) and DependencyTracker.is_active():
+                track_own()
+            return cached
+
+        manager = manager_type(raw_id)
+        context.set_orm_relation_manager(cast(Hashable, cache_key), manager)
+        return manager
 
     def getter(self: OrmInterfaceInstance) -> object:
         """
@@ -799,16 +827,16 @@ def _general_manager_accessor(
         Returns:
             The related manager instance, or `None` if the related object is `None`.
         """
-        manager_type = cast("type[GeneralManager]", manager_class)
         if raw_id_name is not None:
             raw_id = getattr(self._instance, raw_id_name, None)
             if raw_id is None:
                 return None
             state = getattr(self._instance, "_state", None)
+            database_alias = getattr(state, "db", None)
             fields_cache = getattr(state, "fields_cache", {})
             related = fields_cache.get(field_name, _MISSING_RELATED)
             if related is _MISSING_RELATED:
-                return manager_type(raw_id)
+                return raw_id_manager(raw_id, database_alias)
             if related is None:
                 return None
             trusted_hydrate = getattr(manager_type, "_from_trusted_orm_instance", None)

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -126,6 +126,8 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         cls,
         identification: dict[str, object],
     ) -> None:
+        """Track an identification dependency only when a tracker is active."""
+
         if DependencyTracker.is_active():
             if type.__getattribute__(
                 cls,
@@ -140,6 +142,8 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         cls,
         identification: dict[str, object],
     ) -> None:
+        """Record an identification dependency for the default tracking path."""
+
         _track_identification_dependency_active_default(cls, identification)
 
     def _identification_dependency_identifier(self) -> str:
@@ -162,6 +166,8 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         return serialize_dependency_identifier(identification)
 
     def _track_own_identification_dependency_active(self) -> None:
+        """Replay this instance's identification dependency on cached reads."""
+
         manager_class = self.__class__
         if type.__getattribute__(
             manager_class,
@@ -587,13 +593,14 @@ class GeneralManager(metaclass=GeneralManagerMeta):
             Bucket[Self]: Bucket containing manager instances that match the lookups.
         """
         identifier_map = cls.__parse_identification(kwargs) or kwargs
-        logger.debug(
-            "manager filter",
-            context={
-                "manager": type.__getattribute__(cls, "__name__"),
-                "filters": identifier_map,
-            },
-        )
+        if _debug_logging_enabled():
+            logger.debug(
+                "manager filter",
+                context={
+                    "manager": type.__getattribute__(cls, "__name__"),
+                    "filters": identifier_map,
+                },
+            )
         return cast(Bucket[Self], cls.Interface.filter(**identifier_map))
 
     @classmethod
@@ -621,24 +628,26 @@ class GeneralManager(metaclass=GeneralManagerMeta):
             Bucket[Self]: Bucket of manager instances that do not satisfy the lookups.
         """
         identifier_map = cls.__parse_identification(kwargs) or kwargs
-        logger.debug(
-            "manager exclude",
-            context={
-                "manager": type.__getattribute__(cls, "__name__"),
-                "filters": identifier_map,
-            },
-        )
+        if _debug_logging_enabled():
+            logger.debug(
+                "manager exclude",
+                context={
+                    "manager": type.__getattribute__(cls, "__name__"),
+                    "filters": identifier_map,
+                },
+            )
         return cast(Bucket[Self], cls.Interface.exclude(**identifier_map))
 
     @classmethod
     def all(cls) -> Bucket[Self]:
         """Return a bucket containing every managed object of this class."""
-        logger.debug(
-            "manager all",
-            context={
-                "manager": type.__getattribute__(cls, "__name__"),
-            },
-        )
+        if _debug_logging_enabled():
+            logger.debug(
+                "manager all",
+                context={
+                    "manager": type.__getattribute__(cls, "__name__"),
+                },
+            )
         return cast(Bucket[Self], cls.Interface.filter())
 
     @staticmethod

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import json
+import logging
 from collections.abc import Mapping
 from datetime import date, datetime
 from json.encoder import encode_basestring_ascii
-from typing import TYPE_CHECKING, Iterator, Protocol, Self, Type, cast
+from typing import TYPE_CHECKING, ClassVar, Iterator, Protocol, Self, Type, cast
 
 from general_manager.api.property import GraphQLProperty
 from general_manager.bucket.base_bucket import Bucket
@@ -51,19 +52,20 @@ if TYPE_CHECKING:
 logger = get_logger("manager.general")
 
 
+def _debug_logging_enabled() -> bool:
+    is_enabled_for = getattr(logger, "isEnabledFor", None)
+    if callable(is_enabled_for):
+        return bool(is_enabled_for(logging.DEBUG))
+    return True
+
+
 def _serialize_simple_id_identification(
     identification: dict[str, object],
 ) -> str | None:
     if len(identification) != 1 or "id" not in identification:
         return None
     value = identification["id"]
-    if isinstance(value, datetime):
-        serialized_value = encode_basestring_ascii(value.isoformat())
-    elif isinstance(value, date):
-        serialized_value = encode_basestring_ascii(value.isoformat())
-    elif isinstance(value, str):
-        serialized_value = encode_basestring_ascii(value)
-    elif value is True:
+    if value is True:
         serialized_value = "true"
     elif value is False:
         serialized_value = "false"
@@ -71,11 +73,31 @@ def _serialize_simple_id_identification(
         serialized_value = "null"
     elif isinstance(value, int):
         serialized_value = str(value)
+    elif isinstance(value, str):
+        serialized_value = encode_basestring_ascii(value)
     elif isinstance(value, float):
         serialized_value = json.dumps(value)
+    elif isinstance(value, datetime):
+        serialized_value = encode_basestring_ascii(value.isoformat())
+    elif isinstance(value, date):
+        serialized_value = encode_basestring_ascii(value.isoformat())
     else:
         return None
     return f'{{"id": {serialized_value}}}'
+
+
+def _track_identification_dependency_active_default(
+    cls: type[object],
+    identification: dict[str, object],
+) -> None:
+    identifier = _serialize_simple_id_identification(identification)
+    if identifier is None:
+        identifier = serialize_dependency_identifier(identification)
+    DependencyTracker._track_validated(
+        type.__getattribute__(cls, "__name__"),
+        "identification",
+        identifier,
+    )
 
 
 class TrustedOrmRow(Protocol):
@@ -84,13 +106,18 @@ class TrustedOrmRow(Protocol):
     pk: object
 
 
+type _IdentificationDependencyCache = tuple[type[object], object, str]
+
+
 class GeneralManager(metaclass=GeneralManagerMeta):
     chat_exposed: bool = False
+    _gm_uses_default_identification_dependency_active: ClassVar[bool] = True
     Permission: Type[BasePermission]
     _attributes: dict[str, object]
     Interface: Type["InterfaceBase"]
     _old_values: dict[str, object]
     _attribute_value_cache: dict[str, object]
+    _identification_dependency_cache: _IdentificationDependencyCache | None
     _manager_state_valid: bool
     _manager_state_reason: str | None
 
@@ -100,14 +127,46 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         identification: dict[str, object],
     ) -> None:
         if DependencyTracker.is_active():
+            if type.__getattribute__(
+                cls,
+                "_gm_uses_default_identification_dependency_active",
+            ):
+                _track_identification_dependency_active_default(cls, identification)
+            else:
+                cls._track_identification_dependency_active(identification)
+
+    @classmethod
+    def _track_identification_dependency_active(
+        cls,
+        identification: dict[str, object],
+    ) -> None:
+        _track_identification_dependency_active_default(cls, identification)
+
+    def _identification_dependency_identifier(self) -> str:
+        identification = self.__id
+        if len(identification) == 1 and "id" in identification:
+            value = identification["id"]
+            value_class = value.__class__
+            cache = self._identification_dependency_cache
+            if cache is not None and cache[0] is value_class and cache[1] == value:
+                return cache[2]
             identifier = _serialize_simple_id_identification(identification)
-            if identifier is None:
-                identifier = serialize_dependency_identifier(identification)
-            DependencyTracker._track_validated(
-                cls.__name__,
-                "identification",
-                identifier,
-            )
+            if identifier is not None:
+                self._identification_dependency_cache = (
+                    value_class,
+                    value,
+                    identifier,
+                )
+                return identifier
+        self._identification_dependency_cache = None
+        return serialize_dependency_identifier(identification)
+
+    def _track_own_identification_dependency_active(self) -> None:
+        DependencyTracker._track_validated(
+            type.__getattribute__(self.__class__, "__name__"),
+            "identification",
+            self._identification_dependency_identifier(),
+        )
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         """
@@ -120,16 +179,18 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         self._interface = self.Interface(*args, **kwargs)
         self.__id: dict[str, object] = self._interface.identification
         self._attribute_value_cache = {}
+        self._identification_dependency_cache = None
         self._manager_state_valid = True
         self._manager_state_reason = None
         self._track_identification_dependency(self.__id)
-        logger.debug(
-            "instantiated manager",
-            context={
-                "manager": self.__class__.__name__,
-                "identification": self.__id,
-            },
-        )
+        if _debug_logging_enabled():
+            logger.debug(
+                "instantiated manager",
+                context={
+                    "manager": self.__class__.__name__,
+                    "identification": self.__id,
+                },
+            )
 
     @classmethod
     def _from_trusted_orm_instance(
@@ -188,18 +249,20 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         manager._interface = hydrate(instance, search_date=search_date)
         manager.__id = manager._interface.identification
         manager._attribute_value_cache = {}
+        manager._identification_dependency_cache = None
         manager._manager_state_valid = True
         manager._manager_state_reason = None
         if context is not None:
             context.set(cache_key, manager)
         cls._track_identification_dependency(manager.__id)
-        logger.debug(
-            "trusted orm manager hydrated",
-            context={
-                "manager": cls.__name__,
-                "identification": manager.__id,
-            },
-        )
+        if _debug_logging_enabled():
+            logger.debug(
+                "trusted orm manager hydrated",
+                context={
+                    "manager": cls.__name__,
+                    "identification": manager.__id,
+                },
+            )
         return manager
 
     def __str__(self) -> str:
@@ -520,7 +583,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         logger.debug(
             "manager filter",
             context={
-                "manager": cls.__name__,
+                "manager": type.__getattribute__(cls, "__name__"),
                 "filters": identifier_map,
             },
         )
@@ -554,7 +617,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         logger.debug(
             "manager exclude",
             context={
-                "manager": cls.__name__,
+                "manager": type.__getattribute__(cls, "__name__"),
                 "filters": identifier_map,
             },
         )
@@ -566,7 +629,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         logger.debug(
             "manager all",
             context={
-                "manager": cls.__name__,
+                "manager": type.__getattribute__(cls, "__name__"),
             },
         )
         return cast(Bucket[Self], cls.Interface.filter())

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -162,11 +162,18 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         return serialize_dependency_identifier(identification)
 
     def _track_own_identification_dependency_active(self) -> None:
-        DependencyTracker._track_validated(
-            type.__getattribute__(self.__class__, "__name__"),
-            "identification",
-            self._identification_dependency_identifier(),
-        )
+        manager_class = self.__class__
+        if type.__getattribute__(
+            manager_class,
+            "_gm_uses_default_identification_dependency_active",
+        ):
+            DependencyTracker._track_validated(
+                type.__getattribute__(manager_class, "__name__"),
+                "identification",
+                self._identification_dependency_identifier(),
+            )
+            return
+        manager_class._track_identification_dependency_active(self.__id)
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         """

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -7,6 +7,7 @@ import threading
 from _thread import LockType
 from typing import TYPE_CHECKING, ClassVar, Iterable, TypeVar, cast
 
+from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.logging import get_logger
 
@@ -23,6 +24,25 @@ type MetaPreCreationHook = Callable[
 ]
 
 logger = get_logger("manager.meta")
+_MANAGER_DEPENDENCY_TRACKING_CLASS_CACHE: dict[type, type["GeneralManager"] | None] = {}
+_DESCRIPTOR_DEPENDENCY_TRACKING_CLASS_UNKNOWN = object()
+
+
+def _manager_dependency_tracking_class(
+    value_class: type,
+) -> type["GeneralManager"] | None:
+    """Return `value_class` when its instances can track manager dependencies."""
+    try:
+        return _MANAGER_DEPENDENCY_TRACKING_CLASS_CACHE[value_class]
+    except KeyError:
+        pass
+    for candidate_class in value_class.__mro__:
+        if "_track_identification_dependency" in candidate_class.__dict__:
+            manager_class = cast(type["GeneralManager"], value_class)
+            _MANAGER_DEPENDENCY_TRACKING_CLASS_CACHE[value_class] = manager_class
+            return manager_class
+    _MANAGER_DEPENDENCY_TRACKING_CLASS_CACHE[value_class] = None
+    return None
 
 
 class InvalidInterfaceTypeError(TypeError):
@@ -363,7 +383,32 @@ class GeneralManagerMeta(type):
             attrs: dict[str, object],
         ) -> type["GeneralManager"]:
             """Helper to instantiate the class via the default ``type.__new__``."""
-            return cast(type["GeneralManager"], type.__new__(mcs, name, bases, attrs))
+            uses_default_identification_dependency_active = (
+                name == "GeneralManager"
+                or (
+                    "_track_identification_dependency_active" not in attrs
+                    and all(
+                        bool(
+                            getattr(
+                                base,
+                                "_gm_uses_default_identification_dependency_active",
+                                False,
+                            )
+                        )
+                        for base in bases
+                    )
+                )
+            )
+            new_class = cast(
+                type["GeneralManager"],
+                type.__new__(mcs, name, bases, attrs),
+            )
+            type.__setattr__(
+                new_class,
+                "_gm_uses_default_identification_dependency_active",
+                uses_default_identification_dependency_active,
+            )
+            return new_class
 
         if "Interface" in attrs:
             interface_candidate = attrs.pop("Interface")
@@ -463,6 +508,15 @@ class GeneralManagerMeta(type):
                 ) -> None:
                     self._attr_name = descriptor_attr_name
                     self._class = descriptor_class
+                    self._dependency_tracking_value_class: type | object = (
+                        _DESCRIPTOR_DEPENDENCY_TRACKING_CLASS_UNKNOWN
+                    )
+                    self._non_tracking_value_class: type | object = (
+                        _DESCRIPTOR_DEPENDENCY_TRACKING_CLASS_UNKNOWN
+                    )
+                    self._dependency_tracking_manager_class: (
+                        type[GeneralManager] | None
+                    ) = None
 
                 def __get__(
                     self,
@@ -519,28 +573,33 @@ class GeneralManagerMeta(type):
                             pass
                         else:
                             cached_attribute_class = cached_attribute.__class__
-                            for candidate_class in cached_attribute_class.__mro__:
-                                if (
-                                    "_track_identification_dependency"
-                                    not in candidate_class.__dict__
-                                ):
-                                    continue
+                            if cached_attribute_class is self._non_tracking_value_class:
+                                return cached_attribute
+                            if (
+                                cached_attribute_class
+                                is self._dependency_tracking_value_class
+                            ):
+                                manager_class = self._dependency_tracking_manager_class
+                            else:
+                                manager_class = _manager_dependency_tracking_class(
+                                    cached_attribute_class
+                                )
+                                self._dependency_tracking_value_class = (
+                                    cached_attribute_class
+                                )
+                                self._dependency_tracking_manager_class = manager_class
+                                if manager_class is None:
+                                    self._non_tracking_value_class = (
+                                        cached_attribute_class
+                                    )
+                            if (
+                                manager_class is not None
+                                and DependencyTracker.is_active()
+                            ):
                                 manager_attribute = cast(
                                     "GeneralManager", cached_attribute
                                 )
-                                try:
-                                    identification = manager_attribute.identification
-                                except AttributeError:
-                                    break
-                                if isinstance(identification, dict):
-                                    manager_class = cast(
-                                        type["GeneralManager"],
-                                        cached_attribute_class,
-                                    )
-                                    manager_class._track_identification_dependency(
-                                        identification
-                                    )
-                                break
+                                manager_attribute._track_own_identification_dependency_active()
                             return cached_attribute
                     attribute = instance._attributes.get(self._attr_name, _nonExistent)
                     if attribute is _nonExistent:

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import threading
 from _thread import LockType
 from typing import TYPE_CHECKING, ClassVar, Iterable, TypeVar, cast
+from weakref import WeakKeyDictionary
 
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.interface.base_interface import InterfaceBase
@@ -24,7 +25,10 @@ type MetaPreCreationHook = Callable[
 ]
 
 logger = get_logger("manager.meta")
-_MANAGER_DEPENDENCY_TRACKING_CLASS_CACHE: dict[type, type["GeneralManager"] | None] = {}
+_MANAGER_DEPENDENCY_TRACKING_CLASS_CACHE: WeakKeyDictionary[
+    type,
+    type["GeneralManager"] | None,
+] = WeakKeyDictionary()
 _DESCRIPTOR_DEPENDENCY_TRACKING_CLASS_UNKNOWN = object()
 
 

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -133,10 +133,15 @@ def _exact_currency_per_unit_product(
 ) -> str | None:
     """Return the currency unit for exact ``currency / unit * unit`` products."""
 
+    right_parsed = _parse_unit(right_unit)
+    if len(right_parsed._units) != 1:
+        return None
     for currency in currency_units:
         prefix = f"{currency} / "
-        if left_unit.startswith(prefix) and left_unit[len(prefix) :] == right_unit:
-            return currency
+        if left_unit.startswith(prefix):
+            left_denominator = left_unit[len(prefix) :]
+            if _parse_unit(left_denominator) == right_parsed:
+                return currency
     return None
 
 

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -18,6 +18,7 @@ ComparisonOperation: TypeAlias = Callable[[QuantityMagnitude, QuantityMagnitude]
 
 # Set precision for Decimal
 getcontext().prec = 28
+_PERCENT_SCALE = Decimal("100")
 
 # Create a new UnitRegistry
 ureg: pint.UnitRegistry[QuantityMagnitude] = pint.UnitRegistry(
@@ -124,6 +125,19 @@ def _scalar_arithmetic_preserves_unit(unit: str) -> bool:
     if unit == "dimensionless":
         return True
     return bool(_parse_unit(unit).dimensionality)
+
+
+def _exact_currency_per_unit_product(
+    left_unit: str,
+    right_unit: str,
+) -> str | None:
+    """Return the currency unit for exact ``currency / unit * unit`` products."""
+
+    for currency in currency_units:
+        prefix = f"{currency} / "
+        if left_unit.startswith(prefix) and left_unit[len(prefix) :] == right_unit:
+            return currency
+    return None
 
 
 def _quantity_as_float(quantity: MeasurementQuantity) -> PlainQuantity[float]:
@@ -413,6 +427,11 @@ class Measurement:
     version and are not a stable GeneralManager API contract.
     """
 
+    __quantity: MeasurementQuantity | None
+    __magnitude: Decimal
+    __unit: str
+    __quantity_exposed: bool
+
     def __init__(self, value: NumericMagnitude, unit: str) -> None:
         """
         Create a Measurement from a numeric value and a unit label.
@@ -467,13 +486,18 @@ class Measurement:
 
         measurement = cls.__new__(cls)
         decimal_value = _decimal_from_magnitude(value)
-        measurement.__quantity = cast(
-            MeasurementQuantity,
-            ureg.Quantity(decimal_value, _parse_unit(unit)),
-        )
+        measurement.__quantity = None
         measurement.__magnitude = decimal_value
         measurement.__unit = unit
         measurement.__quantity_exposed = False
+        return measurement
+
+    @classmethod
+    def _from_quantity(cls, quantity: MeasurementQuantity) -> Measurement:
+        """Build a measurement from a Pint operation result without reparsing it."""
+
+        measurement = cls.__new__(cls)
+        measurement.__set_quantity(quantity)
         return measurement
 
     def __set_quantity(
@@ -488,14 +512,24 @@ class Measurement:
         self.__unit = unit if unit is not None else str(quantity.units)
         self.__quantity_exposed = False
 
+    def __current_quantity(self) -> MeasurementQuantity:
+        quantity = self.__quantity
+        if quantity is None:
+            quantity = cast(
+                MeasurementQuantity,
+                ureg.Quantity(self.__magnitude, _parse_unit(self.__unit)),
+            )
+            self.__quantity = quantity
+        return quantity
+
     def __current_magnitude(self) -> Decimal:
         if self.__quantity_exposed:
-            return _decimal_from_magnitude(self.__quantity.magnitude)
+            return _decimal_from_magnitude(self.__current_quantity().magnitude)
         return self.__magnitude
 
     def __current_unit(self) -> str:
         if self.__quantity_exposed:
-            return str(self.__quantity.units)
+            return str(self.__current_quantity().units)
         return self.__unit
 
     def __getstate__(self) -> dict[str, str]:
@@ -537,8 +571,9 @@ class Measurement:
         Returns:
             PlainQuantity: Pint quantity representing the measurement value and unit.
         """
+        quantity = self.__current_quantity()
         self.__quantity_exposed = True
-        return self.__quantity
+        return quantity
 
     @property
     def magnitude(self) -> Decimal:
@@ -775,7 +810,7 @@ class Measurement:
             # Both are currencies
             if self.unit != other.unit:
                 raise CurrencyMismatchError("Addition")
-            result_quantity = self.__quantity + other.__quantity
+            result_quantity = self.__current_quantity() + other.__current_quantity()
             if not isinstance(result_quantity, pint.Quantity):
                 raise IncompatibleUnitsError("addition")
             return Measurement(
@@ -783,11 +818,13 @@ class Measurement:
             )
         elif not self.is_currency() and not other.is_currency():
             # Both are physical units
-            if self.__quantity.dimensionality != other.__quantity.dimensionality:
+            left_quantity = self.__current_quantity()
+            right_quantity = other.__current_quantity()
+            if left_quantity.dimensionality != right_quantity.dimensionality:
                 raise IncompatibleUnitsError("addition")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
-                self.__quantity,
-                other.__quantity,
+                left_quantity,
+                right_quantity,
             )
             result_quantity = left_quantity + right_quantity
             if not isinstance(result_quantity, pint.Quantity):
@@ -830,15 +867,17 @@ class Measurement:
             # Both are currencies
             if self.unit != other.unit:
                 raise CurrencyMismatchError("Subtraction")
-            result_quantity = self.__quantity - other.__quantity
+            result_quantity = self.__current_quantity() - other.__current_quantity()
             return Measurement(Decimal(str(result_quantity.magnitude)), str(self.unit))
         elif not self.is_currency() and not other.is_currency():
             # Both are physical units
-            if self.__quantity.dimensionality != other.__quantity.dimensionality:
+            left_quantity = self.__current_quantity()
+            right_quantity = other.__current_quantity()
+            if left_quantity.dimensionality != right_quantity.dimensionality:
                 raise IncompatibleUnitsError("subtraction")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
-                self.__quantity,
-                other.__quantity,
+                left_quantity,
+                right_quantity,
             )
             result_quantity = left_quantity - right_quantity
             return Measurement(
@@ -874,25 +913,41 @@ class Measurement:
         if isinstance(other, Measurement):
             if self.is_currency() and other.is_currency():
                 raise CurrencyScalarOperationError("Multiplication")
+            left_unit = self.__current_unit()
+            right_unit = other.__current_unit()
+            result_currency = _exact_currency_per_unit_product(left_unit, right_unit)
+            if result_currency is not None:
+                return self._from_canonical_parts(
+                    self.__current_magnitude() * other.__current_magnitude(),
+                    result_currency,
+                )
+            result_currency = _exact_currency_per_unit_product(right_unit, left_unit)
+            if result_currency is not None:
+                return self._from_canonical_parts(
+                    self.__current_magnitude() * other.__current_magnitude(),
+                    result_currency,
+                )
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
-                self.__quantity,
-                other.__quantity,
+                self.__current_quantity(),
+                other.__current_quantity(),
             )
             result_quantity = left_quantity * right_quantity
-            return Measurement(
-                _decimal_from_magnitude(result_quantity.magnitude),
-                str(result_quantity.units),
-            )
+            return self._from_quantity(cast(MeasurementQuantity, result_quantity))
         elif _is_numeric_scalar(other):
             if not isinstance(other, Decimal):
                 other = Decimal(str(other))
             unit = self.__current_unit()
+            if unit == "percent":
+                return self._from_canonical_parts(
+                    self.__current_magnitude() * other / _PERCENT_SCALE,
+                    "dimensionless",
+                )
             if _scalar_arithmetic_preserves_unit(unit):
                 return self._from_canonical_parts(
                     self.__current_magnitude() * other,
                     unit,
                 )
-            quantity = self.__quantity
+            quantity = self.__current_quantity()
             scalar: QuantityMagnitude = other
             if _unit_uses_offset(quantity):
                 quantity = cast(MeasurementQuantity, _quantity_as_float(quantity))
@@ -929,24 +984,26 @@ class Measurement:
             if self.is_currency() and other.is_currency() and self.unit != other.unit:
                 raise CurrencyMismatchError("Division")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
-                self.__quantity,
-                other.__quantity,
+                self.__current_quantity(),
+                other.__current_quantity(),
             )
             result_quantity = left_quantity / right_quantity
-            return Measurement(
-                _decimal_from_magnitude(result_quantity.magnitude),
-                str(result_quantity.units),
-            )
+            return self._from_quantity(cast(MeasurementQuantity, result_quantity))
         elif _is_numeric_scalar(other):
             if not isinstance(other, Decimal):
                 other = Decimal(str(other))
             unit = self.__current_unit()
+            if unit == "percent":
+                return self._from_canonical_parts(
+                    self.__current_magnitude() / other / _PERCENT_SCALE,
+                    "dimensionless",
+                )
             if _scalar_arithmetic_preserves_unit(unit):
                 return self._from_canonical_parts(
                     self.__current_magnitude() / other,
                     unit,
                 )
-            quantity = self.__quantity
+            quantity = self.__current_quantity()
             scalar: QuantityMagnitude = other
             if _unit_uses_offset(quantity):
                 quantity = cast(MeasurementQuantity, _quantity_as_float(quantity))
@@ -1027,8 +1084,8 @@ class Measurement:
             raise UnsupportedComparisonError()
         try:
             self_quantity, other_quantity = _prepare_quantities_for_binary_operation(
-                self.__quantity,
-                other.__quantity,
+                self.__current_quantity(),
+                other.__current_quantity(),
             )
             other_converted = _convert_quantity(
                 other_quantity, str(self_quantity.units)
@@ -1121,7 +1178,7 @@ class Measurement:
         if _is_numeric_scalar(other):
             if not isinstance(other, Decimal):
                 other = Decimal(str(other))
-            quantity = self.__quantity
+            quantity = self.__current_quantity()
             scalar: QuantityMagnitude = other
             if _unit_uses_offset(quantity):
                 quantity = cast(MeasurementQuantity, _quantity_as_float(quantity))
@@ -1261,7 +1318,7 @@ class Measurement:
             int: Stable hash suitable for use in dictionaries and sets. Measurements
             that compare equal after unit conversion produce the same hash.
         """
-        quantity = self.__quantity
+        quantity = self.__current_quantity()
         if _unit_uses_offset(quantity):
             quantity = cast(MeasurementQuantity, _quantity_as_float(quantity))
         base_quantity = quantity.to_base_units()

--- a/src/general_manager/utils/json_encoder.py
+++ b/src/general_manager/utils/json_encoder.py
@@ -27,7 +27,8 @@ class CustomJSONEncoder(json.JSONEncoder):
         if isinstance(o, (datetime, date, time)):
             return o.isoformat()
         if isinstance(o, GeneralManager):
-            return f"{o.__class__.__name__}(**{o.identification})"
+            manager_class_name = type.__getattribute__(o.__class__, "__name__")
+            return f"{manager_class_name}(**{o.identification})"
         try:
             return super().default(o)
         except TypeError:

--- a/src/general_manager/utils/json_encoder.py
+++ b/src/general_manager/utils/json_encoder.py
@@ -27,6 +27,7 @@ class CustomJSONEncoder(json.JSONEncoder):
         if isinstance(o, (datetime, date, time)):
             return o.isoformat()
         if isinstance(o, GeneralManager):
+            # Bypass GeneralManagerMeta.__getattribute__ descriptor initialization.
             manager_class_name = type.__getattribute__(o.__class__, "__name__")
             return f"{manager_class_name}(**{o.identification})"
         try:

--- a/src/general_manager/utils/make_cache_key.py
+++ b/src/general_manager/utils/make_cache_key.py
@@ -6,8 +6,12 @@ import inspect
 import json
 from json.encoder import encode_basestring_ascii
 from hashlib import sha256
+from typing import TYPE_CHECKING, cast
 
 from general_manager.utils.json_encoder import CustomJSONEncoder
+
+if TYPE_CHECKING:
+    from general_manager.manager.general_manager import GeneralManager
 
 type CacheKeyArgs = tuple[object, ...]
 type CacheKeyKwargs = Mapping[str, object]
@@ -42,25 +46,70 @@ def _simple_positional_parameter_names(
     return tuple(parameter.name for parameter in parameters)
 
 
+@lru_cache(maxsize=1)
+def _general_manager_class() -> type[object]:
+    from general_manager.manager.general_manager import GeneralManager
+
+    return GeneralManager
+
+
+@lru_cache(maxsize=None)
+def _single_manager_arg_cache_key_parts(
+    func: Callable[..., object],
+    parameter_name: str,
+    module: str,
+    qualname: str,
+) -> tuple[bytes, bytes]:
+    prefix = (f'{{"args": {{{encode_basestring_ascii(parameter_name)}: ').encode()
+    suffix = (
+        f'}}, "module": {encode_basestring_ascii(module)}, '
+        f'"qualname": {encode_basestring_ascii(qualname)}}}'
+    ).encode()
+    return prefix, suffix
+
+
+@lru_cache(maxsize=65536)
+def _single_manager_arg_cache_key_from_repr(
+    func: Callable[..., object],
+    parameter_name: str,
+    module: str,
+    qualname: str,
+    manager_class_name: str,
+    identification_repr: str,
+) -> str:
+    manager_value = f"{manager_class_name}(**{identification_repr})"
+    prefix, suffix = _single_manager_arg_cache_key_parts(
+        func,
+        parameter_name,
+        module,
+        qualname,
+    )
+    hash_builder = sha256(usedforsecurity=False)
+    hash_builder.update(prefix)
+    hash_builder.update(encode_basestring_ascii(manager_value).encode())
+    hash_builder.update(suffix)
+    return hash_builder.hexdigest()
+
+
 def _single_manager_arg_cache_key(
     func: Callable[..., object],
     parameter_name: str,
     value: object,
 ) -> str | None:
     """Return the generic JSON-equivalent key for a single manager argument."""
-    from general_manager.manager.general_manager import GeneralManager
-
-    if not isinstance(value, GeneralManager):
+    if not isinstance(value, _general_manager_class()):
         return None
-    manager_value = f"{value.__class__.__name__}(**{value.identification})"
-    raw = (
-        '{"args": {'
-        f"{encode_basestring_ascii(parameter_name)}: "
-        f"{encode_basestring_ascii(manager_value)}"
-        f'}}, "module": {encode_basestring_ascii(func.__module__)}, '
-        f'"qualname": {encode_basestring_ascii(func.__qualname__)}}}'
-    ).encode()
-    return sha256(raw, usedforsecurity=False).hexdigest()
+    manager = cast("GeneralManager", value)
+    manager_class_name = type.__getattribute__(manager.__class__, "__name__")
+    identification_repr = f"{manager.identification}"
+    return _single_manager_arg_cache_key_from_repr(
+        func,
+        parameter_name,
+        func.__module__,
+        func.__qualname__,
+        manager_class_name,
+        identification_repr,
+    )
 
 
 def make_cache_key(

--- a/src/general_manager/utils/make_cache_key.py
+++ b/src/general_manager/utils/make_cache_key.py
@@ -55,7 +55,6 @@ def _general_manager_class() -> type[object]:
 
 @lru_cache(maxsize=None)
 def _single_manager_arg_cache_key_parts(
-    func: Callable[..., object],
     parameter_name: str,
     module: str,
     qualname: str,
@@ -70,7 +69,6 @@ def _single_manager_arg_cache_key_parts(
 
 @lru_cache(maxsize=65536)
 def _single_manager_arg_cache_key_from_repr(
-    func: Callable[..., object],
     parameter_name: str,
     module: str,
     qualname: str,
@@ -79,7 +77,6 @@ def _single_manager_arg_cache_key_from_repr(
 ) -> str:
     manager_value = f"{manager_class_name}(**{identification_repr})"
     prefix, suffix = _single_manager_arg_cache_key_parts(
-        func,
         parameter_name,
         module,
         qualname,
@@ -103,7 +100,6 @@ def _single_manager_arg_cache_key(
     manager_class_name = type.__getattribute__(manager.__class__, "__name__")
     identification_repr = f"{manager.identification}"
     return _single_manager_arg_cache_key_from_repr(
-        func,
         parameter_name,
         func.__module__,
         func.__qualname__,

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -1600,4 +1600,11 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
 
         filter_section = index_after["filter"]["TestProjectForCommercials"]["name"]
         self.assertEqual(len(filter_section), 1)
-        self.assertEqual(len(next(iter(filter_section.values()))), 1)
+        cache_keys = next(iter(filter_section.values()))
+        prefetch_cache_keys = {
+            cache_key
+            for cache_key in cache_keys
+            if cache_key.startswith("dependency_cache_prefetch_manifest:")
+        }
+        self.assertEqual(len(cache_keys - prefetch_cache_keys), 1)
+        self.assertEqual(len(prefetch_cache_keys), 2)

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -2,6 +2,9 @@ import copy
 from datetime import date, datetime, timedelta
 from unittest.mock import patch
 from django.utils import timezone
+from general_manager.cache.cache_decorator import (
+    _DEPENDENCY_CACHE_PREFETCH_MANIFEST_PREFIX,
+)
 from general_manager.cache.dependency_index import get_full_index
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.utils.testing import GeneralManagerTransactionTestCase
@@ -1604,7 +1607,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
         prefetch_cache_keys = {
             cache_key
             for cache_key in cache_keys
-            if cache_key.startswith("dependency_cache_prefetch_manifest:")
+            if cache_key.startswith(f"{_DEPENDENCY_CACHE_PREFETCH_MANIFEST_PREFIX}:")
         }
         self.assertEqual(len(cache_keys - prefetch_cache_keys), 1)
         self.assertEqual(len(prefetch_cache_keys), 2)

--- a/tests/unit/test_base_interface.py
+++ b/tests/unit/test_base_interface.py
@@ -489,6 +489,17 @@ class InterfaceBaseTests(SimpleTestCase):
         ):
             self.assertFalse(base_interface_module._should_validate_possible_values())
 
+    @override_settings(DEBUG=False, GENERAL_MANAGER={"VALIDATE_INPUT_VALUES": 1})
+    def test_possible_values_toggle_accepts_integer_setting(self):
+        self.assertTrue(base_interface_module._should_validate_possible_values())
+
+    @override_settings(
+        DEBUG=True,
+        GENERAL_MANAGER={"VALIDATE_INPUT_VALUES": object()},
+    )
+    def test_possible_values_toggle_falls_back_to_debug_for_unknown_setting(self):
+        self.assertTrue(base_interface_module._should_validate_possible_values())
+
     def test_input_without_possible_values_skips_validation_setting_lookup(self):
         class NoPossibleValuesInterface(InterfaceBase):
             input_fields: ClassVar = {"id": DummyInput(int, possible_values=None)}
@@ -627,6 +638,30 @@ class InterfaceBaseTests(SimpleTestCase):
                 observer=NoneObserver(),
             )
 
+    def test_execute_with_observability_runs_without_observer(self):
+        self.assertEqual(
+            InterfaceBase._execute_with_observability(
+                target=DummyInterface,
+                operation="read",
+                payload={},
+                func=lambda: "ok",
+                observer=None,
+            ),
+            "ok",
+        )
+
+    def test_execute_with_observability_reraises_without_error_observer(self):
+        error = RuntimeError("failed")
+
+        with self.assertRaisesRegex(RuntimeError, "failed"):
+            InterfaceBase._execute_with_observability(
+                target=DummyInterface,
+                operation="read",
+                payload={},
+                func=lambda: (_ for _ in ()).throw(error),
+                observer=None,
+            )
+
     def test_vals_allowed_lower_and_upper_bounds(self):
         # Lower bound
         inst1 = DummyInterface(a=1, b="v", gm=DummyGM({"id": 21}), vals=1, c=1)
@@ -666,6 +701,15 @@ class InterfaceBaseTests(SimpleTestCase):
         self.assertEqual(second.identification, {"a": 2, "b": "y", "c": None})
         self.assertEqual(fields.keys_calls, 1)
         self.assertEqual(fields.items_calls, 1)
+
+    def test_single_field_input_parsing_plan_refreshes_when_field_removed(self):
+        class SingleFieldInterface(InterfaceBase):
+            input_fields: ClassVar = {"id": DummyInput(int)}
+
+        plan = SingleFieldInterface._get_input_parsing_plan()
+        SingleFieldInterface.input_fields = {}
+
+        self.assertFalse(SingleFieldInterface._input_parsing_plan_is_fresh(plan))
 
     def test_single_required_input_skips_generic_argument_mapping(self):
         class SingleInputInterface(InterfaceBase):

--- a/tests/unit/test_base_interface.py
+++ b/tests/unit/test_base_interface.py
@@ -1,5 +1,6 @@
 # type: ignore
 from django.test import SimpleTestCase, override_settings
+from general_manager.interface import base_interface as base_interface_module
 from general_manager.interface.base_interface import (
     InterfaceBase,
     InvalidInputTypeError,
@@ -453,6 +454,75 @@ class InterfaceBaseTests(SimpleTestCase):
         inst = DummyInterface(a=1, b="foo", gm=DummyGM({"id": 8}), vals=99, c=1)
         self.assertEqual(inst.identification["vals"], 99)
 
+    def test_possible_values_setting_helper_does_not_import_config_per_call(self):
+        import builtins
+
+        with patch("builtins.__import__", wraps=builtins.__import__) as importer:
+            base_interface_module._should_validate_possible_values()
+            base_interface_module._should_validate_possible_values()
+
+        config_imports = [
+            call
+            for call in importer.call_args_list
+            if call.args and call.args[0] == "general_manager.conf"
+        ]
+        self.assertEqual(config_imports, [])
+
+    @override_settings(DEBUG=False, GENERAL_MANAGER_VALIDATE_INPUT_VALUES=True)
+    def test_possible_values_setting_helper_reuses_cached_setting_value(self):
+        with patch.object(
+            base_interface_module,
+            "get_setting",
+            wraps=base_interface_module.get_setting,
+        ) as get_setting:
+            self.assertTrue(base_interface_module._should_validate_possible_values())
+            self.assertTrue(base_interface_module._should_validate_possible_values())
+
+        get_setting.assert_called_once_with("VALIDATE_INPUT_VALUES")
+
+    def test_possible_values_setting_helper_recomputes_after_settings_change(self):
+        with override_settings(DEBUG=False, GENERAL_MANAGER_VALIDATE_INPUT_VALUES=True):
+            self.assertTrue(base_interface_module._should_validate_possible_values())
+
+        with override_settings(
+            DEBUG=True, GENERAL_MANAGER={"VALIDATE_INPUT_VALUES": "off"}
+        ):
+            self.assertFalse(base_interface_module._should_validate_possible_values())
+
+    def test_input_without_possible_values_skips_validation_setting_lookup(self):
+        class NoPossibleValuesInterface(InterfaceBase):
+            input_fields: ClassVar = {"id": DummyInput(int, possible_values=None)}
+
+        with patch(
+            "general_manager.interface.base_interface._should_validate_possible_values",
+            side_effect=AssertionError("setting lookup is unnecessary"),
+        ):
+            instance = NoPossibleValuesInterface(7)
+
+        self.assertEqual(instance.identification, {"id": 7})
+
+    def test_unconstrained_input_skips_bound_and_validator_helpers(self):
+        class UnconstrainedInputInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {"id": Input(int)}
+
+        input_field = UnconstrainedInputInterface.input_fields["id"]
+
+        with (
+            patch.object(
+                input_field,
+                "validate_bounds",
+                side_effect=AssertionError("bounds helper should be skipped"),
+            ),
+            patch.object(
+                input_field,
+                "validate_with_callable",
+                side_effect=AssertionError("validator helper should be skipped"),
+            ),
+        ):
+            instance = UnconstrainedInputInterface(7)
+
+        self.assertEqual(instance.identification, {"id": 7})
+
     def test_input_possible_values_cache_context_is_reused_during_cast_and_validation(
         self,
     ):
@@ -515,6 +585,48 @@ class InterfaceBaseTests(SimpleTestCase):
         inst = DummyInterface(a=1, b="foo", gm=gm, vals=2, c=1)
         self.assertEqual(inst.get_data(), inst.identification)
 
+    def test_execute_with_observability_resolves_success_hooks_once(self):
+        class CountingObserver:
+            before_lookups = 0
+            after_lookups = 0
+
+            @property
+            def before_operation(self):
+                self.before_lookups += 1
+                return lambda **_kwargs: None
+
+            @property
+            def after_operation(self):
+                self.after_lookups += 1
+                return lambda **_kwargs: None
+
+        observer = CountingObserver()
+
+        result = InterfaceBase._execute_with_observability(
+            target=DummyInterface,
+            operation="read",
+            payload={},
+            func=lambda: "ok",
+            observer=observer,
+        )
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(observer.before_lookups, 1)
+        self.assertEqual(observer.after_lookups, 1)
+
+    def test_execute_with_observability_none_hook_still_raises(self):
+        class NoneObserver:
+            before_operation = None
+
+        with self.assertRaises(TypeError):
+            InterfaceBase._execute_with_observability(
+                target=DummyInterface,
+                operation="read",
+                payload={},
+                func=lambda: "ok",
+                observer=NoneObserver(),
+            )
+
     def test_vals_allowed_lower_and_upper_bounds(self):
         # Lower bound
         inst1 = DummyInterface(a=1, b="v", gm=DummyGM({"id": 21}), vals=1, c=1)
@@ -567,6 +679,126 @@ class InterfaceBaseTests(SimpleTestCase):
 
         self.assertEqual(instance.identification, {"id": 7})
 
+    def test_single_required_input_reuses_loaded_input_field_for_validation(self):
+        class CountingFields(dict):
+            getitem_calls = 0
+
+            def __getitem__(self, key):
+                self.getitem_calls += 1
+                return super().__getitem__(key)
+
+        fields = CountingFields({"id": DummyInput(int)})
+
+        class SingleInputInterface(InterfaceBase):
+            input_fields = fields
+
+        instance = SingleInputInterface(7)
+
+        self.assertEqual(instance.identification, {"id": 7})
+        self.assertEqual(fields.getitem_calls, 0)
+
+    def test_input_parsing_uses_fresh_plan_fields_without_item_lookup(self):
+        class UnexpectedItemLookup(AssertionError):
+            pass
+
+        class NoItemLookupFields(dict):
+            def __getitem__(self, key):
+                raise UnexpectedItemLookup
+
+        fields = NoItemLookupFields(
+            {
+                "name": DummyInput(str),
+                "count": DummyInput(int),
+            }
+        )
+
+        class PlannedInterface(InterfaceBase):
+            input_fields = fields
+
+        instance = PlannedInterface(name="demo", count=3)
+
+        self.assertEqual(instance.identification, {"name": "demo", "count": 3})
+
+    def test_exact_keyword_inputs_without_dependencies_skip_generic_argument_mapping(
+        self,
+    ):
+        class ExactKeywordInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "manager": DummyInput(DummyGM),
+                "name": DummyInput(str),
+                "count": DummyInput(int),
+            }
+
+        manager = DummyGM({"id": 7})
+        with patch(
+            "general_manager.interface.base_interface.args_to_kwargs",
+            side_effect=AssertionError("exact keyword input should use fast path"),
+        ):
+            instance = ExactKeywordInterface(
+                manager=manager,
+                name="demo",
+                count=3,
+            )
+
+        self.assertEqual(
+            instance.identification,
+            {"manager": {"id": 7}, "name": "demo", "count": 3},
+        )
+
+    def test_keyword_inputs_with_omitted_optional_skip_generic_argument_mapping(
+        self,
+    ):
+        class OptionalKeywordInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "name": DummyInput(str),
+                "search_date": DummyInput(object, required=False),
+            }
+
+        with patch(
+            "general_manager.interface.base_interface.args_to_kwargs",
+            side_effect=AssertionError("known keyword input should use fast path"),
+        ):
+            instance = OptionalKeywordInterface(name="demo")
+
+        self.assertEqual(
+            instance.identification,
+            {"name": "demo", "search_date": None},
+        )
+
+    def test_keyword_dependency_inputs_fast_path_preserves_input_field_order(
+        self,
+    ):
+        class DependentInput(DummyInput):
+            def cast(self, value, identification=None, *, cache_context=None):
+                del cache_context
+                identification = identification or {}
+                return f"{identification['parent']}:{value}"
+
+        class DependencyInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {
+                "child": DependentInput(str, depends_on=["parent"]),
+                "parent": DummyInput(str),
+                "search_date": DummyInput(object, required=False),
+            }
+
+        with patch(
+            "general_manager.interface.base_interface.args_to_kwargs",
+            side_effect=AssertionError("known dependency input should use fast path"),
+        ):
+            parsed = DependencyInterface(child="child", parent="parent")
+
+        self.assertEqual(
+            list(parsed.identification), ["child", "parent", "search_date"]
+        )
+        self.assertEqual(
+            parsed.identification,
+            {
+                "child": "parent:child",
+                "parent": "parent",
+                "search_date": None,
+            },
+        )
+
     def test_single_required_input_reuses_pure_scalar_parse_inside_run_context(self):
         class SingleInputInterface(InterfaceBase):
             input_fields: ClassVar[dict] = {"id": Input(int)}
@@ -584,6 +816,70 @@ class InterfaceBaseTests(SimpleTestCase):
         self.assertEqual(second.identification, {"id": 7})
         self.assertIsNot(first.identification, second.identification)
         self.assertEqual(cast_input.call_count, 1)
+
+    def test_single_required_keyword_input_reuses_pure_scalar_parse_inside_run_context(
+        self,
+    ):
+        class SingleInputInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {"id": Input(int)}
+
+        input_field = SingleInputInterface.input_fields["id"]
+
+        with (
+            CalculationRunContext(),
+            patch.object(input_field, "cast", wraps=input_field.cast) as cast_input,
+        ):
+            first = SingleInputInterface(id=7)
+            second = SingleInputInterface(id=7)
+
+        self.assertEqual(first.identification, {"id": 7})
+        self.assertEqual(second.identification, {"id": 7})
+        self.assertIsNot(first.identification, second.identification)
+        self.assertEqual(cast_input.call_count, 1)
+
+    def test_single_scalar_input_skips_identification_formatting(self):
+        class SingleInputInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {"id": Input(int)}
+
+        with patch.object(
+            SingleInputInterface,
+            "format_identification",
+            side_effect=AssertionError("scalar identification needs no formatting"),
+        ):
+            parsed = SingleInputInterface(7)
+
+        self.assertEqual(parsed.identification, {"id": 7})
+
+    def test_single_manager_input_still_formats_identification(self):
+        class SingleManagerInputInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {"manager": Input(DummyGM)}
+
+        manager = DummyGM({"id": 7})
+
+        parsed = SingleManagerInputInterface(manager)
+
+        self.assertEqual(parsed.identification, {"manager": {"id": 7}})
+
+    def test_get_capability_handler_skips_initialization_when_already_initialized(
+        self,
+    ):
+        handler = object()
+
+        class InitializedInterface(InterfaceBase):
+            pass
+
+        InitializedInterface._capability_selection = object()  # type: ignore[assignment]
+        InitializedInterface._configured_capabilities_applied = True
+        InitializedInterface._capability_handlers = {"read": handler}
+
+        with patch.object(
+            InitializedInterface,
+            "_ensure_capabilities_initialized",
+            side_effect=AssertionError("initialized lookup should use fast path"),
+        ):
+            result = InitializedInterface.get_capability_handler("read")
+
+        self.assertIs(result, handler)
 
     def test_input_parsing_plan_accepts_id_alias_and_preserves_overwrite_behavior(
         self,
@@ -769,6 +1065,23 @@ class InterfaceBaseTests(SimpleTestCase):
             MutableInterface(a=2)
         parsed = MutableInterface(a=2, maybe="x")
         self.assertEqual(parsed.identification, {"a": 2, "maybe": "x"})
+
+    def test_input_parsing_plan_reflects_single_field_required_mutation(self):
+        fields = {
+            "a": DummyInput(int, required=False),
+        }
+
+        class MutableInterface(InterfaceBase):
+            input_fields = fields
+
+        first = MutableInterface()
+        fields["a"].required = True
+
+        self.assertEqual(first.identification, {"a": None})
+        with self.assertRaises(MissingInputArgumentsError):
+            MutableInterface()
+        parsed = MutableInterface(a=2)
+        self.assertEqual(parsed.identification, {"a": 2})
 
     def test_input_parsing_plan_reflects_dependency_mutation_after_first_parse(self):
         events: list[tuple[str, dict[str, object]]] = []

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -4,7 +4,9 @@ from unittest import mock
 from general_manager.cache.cache_decorator import cached, DependencyTracker
 from general_manager.cache.dependency_cache import (
     DependencyCacheHit,
+    dependency_cache_prefetch_value_bundle_key,
     make_dependency_cache_entry,
+    make_dependency_cache_prefetch_value_bundle,
     read_dependency_cache_hit,
 )
 from general_manager.cache.dependency_index import (
@@ -38,6 +40,7 @@ class FakeCacheBackend:
         self.store = {}
         self.timeouts = {}
         self.get_calls = []
+        self.get_many_calls = []
         self.lock = threading.RLock()
 
     def get(self, key, default=None):
@@ -57,6 +60,16 @@ class FakeCacheBackend:
         if cached_value is not default:
             return _trusted_pickle_loads(cached_value)  # type: ignore
         return default
+
+    def get_many(self, keys):
+        key_tuple = tuple(keys)
+        self.get_many_calls.append(key_tuple)
+        with self.lock:
+            return {
+                key: _trusted_pickle_loads(self.store[key])  # type: ignore
+                for key in key_tuple
+                if key in self.store
+            }
 
     def set(self, key, value, timeout=None):
         """
@@ -846,6 +859,320 @@ class TestCacheDecoratorBackend(SimpleTestCase):
         self.assertEqual(self.fake_cache.get_calls, [])
         self.assertEqual(self.record_calls, [])
 
+    def test_dependency_scope_prefetches_previous_run_manifest_hits(self):
+        calls = []
+
+        @cached(cache="dependency", cache_backend=self.fake_cache)
+        def sample(value):
+            calls.append(value)
+            DependencyTracker.track("Project", "identification", f'{{"id": {value}}}')
+            return value * 3
+
+        key_one = make_cache_key(sample, (1,), {})
+        key_two = make_cache_key(sample, (2,), {})
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        for stored_key in tuple(self.fake_cache.store):
+            if isinstance(stored_key, str) and stored_key.endswith(
+                (":bundle", ":values", ":segments")
+            ):
+                del self.fake_cache.store[stored_key]
+        self.fake_cache.get_calls.clear()
+        self.fake_cache.get_many_calls.clear()
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        self.assertEqual(calls, [1, 2])
+        self.assertNotIn(key_one, self.fake_cache.get_calls)
+        self.assertNotIn(key_two, self.fake_cache.get_calls)
+        self.assertEqual(len(self.fake_cache.get_many_calls), 1)
+        self.assertEqual(set(self.fake_cache.get_many_calls[0]), {key_one, key_two})
+
+    def test_dependency_scope_prefetches_previous_run_bundle_without_get_many(self):
+        calls = []
+
+        @cached(cache="dependency", cache_backend=self.fake_cache)
+        def sample(value):
+            calls.append(value)
+            DependencyTracker.track("Project", "identification", f'{{"id": {value}}}')
+            return value * 3
+
+        key_one = make_cache_key(sample, (1,), {})
+        key_two = make_cache_key(sample, (2,), {})
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        self.fake_cache.get_calls.clear()
+        self.fake_cache.get_many_calls.clear()
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        self.assertEqual(calls, [1, 2])
+        self.assertNotIn(key_one, self.fake_cache.get_calls)
+        self.assertNotIn(key_two, self.fake_cache.get_calls)
+        self.assertEqual(len(self.fake_cache.get_many_calls), 1)
+        self.assertTrue(
+            all(
+                isinstance(cache_key, str) and cache_key.endswith(":values")
+                for cache_key in self.fake_cache.get_many_calls[0]
+            )
+        )
+
+    def test_dependency_scope_prefetches_value_bundle_when_tracker_inactive(self):
+        calls = []
+
+        @cached(cache="dependency", cache_backend=self.fake_cache)
+        def sample(value):
+            calls.append(value)
+            DependencyTracker.track("Project", "identification", f'{{"id": {value}}}')
+            return value * 3
+
+        key_one = make_cache_key(sample, (1,), {})
+        key_two = make_cache_key(sample, (2,), {})
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        self.fake_cache.get_calls.clear()
+        self.fake_cache.get_many_calls.clear()
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        prefetch_hint_gets = [
+            key for key in self.fake_cache.get_calls if key not in {key_one, key_two}
+        ]
+        self.assertTrue(
+            any(
+                isinstance(prefetch_key, str) and prefetch_key.endswith(":segments")
+                for prefetch_key in prefetch_hint_gets
+            )
+        )
+        self.assertFalse(
+            any(
+                isinstance(prefetch_key, str) and prefetch_key.endswith(":bundle")
+                for prefetch_key in prefetch_hint_gets
+            )
+        )
+        self.assertEqual(calls, [1, 2])
+        self.assertEqual(len(self.fake_cache.get_many_calls), 1)
+        self.assertTrue(
+            all(
+                isinstance(cache_key, str) and cache_key.endswith(":values")
+                for cache_key in self.fake_cache.get_many_calls[0]
+            )
+        )
+
+    def test_dependency_scope_value_bundle_accumulates_across_publish_flushes(self):
+        calls = []
+
+        @cached(cache="dependency", cache_backend=self.fake_cache)
+        def sample(value):
+            calls.append(value)
+            DependencyTracker.track("Project", "identification", f'{{"id": {value}}}')
+            return value * 3
+
+        key_one = make_cache_key(sample, (1,), {})
+        key_two = make_cache_key(sample, (2,), {})
+
+        with CalculationRunContext(dependency_cache_publish_batch_size=1):
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        self.fake_cache.get_calls.clear()
+        self.fake_cache.get_many_calls.clear()
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        self.assertEqual(calls, [1, 2])
+        self.assertNotIn(key_one, self.fake_cache.get_calls)
+        self.assertNotIn(key_two, self.fake_cache.get_calls)
+        self.assertEqual(len(self.fake_cache.get_many_calls), 1)
+        self.assertTrue(
+            all(
+                isinstance(cache_key, str) and cache_key.endswith(":values")
+                for cache_key in self.fake_cache.get_many_calls[0]
+            )
+        )
+
+    def test_dependency_scope_old_value_bundle_prefetches_all_values(self):
+        calls = []
+
+        @cached(cache="dependency", cache_backend=self.fake_cache)
+        def sample(value):
+            calls.append(value)
+            DependencyTracker.track("Project", "identification", f'{{"id": {value}}}')
+            return value * 3
+
+        key_one = make_cache_key(sample, (1,), {})
+        key_two = make_cache_key(sample, (2,), {})
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        manifest_key = next(
+            stored_key
+            for stored_key in self.fake_cache.store
+            if isinstance(stored_key, str)
+            and stored_key.startswith("dependency_cache_prefetch_manifest:")
+            and ":segment:" not in stored_key
+            and not stored_key.endswith((":bundle", ":values", ":segments"))
+        )
+        self.fake_cache.store.clear()
+        self.fake_cache.set(
+            dependency_cache_prefetch_value_bundle_key(manifest_key),
+            make_dependency_cache_prefetch_value_bundle(
+                {
+                    key_one: make_dependency_cache_entry(3, ()),
+                    key_two: make_dependency_cache_entry(6, ()),
+                }
+            ),
+        )
+        self.fake_cache.get_calls.clear()
+        self.fake_cache.get_many_calls.clear()
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        self.assertEqual(calls, [1, 2])
+        self.assertNotIn(key_one, self.fake_cache.get_calls)
+        self.assertNotIn(key_two, self.fake_cache.get_calls)
+
+    def test_dependency_scope_prefetches_full_bundle_when_tracker_active(self):
+        calls = []
+
+        @cached(cache="dependency", cache_backend=self.fake_cache)
+        def sample(value):
+            calls.append(value)
+            DependencyTracker.track("Project", "identification", f'{{"id": {value}}}')
+            return value * 3
+
+        key = make_cache_key(sample, (1,), {})
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+
+        self.fake_cache.get_calls.clear()
+        self.fake_cache.get_many_calls.clear()
+
+        with CalculationRunContext():
+            with DependencyTracker() as dependencies:
+                self.assertEqual(sample(1), 3)
+
+        prefetch_hint_gets = [
+            stored_key for stored_key in self.fake_cache.get_calls if stored_key != key
+        ]
+        self.assertTrue(
+            any(
+                isinstance(prefetch_key, str) and prefetch_key.endswith(":segments")
+                for prefetch_key in prefetch_hint_gets
+            )
+        )
+        self.assertEqual(len(self.fake_cache.get_many_calls), 1)
+        self.assertFalse(
+            any(
+                isinstance(cache_key, str) and cache_key.endswith(":values")
+                for cache_key in self.fake_cache.get_many_calls[0]
+            )
+        )
+        self.assertTrue(
+            all(
+                isinstance(cache_key, str) and cache_key.endswith(":bundle")
+                for cache_key in self.fake_cache.get_many_calls[0]
+            )
+        )
+        self.assertEqual(
+            dependencies,
+            {("Project", "identification", '{"id": 1}')},
+        )
+        self.assertEqual(calls, [1])
+
+    def test_dependency_scope_prefetch_manifest_is_attempted_once_per_context(self):
+        calls = []
+
+        @cached(cache="dependency", cache_backend=self.fake_cache)
+        def sample(value):
+            calls.append(value)
+            DependencyTracker.track("Project", "identification", f'{{"id": {value}}}')
+            return value * 3
+
+        key_one = make_cache_key(sample, (1,), {})
+        key_two = make_cache_key(sample, (2,), {})
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+            self.assertEqual(sample(2), 6)
+
+        prefetch_hint_gets = [
+            key for key in self.fake_cache.get_calls if key not in {key_one, key_two}
+        ]
+        self.assertEqual(len(prefetch_hint_gets), 5)
+        self.assertEqual(len(set(prefetch_hint_gets)), 4)
+        self.assertTrue(
+            any(
+                isinstance(prefetch_key, str) and prefetch_key.endswith(":segments")
+                for prefetch_key in prefetch_hint_gets
+            )
+        )
+        self.assertTrue(
+            any(
+                isinstance(prefetch_key, str) and prefetch_key.endswith(":values")
+                for prefetch_key in prefetch_hint_gets
+            )
+        )
+        self.assertTrue(
+            any(
+                isinstance(prefetch_key, str) and prefetch_key.endswith(":bundle")
+                for prefetch_key in prefetch_hint_gets
+            )
+        )
+        self.assertEqual(calls, [1, 2])
+
+    def test_dependency_scope_stale_prefetch_manifest_falls_back_to_compute(self):
+        calls = []
+
+        @cached(cache="dependency", cache_backend=self.fake_cache)
+        def sample(value):
+            calls.append(value)
+            DependencyTracker.track("Project", "identification", f'{{"id": {value}}}')
+            return value * 3
+
+        key = make_cache_key(sample, (1,), {})
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+
+        del self.fake_cache.store[key]
+        for stored_key in tuple(self.fake_cache.store):
+            if isinstance(stored_key, str) and stored_key.endswith(
+                (":bundle", ":values", ":segments")
+            ):
+                del self.fake_cache.store[stored_key]
+        self.fake_cache.get_calls.clear()
+        self.fake_cache.get_many_calls.clear()
+
+        with CalculationRunContext():
+            self.assertEqual(sample(1), 3)
+
+        self.assertEqual(calls, [1, 1])
+        self.assertEqual(self.fake_cache.get_many_calls, [(key,)])
+        self.assertIn(key, self.fake_cache.get_calls)
+
 
 class TestCacheDecoratorScopes(SimpleTestCase):
     def test_bare_cached_decorator_reuses_value_inside_context_only(self):
@@ -950,6 +1277,53 @@ class TestCacheDecoratorScopes(SimpleTestCase):
 
         self.assertEqual(sample(3), 6)
         self.assertEqual(calls, 2)
+
+    def test_run_scope_uses_active_context_without_context_manager(self):
+        calls = 0
+
+        @cached(cache="run")
+        def sample(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        with (
+            CalculationRunContext(),
+            mock.patch(
+                "general_manager.cache.cache_decorator.ensure_calculation_run_context",
+                side_effect=AssertionError(
+                    "active run context should be used directly"
+                ),
+            ),
+        ):
+            self.assertEqual(sample(3), 6)
+            self.assertEqual(sample(3), 6)
+
+        self.assertEqual(calls, 1)
+
+    def test_run_scope_uses_active_context_without_get_or_set_loader(self):
+        calls = 0
+
+        @cached(cache="run")
+        def sample(value):
+            nonlocal calls
+            calls += 1
+            return value * 2
+
+        with (
+            CalculationRunContext(),
+            mock.patch.object(
+                CalculationRunContext,
+                "get_or_set",
+                side_effect=AssertionError(
+                    "active run cache should use direct context access"
+                ),
+            ),
+        ):
+            self.assertEqual(sample(3), 6)
+            self.assertEqual(sample(3), 6)
+
+        self.assertEqual(calls, 1)
 
     def test_run_scope_creates_context_when_missing_for_single_call(self):
         calls = 0

--- a/tests/unit/test_cache_tracker.py
+++ b/tests/unit/test_cache_tracker.py
@@ -1,7 +1,18 @@
 import threading
 
+from general_manager.cache import cache_tracker as cache_tracker_module
 from general_manager.cache.cache_tracker import DependencyTracker
 from unittest import TestCase
+
+
+class RecordingDependencyCollector:
+    def __init__(self) -> None:
+        self.dependencies: set[tuple[str, str, str]] = set()
+        self.add_calls = 0
+
+    def add(self, dependency: tuple[str, str, str]) -> None:
+        self.add_calls += 1
+        self.dependencies.add(dependency)
 
 
 class TestDependencyTracker(TestCase):
@@ -122,6 +133,119 @@ class TestDependencyTracker(TestCase):
                 dependencies,
                 {("TestClass", "identification", "TestIdentifier")},
             )
+
+    def test_dependency_tracker_skips_consecutive_duplicate_collector_adds(self):
+        """Avoid repeated collector writes for immediate duplicate dependencies."""
+        with DependencyTracker():
+            collector = RecordingDependencyCollector()
+            cache_tracker_module._dependency_storage.dependencies[0] = collector  # type: ignore[list-item]
+
+            DependencyTracker._track_validated(
+                "TestClass",
+                "identification",
+                "TestIdentifier",
+            )
+            DependencyTracker._track_validated(
+                "TestClass",
+                "identification",
+                "TestIdentifier",
+            )
+
+        self.assertEqual(collector.add_calls, 1)
+        self.assertEqual(
+            collector.dependencies,
+            {("TestClass", "identification", "TestIdentifier")},
+        )
+
+    def test_dependency_tracker_skips_nonconsecutive_duplicate_collector_adds(self):
+        """Avoid repeated collector writes for duplicates within one stack state."""
+        with DependencyTracker():
+            collector = RecordingDependencyCollector()
+            cache_tracker_module._dependency_storage.dependencies[0] = collector  # type: ignore[list-item]
+
+            DependencyTracker._track_validated(
+                "TestClass",
+                "identification",
+                "TestIdentifier",
+            )
+            DependencyTracker._track_validated(
+                "OtherClass",
+                "filter",
+                "OtherIdentifier",
+            )
+            DependencyTracker._track_validated(
+                "TestClass",
+                "identification",
+                "TestIdentifier",
+            )
+
+        self.assertEqual(collector.add_calls, 2)
+        self.assertEqual(
+            collector.dependencies,
+            {
+                ("TestClass", "identification", "TestIdentifier"),
+                ("OtherClass", "filter", "OtherIdentifier"),
+            },
+        )
+
+    def test_dependency_tracker_duplicate_skip_respects_nested_contexts(self):
+        """Entering a nested tracker must still record the dependency there."""
+        with DependencyTracker():
+            outer_collector = RecordingDependencyCollector()
+            cache_tracker_module._dependency_storage.dependencies[0] = outer_collector  # type: ignore[list-item]
+            DependencyTracker._track_validated(
+                "TestClass",
+                "identification",
+                "TestIdentifier",
+            )
+            DependencyTracker._track_validated(
+                "TestClass",
+                "identification",
+                "TestIdentifier",
+            )
+
+            with DependencyTracker():
+                inner_collector = RecordingDependencyCollector()
+                cache_tracker_module._dependency_storage.dependencies[1] = (
+                    inner_collector  # type: ignore[list-item]
+                )
+                DependencyTracker._track_validated(
+                    "TestClass",
+                    "identification",
+                    "TestIdentifier",
+                )
+                DependencyTracker._track_validated(
+                    "TestClass",
+                    "identification",
+                    "TestIdentifier",
+                )
+
+        self.assertEqual(outer_collector.add_calls, 2)
+        self.assertEqual(inner_collector.add_calls, 1)
+        self.assertEqual(
+            inner_collector.dependencies,
+            {("TestClass", "identification", "TestIdentifier")},
+        )
+
+    def test_dependency_tracker_duplicate_skip_checks_all_active_collectors(self):
+        """Manual inner collector mutation must not prevent outer propagation."""
+        dependency = ("TestClass", "identification", "TestIdentifier")
+
+        with DependencyTracker():
+            outer_collector = RecordingDependencyCollector()
+            cache_tracker_module._dependency_storage.dependencies[0] = outer_collector  # type: ignore[list-item]
+
+            with DependencyTracker():
+                inner_collector = RecordingDependencyCollector()
+                inner_collector.dependencies.add(dependency)
+                cache_tracker_module._dependency_storage.dependencies[1] = (
+                    inner_collector  # type: ignore[list-item]
+                )
+
+                DependencyTracker._track_validated(*dependency)
+
+        self.assertEqual(outer_collector.dependencies, {dependency})
+        self.assertEqual(inner_collector.dependencies, {dependency})
 
     def test_dependency_tracker_propagates_nested_tracks_to_outer_context(self):
         """Record nested dependencies in both nested and enclosing collectors."""

--- a/tests/unit/test_calculation_interface.py
+++ b/tests/unit/test_calculation_interface.py
@@ -1,7 +1,7 @@
 from typing import ClassVar
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from general_manager.bucket.calculation_bucket import CalculationBucket
 from general_manager.interface import CalculationInterface
 from general_manager.interface.capabilities.calculation import (
@@ -12,6 +12,9 @@ from general_manager.interface.capabilities.configuration import (
     InterfaceCapabilityConfig,
 )
 from general_manager.manager.input import Input
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.permission.manager_based_permission import ManagerBasedPermission
+from general_manager.cache.cache_tracker import DependencyTracker
 
 
 class DummyCalculationInterface(CalculationInterface):
@@ -111,6 +114,59 @@ class TestCalculationInterface(TestCase):
         self.assertEqual(attributes["field1"](interface), "alpha")
         self.assertEqual(attributes["field2"](interface), "ALPHA")
         self.assertEqual(attributes["field2"](interface), "ALPHA")
+
+    def test_cached_manager_input_uses_manager_dependency_fast_path(self):
+        class RelatedInterface:
+            def __init__(self, manager_id=None, *, id=None):
+                if id is not None:
+                    manager_id = id
+                self.identification = {"id": manager_id}
+
+        with override_settings(AUTOCREATE_GRAPHQL=False):
+
+            class RelatedManager(GeneralManager):
+                pass
+
+        RelatedManager.Interface = RelatedInterface  # type: ignore[assignment]
+        RelatedManager.Permission = ManagerBasedPermission  # type: ignore[assignment]
+        RelatedManager._attributes = {}
+
+        class ManagerInputCalculationInterface(CalculationInterface):
+            input_fields: ClassVar[dict[str, Input]] = {
+                "manager": Input(type=RelatedManager),
+            }
+
+        class ManagerInputCalculation:
+            Interface = ManagerInputCalculationInterface
+
+        ManagerInputCalculationInterface._parent_class = ManagerInputCalculation
+        interface = ManagerInputCalculationInterface("related-id")
+        attributes = ManagerInputCalculationInterface.get_attributes()
+        manager = attributes["manager"](interface)
+        self.assertIsInstance(manager, RelatedManager)
+
+        track_calls = []
+        original_track = RelatedManager._track_identification_dependency
+
+        def track_identification(identification):
+            track_calls.append(identification)
+            return original_track(identification)
+
+        with (
+            DependencyTracker() as dependencies,
+            patch.object(
+                RelatedManager,
+                "_track_identification_dependency",
+                side_effect=track_identification,
+            ),
+        ):
+            self.assertIs(attributes["manager"](interface), manager)
+
+        self.assertEqual(track_calls, [manager.identification])
+        self.assertIn(
+            (RelatedManager.__name__, "identification", '{"id": "related-id"}'),
+            dependencies,
+        )
 
     def test_filter(self):
         """

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -40,6 +40,18 @@ def make_pending_publication(cache_key: str) -> PendingDependencyCachePublicatio
     )
 
 
+class CountingHashKey:
+    def __init__(self) -> None:
+        self.hash_calls = 0
+
+    def __hash__(self) -> int:
+        self.hash_calls += 1
+        return 1
+
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
+
 class CalculationFailed(RuntimeError):
     """Test exception used to exercise context cleanup."""
 
@@ -119,6 +131,18 @@ def test_get_or_set_reuses_loaded_value_inside_context() -> None:
         assert ctx.get_or_set(("answer",), loader) == 42
 
     assert calls == 1
+
+
+def test_get_or_set_hit_uses_single_mapping_lookup() -> None:
+    key = CountingHashKey()
+
+    with CalculationRunContext() as ctx:
+        assert ctx.get_or_set(key, lambda: 42) == 42
+        key.hash_calls = 0
+
+        assert ctx.get_or_set(key, lambda: 99) == 42
+
+    assert key.hash_calls == 1
 
 
 def test_get_or_set_does_not_cache_failed_loader() -> None:

--- a/tests/unit/test_capability_core_utils.py
+++ b/tests/unit/test_capability_core_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import pytest
 from unittest.mock import Mock
 
@@ -56,6 +57,28 @@ def test_with_observability_no_capability():
     assert result == 42
     assert calls == ["executed"]
     target.get_capability_handler.assert_called_once_with("observability")
+
+
+def test_with_observability_resolves_handler_once():
+    class Target:
+        handler_lookups = 0
+
+        @property
+        def get_capability_handler(self):
+            self.handler_lookups += 1
+            return lambda _name: None
+
+    target = Target()
+
+    result = with_observability(
+        target,
+        operation="test_op",
+        payload={},
+        func=lambda: "result",
+    )
+
+    assert result == "result"
+    assert target.handler_lookups == 1
 
 
 def test_with_observability_before_operation():
@@ -218,9 +241,17 @@ def test_with_observability_reuses_same_payload_copy_for_all_hooks():
 def test_with_observability_does_not_copy_payload_without_capability():
     """Payload conversion should be skipped when no capability is registered."""
 
-    class BrokenMapping(dict[str, object]):
+    class BrokenMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            if key == "key":
+                return "value"
+            raise KeyError(key)
+
         def __iter__(self):
             raise PayloadCopyError
+
+        def __len__(self) -> int:
+            return 1
 
     target = Mock()
     target.get_capability_handler = Mock(return_value=None)
@@ -228,7 +259,7 @@ def test_with_observability_does_not_copy_payload_without_capability():
     result = with_observability(
         target,
         operation="test",
-        payload=BrokenMapping({"key": "value"}),
+        payload=BrokenMapping(),
         func=lambda: "ok",
     )
 

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -1,6 +1,7 @@
 # type: ignore
 
 from datetime import datetime
+from typing import ClassVar
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -226,6 +227,15 @@ class InitTrackingTrustedManager(GeneralManager):
         super().__init__(pk, **kwargs)
 
 
+class CustomTrackingTrustedManager(GeneralManager):
+    tracking_calls: ClassVar[list[dict[str, object]]] = []
+
+    @classmethod
+    def _track_identification_dependency_active(cls, identification):
+        cls.tracking_calls.append(dict(identification))
+        DependencyTracker.track(cls.__name__, "all", "")
+
+
 class DatabaseBucketTestCase(TestCase):
     def setUp(self):
         """
@@ -239,6 +249,8 @@ class DatabaseBucketTestCase(TestCase):
         TrustedUserManager.Interface = TrustedDummyInterface
         GroupBackedTrustedUserManager.Interface = GroupBackedTrustedInterface
         InitTrackingTrustedManager.Interface = TrustedDummyInterface
+        CustomTrackingTrustedManager.Interface = TrustedDummyInterface
+        CustomTrackingTrustedManager.tracking_calls = []
         DummyInterface._parent_class = UserManager
         TrustedDummyInterface._parent_class = TrustedUserManager
         # Create some test users
@@ -538,6 +550,44 @@ class DatabaseBucketTestCase(TestCase):
             ),
             dependencies,
         )
+
+    def test_cached_trusted_manager_reuse_preserves_custom_dependency_tracking(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            CustomTrackingTrustedManager,
+        )
+
+        with CalculationRunContext():
+            list(bucket)
+            with DependencyTracker() as dependencies:
+                list(bucket)
+
+        self.assertEqual(
+            CustomTrackingTrustedManager.tracking_calls,
+            [{"id": self.u1.id}, {"id": self.u2.id}],
+        )
+        self.assertIn(("CustomTrackingTrustedManager", "all", ""), dependencies)
+        self.assertNotIn(
+            (
+                "CustomTrackingTrustedManager",
+                "identification",
+                f'{{"id": {self.u1.id}}}',
+            ),
+            dependencies,
+        )
+
+    def test_instance_tracking_helper_preserves_custom_dependency_tracking(self):
+        manager = CustomTrackingTrustedManager(self.u1.id)
+        CustomTrackingTrustedManager.tracking_calls = []
+
+        with DependencyTracker() as dependencies:
+            manager._track_own_identification_dependency_active()
+
+        self.assertEqual(
+            CustomTrackingTrustedManager.tracking_calls,
+            [{"id": self.u1.id}],
+        )
+        self.assertEqual(dependencies, {("CustomTrackingTrustedManager", "all", "")})
 
     def test_equivalent_database_buckets_share_index_inside_run_context(self):
         """Share a bucket index for equivalent querysets in one run context."""

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -16,6 +16,7 @@ from general_manager.bucket.database_bucket import (
     QuerysetFilteringError,
     _restore_database_bucket_from_primary_keys,
 )
+from general_manager.cache.dependency_index import serialize_dependency_identifier
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.manager.general_manager import GeneralManager
@@ -501,6 +502,43 @@ class DatabaseBucketTestCase(TestCase):
         )
         self.assertIs(first_managers[0], second_managers[0])
 
+    def test_cached_trusted_managers_replay_identification_dependencies_in_bulk(self):
+        bucket = DatabaseBucket(
+            User.objects.filter(username__in=["alice", "bob"]).order_by("username"),
+            TrustedUserManager,
+        )
+
+        with CalculationRunContext():
+            list(bucket)
+            with (
+                patch.object(
+                    TrustedUserManager,
+                    "_track_identification_dependency",
+                    side_effect=AssertionError(
+                        "cached manager dependencies should be replayed in bulk"
+                    ),
+                ),
+                DependencyTracker() as dependencies,
+            ):
+                list(bucket)
+
+        self.assertIn(
+            (
+                "TrustedUserManager",
+                "identification",
+                f'{{"id": {self.u1.id}}}',
+            ),
+            dependencies,
+        )
+        self.assertIn(
+            (
+                "TrustedUserManager",
+                "identification",
+                f'{{"id": {self.u2.id}}}',
+            ),
+            dependencies,
+        )
+
     def test_equivalent_database_buckets_share_index_inside_run_context(self):
         """Share a bucket index for equivalent querysets in one run context."""
         first_bucket = DatabaseBucket(
@@ -586,6 +624,56 @@ class DatabaseBucketTestCase(TestCase):
             self.assertEqual(bucket.get(pk=self.u1.pk).identification["id"], self.u1.id)
             self.assertEqual(bucket[1].identification["id"], self.u2.id)
             self.assertIn(self.u1, bucket)
+
+    def test_tracking_unsorted_all_bucket_skips_empty_mapping_normalization(self):
+        """Avoid serializing empty mappings that are not part of tracked output."""
+        bucket = DatabaseBucket(User.objects.all(), UserManager)
+        original_normalize = DatabaseBucket._normalize_dependency_mapping
+        normalized_definitions = []
+
+        def spy_normalize(definitions):
+            normalized_definitions.append(definitions)
+            return original_normalize(definitions)
+
+        with (
+            patch.object(
+                DatabaseBucket,
+                "_normalize_dependency_mapping",
+                side_effect=spy_normalize,
+            ),
+            DependencyTracker() as dependencies,
+        ):
+            bucket._track_effective_dependencies()
+
+        self.assertEqual(normalized_definitions, [])
+        self.assertIn(("UserManager", "all", ""), dependencies)
+
+    def test_tracking_sorted_all_bucket_keeps_empty_mappings_in_sort_payload(self):
+        """Sorted buckets still publish empty filters/excludes for sort identity."""
+        bucket = DatabaseBucket(
+            User.objects.all(),
+            UserManager,
+            sort_keys=("username",),
+            sort_reverse=True,
+        )
+
+        with DependencyTracker() as dependencies:
+            bucket._track_effective_dependencies()
+
+        expected_sort_identifier = serialize_dependency_identifier(
+            {
+                "__sort__username": {
+                    "filters": {},
+                    "excludes": {},
+                    "reverse": True,
+                }
+            }
+        )
+        self.assertIn(("UserManager", "all", ""), dependencies)
+        self.assertIn(
+            ("UserManager", "filter", expected_sort_identifier),
+            dependencies,
+        )
 
     def test_filtered_count_populates_primary_key_snapshot_for_iteration(self):
         bucket = DatabaseBucket(

--- a/tests/unit/test_dependency_cache.py
+++ b/tests/unit/test_dependency_cache.py
@@ -223,7 +223,7 @@ class DependencyCacheEntryTests(SimpleTestCase):
         self.assertEqual(hit.value, "ready")
         self.assertEqual(hit.dependencies, frozenset(dependencies))
 
-    def test_legacy_combined_payload_still_rejects_malformed_dependencies(
+    def test_legacy_combined_payload_version_is_treated_as_cache_miss(
         self,
     ) -> None:
         cache_backend = PickleCache()
@@ -233,7 +233,7 @@ class DependencyCacheEntryTests(SimpleTestCase):
             DependencyCacheEntry(
                 version=1,
                 value="legacy",
-                dependencies=frozenset({("Project", "bad-action", '{"id": 1}')}),  # type: ignore[arg-type]
+                dependencies=frozenset({("Project", "identification", '{"id": 1}')}),
             ),
             None,
         )

--- a/tests/unit/test_dependency_cache.py
+++ b/tests/unit/test_dependency_cache.py
@@ -13,9 +13,18 @@ from general_manager.cache.dependency_cache import (
     DEPENDENCY_CACHE_ENTRY_VERSION,
     DependencyCacheEntry,
     DependencyCacheHit,
+    DependencyCachePrefetchBundle,
+    DependencyCachePrefetchValueBundle,
     make_dependency_cache_entry,
+    make_dependency_cache_prefetch_bundle,
+    make_dependency_cache_prefetch_value_bundle,
     read_dependency_cache_hit,
+    read_dependency_cache_prefetch_bundle_entries,
+    read_dependency_cache_prefetch_bundle_hits,
+    read_dependency_cache_prefetch_bundle_values,
     read_many_dependency_cache_hits,
+    read_many_dependency_cache_prefetch_bundle_hits,
+    read_many_dependency_cache_prefetch_bundle_values,
     replay_dependency_cache_hit,
 )
 from general_manager.cache.dependency_index import Dependency
@@ -316,6 +325,157 @@ class DependencyCacheEntryTests(SimpleTestCase):
 
         self.assertEqual([hits["cache-0"].value, hits["cache-1"].value], [0, 1])
         self.assertEqual(cache_backend.get_calls, ["cache-0", "cache-1"])
+
+    def test_prefetch_bundle_readers_filter_invalid_entries(self) -> None:
+        cache_backend = PickleCache()
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+        valid_entry = make_dependency_cache_entry("ready", dependencies)
+        cache_backend.set(
+            "bundle",
+            DependencyCachePrefetchBundle(
+                version=1,
+                entries={
+                    "cache-a": valid_entry,
+                    "cache-legacy": DependencyCacheEntry(
+                        version=1,
+                        value="legacy",
+                        dependencies=frozenset(dependencies),
+                    ),
+                    "cache-future": DependencyCacheEntry(
+                        version=999,
+                        value="future",
+                        dependencies=frozenset(dependencies),
+                    ),
+                    "cache-invalid": "not an entry",  # type: ignore[dict-item]
+                    1: valid_entry,  # type: ignore[dict-item]
+                },
+            ),
+            None,
+        )
+
+        entries = read_dependency_cache_prefetch_bundle_entries(
+            cache_backend,
+            "bundle",
+        )
+        hits = read_dependency_cache_prefetch_bundle_hits(cache_backend, "bundle")
+
+        self.assertEqual(set(entries), {"cache-a", "cache-legacy", "cache-future"})
+        self.assertEqual(set(hits), {"cache-a"})
+        self.assertEqual(hits["cache-a"].value, "ready")
+
+    def test_prefetch_bundle_readers_reject_wrong_payload_versions(self) -> None:
+        cache_backend = PickleCache()
+        cache_backend.set(
+            "bundle",
+            DependencyCachePrefetchBundle(version=999, entries={}),
+            None,
+        )
+        cache_backend.set(
+            "values",
+            DependencyCachePrefetchValueBundle(version=999, values={"cache-a": 1}),
+            None,
+        )
+
+        self.assertEqual(
+            read_dependency_cache_prefetch_bundle_entries(cache_backend, "bundle"),
+            {},
+        )
+        self.assertEqual(
+            read_dependency_cache_prefetch_bundle_values(cache_backend, "values"),
+            {},
+        )
+
+    def test_many_prefetch_bundle_readers_filter_payloads_and_entries(self) -> None:
+        cache_backend = PickleCache()
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+        valid_entry = make_dependency_cache_entry("ready", dependencies)
+        cache_backend.set("not-bundle", object(), None)
+        cache_backend.set(
+            "wrong-version-bundle",
+            DependencyCachePrefetchBundle(
+                version=999, entries={"cache-a": valid_entry}
+            ),
+            None,
+        )
+        cache_backend.set(
+            "bundle",
+            DependencyCachePrefetchBundle(
+                version=1,
+                entries={
+                    "cache-a": valid_entry,
+                    "cache-future": DependencyCacheEntry(
+                        version=999,
+                        value="future",
+                        dependencies=frozenset(dependencies),
+                    ),
+                    1: valid_entry,  # type: ignore[dict-item]
+                },
+            ),
+            None,
+        )
+        cache_backend.set("not-values", object(), None)
+        cache_backend.set(
+            "wrong-version-values",
+            DependencyCachePrefetchValueBundle(version=999, values={"cache-a": 1}),
+            None,
+        )
+        cache_backend.set(
+            "values",
+            DependencyCachePrefetchValueBundle(
+                version=1,
+                values={
+                    "cache-a": "ready",
+                    1: "ignored",  # type: ignore[dict-item]
+                },
+            ),
+            None,
+        )
+
+        hits = read_many_dependency_cache_prefetch_bundle_hits(
+            cache_backend,
+            ("not-bundle", "wrong-version-bundle", "bundle"),
+        )
+        values = read_many_dependency_cache_prefetch_bundle_values(
+            cache_backend,
+            ("not-values", "wrong-version-values", "values"),
+        )
+
+        self.assertEqual(set(hits), {"cache-a"})
+        self.assertEqual(hits["cache-a"].value, "ready")
+        self.assertEqual(values, {"cache-a": "ready"})
+
+    def test_prefetch_bundle_reads_fall_back_without_get_many(self) -> None:
+        cache_backend = PickleCacheWithoutGetMany()
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+        cache_backend.set(
+            "bundle",
+            make_dependency_cache_prefetch_bundle(
+                {"cache-a": make_dependency_cache_entry("ready", dependencies)}
+            ),
+            None,
+        )
+        cache_backend.set(
+            "values",
+            make_dependency_cache_prefetch_value_bundle(
+                {"cache-a": make_dependency_cache_entry("ready", dependencies)}
+            ),
+            None,
+        )
+
+        self.assertEqual(
+            read_many_dependency_cache_prefetch_bundle_hits(cache_backend, ()), {}
+        )
+        hits = read_many_dependency_cache_prefetch_bundle_hits(
+            cache_backend, ("bundle",)
+        )
+        values = read_many_dependency_cache_prefetch_bundle_values(
+            cache_backend,
+            ("missing", "values"),
+        )
+
+        self.assertEqual(set(hits), {"cache-a"})
+        self.assertEqual(values, {"cache-a": "ready"})
+        self.assertEqual(cache_backend.get_calls, ["bundle", "missing", "values"])
 
     def test_replay_dependency_cache_hit_tracks_dependencies(self) -> None:
         hit = DependencyCacheHit(

--- a/tests/unit/test_dependency_cache.py
+++ b/tests/unit/test_dependency_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pickle
+import pickletools
 from collections.abc import Iterable, Mapping
 from typing import cast
 from unittest.mock import patch
@@ -83,6 +84,18 @@ class DependencyCacheEntryTests(SimpleTestCase):
         self.assertEqual(entry.version, DEPENDENCY_CACHE_ENTRY_VERSION)
         self.assertEqual(entry.value, {"status": "ready"})
         self.assertEqual(entry.dependencies, frozenset(dependencies))
+
+    def test_dependency_cache_entry_pickle_uses_compact_reducer(self) -> None:
+        dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}
+        entry = make_dependency_cache_entry("ready", dependencies)
+
+        opcodes = [
+            opcode.name
+            for opcode, _argument, _position in pickletools.genops(pickle.dumps(entry))
+        ]
+
+        self.assertNotIn("BUILD", opcodes)
+        self.assertIn("REDUCE", opcodes)
 
     def test_reads_falsey_combined_values_as_hits(self) -> None:
         values: list[object] = [None, False, 0, [], {}]
@@ -319,3 +332,39 @@ class DependencyCacheEntryTests(SimpleTestCase):
             replay_dependency_cache_hit(hit)
 
         self.assertEqual(dependencies, set(hit.dependencies))
+
+    def test_replay_framework_captured_hit_uses_trusted_bulk_path(self) -> None:
+        with DependencyTracker() as captured_dependencies:
+            DependencyTracker.track("Project", "identification", '{"id": 1}')
+            DependencyTracker.track("User", "filter", '{"active": true}')
+            DependencyTracker.track("User", "all", "")
+
+        cache_backend = PickleCache()
+        entry = make_dependency_cache_entry("ready", captured_dependencies)
+        cache_backend.set("cache-a", entry, None)
+        hit = read_dependency_cache_hit(cache_backend, "cache-a")
+        self.assertIsInstance(hit, DependencyCacheHit)
+        assert isinstance(hit, DependencyCacheHit)
+
+        with patch.object(
+            DependencyTracker,
+            "track",
+            side_effect=AssertionError("trusted replay should not track one-by-one"),
+        ):
+            with DependencyTracker() as dependencies:
+                replay_dependency_cache_hit(hit)
+
+        self.assertEqual(dependencies, set(captured_dependencies))
+
+    def test_replay_untrusted_hit_rejects_malformed_dependency(self) -> None:
+        hit = DependencyCacheHit(
+            value="ready",
+            dependencies=frozenset(
+                {
+                    ("Project", "fetch", '{"id": 1}'),  # type: ignore[arg-type]
+                }
+            ),
+        )
+
+        with self.assertRaises(ValueError):
+            replay_dependency_cache_hit(hit)

--- a/tests/unit/test_dependency_cache.py
+++ b/tests/unit/test_dependency_cache.py
@@ -385,6 +385,60 @@ class DependencyCacheEntryTests(SimpleTestCase):
             {},
         )
 
+    def test_prefetch_bundle_readers_reject_non_mapping_payloads(self) -> None:
+        class DirectCache:
+            def __init__(self) -> None:
+                self.store: dict[str, object] = {
+                    "bundle": DependencyCachePrefetchBundle(
+                        version=1,
+                        entries="not a mapping",  # type: ignore[arg-type]
+                    ),
+                    "values": DependencyCachePrefetchValueBundle(
+                        version=1,
+                        values="not a mapping",  # type: ignore[arg-type]
+                    ),
+                }
+
+            def get(self, key: str, default: object = None) -> object:
+                return self.store.get(key, default)
+
+            def set(
+                self,
+                key: str,
+                value: object,
+                timeout: int | None = None,
+            ) -> None:
+                del timeout
+                self.store[key] = value
+
+            def get_many(self, keys: Iterable[str]) -> Mapping[str, object]:
+                return {key: self.store[key] for key in keys if key in self.store}
+
+        cache_backend = DirectCache()
+
+        self.assertEqual(
+            read_dependency_cache_prefetch_bundle_entries(cache_backend, "bundle"),
+            {},
+        )
+        self.assertEqual(
+            read_dependency_cache_prefetch_bundle_hits(cache_backend, "bundle"),
+            {},
+        )
+        self.assertEqual(
+            read_dependency_cache_prefetch_bundle_values(cache_backend, "values"),
+            {},
+        )
+        self.assertEqual(
+            read_many_dependency_cache_prefetch_bundle_hits(cache_backend, ("bundle",)),
+            {},
+        )
+        self.assertEqual(
+            read_many_dependency_cache_prefetch_bundle_values(
+                cache_backend, ("values",)
+            ),
+            {},
+        )
+
     def test_many_prefetch_bundle_readers_filter_payloads_and_entries(self) -> None:
         cache_backend = PickleCache()
         dependencies: set[Dependency] = {("Project", "identification", '{"id": 1}')}

--- a/tests/unit/test_dependency_matching.py
+++ b/tests/unit/test_dependency_matching.py
@@ -122,6 +122,45 @@ def test_single_key_scalar_dependency_mapping_serialization_skips_json_dumps() -
         )
 
 
+def test_multi_key_simple_dependency_mapping_serialization_skips_generic_path() -> None:
+    payload = {
+        "target_date": date(2026, 1, 2),
+        "derivative": {"id": 7},
+        "search_date": None,
+    }
+
+    with (
+        patch(
+            "general_manager.cache.dependency_matching.json.dumps",
+            side_effect=AssertionError("simple mapping uses fast path"),
+        ),
+        patch(
+            "general_manager.cache.dependency_matching.normalize_dependency_value",
+            side_effect=AssertionError("simple mapping does not need normalization"),
+        ),
+    ):
+        assert serialize_normalized_value(payload) == (
+            '{"derivative": {"id": 7}, "search_date": null, '
+            '"target_date": "2026-01-02"}'
+        )
+
+
+def test_sorted_two_key_simple_dependency_mapping_serialization_skips_sorting() -> None:
+    payload = {
+        "bill_of_material": {"id": 7},
+        "search_date": None,
+    }
+
+    with patch(
+        "general_manager.cache.dependency_matching.sorted",
+        side_effect=AssertionError("already-sorted two-key mapping skips sorting"),
+        create=True,
+    ):
+        assert serialize_normalized_value(payload) == (
+            '{"bill_of_material": {"id": 7}, "search_date": null}'
+        )
+
+
 def test_primitive_dependency_serialization_matches_json_contract() -> None:
     assert serialize_normalized_value("abc") == '"abc"'
     assert serialize_normalized_value(3) == "3"

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -2,25 +2,30 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 import pickle
-from typing import cast
+from typing import ClassVar, cast
 from unittest import mock
 
 from django.core.cache import cache, cache as coordination_cache
 from django.test import SimpleTestCase, override_settings
 
+from general_manager.cache import dependency_cache as dependency_cache_module
+from general_manager.cache import dependency_publish as dependency_publish_module
+from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_cache import (
     DependencyCacheEntry,
     DependencyCacheHit,
+    TRUSTED_DEPENDENCY_CACHE_ENTRY_VERSION,
 )
 from general_manager.cache.dependency_index import (
     Dependency,
     begin_dependency_data_change,
     end_dependency_data_change,
+    generic_cache_invalidation,
     get_dependency_generation,
 )
 from general_manager.cache.dependency_shards import (
     cache_set_members,
-    exact_lookup_shard_key,
+    composite_lookup_shard_key,
     record_many_cache_dependencies,
 )
 from general_manager.cache.dependency_publish import (
@@ -34,6 +39,8 @@ from general_manager.cache.dependency_publish import (
     wait_for_cached_dependency_hit,
     _compute_lock_key,
 )
+from general_manager.interface import CalculationInterface
+from general_manager.manager import GeneralManager
 
 
 TEST_CACHES = {
@@ -95,6 +102,11 @@ class FakeDependencyCachePartialSetManyBackend(FakeDependencyCacheBackend):
             if key not in self.failed_keys:
                 self.set(key, value, timeout)
         return sorted(self.failed_keys & payloads.keys())
+
+
+class PublishedTrustedManager:
+    def __init__(self, identification: int) -> None:
+        self.identification = identification
 
 
 def cache_entry(
@@ -221,6 +233,55 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertEqual(cache_backend.timeouts[cache_key], 30)
         self.assertNotIn(f"{cache_key}:deps", cache_backend.store)
 
+    def test_publish_trusted_entry_still_uses_dependency_invalidation(self) -> None:
+        cache_key = "trusted-cache"
+        with DependencyTracker() as dependencies:
+            DependencyTracker.track("PublishedTrustedManager", "identification", "42")
+
+        publish_dependency_cache_entry(
+            cache_key=cache_key,
+            result={"status": "ready"},
+            dependencies=dependencies,
+            cache_backend=cache,
+            timeout=None,
+            started_generation=get_dependency_generation(),
+        )
+
+        payload = cache.get(cache_key)
+        self.assertIsInstance(payload, DependencyCacheEntry)
+        assert isinstance(payload, DependencyCacheEntry)
+        self.assertEqual(payload.version, TRUSTED_DEPENDENCY_CACHE_ENTRY_VERSION)
+        self.assertEqual(payload.value, {"status": "ready"})
+        self.assertEqual(payload.dependencies, frozenset(dependencies))
+        self.assertEqual(
+            cache_set_members(
+                composite_lookup_shard_key(
+                    "PublishedTrustedManager",
+                    "filter",
+                    "identification",
+                )
+            ),
+            {cache_key},
+        )
+
+        generic_cache_invalidation(
+            sender=PublishedTrustedManager,
+            instance=PublishedTrustedManager(42),
+            old_relevant_values={},
+        )
+
+        self.assertIsNone(cache.get(cache_key))
+        self.assertEqual(
+            cache_set_members(
+                composite_lookup_shard_key(
+                    "PublishedTrustedManager",
+                    "filter",
+                    "identification",
+                )
+            ),
+            set(),
+        )
+
     def test_batch_publish_records_shards_once_before_bulk_value_write(self) -> None:
         cache_backend = FakeDependencyCacheSetManyBackend()
         events: list[str] = []
@@ -268,15 +329,9 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertIsNone(cache.get("dependency_index"))
         self.assertEqual(
             cache_set_members(
-                exact_lookup_shard_key("Project", "filter", "identification", "eq", "1")
+                composite_lookup_shard_key("Project", "filter", "identification")
             ),
-            {"cache-a"},
-        )
-        self.assertEqual(
-            cache_set_members(
-                exact_lookup_shard_key("Project", "filter", "identification", "eq", "2")
-            ),
-            {"cache-b"},
+            {"cache-a", "cache-b"},
         )
         self.assertEqual(len(cache_backend.set_many_calls), 1)
         self.assertEqual(
@@ -289,6 +344,300 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertEqual(
             cache_entry(cache_backend, "cache-b").dependencies,
             frozenset({("Project", "identification", "2")}),
+        )
+
+    def test_batch_publish_skips_calculation_identity_dependency_metadata(
+        self,
+    ) -> None:
+        class DependencyPublishCalculationIdentity(GeneralManager):
+            class Interface(CalculationInterface):
+                input_fields: ClassVar[dict] = {}
+
+        cache_backend = FakeDependencyCacheSetManyBackend()
+        calculation_dependency: Dependency = (
+            DependencyPublishCalculationIdentity.__name__,
+            "identification",
+            '{"id": 99}',
+        )
+        project_dependency: Dependency = (
+            "Project",
+            "identification",
+            '{"id": 1}',
+        )
+
+        publish_dependency_cache_entries(
+            [
+                self.make_pending_publication(
+                    cache_key="cache-a",
+                    result="alpha",
+                    dependencies={calculation_dependency, project_dependency},
+                    cache_backend=cache_backend,
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            cache_set_members(
+                composite_lookup_shard_key(
+                    DependencyPublishCalculationIdentity.__name__,
+                    "filter",
+                    "identification",
+                )
+            ),
+            set(),
+        )
+        self.assertEqual(
+            cache_set_members(
+                composite_lookup_shard_key(
+                    "Project",
+                    "filter",
+                    "identification",
+                )
+            ),
+            {"cache-a"},
+        )
+        self.assertEqual(
+            cache_entry(cache_backend, "cache-a").dependencies,
+            frozenset({calculation_dependency, project_dependency}),
+        )
+
+    def test_batch_publish_reuses_metadata_dependencies_for_prefetch_bundle(
+        self,
+    ) -> None:
+        cache_backend = FakeDependencyCacheSetManyBackend()
+        lease_id = "lease-cache-a"
+
+        with mock.patch(
+            "general_manager.cache.dependency_publish._metadata_dependency_set",
+            wraps=dependency_publish_module._metadata_dependency_set,
+        ) as metadata_dependency_set:
+            publish_dependency_cache_entries(
+                [
+                    PendingDependencyCachePublication(
+                        cache_key="cache-a",
+                        result="alpha",
+                        dependencies=frozenset(
+                            {("Project", "identification", '{"id": 1}')}
+                        ),
+                        cache_backend=cache_backend,
+                        timeout=None,
+                        started_generation=get_dependency_generation(),
+                        lease=CacheComputeLease(
+                            key=_compute_lock_key("cache-a"),
+                            token=lease_id,
+                        ),
+                        prefetch_manifest_key="dependency-cache-prefetch-manifest:test",
+                    )
+                ]
+            )
+
+        self.assertEqual(metadata_dependency_set.call_count, 1)
+
+    def test_batch_publish_records_prefetch_bundle_for_invalidation(self) -> None:
+        manifest_key = "dependency-cache-prefetch-manifest:test"
+        lease_id = "lease-cache-a"
+        segment_token = dependency_cache_module.dependency_cache_prefetch_segment_token(
+            ("cache-a",)
+        )
+        bundle_key = (
+            dependency_cache_module.dependency_cache_prefetch_segment_bundle_key(
+                manifest_key,
+                segment_token,
+            )
+        )
+        value_bundle_key = (
+            dependency_cache_module.dependency_cache_prefetch_segment_value_bundle_key(
+                manifest_key,
+                segment_token,
+            )
+        )
+        segment_index_key = (
+            dependency_cache_module.dependency_cache_prefetch_segment_index_key(
+                manifest_key
+            )
+        )
+        old_bundle_key = dependency_cache_module.dependency_cache_prefetch_bundle_key(
+            manifest_key
+        )
+        old_value_bundle_key = (
+            dependency_cache_module.dependency_cache_prefetch_value_bundle_key(
+                manifest_key
+            )
+        )
+
+        publish_dependency_cache_entries(
+            [
+                PendingDependencyCachePublication(
+                    cache_key="cache-a",
+                    result="alpha",
+                    dependencies=frozenset(
+                        {("PublishedTrustedManager", "identification", "42")}
+                    ),
+                    cache_backend=cache,
+                    timeout=None,
+                    started_generation=get_dependency_generation(),
+                    lease=CacheComputeLease(
+                        key=_compute_lock_key("cache-a"),
+                        token=lease_id,
+                    ),
+                    prefetch_manifest_key=manifest_key,
+                )
+            ]
+        )
+
+        self.assertIsNotNone(cache.get(bundle_key))
+        self.assertIsNotNone(cache.get(value_bundle_key))
+        self.assertEqual(cache.get(segment_index_key), (segment_token,))
+        self.assertIsNone(cache.get(old_bundle_key))
+        self.assertIsNone(cache.get(old_value_bundle_key))
+        self.assertIn(
+            bundle_key,
+            cache_set_members(
+                composite_lookup_shard_key(
+                    "PublishedTrustedManager",
+                    "filter",
+                    "identification",
+                )
+            ),
+        )
+        self.assertIn(
+            value_bundle_key,
+            cache_set_members(
+                composite_lookup_shard_key(
+                    "PublishedTrustedManager",
+                    "filter",
+                    "identification",
+                )
+            ),
+        )
+
+        generic_cache_invalidation(
+            sender=PublishedTrustedManager,
+            instance=PublishedTrustedManager(42),
+            old_relevant_values={},
+        )
+
+        self.assertIsNone(cache.get(bundle_key))
+        self.assertIsNone(cache.get(value_bundle_key))
+
+    def test_prefetch_bundle_accumulates_across_publish_flushes(self) -> None:
+        manifest_key = "dependency-cache-prefetch-manifest:test"
+        lease_a = "lease-a"
+        lease_b = "lease-b"
+        segment_index_key = (
+            dependency_cache_module.dependency_cache_prefetch_segment_index_key(
+                manifest_key
+            )
+        )
+        segment_a = dependency_cache_module.dependency_cache_prefetch_segment_token(
+            ("cache-a",)
+        )
+        segment_b = dependency_cache_module.dependency_cache_prefetch_segment_token(
+            ("cache-b",)
+        )
+        segment_a_bundle_key = (
+            dependency_cache_module.dependency_cache_prefetch_segment_bundle_key(
+                manifest_key,
+                segment_a,
+            )
+        )
+        segment_a_value_bundle_key = (
+            dependency_cache_module.dependency_cache_prefetch_segment_value_bundle_key(
+                manifest_key,
+                segment_a,
+            )
+        )
+        segment_value_keys = (
+            dependency_cache_module.dependency_cache_prefetch_segment_value_bundle_key(
+                manifest_key,
+                segment_a,
+            ),
+            dependency_cache_module.dependency_cache_prefetch_segment_value_bundle_key(
+                manifest_key,
+                segment_b,
+            ),
+        )
+        old_bundle_key = dependency_cache_module.dependency_cache_prefetch_bundle_key(
+            manifest_key
+        )
+        old_value_bundle_key = (
+            dependency_cache_module.dependency_cache_prefetch_value_bundle_key(
+                manifest_key
+            )
+        )
+        entry_a = PendingDependencyCachePublication(
+            cache_key="cache-a",
+            result="alpha",
+            dependencies=frozenset(
+                {("PublishedTrustedManager", "identification", "42")}
+            ),
+            cache_backend=cache,
+            timeout=None,
+            started_generation=get_dependency_generation(),
+            lease=CacheComputeLease(
+                key=_compute_lock_key("cache-a"),
+                token=lease_a,
+            ),
+            prefetch_manifest_key=manifest_key,
+        )
+        entry_b = PendingDependencyCachePublication(
+            cache_key="cache-b",
+            result="bravo",
+            dependencies=frozenset(
+                {("PublishedTrustedManager", "identification", "43")}
+            ),
+            cache_backend=cache,
+            timeout=None,
+            started_generation=get_dependency_generation(),
+            lease=CacheComputeLease(
+                key=_compute_lock_key("cache-b"),
+                token=lease_b,
+            ),
+            prefetch_manifest_key=manifest_key,
+        )
+
+        publish_dependency_cache_entries([entry_a])
+        publish_dependency_cache_entries([entry_b])
+
+        self.assertEqual(set(cache.get(segment_index_key)), {segment_a, segment_b})
+        self.assertEqual(
+            dependency_cache_module.read_many_dependency_cache_prefetch_bundle_values(
+                cache,
+                segment_value_keys,
+            ),
+            {"cache-a": "alpha", "cache-b": "bravo"},
+        )
+        self.assertIsNone(cache.get(old_bundle_key))
+        self.assertIsNone(cache.get(old_value_bundle_key))
+        self.assertIn(
+            segment_a_bundle_key,
+            cache_set_members(
+                composite_lookup_shard_key(
+                    "PublishedTrustedManager",
+                    "filter",
+                    "identification",
+                )
+            ),
+        )
+        self.assertIn(
+            segment_a_value_bundle_key,
+            cache_set_members(
+                composite_lookup_shard_key(
+                    "PublishedTrustedManager",
+                    "filter",
+                    "identification",
+                )
+            ),
+        )
+        self.assertNotIn(
+            old_bundle_key,
+            cache_set_members(
+                composite_lookup_shard_key(
+                    "PublishedTrustedManager",
+                    "filter",
+                    "identification",
+                )
+            ),
         )
 
     def test_batch_publish_falls_back_to_per_key_set_without_set_many(self) -> None:

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -265,8 +265,8 @@ class TestDependencyPublish(SimpleTestCase):
         )
 
         generic_cache_invalidation(
-            sender=PublishedTrustedManager,
-            instance=PublishedTrustedManager(42),
+            sender=cast(type[GeneralManager], PublishedTrustedManager),
+            instance=cast(GeneralManager, PublishedTrustedManager(42)),
             old_relevant_values={},
         )
 

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -30,6 +30,7 @@ from general_manager.cache.dependency_shards import (
     request_query_shard_key,
     reverse_membership_key,
     scan_lookup_shard_key,
+    _cache_set_add_many,
     _shard_keys_for_dependency,
 )
 from general_manager.cache.dependency_index import (
@@ -137,12 +138,18 @@ class DependencyShardKeyTests(TestCase):
             ],
         )
 
-        exact_key = exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+        status_key = composite_lookup_shard_key("Project", "filter", "status")
         scan_key = scan_lookup_shard_key("Project", "filter", "priority__gte", "gte")
         request_key = request_query_shard_key("RemoteProject")
         all_key = all_records_shard_key("Project")
 
-        assert cache_set_members(exact_key) == {"cache-a"}
+        assert cache_set_members(status_key) == {"cache-a"}
+        assert (
+            cache_set_members(
+                exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+            )
+            == set()
+        )
         assert cache_set_members(scan_key) == {"cache-a"}
         assert cache_set_members(request_key) == {"cache-a"}
         assert cache_set_members(all_key) == {"cache-a"}
@@ -150,7 +157,7 @@ class DependencyShardKeyTests(TestCase):
         reverse = cache.get(reverse_membership_key("cache-a"))
         assert reverse == ReverseDependencyMembership(
             cache_key="cache-a",
-            shard_keys=frozenset({exact_key, scan_key, request_key, all_key}),
+            shard_keys=frozenset({status_key, scan_key, request_key, all_key}),
             composite_dependencies=frozenset(),
             simple_dependencies=frozenset(
                 {
@@ -179,12 +186,63 @@ class DependencyShardKeyTests(TestCase):
             {("Project", "filter", identifier)}
         )
 
+    def test_record_exact_dependency_uses_lookup_level_candidate_shard(self) -> None:
+        identifier = json.dumps({"status": "open"})
+
+        record_cache_dependencies("cache-a", [("Project", "filter", identifier)])
+
+        assert cache_set_members(
+            composite_lookup_shard_key("Project", "filter", "status")
+        ) == {"cache-a"}
+        assert (
+            cache_set_members(
+                exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+            )
+            == set()
+        )
+        reverse = cache.get(reverse_membership_key("cache-a"))
+        assert isinstance(reverse, ReverseDependencyMembership)
+        assert reverse.simple_dependencies == frozenset(
+            {("Project", "filter", identifier)}
+        )
+
+    def test_record_identification_dependency_uses_lookup_level_candidate_shard(
+        self,
+    ) -> None:
+        identifier = json.dumps({"id": 1})
+
+        record_cache_dependencies(
+            "cache-a",
+            [("Project", "identification", identifier)],
+        )
+
+        assert cache_set_members(
+            composite_lookup_shard_key("Project", "filter", "identification")
+        ) == {"cache-a"}
+        assert (
+            cache_set_members(
+                exact_lookup_shard_key(
+                    "Project",
+                    "filter",
+                    "identification",
+                    "eq",
+                    identifier,
+                )
+            )
+            == set()
+        )
+        reverse = cache.get(reverse_membership_key("cache-a"))
+        assert isinstance(reverse, ReverseDependencyMembership)
+        assert reverse.simple_dependencies == frozenset(
+            {("Project", "identification", identifier)}
+        )
+
     def test_remove_cache_key_uses_reverse_membership_without_scanning(self) -> None:
         record_cache_dependencies(
             "cache-a",
             [("Project", "filter", json.dumps({"status": "open"}))],
         )
-        shard_key = exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+        shard_key = composite_lookup_shard_key("Project", "filter", "status")
 
         remove_cache_key_from_shards("cache-a")
 
@@ -346,19 +404,15 @@ class DependencyShardKeyTests(TestCase):
             record_many_cache_dependencies(entries)
 
         cache_keys = {f"cache-{index}" for index in range(25)}
-        status_shard = exact_lookup_shard_key(
+        status_shard = composite_lookup_shard_key(
             "Project",
             "filter",
             "status",
-            "eq",
-            "open",
         )
-        priority_shard = exact_lookup_shard_key(
+        priority_shard = composite_lookup_shard_key(
             "Project",
             "filter",
             "priority",
-            "eq",
-            3,
         )
 
         assert counting_cache.store[status_shard] == cache_keys
@@ -377,6 +431,46 @@ class DependencyShardKeyTests(TestCase):
         assert counting_cache.set_calls == []
         assert len(counting_cache.get_many_calls) <= 2
         assert len(counting_cache.set_many_calls) <= 2
+
+    def test_cache_set_add_many_skips_member_decoding_for_new_shards(self) -> None:
+        """Cold shard writes should store pending members without merge work."""
+        additions = {"dependency-shard:new": {"cache-a", "cache-b"}}
+
+        with (
+            mock.patch(
+                "general_manager.cache.dependency_shards._cache_get_many",
+                return_value={},
+            ),
+            mock.patch(
+                "general_manager.cache.dependency_shards._cache_member_set",
+                side_effect=AssertionError("new shards should not decode members"),
+            ),
+            mock.patch(
+                "general_manager.cache.dependency_shards._cache_set_many",
+            ) as set_many,
+        ):
+            _cache_set_add_many(additions)
+
+        set_many.assert_called_once_with(additions)
+
+    def test_cache_set_add_many_reuses_exact_set_inputs(self) -> None:
+        """Shard publication should not copy member sets it already owns."""
+        members = {"cache-a", "cache-b"}
+        additions = {"dependency-shard:new": members}
+
+        with (
+            mock.patch(
+                "general_manager.cache.dependency_shards._cache_get_many",
+                return_value={},
+            ),
+            mock.patch(
+                "general_manager.cache.dependency_shards._cache_set_many",
+            ) as set_many,
+        ):
+            _cache_set_add_many(additions)
+
+        payload = set_many.call_args.args[0]
+        assert payload["dependency-shard:new"] is members
 
     def test_record_many_cache_dependencies_reuses_shard_plan_for_duplicates(
         self,
@@ -403,9 +497,14 @@ class DependencyShardKeyTests(TestCase):
                 "general_manager.cache.dependency_shards.parse_dependency_identifier",
                 wraps=parse_dependency_identifier,
             ) as mocked_parse,
+            mock.patch(
+                "general_manager.cache.dependency_shards._shard_keys_for_dependency",
+                wraps=_shard_keys_for_dependency,
+            ) as mocked_plan,
         ):
             record_many_cache_dependencies(entries)
 
+        assert mocked_plan.call_count == 1
         assert mocked_parse.call_count == 1
 
     def test_record_many_cache_dependencies_replaces_existing_memberships_in_bulk(
@@ -419,12 +518,10 @@ class DependencyShardKeyTests(TestCase):
             "eq",
             "old",
         )
-        new_shard = exact_lookup_shard_key(
+        new_shard = composite_lookup_shard_key(
             "Project",
             "filter",
             "status",
-            "eq",
-            "new",
         )
         reverse_a = reverse_membership_key("cache-a")
         reverse_b = reverse_membership_key("cache-b")
@@ -541,7 +638,7 @@ class DependencyIndexShardFacadeTests(TestCase):
 
         assert cache.get("dependency_index") is None
         assert cache_set_members(
-            exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+            composite_lookup_shard_key("Project", "filter", "status")
         ) == {"cache-a"}
 
     def test_capture_old_values_uses_sharded_lookup_registry(self) -> None:
@@ -576,11 +673,32 @@ class DependencyIndexShardFacadeTests(TestCase):
 
         assert cache.get("cache-a") is None
         assert (
-            cache_set_members(
-                exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
-            )
+            cache_set_members(composite_lookup_shard_key("Project", "filter", "status"))
             == set()
         )
+
+    def test_generic_cache_invalidation_keeps_nonmatching_exact_lookup_candidate(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "cache-a",
+            [("Project", "filter", json.dumps({"status": "open"}))],
+        )
+        cache.set("cache-a", "cached-value", None)
+
+        generic_cache_invalidation(
+            sender=Project,
+            instance=SimpleNamespace(status="closed"),
+            old_relevant_values={"status": "pending"},
+        )
+
+        assert cache.get("cache-a") == "cached-value"
+        assert cache_set_members(
+            composite_lookup_shard_key("Project", "filter", "status")
+        ) == {"cache-a"}
 
     def test_generic_cache_invalidation_invalidates_matching_filter_when_lookup_unchanged(
         self,
@@ -602,9 +720,7 @@ class DependencyIndexShardFacadeTests(TestCase):
 
         assert cache.get("cache-a") is None
         assert (
-            cache_set_members(
-                exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
-            )
+            cache_set_members(composite_lookup_shard_key("Project", "filter", "status"))
             == set()
         )
 
@@ -626,9 +742,7 @@ class DependencyIndexShardFacadeTests(TestCase):
 
         assert cache.get("cache-a") is None
         assert (
-            cache_set_members(
-                exact_lookup_shard_key("Project", "filter", "status", "eq", None)
-            )
+            cache_set_members(composite_lookup_shard_key("Project", "filter", "status"))
             == set()
         )
 
@@ -653,7 +767,7 @@ class DependencyIndexShardFacadeTests(TestCase):
         assert cache.get("dependency_index") is None
         assert cache.get("legacy-cache") is None
         assert cache_set_members(
-            exact_lookup_shard_key("Project", "filter", "status", "eq", "open")
+            composite_lookup_shard_key("Project", "filter", "status")
         ) == {"cache-a"}
 
     def test_generic_cache_invalidation_invalidates_identification_dependency(
@@ -680,33 +794,23 @@ class DependencyIndexShardFacadeTests(TestCase):
         class Project:
             pass
 
-        cache_key = "cache-a"
         identification = {"id": 2}
         record_dependencies(
-            cache_key,
-            [("Project", "filter", json.dumps({"status": "open"}))],
+            "cache-a",
+            [("Project", "identification", json.dumps({"id": 1}))],
         )
-        cache.set(
-            reverse_membership_key(cache_key),
-            ReverseDependencyMembership(
-                cache_key=cache_key,
-                shard_keys=frozenset(),
-                composite_dependencies=frozenset(),
-                simple_dependencies=frozenset(
-                    {("Project", "identification", json.dumps({"id": 1}))}
-                ),
-            ),
-            None,
-        )
-        cache.set(cache_key, "cached-value", None)
+        cache.set("cache-a", "cached-value", None)
 
         generic_cache_invalidation(
             sender=Project,
-            instance=SimpleNamespace(identification=identification, status="closed"),
-            old_relevant_values={"status": "open"},
+            instance=SimpleNamespace(identification=identification),
+            old_relevant_values={},
         )
 
-        assert cache.get(cache_key) == "cached-value"
+        assert cache.get("cache-a") == "cached-value"
+        assert cache_set_members(
+            composite_lookup_shard_key("Project", "filter", "identification")
+        ) == {"cache-a"}
 
     def test_generic_cache_invalidation_uses_request_query_match_when_candidate(
         self,

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -256,7 +256,7 @@ class DependencyShardKeyTests(TestCase):
             "cache-all-filter"
         }
 
-    def test_candidate_lookup_combines_exact_scan_and_composite_shards(self) -> None:
+    def test_candidate_lookup_combines_scan_and_composite_shards(self) -> None:
         record_cache_dependencies(
             "cache-exact",
             [("Project", "filter", json.dumps({"status": "open"}))],
@@ -268,6 +268,11 @@ class DependencyShardKeyTests(TestCase):
         record_cache_dependencies(
             "cache-combo",
             [("Project", "filter", json.dumps({"status": "open", "priority": 3}))],
+        )
+        cache.set(
+            exact_lookup_shard_key("Project", "filter", "status", "eq", "closed"),
+            {"legacy-exact"},
+            None,
         )
 
         assert candidate_cache_keys_for_lookup(
@@ -847,7 +852,7 @@ class DependencyIndexShardFacadeTests(TestCase):
             [("Project", "filter", json.dumps({"status": "seed"}))],
         )
         cache.set(
-            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            composite_lookup_shard_key("Project", "filter", "status"),
             {cache_key},
             None,
         )
@@ -884,7 +889,7 @@ class DependencyIndexShardFacadeTests(TestCase):
             [("Project", "filter", json.dumps({"status": "seed"}))],
         )
         cache.set(
-            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            composite_lookup_shard_key("Project", "filter", "status"),
             {"cache-a"},
             None,
         )
@@ -910,7 +915,7 @@ class DependencyIndexShardFacadeTests(TestCase):
             [("Project", "filter", json.dumps({"status": "seed"}))],
         )
         cache.set(
-            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            composite_lookup_shard_key("Project", "filter", "status"),
             {cache_key},
             None,
         )
@@ -946,7 +951,7 @@ class DependencyIndexShardFacadeTests(TestCase):
             [("Project", "filter", json.dumps({"status": "seed"}))],
         )
         cache.set(
-            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            composite_lookup_shard_key("Project", "filter", "status"),
             {cache_key},
             None,
         )
@@ -986,7 +991,7 @@ class DependencyIndexShardFacadeTests(TestCase):
             [("Project", "filter", json.dumps({"status": "seed"}))],
         )
         cache.set(
-            exact_lookup_shard_key("Project", "filter", "status", "eq", "open"),
+            composite_lookup_shard_key("Project", "filter", "status"),
             {cache_key},
             None,
         )

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -7,6 +7,9 @@ from unittest.mock import Mock, patch
 from django.apps import apps
 from django.db import models
 
+from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.run_context import CalculationRunContext
+from general_manager.cache.signals import data_change
 from general_manager.interface.capabilities.orm_utils.field_descriptors import (
     _FieldDescriptorBuilder,
     _general_manager_accessor,
@@ -14,6 +17,7 @@ from general_manager.interface.capabilities.orm_utils.field_descriptors import (
     build_field_descriptors,
 )
 from general_manager.bootstrap import initialize_general_manager_classes
+from general_manager.manager.general_manager import GeneralManager
 
 
 def test_general_manager_many_accessor_uses_explicit_relation_field_name() -> None:
@@ -289,6 +293,131 @@ def test_general_manager_fk_accessor_uses_raw_id_without_loading_relation() -> N
     assert isinstance(result, RelatedManager)
     assert calls == [7]
     assert not interface_instance._instance.loaded_relation
+
+
+def test_general_manager_fk_accessor_reuses_raw_id_manager_in_run_context() -> None:
+    calls: list[object] = []
+
+    class RelatedManager:
+        def __init__(self, pk: object) -> None:
+            calls.append(pk)
+
+    source = SimpleNamespace(
+        owner_id=7,
+        _state=SimpleNamespace(fields_cache={}),
+    )
+    accessor = _general_manager_accessor(
+        "owner",
+        RelatedManager,
+        raw_id_name="owner_id",
+    )
+    interface_instance = SimpleNamespace(_instance=source)
+
+    with CalculationRunContext():
+        first = accessor(interface_instance)
+        second = accessor(interface_instance)
+
+    assert first is second
+    assert calls == [7]
+
+
+def test_general_manager_fk_accessor_clears_raw_id_cache_on_data_change() -> None:
+    calls: list[object] = []
+
+    class RelatedManager:
+        def __init__(self, pk: object) -> None:
+            calls.append(pk)
+
+    source = SimpleNamespace(
+        owner_id=7,
+        _state=SimpleNamespace(fields_cache={}),
+    )
+    accessor = _general_manager_accessor(
+        "owner",
+        RelatedManager,
+        raw_id_name="owner_id",
+    )
+    interface_instance = SimpleNamespace(_instance=source)
+
+    @data_change
+    def mutate(instance: object) -> object:
+        return instance
+
+    with CalculationRunContext():
+        first = accessor(interface_instance)
+        mutate(SimpleNamespace(identification={"id": 1}))
+        second = accessor(interface_instance)
+
+    assert first is not second
+    assert calls == [7, 7]
+
+
+def test_general_manager_fk_accessor_scopes_raw_id_cache_by_database_alias() -> None:
+    calls: list[object] = []
+
+    class RelatedManager:
+        def __init__(self, pk: object) -> None:
+            calls.append(pk)
+
+    accessor = _general_manager_accessor(
+        "owner",
+        RelatedManager,
+        raw_id_name="owner_id",
+    )
+    default_source = SimpleNamespace(
+        owner_id=7,
+        _state=SimpleNamespace(db="default", fields_cache={}),
+    )
+    replica_source = SimpleNamespace(
+        owner_id=7,
+        _state=SimpleNamespace(db="replica", fields_cache={}),
+    )
+
+    with CalculationRunContext():
+        default_manager = accessor(SimpleNamespace(_instance=default_source))
+        replica_manager = accessor(SimpleNamespace(_instance=replica_source))
+
+    assert default_manager is not replica_manager
+    assert calls == [7, 7]
+
+
+def test_general_manager_fk_accessor_replays_dependency_for_cached_raw_id_manager() -> (
+    None
+):
+    calls: list[object] = []
+
+    class RelatedInterface:
+        def __init__(self, manager_id: object) -> None:
+            calls.append(manager_id)
+            self.identification = {"id": manager_id}
+
+    class RelatedManager(GeneralManager):
+        pass
+
+    RelatedManager.Interface = RelatedInterface  # type: ignore[assignment]
+
+    source = SimpleNamespace(
+        owner_id=7,
+        _state=SimpleNamespace(fields_cache={}),
+    )
+    accessor = _general_manager_accessor(
+        "owner",
+        RelatedManager,
+        raw_id_name="owner_id",
+    )
+    interface_instance = SimpleNamespace(_instance=source)
+
+    with CalculationRunContext():
+        accessor(interface_instance)
+        with DependencyTracker() as dependencies:
+            accessor(interface_instance)
+
+    assert (
+        "RelatedManager",
+        "identification",
+        '{"id": 7}',
+    ) in dependencies
+    assert calls == [7]
 
 
 def test_build_field_descriptors_disambiguates_duplicate_reverse_relations() -> None:

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -420,6 +420,54 @@ def test_general_manager_fk_accessor_replays_dependency_for_cached_raw_id_manage
     assert calls == [7]
 
 
+def test_general_manager_fk_accessor_replays_custom_tracking_for_cached_raw_id_manager() -> (
+    None
+):
+    calls: list[object] = []
+    tracked: list[dict[str, object]] = []
+
+    class RelatedInterface:
+        def __init__(self, manager_id: object) -> None:
+            calls.append(manager_id)
+            self.identification = {"id": manager_id}
+
+    class RelatedManager(GeneralManager):
+        @classmethod
+        def _track_identification_dependency_active(
+            cls,
+            identification: dict[str, object],
+        ) -> None:
+            tracked.append(dict(identification))
+            DependencyTracker.track("CustomRelatedManager", "all", "")
+
+    RelatedManager.Interface = RelatedInterface  # type: ignore[assignment]
+
+    source = SimpleNamespace(
+        owner_id=7,
+        _state=SimpleNamespace(fields_cache={}),
+    )
+    accessor = _general_manager_accessor(
+        "owner",
+        RelatedManager,
+        raw_id_name="owner_id",
+    )
+    interface_instance = SimpleNamespace(_instance=source)
+
+    with CalculationRunContext():
+        accessor(interface_instance)
+        with DependencyTracker() as dependencies:
+            accessor(interface_instance)
+
+    assert tracked == [{"id": 7}]
+    assert ("CustomRelatedManager", "all", "") in dependencies
+    assert (
+        "RelatedManager",
+        "identification",
+        '{"id": 7}',
+    ) not in dependencies
+    assert calls == [7]
+
+
 def test_build_field_descriptors_disambiguates_duplicate_reverse_relations() -> None:
     class SourceModel(models.Model):
         class Meta:

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+
 from django.test import TestCase, override_settings
 from general_manager.bootstrap import (
     InvalidPermissionClassError,
@@ -9,6 +11,7 @@ from general_manager.manager.general_manager import (
     TrustedOrmHydrationNotSupportedError,
     UnsupportedUnionOperandError,
 )
+from general_manager.manager import general_manager as general_manager_module
 from general_manager.manager.meta import GeneralManagerMeta, InvalidManagerStateError
 from general_manager.permission.manager_based_permission import (
     AdditiveManagerPermission,
@@ -149,6 +152,55 @@ class GeneralManagerTestCase(TestCase):
         TemporaryManager.Permission = ManagerBasedPermission  # type: ignore
         return TemporaryManager
 
+    def test_class_dependency_tracking_reads_name_without_metaclass_lookup(self):
+        manager_class = self._temporary_manager_class()
+        original_getattribute = GeneralManagerMeta.__getattribute__
+
+        def fail_on_name_lookup(cls, attribute_name):
+            if attribute_name == "__name__":
+                raise AssertionError
+            return original_getattribute(cls, attribute_name)
+
+        with (
+            DependencyTracker() as dependencies,
+            patch.object(
+                GeneralManagerMeta,
+                "__getattribute__",
+                fail_on_name_lookup,
+            ),
+        ):
+            manager_class._track_identification_dependency_active({"id": "tracked"})
+
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "tracked"}'),
+            dependencies,
+        )
+
+    def test_instance_dependency_tracking_reads_name_without_metaclass_lookup(self):
+        manager_class = self._temporary_manager_class()
+        manager = manager_class(id="tracked")
+        original_getattribute = GeneralManagerMeta.__getattribute__
+
+        def fail_on_name_lookup(cls, attribute_name):
+            if attribute_name == "__name__":
+                raise AssertionError
+            return original_getattribute(cls, attribute_name)
+
+        with (
+            DependencyTracker() as dependencies,
+            patch.object(
+                GeneralManagerMeta,
+                "__getattribute__",
+                fail_on_name_lookup,
+            ),
+        ):
+            manager._track_own_identification_dependency_active()
+
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "dummy_id"}'),
+            dependencies,
+        )
+
     def test_temporary_manager_class_does_not_register_graphql_interface(self):
         pending_graphql_interfaces = list(GeneralManagerMeta.pending_graphql_interfaces)
 
@@ -175,6 +227,23 @@ class GeneralManagerTestCase(TestCase):
         )
         self.assertIsInstance(manager, GeneralManager)
 
+    def test_manager_init_skips_disabled_debug_logging(self):
+        class DisabledDebugLogger:
+            debug_calls = 0
+
+            def isEnabledFor(self, _level):
+                return False
+
+            def debug(self, *_args, **_kwargs):
+                self.debug_calls += 1
+
+        fake_logger = DisabledDebugLogger()
+
+        with patch("general_manager.manager.general_manager.logger", fake_logger):
+            self.manager()
+
+        self.assertEqual(fake_logger.debug_calls, 0)
+
     def test_manager_init_does_not_serialize_identifier_without_dependency_tracker(
         self,
     ):
@@ -192,6 +261,40 @@ class GeneralManagerTestCase(TestCase):
             ("GeneralManager", "identification", '{"id": "dummy_id"}'),
             dependencies,
         )
+
+    def test_default_identification_tracking_wrapper_uses_fast_active_path(self):
+        manager_class = self._temporary_manager_class()
+
+        with (
+            DependencyTracker() as dependencies,
+            patch.object(
+                manager_class,
+                "_track_identification_dependency_active",
+                side_effect=AssertionError("default wrapper should use fast path"),
+            ),
+        ):
+            manager_class._track_identification_dependency({"id": "tracked"})
+
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "tracked"}'),
+            dependencies,
+        )
+
+    def test_identification_tracking_wrapper_preserves_active_override(self):
+        base_class = self._temporary_manager_class()
+        calls = []
+
+        class OverrideManager(base_class):
+            @classmethod
+            def _track_identification_dependency_active(cls, identification):
+                calls.append((cls, identification))
+
+        identification = {"id": "tracked"}
+
+        with DependencyTracker():
+            OverrideManager._track_identification_dependency(identification)
+
+        self.assertEqual(calls, [(OverrideManager, identification)])
 
     def test_manager_init_tracks_scalar_id_without_generic_serializer(self):
         with (
@@ -220,6 +323,68 @@ class GeneralManagerTestCase(TestCase):
 
         self.assertIn(
             ("GeneralManager", "identification", '{"id": "dummy_id"}'),
+            dependencies,
+        )
+
+    def test_manager_init_tracks_int_id_without_date_type_checks(self):
+        class RaisingInstanceCheck(type):
+            def __instancecheck__(cls, instance):
+                raise AssertionError
+
+        class RaisingDate(metaclass=RaisingInstanceCheck):
+            pass
+
+        class IntInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        manager_class = self._temporary_manager_class()
+        manager_class.Interface = IntInterface  # type: ignore[assignment]
+
+        with (
+            DependencyTracker() as dependencies,
+            patch("general_manager.manager.general_manager.datetime", RaisingDate),
+            patch("general_manager.manager.general_manager.date", RaisingDate),
+        ):
+            manager_class(7)
+
+        self.assertIn(
+            (manager_class.__name__, "identification", '{"id": 7}'),
+            dependencies,
+        )
+
+    def test_manager_init_scalar_id_fast_path_preserves_bool_and_temporal_values(self):
+        class ScalarInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        manager_class = self._temporary_manager_class()
+        manager_class.Interface = ScalarInterface  # type: ignore[assignment]
+
+        with DependencyTracker() as dependencies:
+            manager_class(True)
+            manager_class(False)
+            manager_class(date(2026, 1, 2))
+            manager_class(datetime(2026, 1, 2, 3, 4, 5))
+
+        self.assertIn(
+            (manager_class.__name__, "identification", '{"id": true}'),
+            dependencies,
+        )
+        self.assertIn(
+            (manager_class.__name__, "identification", '{"id": false}'),
+            dependencies,
+        )
+        self.assertIn(
+            (manager_class.__name__, "identification", '{"id": "2026-01-02"}'),
+            dependencies,
+        )
+        self.assertIn(
+            (
+                manager_class.__name__,
+                "identification",
+                '{"id": "2026-01-02T03:04:05"}',
+            ),
             dependencies,
         )
 
@@ -501,6 +666,263 @@ class GeneralManagerTestCase(TestCase):
             create=True,
         ):
             self.assertEqual(instance.id, "dummy_id")
+
+    def test_cached_descriptor_read_tracks_cached_manager_dependency(self):
+        related_class = self._temporary_manager_class()
+
+        class RelatedInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        related_class.Interface = RelatedInterface  # type: ignore[assignment]
+        related = related_class("related-id")
+
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"related": lambda _interface: related}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertIs(owner.related, related)
+
+        with DependencyTracker() as dependencies:
+            self.assertIs(owner.related, related)
+
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "related-id"}'),
+            dependencies,
+        )
+
+    def test_cached_manager_descriptor_replay_uses_active_tracking_path(self):
+        related_class = self._temporary_manager_class()
+
+        class RelatedInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        related_class.Interface = RelatedInterface  # type: ignore[assignment]
+        related = related_class("related-id")
+
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"related": lambda _interface: related}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertIs(owner.related, related)
+
+        with (
+            DependencyTracker() as dependencies,
+            patch(
+                "general_manager.manager.meta.DependencyTracker.is_active",
+                side_effect=[True, AssertionError],
+            ),
+        ):
+            self.assertIs(owner.related, related)
+
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "related-id"}'),
+            dependencies,
+        )
+
+    def test_cached_manager_descriptor_reuses_identification_dependency_identifier(
+        self,
+    ):
+        related_class = self._temporary_manager_class()
+
+        class RelatedInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        related_class.Interface = RelatedInterface  # type: ignore[assignment]
+        related = related_class("related-id")
+
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"related": lambda _interface: related}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertIs(owner.related, related)
+
+        with (
+            DependencyTracker() as dependencies,
+            patch(
+                "general_manager.manager.general_manager."
+                "_serialize_simple_id_identification",
+                wraps=general_manager_module._serialize_simple_id_identification,
+            ) as serialize_simple_id,
+        ):
+            self.assertIs(owner.related, related)
+            self.assertIs(owner.related, related)
+
+        self.assertEqual(serialize_simple_id.call_count, 1)
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "related-id"}'),
+            dependencies,
+        )
+
+    def test_cached_manager_descriptor_rechecks_mutated_identification_dependency(
+        self,
+    ):
+        related_class = self._temporary_manager_class()
+
+        class RelatedInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        related_class.Interface = RelatedInterface  # type: ignore[assignment]
+        related = related_class("related-id")
+
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"related": lambda _interface: related}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertIs(owner.related, related)
+
+        with DependencyTracker() as dependencies:
+            self.assertIs(owner.related, related)
+            related.identification["id"] = "changed-id"
+            self.assertIs(owner.related, related)
+
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "related-id"}'),
+            dependencies,
+        )
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "changed-id"}'),
+            dependencies,
+        )
+
+    def test_cached_descriptor_read_skips_manager_tracking_when_inactive(self):
+        related_class = self._temporary_manager_class()
+
+        class RelatedInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        related_class.Interface = RelatedInterface  # type: ignore[assignment]
+        related = related_class("related-id")
+
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"related": lambda _interface: related}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertIs(owner.related, related)
+
+        with patch.object(
+            related_class,
+            "_track_identification_dependency",
+            side_effect=AssertionError("inactive tracker should skip tracking"),
+        ):
+            self.assertIs(owner.related, related)
+
+    def test_cached_scalar_descriptor_read_reuses_non_manager_tracking_result(self):
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"name": lambda _interface: "cached-name"}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertEqual(owner.name, "cached-name")
+
+        with DependencyTracker():
+            self.assertEqual(owner.name, "cached-name")
+            with patch(
+                "general_manager.manager.meta._manager_dependency_tracking_class",
+                side_effect=AssertionError(
+                    "cached scalar tracking result should be reused"
+                ),
+            ):
+                self.assertEqual(owner.name, "cached-name")
+
+    def test_cached_scalar_descriptor_read_skips_tracker_check_after_class_is_known(
+        self,
+    ):
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"name": lambda _interface: "cached-name"}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertEqual(owner.name, "cached-name")
+
+        with DependencyTracker():
+            self.assertEqual(owner.name, "cached-name")
+
+        with patch(
+            "general_manager.manager.meta.DependencyTracker.is_active",
+            side_effect=AssertionError(
+                "known scalar cached values do not need tracker checks"
+            ),
+        ):
+            self.assertEqual(owner.name, "cached-name")
+
+    def test_cached_scalar_descriptor_read_remembers_non_tracking_value_class(self):
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"name": lambda _interface: "cached-name"}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertEqual(owner.name, "cached-name")
+        self.assertEqual(owner.name, "cached-name")
+        descriptor = vars(owner_class)["name"]
+
+        self.assertIs(descriptor._non_tracking_value_class, str)
+
+    def test_cached_descriptor_rechecks_tracking_when_cached_value_class_changes(
+        self,
+    ):
+        related_class = self._temporary_manager_class()
+
+        class RelatedInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        related_class.Interface = RelatedInterface  # type: ignore[assignment]
+        related = related_class("related-id")
+
+        owner_class = self._temporary_manager_class()
+        owner_class._attributes = {"value": lambda _interface: "cached-name"}
+        GeneralManagerMeta.create_at_properties_for_attributes(
+            owner_class._attributes.keys(),
+            owner_class,
+        )
+        owner = owner_class("dummy_id")
+        self.assertEqual(owner.value, "cached-name")
+
+        with DependencyTracker():
+            self.assertEqual(owner.value, "cached-name")
+
+        owner._attribute_value_cache["value"] = related
+        with DependencyTracker() as dependencies:
+            self.assertIs(owner.value, related)
+
+        self.assertIn(
+            ("TemporaryManager", "identification", '{"id": "related-id"}'),
+            dependencies,
+        )
+
+    def test_manager_dependency_tracking_class_detection_is_cached(self):
+        from general_manager.manager.meta import _manager_dependency_tracking_class
+
+        manager_class = self._temporary_manager_class()
+
+        self.assertIs(_manager_dependency_tracking_class(manager_class), manager_class)
+        self.assertIsNone(_manager_dependency_tracking_class(str))
 
     def test_initialized_manager_inherited_method_skips_attribute_initialization(self):
         manager_class = self._temporary_manager_class()

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -820,8 +820,8 @@ class GeneralManagerTestCase(TestCase):
         self.assertIs(owner.related, related)
 
         with patch.object(
-            related_class,
-            "_track_identification_dependency",
+            related,
+            "_track_own_identification_dependency_active",
             side_effect=AssertionError("inactive tracker should skip tracking"),
         ):
             self.assertIs(owner.related, related)
@@ -1049,6 +1049,25 @@ class GeneralManagerTestCase(TestCase):
         self.assertEqual(forwarded, composite_identification)
         self.assertIsNot(forwarded, composite_identification)
         self.assertEqual(result, [])
+
+    def test_query_debug_logging_skips_context_when_debug_disabled(self):
+        class DisabledDebugLogger:
+            def isEnabledFor(self, _level):
+                return False
+
+            def debug(self, *_args, **_kwargs):
+                raise AssertionError
+
+        with (
+            patch.object(DummyInterface, "filter", return_value=[]),
+            patch.object(DummyInterface, "exclude", return_value=[]),
+            patch(
+                "general_manager.manager.general_manager.logger", DisabledDebugLogger()
+            ),
+        ):
+            self.manager.filter(owner=self.manager())
+            self.manager.exclude(owner=self.manager())
+            self.manager.all()
 
     def test_classmethod_get(self):
         """

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -70,6 +70,28 @@ class GraphQLPropertyTests(TestCase):
         prop = GraphQLProperty(mock_getter)
         self.assertEqual(prop.graphql_type_hint, str)
 
+    def test_graphql_property_uses_cached_resolver_after_set_name(self):
+        """Descriptor access should not redo cached resolver lookup after setup."""
+        calls = []
+
+        def mock_getter(instance) -> str:
+            calls.append(instance)
+            return "test"
+
+        prop = GraphQLProperty(mock_getter)
+        owner = type("Owner", (), {})
+        instance = object()
+        prop.__set_name__(owner, "value")
+
+        with patch.object(
+            prop,
+            "_get_cached_fget",
+            side_effect=AssertionError("cached resolver should be used directly"),
+        ):
+            self.assertEqual(prop.__get__(instance, owner), "test")
+
+        self.assertEqual(calls, [instance])
+
     def test_graph_ql_property_direct_decorator_requires_return_annotation(self):
         """Public decorator validates direct usage at decoration time."""
 

--- a/tests/unit/test_json_encoder.py
+++ b/tests/unit/test_json_encoder.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 import pytest
 
 from general_manager.utils import json_encoder
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.meta import GeneralManagerMeta
 
 
 class FakeGeneralManager:
@@ -38,6 +40,33 @@ def test_serialize_general_manager() -> None:
         dumped = json.dumps(gm, cls=json_encoder.CustomJSONEncoder)
         expected = f'"{gm.__class__.__name__}(**{gm.identification})"'
         assert dumped == expected
+
+
+def test_serialize_general_manager_reads_name_without_metaclass_lookup() -> None:
+    class JsonInterface:
+        def __init__(self, manager_id: int) -> None:
+            self.identification = {"id": manager_id}
+
+    class JsonManager(GeneralManager):
+        pass
+
+    JsonManager.Interface = JsonInterface  # type: ignore[assignment]
+    manager = JsonManager(7)
+    original_getattribute = GeneralManagerMeta.__getattribute__
+
+    def fail_on_name_lookup(cls: type, attribute_name: str) -> object:
+        if attribute_name == "__name__":
+            raise AssertionError
+        return original_getattribute(cls, attribute_name)
+
+    with patch.object(
+        GeneralManagerMeta,
+        "__getattribute__",
+        fail_on_name_lookup,
+    ):
+        dumped = json.dumps(manager, cls=json_encoder.CustomJSONEncoder)
+
+    assert dumped == "\"JsonManager(**{'id': 7})\""
 
 
 def test_standard_json_values_keep_standard_behavior() -> None:

--- a/tests/unit/test_make_cache_key.py
+++ b/tests/unit/test_make_cache_key.py
@@ -133,6 +133,45 @@ class TestMakeCacheKey(SimpleTestCase):
 
         self.assertEqual(result, expected)
 
+    def test_single_manager_fast_path_supports_unhashable_callable_instances(self):
+        from general_manager.manager.general_manager import GeneralManager
+
+        class CacheKeyInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        class CacheKeyManager(GeneralManager):
+            pass
+
+        CacheKeyManager.Interface = CacheKeyInterface
+
+        class CallableWithoutHash:
+            __hash__ = None  # type: ignore[assignment]
+
+            def __init__(self) -> None:
+                self.__module__ = __name__
+                self.__qualname__ = "CallableWithoutHash"
+
+            def __eq__(self, other):
+                return isinstance(other, CallableWithoutHash)
+
+            def __call__(self, manager):
+                return manager
+
+        callable_instance = CallableWithoutHash()
+        manager = CacheKeyManager(7)
+        payload = {
+            "module": callable_instance.__module__,
+            "qualname": callable_instance.__qualname__,
+            "args": {"manager": manager},
+        }
+        raw = json.dumps(payload, sort_keys=True, cls=CustomJSONEncoder).encode()
+        expected = hashlib.sha256(raw, usedforsecurity=False).hexdigest()
+
+        result = make_cache_key(callable_instance, (manager,), {})
+
+        self.assertEqual(result, expected)
+
     def test_single_manager_fast_path_reuses_static_json_fragments(self):
         from general_manager.manager.general_manager import GeneralManager
 

--- a/tests/unit/test_make_cache_key.py
+++ b/tests/unit/test_make_cache_key.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import builtins
 import hashlib
 import inspect
 import json
@@ -7,7 +8,9 @@ from unittest.mock import patch
 from django.test import SimpleTestCase
 
 from general_manager.utils.json_encoder import CustomJSONEncoder
+from general_manager.utils import make_cache_key as make_cache_key_module
 from general_manager.utils.make_cache_key import make_cache_key
+from general_manager.manager.meta import GeneralManagerMeta
 
 
 class TestMakeCacheKey(SimpleTestCase):
@@ -130,6 +133,98 @@ class TestMakeCacheKey(SimpleTestCase):
 
         self.assertEqual(result, expected)
 
+    def test_single_manager_fast_path_reuses_static_json_fragments(self):
+        from general_manager.manager.general_manager import GeneralManager
+
+        class CacheKeyInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        class CacheKeyManager(GeneralManager):
+            pass
+
+        CacheKeyManager.Interface = CacheKeyInterface
+
+        def sample_function(manager):
+            return manager
+
+        first_manager = CacheKeyManager(7)
+        second_manager = CacheKeyManager(8)
+
+        with patch(
+            "general_manager.utils.make_cache_key.encode_basestring_ascii",
+            wraps=make_cache_key_module.encode_basestring_ascii,
+        ) as encode_string:
+            make_cache_key(sample_function, (first_manager,), {})
+            first_call_count = encode_string.call_count
+            make_cache_key(sample_function, (second_manager,), {})
+
+        self.assertEqual(encode_string.call_count - first_call_count, 1)
+
+    def test_single_manager_fast_path_reuses_hashed_key_for_equivalent_manager(self):
+        from general_manager.manager.general_manager import GeneralManager
+
+        class CacheKeyInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        class CacheKeyManager(GeneralManager):
+            pass
+
+        CacheKeyManager.Interface = CacheKeyInterface
+
+        def sample_function(manager):
+            return manager
+
+        with patch(
+            "general_manager.utils.make_cache_key.sha256",
+            wraps=hashlib.sha256,
+        ) as hash_factory:
+            first_result = make_cache_key(sample_function, (CacheKeyManager(7),), {})
+            second_result = make_cache_key(
+                sample_function,
+                (CacheKeyManager(7),),
+                {},
+            )
+
+        self.assertEqual(first_result, second_result)
+        self.assertEqual(hash_factory.call_count, 1)
+
+    def test_single_manager_fast_path_caches_general_manager_class_lookup(self):
+        from general_manager.manager.general_manager import GeneralManager
+
+        class CacheKeyInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        class CacheKeyManager(GeneralManager):
+            pass
+
+        CacheKeyManager.Interface = CacheKeyInterface
+
+        def sample_function(manager):
+            return manager
+
+        manager = CacheKeyManager(7)
+        imports = 0
+        real_import = builtins.__import__
+
+        def counting_import(name, *args, **kwargs):
+            nonlocal imports
+            if name == "general_manager.manager.general_manager":
+                imports += 1
+            return real_import(name, *args, **kwargs)
+
+        make_cache_key_module._general_manager_class.cache_clear()
+        try:
+            with patch("builtins.__import__", side_effect=counting_import):
+                make_cache_key(sample_function, (manager,), {})
+                make_cache_key(sample_function, (manager,), {})
+        finally:
+            make_cache_key_module._general_manager_class.cache_clear()
+
+        self.assertEqual(imports, 1)
+
     def test_make_cache_key_fast_path_for_non_ascii_manager_arg_matches_generic_key(
         self,
     ):
@@ -157,6 +252,68 @@ class TestMakeCacheKey(SimpleTestCase):
         expected = hashlib.sha256(raw, usedforsecurity=False).hexdigest()
 
         self.assertEqual(make_cache_key(sample_function, (manager,), {}), expected)
+
+    def test_make_cache_key_single_manager_arg_respects_changed_function_module(self):
+        from general_manager.manager.general_manager import GeneralManager
+
+        class CacheKeyInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        class CacheKeyManager(GeneralManager):
+            pass
+
+        CacheKeyManager.Interface = CacheKeyInterface
+
+        def sample_function(manager):
+            return manager
+
+        manager = CacheKeyManager(7)
+        result1 = make_cache_key(sample_function, (manager,), {})
+
+        sample_function.__module__ = "different_module"
+        result2 = make_cache_key(sample_function, (manager,), {})
+
+        self.assertNotEqual(result1, result2)
+
+    def test_single_manager_fast_path_reads_name_without_metaclass_lookup(self):
+        from general_manager.manager.general_manager import GeneralManager
+
+        class CacheKeyInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+        class CacheKeyManager(GeneralManager):
+            pass
+
+        CacheKeyManager.Interface = CacheKeyInterface
+
+        def sample_function(manager):
+            return manager
+
+        manager = CacheKeyManager(7)
+        original_getattribute = GeneralManagerMeta.__getattribute__
+
+        def fail_on_name_lookup(cls, attribute_name):
+            if attribute_name == "__name__":
+                raise AssertionError
+            return original_getattribute(cls, attribute_name)
+
+        with patch.object(
+            GeneralManagerMeta,
+            "__getattribute__",
+            fail_on_name_lookup,
+        ):
+            result = make_cache_key(sample_function, (manager,), {})
+
+        payload = {
+            "module": sample_function.__module__,
+            "qualname": sample_function.__qualname__,
+            "args": {"manager": manager},
+        }
+        raw = json.dumps(payload, sort_keys=True, cls=CustomJSONEncoder).encode()
+        expected = hashlib.sha256(raw, usedforsecurity=False).hexdigest()
+        self.assertEqual(result, expected)
 
     def test_make_cache_key_with_different_args(self):
         """

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -279,6 +279,14 @@ class MeasurementTestCase(TestCase):
         result = m1 * m2
         self.assertEqual(str(result), "6 meter * second")
 
+    def test_currency_per_unit_product_does_not_collapse_compound_right_unit(self):
+        result = Measurement(2, "EUR / kilogram / second") * Measurement(
+            3,
+            "kilogram / second",
+        )
+
+        self.assertEqual(str(result), "6 EUR / second ** 2")
+
     def test_division_same_units(self):
         m1 = Measurement(10, "meter")
         result = m1 / 2

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 from general_manager.measurement.measurement import Measurement, ureg
 from decimal import Decimal
@@ -505,6 +507,26 @@ class MeasurementTestCase(TestCase):
         self.assertEqual(result.magnitude, Decimal("1000"))
         self.assertEqual(str(result), "1000")
 
+    def test_percentage_scalar_arithmetic_avoids_rebuilding_result_quantity(self):
+        from general_manager.measurement import measurement as measurement_module
+
+        measurement = Measurement(Decimal("200"), "%")
+
+        with patch.object(
+            measurement_module,
+            "_build_quantity",
+            side_effect=AssertionError(
+                "percentage scalar arithmetic should not rebuild the Pint result"
+            ),
+        ):
+            multiplied = measurement * Decimal("500")
+            divided = measurement / Decimal("500")
+
+        self.assertEqual(multiplied.unit, "dimensionless")
+        self.assertEqual(multiplied.magnitude, Decimal("1000"))
+        self.assertEqual(divided.unit, "dimensionless")
+        self.assertEqual(divided.magnitude, Decimal("0.004"))
+
     def test_dimensionless_values(self):
         """
         Test initialization, arithmetic operations, and comparisons for dimensionless Measurement instances.
@@ -550,6 +572,35 @@ class MeasurementTestCase(TestCase):
         result_div = m1 / m2
         self.assertEqual(str(result_div), "50 EUR")
         self.assertEqual(result_div.quantity.units, ureg("EUR / dimensionless"))
+
+    def test_same_unit_addition_defers_result_quantity_until_exposed(self):
+        m1 = Measurement(100, "EUR")
+        m2 = Measurement(50, "EUR")
+
+        with patch.object(ureg, "Quantity", wraps=ureg.Quantity) as quantity:
+            result = m1 + m2
+            self.assertEqual(result.magnitude, Decimal("150"))
+            self.assertEqual(result.unit, "EUR")
+            self.assertEqual(str(result), "150 EUR")
+            quantity.assert_not_called()
+
+            self.assertEqual(str(result.quantity.units), "EUR")
+
+        quantity.assert_called_once()
+
+    def test_scalar_multiplication_defers_result_quantity_until_exposed(self):
+        measurement = Measurement(25, "kilogram")
+
+        with patch.object(ureg, "Quantity", wraps=ureg.Quantity) as quantity:
+            result = measurement * Decimal("2")
+            self.assertEqual(result.magnitude, Decimal("50"))
+            self.assertEqual(result.unit, "kilogram")
+            self.assertEqual(str(result), "50 kilogram")
+            quantity.assert_not_called()
+
+            self.assertEqual(str(result.quantity.units), "kilogram")
+
+        quantity.assert_called_once()
 
     def test_calculation_with_other_dimension_and_currency(self):
         """
@@ -597,6 +648,54 @@ class MeasurementTestCase(TestCase):
         m3 = m1 * m2
         self.assertIn(str(m3), ["200 meter * EUR", "200 EUR * meter"])
         self.assertEqual(str(m3.to("EUR * kilometer")), "0.2 EUR * kilometer")
+
+    def test_measurement_multiplication_reuses_pint_result_quantity(self):
+        m1 = Measurement(100, "EUR")
+        m2 = Measurement(2, "meter")
+
+        with patch(
+            "general_manager.measurement.measurement._build_quantity",
+            side_effect=AssertionError(
+                "measurement multiplication should not rebuild the Pint result"
+            ),
+        ):
+            result = m1 * m2
+
+        self.assertIn(str(result), ["200 meter * EUR", "200 EUR * meter"])
+        self.assertEqual(str(result.to("EUR * kilometer")), "0.2 EUR * kilometer")
+
+    def test_exact_currency_per_unit_multiplication_avoids_pint_result(self):
+        price = Measurement(Decimal("12"), "EUR / kilogram")
+        weight = Measurement(Decimal("3"), "kilogram")
+
+        with patch.object(
+            Measurement,
+            "_from_quantity",
+            side_effect=AssertionError(
+                "exact currency-per-unit multiplication should not use Pint"
+            ),
+        ):
+            left_result = price * weight
+            right_result = weight * price
+
+        self.assertEqual(left_result.unit, "EUR")
+        self.assertEqual(left_result.magnitude, Decimal("36"))
+        self.assertEqual(right_result.unit, "EUR")
+        self.assertEqual(right_result.magnitude, Decimal("36"))
+
+    def test_measurement_division_reuses_pint_result_quantity(self):
+        m1 = Measurement(100, "EUR")
+        m2 = Measurement(2, "meter")
+
+        with patch(
+            "general_manager.measurement.measurement._build_quantity",
+            side_effect=AssertionError(
+                "measurement division should not rebuild the Pint result"
+            ),
+        ):
+            result = m1 / m2
+
+        self.assertEqual(str(result), "50 EUR / meter")
 
     def test_invalid_measurement_initialization_error(self):
         """Test that InvalidMeasurementInitializationError is raised for invalid value types."""


### PR DESCRIPTION
## Summary

- Reduces framework overhead in dependency-cache hot/cold paths and run-context reuse.
- Adds run-scoped reuse for ORM bucket/relation managers while replaying dependency tracking correctly.
- Optimizes dependency publication/sharding, cache-key construction, input parsing, measurement arithmetic, and related GraphQL/property paths without changing public APIs.
- Adds regression coverage for cache dependency behavior, invalidation, input ordering, measurement edge cases, bucket/query reuse, GraphQL behavior, and cache-key fast paths.

## Validation

- `python -m pytest tests/unit/test_make_cache_key.py tests/unit/test_field_descriptors.py tests/unit/test_calculation_run_context.py tests/unit/test_cache_decorator.py tests/unit/test_cache_tracker.py tests/unit/test_dependency_cache.py tests/unit/test_dependency_publish.py tests/unit/test_dependency_shards.py tests/unit/test_general_manager.py tests/unit/test_measurement.py tests/unit/test_base_interface.py tests/unit/test_database_bucket.py tests/unit/test_dependency_matching.py tests/unit/test_json_encoder.py tests/unit/test_calculation_interface.py tests/unit/test_capability_core_utils.py tests/unit/test_graph_ql.py` -> 640 passed
- `pre-commit run --all-files` -> passed
- KnowledgeHub compose benchmark after rebase, 6 projects cold after Redis `FLUSHALL`: calculation `46.355s`, end-to-end `46.990s`, total `-30577776.87`
- KnowledgeHub compose benchmark after rebase, 6 projects hot/no flush: calculation `0.090s`, end-to-end `0.115s`, total `-30577776.87`

## Notes

The branch was rebased onto `origin/main` before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster caching and prefetching for repeated calculations, improving response times in cache-heavy workflows.
  * Improved support for reusing related database managers and cached interface values across a run.

* **Bug Fixes**
  * Reduced unnecessary recalculation and dependency tracking for repeated reads.
  * Improved handling of cached values, manager serialization, and measurement arithmetic to preserve correct results while avoiding extra work.
  * Fixed several edge cases around input validation, observability hooks, and dependency cache invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->