### PR TITLE
[codex] Cache Measurement/Pint hot paths

### DIFF
--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -91,11 +91,19 @@ def _unit_uses_offset_for_unit_string(unit: str) -> bool:
     return False
 
 
+@lru_cache(maxsize=512)
 def _pint_unit_components(unit: str) -> tuple[tuple[str, object], ...]:
     """Return Pint unit component names and powers for one unit expression."""
 
     parsed_unit = _parse_unit(unit)
     return tuple(parsed_unit._units.items())
+
+
+@lru_cache(maxsize=512)
+def _unit_dimensionality(unit: str) -> object:
+    """Return Pint dimensionality metadata for one unit expression."""
+
+    return _parse_unit(unit).dimensionality
 
 
 def _pint_unit_component_uses_offset(unit_name: str) -> bool:
@@ -187,12 +195,12 @@ def _convert_quantity(
     return source_quantity.to(target_unit)
 
 
+@lru_cache(maxsize=512)
 def _currency_component(unit: str) -> tuple[str, int] | None:
     """Return the single configured currency component in a unit expression."""
 
-    parsed_unit = ureg.parse_units(str(unit))
     currency_components: list[tuple[str, int]] = []
-    for unit_name, power in parsed_unit._units.items():
+    for unit_name, power in _pint_unit_components(unit):
         currency_power = _integer_unit_power(power)
         if currency_power is not None and unit_name in currency_units:
             currency_components.append((unit_name, currency_power))
@@ -213,11 +221,67 @@ def _integer_unit_power(power: object) -> int | None:
     return None
 
 
+@lru_cache(maxsize=512)
 def _unit_without_currency(unit: str, currency: str, power: int) -> str:
     """Return a unit expression with one currency component removed."""
 
-    stripped_unit = ureg.parse_units(str(unit)) / (ureg.parse_units(currency) ** power)
+    stripped_unit = _parse_unit(unit) / (_parse_unit(currency) ** power)
     return str(stripped_unit)
+
+
+def _is_implicit_cross_currency_conversion(
+    source_unit: str,
+    target_unit: str,
+) -> bool:
+    """Return whether a conversion would require an explicit exchange rate."""
+
+    source_currency = _currency_component(source_unit)
+    target_currency = _currency_component(target_unit)
+    return (
+        source_currency is not None
+        and target_currency is not None
+        and source_currency[0] != target_currency[0]
+    )
+
+
+@lru_cache(maxsize=1024)
+def _multiplicative_conversion_factor(
+    source_unit: str,
+    target_unit: str,
+) -> Decimal | None:
+    """Return a cached Decimal factor for safe multiplicative conversions."""
+
+    try:
+        if (
+            _unit_uses_offset_for_unit_string(source_unit)
+            or _unit_uses_offset_for_unit_string(target_unit)
+            or _is_implicit_cross_currency_conversion(source_unit, target_unit)
+        ):
+            return None
+        converted_quantity = ureg.Quantity(
+            Decimal("1"),
+            _parse_unit(source_unit),
+        ).to(_parse_unit(target_unit))
+    except pint.errors.PintError:
+        return None
+    return _decimal_from_magnitude(converted_quantity.magnitude)
+
+
+def _cached_multiplicative_conversion_factor(
+    source_unit: str,
+    target_unit: str,
+) -> Decimal | None:
+    """Return a cached factor keyed by canonical source and target units."""
+
+    try:
+        source_canonical_unit = _canonical_unit_string(source_unit)
+        target_canonical_unit = _canonical_unit_string(target_unit)
+    except pint.errors.PintError:
+        return None
+    return _multiplicative_conversion_factor(
+        source_canonical_unit,
+        target_canonical_unit,
+    )
 
 
 def convert_magnitude(value: Decimal, source_unit: str, target_unit: str) -> Decimal:
@@ -229,6 +293,13 @@ def convert_magnitude(value: Decimal, source_unit: str, target_unit: str) -> Dec
     stays as ``Decimal``. For those conversions, convert through ``float`` and then
     round-trip back to ``Decimal`` via ``str``.
     """
+
+    conversion_factor = _cached_multiplicative_conversion_factor(
+        source_unit,
+        target_unit,
+    )
+    if conversion_factor is not None:
+        return _decimal_from_magnitude(value * conversion_factor)
 
     converted_quantity = _convert_quantity(
         _build_quantity(value, source_unit), target_unit
@@ -830,10 +901,10 @@ class Measurement:
             )
         elif not self.is_currency() and not other.is_currency():
             # Both are physical units
+            if _unit_dimensionality(left_unit) != _unit_dimensionality(right_unit):
+                raise IncompatibleUnitsError("addition")
             left_quantity = self.__current_quantity()
             right_quantity = other.__current_quantity()
-            if left_quantity.dimensionality != right_quantity.dimensionality:
-                raise IncompatibleUnitsError("addition")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
                 left_quantity,
                 right_quantity,
@@ -883,10 +954,10 @@ class Measurement:
             return Measurement(Decimal(str(result_quantity.magnitude)), str(self.unit))
         elif not self.is_currency() and not other.is_currency():
             # Both are physical units
+            if _unit_dimensionality(left_unit) != _unit_dimensionality(right_unit):
+                raise IncompatibleUnitsError("subtraction")
             left_quantity = self.__current_quantity()
             right_quantity = other.__current_quantity()
-            if left_quantity.dimensionality != right_quantity.dimensionality:
-                raise IncompatibleUnitsError("subtraction")
             left_quantity, right_quantity = _prepare_quantities_for_binary_operation(
                 left_quantity,
                 right_quantity,

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -66,6 +66,45 @@ class MeasurementTestCase(TestCase):
 
         self.assertEqual(str(converted), "125000 EUR / metric_ton")
 
+    def test_convert_magnitude_uses_cached_multiplicative_factor(self):
+        from general_manager.measurement import measurement as measurement_module
+
+        measurement_module._parse_unit.cache_clear()
+        measurement_module._canonical_unit_string.cache_clear()
+        measurement_module._multiplicative_conversion_factor.cache_clear()
+
+        cases = [
+            (Decimal("1"), "percent", "dimensionless", Decimal("0.01")),
+            (Decimal("2000"), "EUR * percent / kilogram", "EUR/kg", Decimal("20")),
+            (Decimal("100"), "EUR / metric_ton", "EUR/kg", Decimal("0.1")),
+        ]
+
+        with patch.object(
+            measurement_module,
+            "_build_quantity",
+            side_effect=AssertionError(
+                "eligible multiplicative conversions should not build a quantity"
+            ),
+        ):
+            for value, source, target, expected in cases:
+                with self.subTest(source=source, target=target):
+                    self.assertEqual(
+                        measurement_module.convert_magnitude(value, source, target),
+                        expected,
+                    )
+
+        first_cache = measurement_module._multiplicative_conversion_factor.cache_info()
+        self.assertGreaterEqual(first_cache.misses, len(cases))
+
+        for value, source, target, expected in cases:
+            self.assertEqual(
+                measurement_module.convert_magnitude(value, source, target),
+                expected,
+            )
+
+        second_cache = measurement_module._multiplicative_conversion_factor.cache_info()
+        self.assertGreaterEqual(second_cache.hits, first_cache.hits + len(cases))
+
     def test_compound_currency_conversion_requires_exchange_rate(self):
         from general_manager.measurement.measurement import MissingExchangeRateError
 
@@ -73,6 +112,26 @@ class MeasurementTestCase(TestCase):
 
         with self.assertRaises(MissingExchangeRateError):
             m.to("EUR/t")
+
+    def test_cross_currency_conversion_still_requires_exchange_rate(self):
+        from general_manager.measurement import measurement as measurement_module
+        from general_manager.measurement.measurement import MissingExchangeRateError
+
+        measurement_module._multiplicative_conversion_factor.cache_clear()
+
+        with self.assertRaises(MissingExchangeRateError):
+            Measurement(Decimal("100"), "USD / metric_ton").to("EUR/t")
+
+    def test_explicit_cross_currency_conversion_uses_existing_exchange_rate_behavior(
+        self,
+    ):
+        converted = Measurement(Decimal("100"), "USD / metric_ton").to(
+            "EUR/t",
+            exchange_rate=1.25,
+        )
+
+        self.assertEqual(converted.magnitude, Decimal("125"))
+        self.assertEqual(converted.unit, "EUR / metric_ton")
 
     def test_fractional_currency_power_falls_back_to_pint_conversion(self):
         m = Measurement(4, "EUR ** 0.5")
@@ -142,6 +201,24 @@ class MeasurementTestCase(TestCase):
         with self.assertRaises(UndefinedUnitError):
             m.to("not_a_real_unit")
 
+    def test_invalid_conversion_falls_back_after_factor_rejects_path(self):
+        from general_manager.measurement import measurement as measurement_module
+
+        measurement_module._multiplicative_conversion_factor.cache_clear()
+
+        self.assertIsNone(
+            measurement_module._cached_multiplicative_conversion_factor(
+                "not_a_real_unit",
+                "meter",
+            )
+        )
+        with self.assertRaises(UndefinedUnitError):
+            Measurement(Decimal("1"), "kilogram").to("not_a_real_unit")
+
+    def test_invalid_conversion_still_raises_pint_error(self):
+        with self.assertRaises(DimensionalityError):
+            Measurement(Decimal("1"), "meter").to("second")
+
     def test_physical_unit_conversion(self):
         m = Measurement(1, "kilometer")
         converted = m.to("meter")
@@ -152,6 +229,20 @@ class MeasurementTestCase(TestCase):
         converted = m.to("degF")
         self.assertEqual(converted.unit, "degree_Fahrenheit")
         self.assertAlmostEqual(float(converted.magnitude), 77.0)
+
+    def test_offset_conversion_still_uses_pint_fallback(self):
+        from general_manager.measurement import measurement as measurement_module
+
+        measurement_module._multiplicative_conversion_factor.cache_clear()
+
+        converted = Measurement(Decimal("25"), "degC").to("degF")
+
+        self.assertEqual(converted.unit, "degree_Fahrenheit")
+        self.assertAlmostEqual(float(converted.magnitude), 77.0)
+        self.assertEqual(
+            measurement_module._multiplicative_conversion_factor.cache_info().currsize,
+            1,
+        )
 
     def test_offset_unit_from_string_conversion(self):
         converted = Measurement.from_string("25 degC").to("degF")
@@ -226,6 +317,63 @@ class MeasurementTestCase(TestCase):
             Measurement(2, "kg")
 
         self.assertEqual(mocked.call_count, 1)
+
+    def test_currency_component_uses_cached_parse_unit(self):
+        from general_manager.measurement import measurement as measurement_module
+
+        measurement_module._parse_unit.cache_clear()
+        measurement_module._pint_unit_components.cache_clear()
+        measurement_module._currency_component.cache_clear()
+
+        with patch.object(
+            measurement_module,
+            "_parse_unit",
+            wraps=measurement_module._parse_unit,
+        ) as mocked:
+            self.assertEqual(
+                measurement_module._currency_component("EUR / kilogram"),
+                ("EUR", 1),
+            )
+            self.assertEqual(
+                measurement_module._currency_component("EUR / kilogram"),
+                ("EUR", 1),
+            )
+
+        self.assertEqual(mocked.call_count, 1)
+        self.assertGreaterEqual(
+            measurement_module._currency_component.cache_info().hits,
+            1,
+        )
+
+    def test_unit_without_currency_is_cached(self):
+        from general_manager.measurement import measurement as measurement_module
+
+        measurement_module._parse_unit.cache_clear()
+        measurement_module._unit_without_currency.cache_clear()
+
+        with patch.object(
+            measurement_module,
+            "_parse_unit",
+            wraps=measurement_module._parse_unit,
+        ) as mocked:
+            first = measurement_module._unit_without_currency(
+                "USD / kilogram",
+                "USD",
+                1,
+            )
+            second = measurement_module._unit_without_currency(
+                "USD / kilogram",
+                "USD",
+                1,
+            )
+
+        self.assertEqual(first, "1 / kilogram")
+        self.assertEqual(second, "1 / kilogram")
+        self.assertEqual(mocked.call_count, 2)
+        self.assertGreaterEqual(
+            measurement_module._unit_without_currency.cache_info().hits,
+            1,
+        )
 
     def test_measurement_reuses_canonical_values_until_quantity_is_exposed(self):
         measurement = Measurement(Decimal("1.2300"), "kg / m ** 3")
@@ -693,6 +841,12 @@ class MeasurementTestCase(TestCase):
         m3 = m1 * m2
         self.assertEqual(str(m3), "2000 EUR * percent")
         self.assertEqual(str(m3.to("EUR")), "20 EUR")
+
+    def test_currency_percent_arithmetic_result_unit_is_unchanged(self):
+        result = Measurement(Decimal("100"), "EUR") * Measurement(Decimal("20"), "%")
+
+        self.assertEqual(str(result), "2000 EUR * percent")
+        self.assertEqual(str(result.to("EUR")), "20 EUR")
 
     def test_conversion_to_complex_units(self):
         """


### PR DESCRIPTION
## Summary
- Add internal bounded LRU caches for stable Measurement unit metadata and currency-unit helpers.
- Add a guarded cached multiplicative conversion-factor path in `convert_magnitude()` for safe non-offset conversions.
- Preserve Pint fallback behavior for offset units, invalid/incompatible conversions, and explicit exchange-rate currency paths.

## Impact
- Speeds repeated Measurement/Pint conversion hot paths without changing public API or arithmetic result behavior.
- Keeps `EUR * percent` arithmetic output unchanged until explicit `.to("EUR")` conversion.

Refs #327

## Validation
- `python -m pytest tests/unit/test_measurement.py -q` -> 99 passed, 5 subtests passed
- `python -m pytest tests/unit/test_measurement_field.py -q` -> 33 passed
- `ruff check src/general_manager/measurement/measurement.py tests/unit/test_measurement.py` -> passed
- `ruff format --check src/general_manager/measurement/measurement.py tests/unit/test_measurement.py` -> passed
- `mypy src/general_manager/measurement/measurement.py` -> passed
- `git diff --check` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved unit and currency conversion handling for more reliable Decimal-based calculations.
  * Added support for safer conversion paths when working across currencies and offset units.

* **Bug Fixes**
  * Reduced repeated conversion work to improve consistency and performance.
  * Preserved expected results for currency-plus-percent calculations and other mixed-unit conversions.

* **Tests**
  * Added coverage for cached conversion behavior, cross-currency cases, offset-unit fallbacks, and invalid conversion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->