### PR TITLE
[codex] Skip exact measurement unit conversions

### DIFF
--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -702,6 +702,10 @@ class Measurement:
         each unit expression contains exactly one configured currency component;
         expressions with zero, multiple, inverse, or mismatched-power currency
         components fall back to Pint conversion and may raise Pint errors.
+        When ``target_unit`` matches the current canonical unit exactly, or
+        ``_canonical_unit_string(target_unit)`` canonicalizes to the current
+        unit, ``to()`` returns this ``Measurement`` object unchanged instead of
+        allocating a converted copy.
         Components with explicit power one, such as ``EUR ** 1``, are treated as
         the same currency component; expressions such as ``EUR / EUR`` simplify
         before this check and therefore are not currency conversions.
@@ -759,14 +763,11 @@ class Measurement:
                 return Measurement(value, target_unit)
 
         if self.is_currency():
-            if str(self.unit) == str(target_unit):
-                return self  # Same currency, no conversion needed
-            elif exchange_rate is not None:
+            if exchange_rate is not None:
                 # Convert using the provided exchange rate
                 value = self.magnitude * Decimal(str(exchange_rate))
                 return Measurement(value, target_unit)
-            else:
-                raise MissingExchangeRateError()
+            raise MissingExchangeRateError()
         else:
             # Standard conversion for physical units
             value = convert_magnitude(self.magnitude, self.unit, target_unit)

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -728,6 +728,12 @@ class Measurement:
             pint.errors.PintError: If `target_unit` is invalid or incompatible
                 with the source unit.
         """
+        if self.unit == target_unit:
+            return self
+        target_canonical_unit = _canonical_unit_string(target_unit)
+        if self.unit == target_canonical_unit:
+            return self
+
         source_currency = _currency_component(self.unit)
         target_currency = _currency_component(target_unit)
         if (

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -5,7 +5,7 @@ from general_manager.measurement.measurement import Measurement, ureg
 from decimal import Decimal
 from random import Random
 import pickle
-from pint.errors import DimensionalityError
+from pint.errors import DimensionalityError, UndefinedUnitError
 from typing import Any
 
 
@@ -87,10 +87,44 @@ class MeasurementTestCase(TestCase):
 
         self.assertEqual(str(converted), "100000 EUR / metric_ton")
 
+    def test_same_canonical_physical_unit_conversion_returns_same_object(self):
+        m = Measurement(1, "kilogram")
+
+        converted = m.to("kilogram")
+
+        self.assertIs(converted, m)
+
+    def test_alias_target_unit_conversion_returns_same_object(self):
+        m = Measurement(1, "kilogram")
+
+        converted = m.to("kg")
+
+        self.assertIs(converted, m)
+
+    def test_compound_alias_target_unit_conversion_returns_same_object(self):
+        m = Measurement(1, "EUR / kilogram")
+
+        converted = m.to("EUR/kg")
+
+        self.assertIs(converted, m)
+
+    def test_same_currency_conversion_returns_same_object(self):
+        m = Measurement(1, "EUR")
+
+        converted = m.to("EUR")
+
+        self.assertIs(converted, m)
+
     def test_invalid_currency_conversion(self):
         m = Measurement(100, "EUR")
         with self.assertRaises(ValueError):
             m.to("USD")
+
+    def test_invalid_target_unit_conversion_raises_pint_error(self):
+        m = Measurement(1, "kilogram")
+
+        with self.assertRaises(UndefinedUnitError):
+            m.to("not_a_real_unit")
 
     def test_physical_unit_conversion(self):
         m = Measurement(1, "kilometer")

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -120,6 +120,22 @@ class MeasurementTestCase(TestCase):
         with self.assertRaises(ValueError):
             m.to("USD")
 
+    def test_currency_to_non_currency_conversion_requires_exchange_rate(self):
+        from general_manager.measurement.measurement import MissingExchangeRateError
+
+        m = Measurement(2, "EUR")
+
+        with self.assertRaises(MissingExchangeRateError):
+            m.to("meter")
+
+    def test_currency_to_non_currency_conversion_uses_exchange_rate_fallback(self):
+        m = Measurement(2, "EUR")
+
+        converted = m.to("meter", exchange_rate=3.0)
+
+        self.assertEqual(converted.magnitude, Decimal("6"))
+        self.assertEqual(converted.unit, "meter")
+
     def test_invalid_target_unit_conversion_raises_pint_error(self):
         m = Measurement(1, "kilogram")
 


### PR DESCRIPTION
## Summary
- Add an exact-unit fast path to `Measurement.to()` for canonical target unit matches.
- Cover canonical physical units, aliases, compound currency/physical aliases, same-currency no-ops, and invalid target unit preservation.

## Validation
- RED: `python -m pytest tests/unit/test_measurement.py -q` failed on the new identity tests before implementation.
- GREEN: `python -m pytest tests/unit/test_measurement.py -q` passed with `81 passed, 2 subtests passed`.
- `ruff check`
- `mypy src/general_manager/measurement/measurement.py`
- Pre-commit hooks during commit: ruff lint/format, EOF, trailing whitespace, mixed line ending, merge conflict, debug statements, strict mypy.

## Review
- Independent reviewer subagent found no critical, important, or minor issues and assessed the patch as ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unit conversions now immediately reuse the existing measurement when the requested unit is already the same (including canonical and equivalent aliases), avoiding unnecessary conversion steps.
  * Invalid unit conversions now raise the correct errors for both unsupported physical units and unsupported currencies.
* **Tests**
  * Expanded unit-conversion tests to verify identity reuse for canonical/alias-preserving conversions and to validate the updated error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->