### PR TITLE
[codex] Fix lazy PathMap search performance

### DIFF
--- a/docs/chat_implementation_plan.md
+++ b/docs/chat_implementation_plan.md
@@ -176,7 +176,8 @@ Auto-generate from two sources:
 - **GraphQL schema**: manager names + docstrings (one line each), available tool
   descriptions.
 - **PathMap**: compact relationship graph (adjacency list) derived from
-  `PathMap.mapping`, which covers all interface types.
+  PathMap's cached adjacency graph, which covers all interface types without
+  materializing every source/destination tracer.
 - Append developer-provided `system_prompt` from settings.
 
 **Acceptance criteria**:

--- a/docs/concepts/utils.md
+++ b/docs/concepts/utils.md
@@ -90,9 +90,9 @@ propagate.
 
 ## Path mapping and small transforms
 
-`PathMap` supports nested path mapping where integrations need stable source-to-target field paths. It builds a singleton cache from registered `GeneralManager` classes and records `PathTracer` objects keyed by `(start_class_name, destination_class_name)`. A tracer can exist with `tracer.path is None` when both classes are registered but no route is reachable; `PathMap.to(...)` returns `None` only when no mapping key exists.
+`PathMap` supports nested path mapping where integrations need stable source-to-target field paths. It keeps singleton graph metadata from registered `GeneralManager` classes and records requested `PathTracer` objects in a partial pair cache keyed by `(start_class_name, destination_class_name)`. A tracer can exist with `tracer.path is None` when both classes are registered but no route is reachable; `PathMap.to(...)` returns `None` when the source or destination is unknown, or when the source and destination are the same class.
 
-Path discovery uses `Interface.get_attribute_types()` entries that expose a `type` key and `@GraphQLProperty` return annotations. Only `GeneralManager` subclasses are traversed. The search skips attributes already in the current path and skips edges back to the original start class to avoid cycles. A tracer's `.path` is `[]` for the same start and destination class, a list of attribute names for the first route found, or `None` when unreachable.
+Path discovery uses `Interface.get_attribute_types()` entries that expose a `type` key and `@GraphQLProperty` return annotations. Only `GeneralManager` subclasses are traversed, and each manager class is expanded once per lookup to avoid cycles. Direct `PathTracer` construction represents same-class paths as `[]`; `PathMap.to(...)` treats same-class lookups as no traversal and returns `None`. Reachable paths are lists of attribute names, and unreachable paths are cached as tracers with `path is None`.
 
 ```python
 path_map = PathMap(Project)
@@ -105,7 +105,7 @@ connected_names = path_map.get_all_connected()
 
 Use `PathMap(SomeManagerClass).to(TargetManager)` when you need the cached `PathTracer` and its `.path`. Destinations are manager classes or string class names, not manager instances. Path lookup is lazy: constructing `PathMap` only refreshes manager graph metadata, and the first `to()` or `go_to()` for a `(source, destination)` pair resolves and caches only that pair. Missing paths are cached as tracers with `path is None`, so repeated misses return quickly without re-searching the graph.
 
-Use `PathMap(manager_instance).go_to(TargetManager)` when you want to traverse the path from a concrete instance. `go_to()` returns `None` when no mapping key exists, when the cached tracer is unreachable (`path is None`), when the tracer has an empty same-class path, or when bucket traversal has no entries to merge. If a traversable path exists but the `PathMap` was created from a class or string start, `go_to()` raises `MissingStartInstanceError`.
+Use `PathMap(manager_instance).go_to(TargetManager)` when you want to traverse the path from a concrete instance. `go_to()` returns `None` when no mapping key can be created, for same-class lookups, when the cached tracer is unreachable (`path is None`), or when bucket traversal has no entries to merge. If a traversable path exists but the `PathMap` was created from a class or string start, `go_to()` raises `MissingStartInstanceError`.
 
 Use `PathMap(SomeManagerClass).get_all_connected()` to list reachable destination manager class names. It walks the cached adjacency graph and does not materialize every possible source/destination tracer.
 

--- a/docs/concepts/utils.md
+++ b/docs/concepts/utils.md
@@ -103,7 +103,11 @@ customer_or_bucket = PathMap(project).go_to(Customer)
 connected_names = path_map.get_all_connected()
 ```
 
-Use `PathMap(SomeManagerClass).to(TargetManager)` when you only need the cached `PathTracer` and its `.path`. Destinations are manager classes or string class names, not manager instances. Use `PathMap(manager_instance).go_to(TargetManager)` when you want to traverse the path from a concrete instance. `go_to()` returns `None` when no mapping key exists, when the cached tracer is unreachable (`path is None`), when the tracer has an empty same-class path, or when bucket traversal has no entries to merge. If a traversable path exists but the `PathMap` was created from a class or string start, `go_to()` raises `MissingStartInstanceError`.
+Use `PathMap(SomeManagerClass).to(TargetManager)` when you need the cached `PathTracer` and its `.path`. Destinations are manager classes or string class names, not manager instances. Path lookup is lazy: constructing `PathMap` only refreshes manager graph metadata, and the first `to()` or `go_to()` for a `(source, destination)` pair resolves and caches only that pair. Missing paths are cached as tracers with `path is None`, so repeated misses return quickly without re-searching the graph.
+
+Use `PathMap(manager_instance).go_to(TargetManager)` when you want to traverse the path from a concrete instance. `go_to()` returns `None` when no mapping key exists, when the cached tracer is unreachable (`path is None`), when the tracer has an empty same-class path, or when bucket traversal has no entries to merge. If a traversable path exists but the `PathMap` was created from a class or string start, `go_to()` raises `MissingStartInstanceError`.
+
+Use `PathMap(SomeManagerClass).get_all_connected()` to list reachable destination manager class names. It walks the cached adjacency graph and does not materialize every possible source/destination tracer.
 
 Bucket-valued paths are traversed one entry at a time. For each path segment, `PathTracer.traverse_path()` reads the attribute from every bucket entry and unions the resulting managers or buckets into one value. Every traversed attribute must return a `GeneralManager` or `Bucket`; other values raise `InvalidPathTraversalValueError`.
 

--- a/src/general_manager/chat/system_prompt.py
+++ b/src/general_manager/chat/system_prompt.py
@@ -257,6 +257,7 @@ def _relationship_lines(
     relationship_lines: list[str] = []
     exposed_names = [name for name in manager_names if name in index]
     if len(exposed_names) > PROMPT_MANAGER_DETAIL_LIMIT:
+        # Bound lazy path resolution to avoid reintroducing CPU-bound O(n^2) work.
         return relationship_lines
     for from_manager in exposed_names:
         path_map = PathMap(from_manager)

--- a/src/general_manager/chat/system_prompt.py
+++ b/src/general_manager/chat/system_prompt.py
@@ -255,16 +255,20 @@ def _relationship_lines(
     index: dict[str, dict[str, object]], manager_names: list[str]
 ) -> list[str]:
     relationship_lines: list[str] = []
-    if not PathMap.mapping and manager_names:
-        PathMap(manager_names[0])
-    for (from_manager, to_manager), tracer in sorted(PathMap.mapping.items()):
-        if from_manager not in index or to_manager not in index:
-            continue
-        path = getattr(tracer, "path", None)
-        if path:
-            relationship_lines.append(
-                f"{from_manager} -> {to_manager}: {' -> '.join(path)}"
-            )
+    exposed_names = [name for name in manager_names if name in index]
+    if len(exposed_names) > PROMPT_MANAGER_DETAIL_LIMIT:
+        return relationship_lines
+    for from_manager in exposed_names:
+        path_map = PathMap(from_manager)
+        for to_manager in exposed_names:
+            if from_manager == to_manager:
+                continue
+            tracer = path_map.to(to_manager)
+            path = getattr(tracer, "path", None) if tracer is not None else None
+            if path:
+                relationship_lines.append(
+                    f"{from_manager} -> {to_manager}: {' -> '.join(path)}"
+                )
     return relationship_lines
 
 

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -100,9 +100,11 @@ class PathMap:
         Returns:
             PathMap: The singleton PathMap instance.
         """
+        force_refresh = False
         if not hasattr(cls, "instance"):
             cls.instance = super().__new__(cls)
-        cls._ensure_graph_current()
+            force_refresh = not cls.mapping
+        cls._ensure_graph_current(force=force_refresh)
         return cls.instance
 
     @classmethod

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -1,6 +1,7 @@
 """Utilities for tracing relationships between GeneralManager classes."""
 
 from __future__ import annotations
+from collections import deque
 from collections.abc import Mapping
 from typing import ClassVar, cast, get_args
 from general_manager.manager.meta import GeneralManagerMeta
@@ -12,6 +13,8 @@ from general_manager.manager.general_manager import GeneralManager
 
 type PathStart = str
 type PathDestination = str
+type PathEdge = tuple[str, PathDestination]
+type PathEdgeQueue = deque[PathEdge]
 type TraversalValue = GeneralManager | Bucket[GeneralManager]
 
 
@@ -34,6 +37,42 @@ class InvalidPathTraversalValueError(TypeError):
         super().__init__(
             "Path traversal attributes must resolve to a GeneralManager or Bucket."
         )
+
+
+def _as_manager_class(value: object) -> type[GeneralManager] | None:
+    """Return value when it is a GeneralManager subclass."""
+    if value is None or not isinstance(value, type):
+        return None
+    if not issubclass(value, GeneralManager):
+        return None
+    return value
+
+
+def _iter_manager_connections(
+    manager_class: type[GeneralManager],
+) -> list[tuple[str, type[GeneralManager]]]:
+    """Return traversable manager edges declared by interface fields and GraphQL properties."""
+    current_connections: dict[str, object] = {}
+    for attr_name, attr_value in manager_class.Interface.get_attribute_types().items():
+        if isinstance(attr_value, Mapping):
+            current_connections[attr_name] = attr_value.get("type")
+    for attr_name, attr_value in manager_class.__dict__.items():
+        if not isinstance(attr_value, GraphQLProperty):
+            continue
+        type_hints = get_args(attr_value.graphql_type_hint)
+        field_type = (
+            type_hints[0]
+            if type_hints
+            else cast(type[object], attr_value.graphql_type_hint)
+        )
+        current_connections[attr_name] = field_type
+
+    connections: list[tuple[str, type[GeneralManager]]] = []
+    for attr_name, attr_type in current_connections.items():
+        manager_type = _as_manager_class(attr_type)
+        if manager_type is not None:
+            connections.append((attr_name, manager_type))
+    return connections
 
 
 class PathMap:
@@ -229,29 +268,8 @@ class PathTracer:
         Returns:
             list[str] | None: Updated list of attribute names leading to the destination, or None if no route exists.
         """
-        current_connections: dict[str, object] = {}
-        for (
-            attr_name,
-            attr_value,
-        ) in current_manager.Interface.get_attribute_types().items():
-            if isinstance(attr_value, Mapping):
-                current_connections[attr_name] = attr_value.get("type")
-        for attr_name, attr_value in current_manager.__dict__.items():
-            if not isinstance(attr_value, GraphQLProperty):
-                continue
-            type_hints = get_args(attr_value.graphql_type_hint)
-            field_type = (
-                type_hints[0]
-                if type_hints
-                else cast(type[object], attr_value.graphql_type_hint)
-            )
-            current_connections[attr_name] = field_type
-        for attr, attr_type in current_connections.items():
+        for attr, attr_type in _iter_manager_connections(current_manager):
             if attr in path or attr_type == self.start_class:
-                continue
-            if attr_type is None or not isinstance(attr_type, type):
-                continue
-            if not issubclass(attr_type, GeneralManager):
                 continue
             if attr_type == self.destination_class:
                 return [*path, attr]

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -230,7 +230,12 @@ class PathTracer:
     """
 
     def __init__(
-        self, start_class: type[GeneralManager], destination_class: type[GeneralManager]
+        self,
+        start_class: type[GeneralManager],
+        destination_class: type[GeneralManager],
+        path: list[str] | None = None,
+        *,
+        search: bool = True,
     ) -> None:
         """
         Initialise a path tracer between two manager classes.
@@ -238,42 +243,55 @@ class PathTracer:
         Parameters:
             start_class (type[GeneralManager]): Origin manager class where traversal begins.
             destination_class (type[GeneralManager]): Target manager class to reach.
+            path (list[str] | None): Precomputed path used by lazy PathMap lookup when search is False.
+            search (bool): Whether to compute the path during construction.
 
         Returns:
             None
         """
         self.start_class = start_class
         self.destination_class = destination_class
-        if self.start_class == self.destination_class:
-            self.path: list[str] | None = []
+        if not search:
+            self.path = path
+        elif self.start_class == self.destination_class:
+            self.path = []
         else:
-            self.path = self.create_path(start_class, [])
+            self.path = self.create_path(start_class, [], {start_class})
 
     def create_path(
-        self, current_manager: type[GeneralManager], path: list[str]
+        self,
+        current_manager: type[GeneralManager],
+        path: list[str],
+        visited_managers: set[type[GeneralManager]] | None = None,
     ) -> list[str] | None:
         """
         Recursively compute the traversal path from `current_manager` to the destination class.
 
         Candidate edges come from `Interface.get_attribute_types()` entries that
         expose a `type` key and from `@GraphQLProperty` return annotations. Only
-        GeneralManager subclasses are traversed. The search skips attributes
-        already in the current path and skips edges back to the original start
-        class to avoid cycles.
+        GeneralManager subclasses are traversed. Each manager class is expanded
+        at most once, which bounds missing-path and cyclic graph searches.
 
         Parameters:
             current_manager (type[GeneralManager]): Manager class used as the current traversal node.
             path (list[str]): Sequence of attribute names accumulated along the traversal.
+            visited_managers (set[type[GeneralManager]] | None): Manager classes already expanded during this search.
 
         Returns:
             list[str] | None: Updated list of attribute names leading to the destination, or None if no route exists.
         """
+        if visited_managers is None:
+            visited_managers = {current_manager}
+
         for attr, attr_type in _iter_manager_connections(current_manager):
             if attr in path or attr_type == self.start_class:
                 continue
             if attr_type == self.destination_class:
                 return [*path, attr]
-            result = self.create_path(attr_type, [*path, attr])
+            if attr_type in visited_managers:
+                continue
+            visited_managers.add(attr_type)
+            result = self.create_path(attr_type, [*path, attr], visited_managers)
             if result:
                 return result
 

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -14,6 +14,7 @@ from general_manager.manager.general_manager import GeneralManager
 type PathStart = str
 type PathDestination = str
 type PathEdge = tuple[str, PathDestination]
+type PathClassEdge = tuple[str, type[GeneralManager]]
 type TraversalValue = GeneralManager | Bucket[GeneralManager]
 
 
@@ -88,6 +89,9 @@ class PathMap:
     _registry_signature: ClassVar[tuple[type[GeneralManager], ...]] = ()
     _classes_by_name: ClassVar[dict[str, type[GeneralManager]]] = {}
     _adjacency: ClassVar[dict[PathStart, tuple[PathEdge, ...]]] = {}
+    _class_adjacency: ClassVar[
+        dict[type[GeneralManager], tuple[PathClassEdge, ...]]
+    ] = {}
 
     def __new__(cls, *args: object, **kwargs: object) -> PathMap:
         """
@@ -123,14 +127,36 @@ class PathMap:
             manager_class.__name__: manager_class
             for manager_class in registry_signature
         }
+        cls._class_adjacency = {
+            manager_class: tuple(_iter_manager_connections(manager_class))
+            for manager_class in registry_signature
+        }
         cls._adjacency = {
             manager_class.__name__: tuple(
                 (attr, target_class.__name__)
-                for attr, target_class in _iter_manager_connections(manager_class)
+                for attr, target_class in cls._class_adjacency[manager_class]
             )
             for manager_class in registry_signature
         }
         cls.mapping.clear()
+
+    @classmethod
+    def _edges_for_class(
+        cls,
+        manager_class: type[GeneralManager],
+    ) -> tuple[PathClassEdge, ...]:
+        """Return cached outgoing edges for registered or discovered manager classes."""
+        edges = cls._class_adjacency.get(manager_class)
+        if edges is not None:
+            return edges
+
+        edges = tuple(_iter_manager_connections(manager_class))
+        cls._class_adjacency[manager_class] = edges
+        cls._adjacency.setdefault(
+            manager_class.__name__,
+            tuple((attr, target_class.__name__) for attr, target_class in edges),
+        )
+        return edges
 
     @classmethod
     def _find_path(
@@ -142,19 +168,26 @@ class PathMap:
         if start_class_name == destination_class_name:
             return []
 
-        visited = {start_class_name}
-        queue: deque[tuple[PathStart, list[str]]] = deque([(start_class_name, [])])
+        start_class = cls._classes_by_name.get(start_class_name)
+        destination_class = cls._classes_by_name.get(destination_class_name)
+        if start_class is None or destination_class is None:
+            return None
+
+        visited = {start_class}
+        queue: deque[tuple[type[GeneralManager], list[str]]] = deque(
+            [(start_class, [])]
+        )
 
         while queue:
-            current_class_name, current_path = queue.popleft()
-            for attr, next_class_name in cls._adjacency.get(current_class_name, ()):
-                if next_class_name in visited:
+            current_class, current_path = queue.popleft()
+            for attr, next_class in cls._edges_for_class(current_class):
+                if next_class in visited:
                     continue
                 next_path = [*current_path, attr]
-                if next_class_name == destination_class_name:
+                if next_class == destination_class:
                     return next_path
-                visited.add(next_class_name)
-                queue.append((next_class_name, next_path))
+                visited.add(next_class)
+                queue.append((next_class, next_path))
 
         return None
 
@@ -275,18 +308,22 @@ class PathMap:
         Returns:
             set[str]: Destination class names reachable from the current start_class_name.
         """
+        start_class = self._classes_by_name.get(self.start_class_name)
+        if start_class is None:
+            return set()
+
         connected_classes: set[str] = set()
-        visited = {self.start_class_name}
-        queue: deque[PathStart] = deque([self.start_class_name])
+        visited = {start_class}
+        queue: deque[type[GeneralManager]] = deque([start_class])
 
         while queue:
-            current_class_name = queue.popleft()
-            for _attr, next_class_name in self._adjacency.get(current_class_name, ()):
-                if next_class_name in visited:
+            current_class = queue.popleft()
+            for _attr, next_class in self._edges_for_class(current_class):
+                if next_class in visited:
                     continue
-                visited.add(next_class_name)
-                connected_classes.add(next_class_name)
-                queue.append(next_class_name)
+                visited.add(next_class)
+                connected_classes.add(next_class.__name__)
+                queue.append(next_class)
 
         return connected_classes
 

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -113,13 +113,13 @@ class PathMap:
         Returns:
             None
         """
-        cls._ensure_graph_current()
+        cls._ensure_graph_current(force=True)
 
     @classmethod
-    def _ensure_graph_current(cls) -> None:
+    def _ensure_graph_current(cls, *, force: bool = False) -> None:
         """Refresh class and adjacency caches when the manager registry changes."""
         registry_signature = tuple(GeneralManagerMeta.all_classes)
-        if cls._registry_signature == registry_signature:
+        if not force and cls._registry_signature == registry_signature:
             return
 
         cls._registry_signature = registry_signature
@@ -322,7 +322,8 @@ class PathMap:
                 if next_class in visited:
                     continue
                 visited.add(next_class)
-                connected_classes.add(next_class.__name__)
+                if next_class.__name__ in self._classes_by_name:
+                    connected_classes.add(next_class.__name__)
                 queue.append(next_class)
 
         return connected_classes

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -56,16 +56,21 @@ def _iter_manager_connections(
     for attr_name, attr_value in manager_class.Interface.get_attribute_types().items():
         if isinstance(attr_value, Mapping):
             current_connections[attr_name] = attr_value.get("type")
-    for attr_name, attr_value in manager_class.__dict__.items():
-        if not isinstance(attr_value, GraphQLProperty):
-            continue
-        type_hints = get_args(attr_value.graphql_type_hint)
-        field_type = (
-            type_hints[0]
-            if type_hints
-            else cast(type[object], attr_value.graphql_type_hint)
-        )
-        current_connections[attr_name] = field_type
+    seen_attrs: set[str] = set()
+    for mro_class in manager_class.__mro__:
+        for attr_name, attr_value in mro_class.__dict__.items():
+            if attr_name in seen_attrs:
+                continue
+            seen_attrs.add(attr_name)
+            if not isinstance(attr_value, GraphQLProperty):
+                continue
+            type_hints = get_args(attr_value.graphql_type_hint)
+            field_type = (
+                type_hints[0]
+                if type_hints
+                else cast(type[object], attr_value.graphql_type_hint)
+            )
+            current_connections[attr_name] = field_type
 
     connections: list[tuple[str, type[GeneralManager]]] = []
     for attr_name, attr_type in current_connections.items():

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -322,7 +322,7 @@ class PathMap:
                 if next_class in visited:
                     continue
                 visited.add(next_class)
-                if next_class.__name__ in self._classes_by_name:
+                if self._classes_by_name.get(next_class.__name__) is next_class:
                     connected_classes.add(next_class.__name__)
                 queue.append(next_class)
 

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -284,7 +284,7 @@ class PathTracer:
             visited_managers = {current_manager}
 
         for attr, attr_type in _iter_manager_connections(current_manager):
-            if attr in path or attr_type == self.start_class:
+            if attr_type == self.start_class:
                 continue
             if attr_type == self.destination_class:
                 return [*path, attr]

--- a/src/general_manager/utils/path_mapping.py
+++ b/src/general_manager/utils/path_mapping.py
@@ -14,7 +14,6 @@ from general_manager.manager.general_manager import GeneralManager
 type PathStart = str
 type PathDestination = str
 type PathEdge = tuple[str, PathDestination]
-type PathEdgeQueue = deque[PathEdge]
 type TraversalValue = GeneralManager | Bucket[GeneralManager]
 
 
@@ -79,43 +78,117 @@ class PathMap:
     """
     Maintain cached traversal paths between GeneralManager classes.
 
-    The class-level mapping stores one PathTracer for each registered
-    start/destination class-name pair. A cached tracer may have ``path is None``
-    when the classes are known but no route exists.
+    The class-level mapping stores lazily resolved PathTracer objects for
+    requested start/destination class-name pairs. A cached tracer may have
+    ``path is None`` when the classes are known but no route exists.
     """
 
     instance: PathMap
     mapping: ClassVar[dict[tuple[PathStart, PathDestination], PathTracer]] = {}
+    _registry_signature: ClassVar[tuple[type[GeneralManager], ...]] = ()
+    _classes_by_name: ClassVar[dict[str, type[GeneralManager]]] = {}
+    _adjacency: ClassVar[dict[PathStart, tuple[PathEdge, ...]]] = {}
 
     def __new__(cls, *args: object, **kwargs: object) -> PathMap:
         """
-        Obtain the singleton PathMap, initializing the path mapping on first instantiation.
+        Obtain the singleton PathMap, refreshing graph metadata on each construction.
 
         Returns:
             PathMap: The singleton PathMap instance.
         """
         if not hasattr(cls, "instance"):
             cls.instance = super().__new__(cls)
-            cls.create_path_mapping()
+        cls._ensure_graph_current()
         return cls.instance
 
     @classmethod
     def create_path_mapping(cls) -> None:
         """
-        Populate the path mapping with tracers for every distinct pair of managed classes.
-
-        The generated tracers capture the attribute sequence needed to navigate from the start class to the destination class and are cached on the singleton instance.
+        Refresh path graph metadata without eagerly creating all pair tracers.
 
         Returns:
             None
         """
-        all_managed_classes = GeneralManagerMeta.all_classes
-        for start_class in all_managed_classes:
-            for destination_class in all_managed_classes:
-                if start_class != destination_class:
-                    cls.instance.mapping[
-                        (start_class.__name__, destination_class.__name__)
-                    ] = PathTracer(start_class, destination_class)
+        cls._ensure_graph_current()
+
+    @classmethod
+    def _ensure_graph_current(cls) -> None:
+        """Refresh class and adjacency caches when the manager registry changes."""
+        registry_signature = tuple(GeneralManagerMeta.all_classes)
+        if cls._registry_signature == registry_signature:
+            return
+
+        cls._registry_signature = registry_signature
+        cls._classes_by_name = {
+            manager_class.__name__: manager_class
+            for manager_class in registry_signature
+        }
+        cls._adjacency = {
+            manager_class.__name__: tuple(
+                (attr, target_class.__name__)
+                for attr, target_class in _iter_manager_connections(manager_class)
+            )
+            for manager_class in registry_signature
+        }
+        cls.mapping.clear()
+
+    @classmethod
+    def _find_path(
+        cls,
+        start_class_name: PathStart,
+        destination_class_name: PathDestination,
+    ) -> list[str] | None:
+        """Find the shortest attribute path between two registered managers."""
+        if start_class_name == destination_class_name:
+            return []
+
+        visited = {start_class_name}
+        queue: deque[tuple[PathStart, list[str]]] = deque([(start_class_name, [])])
+
+        while queue:
+            current_class_name, current_path = queue.popleft()
+            for attr, next_class_name in cls._adjacency.get(current_class_name, ()):
+                if next_class_name in visited:
+                    continue
+                next_path = [*current_path, attr]
+                if next_class_name == destination_class_name:
+                    return next_path
+                visited.add(next_class_name)
+                queue.append((next_class_name, next_path))
+
+        return None
+
+    @staticmethod
+    def _destination_name(
+        path_destination: PathDestination | type[GeneralManager] | str,
+    ) -> PathDestination:
+        """Return the class-name key for a path destination input."""
+        if isinstance(path_destination, type):
+            return path_destination.__name__
+        return path_destination
+
+    def _get_or_create_tracer(
+        self,
+        destination_class_name: PathDestination,
+    ) -> PathTracer | None:
+        """Return the cached tracer for one pair, computing only that pair when needed."""
+        if self.start_class_name == destination_class_name:
+            return None
+
+        key = (self.start_class_name, destination_class_name)
+        tracer = self.mapping.get(key)
+        if tracer is not None:
+            return tracer
+
+        start_class = self._classes_by_name.get(self.start_class_name)
+        destination_class = self._classes_by_name.get(destination_class_name)
+        if start_class is None or destination_class is None:
+            return None
+
+        path = self._find_path(self.start_class_name, destination_class_name)
+        tracer = PathTracer(start_class, destination_class, path, search=False)
+        self.mapping[key] = tracer
+        return tracer
 
     def __init__(
         self,
@@ -152,23 +225,18 @@ class PathMap:
         """
         Retrieve the cached path tracer from the start class to the desired destination.
 
-        ``None`` means no cached key exists for the start/destination names. A
-        non-``None`` tracer can still be unreachable; inspect ``tracer.path`` for
-        ``None`` before treating it as a usable route.
+        ``None`` means either the start or destination class name is not
+        registered, or the requested pair uses the same start and destination
+        class. A non-``None`` tracer can still be unreachable; inspect
+        ``tracer.path`` for ``None`` before treating it as a usable route.
 
         Parameters:
             path_destination (PathDestination | type[GeneralManager] | str): Target manager identifier, either as a manager class or string class name. Destination instances are not accepted.
 
         Returns:
-            PathTracer | None: The cached tracer for the registered class-name pair, or None when no mapping key exists.
+            PathTracer | None: The cached tracer for the registered class-name pair, or None when no mapping key can be created.
         """
-        if isinstance(path_destination, type):
-            path_destination = path_destination.__name__
-
-        tracer = self.mapping.get((self.start_class_name, path_destination), None)
-        if not tracer:
-            return None
-        return tracer
+        return self._get_or_create_tracer(self._destination_name(path_destination))
 
     def go_to(
         self, path_destination: PathDestination | type[GeneralManager] | str
@@ -176,11 +244,11 @@ class PathMap:
         """
         Traverse the cached path from the configured start to the given destination.
 
-        The lookup first resolves a cached tracer. Missing tracer keys and
-        tracers with ``path is None`` return ``None``. A tracer with an empty
-        path also returns ``None`` because no traversal is required. If a
-        traversable path exists but this PathMap was created from a class or
-        string start, MissingStartInstanceError is raised.
+        The lookup lazily resolves and caches the requested tracer. Missing
+        tracer keys and tracers with ``path is None`` return ``None``. A tracer
+        with an empty path also returns ``None`` because no traversal is
+        required. If a traversable path exists but this PathMap was created from
+        a class or string start, MissingStartInstanceError is raised.
 
         Parameters:
             path_destination (PathDestination | type[GeneralManager] | str): Destination specified as a manager class or string class name. Destination instances are not accepted.
@@ -191,10 +259,7 @@ class PathMap:
         Raises:
             MissingStartInstanceError: If the cached path requires a concrete start instance but the PathMap was constructed without one.
         """
-        if isinstance(path_destination, type):
-            path_destination = path_destination.__name__
-
-        tracer = self.mapping.get((self.start_class_name, path_destination), None)
+        tracer = self._get_or_create_tracer(self._destination_name(path_destination))
         if not tracer:
             return None
         if not tracer.path:
@@ -205,18 +270,24 @@ class PathMap:
 
     def get_all_connected(self) -> set[str]:
         """
-        Return the set of destination class names that are reachable from the configured start.
+        Return the set of destination class names reachable from the configured start.
 
         Returns:
             set[str]: Destination class names reachable from the current start_class_name.
         """
         connected_classes: set[str] = set()
-        for path_tuple, path_obj in self.mapping.items():
-            if path_tuple[0] == self.start_class_name:
-                destination_class_name = path_tuple[1]
-                if path_obj.path is None:
+        visited = {self.start_class_name}
+        queue: deque[PathStart] = deque([self.start_class_name])
+
+        while queue:
+            current_class_name = queue.popleft()
+            for _attr, next_class_name in self._adjacency.get(current_class_name, ()):
+                if next_class_name in visited:
                     continue
-                connected_classes.add(destination_class_name)
+                visited.add(next_class_name)
+                connected_classes.add(next_class_name)
+                queue.append(next_class_name)
+
         return connected_classes
 
 

--- a/tests/unit/test_chat_system_prompt.py
+++ b/tests/unit/test_chat_system_prompt.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import graphene
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
@@ -36,18 +34,20 @@ class ChatSystemPromptTests(SimpleTestCase):
         if hasattr(PathMap, "instance"):
             delattr(PathMap, "instance")
 
-        class PartInterface(BaseTestInterface):
-            pass
-
-        class PartManager(GeneralManager):
-            Interface = PartInterface
-            chat_exposed = True
-
         class MaterialInterface(BaseTestInterface):
             pass
 
         class MaterialManager(GeneralManager):
             Interface = MaterialInterface
+            chat_exposed = True
+
+        class PartInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):  # type: ignore[no-untyped-def]
+                return {"material": {"type": MaterialManager}}
+
+        class PartManager(GeneralManager):
+            Interface = PartInterface
             chat_exposed = True
 
         class SecretInterface(BaseTestInterface):
@@ -82,12 +82,6 @@ class ChatSystemPromptTests(SimpleTestCase):
             "MaterialManager": MaterialManager,
             "SecretManager": SecretManager,
         }
-        PathMap.mapping[("PartManager", "MaterialManager")] = SimpleNamespace(
-            path=["material"]
-        )
-        PathMap.mapping[("PartManager", "SecretManager")] = SimpleNamespace(
-            path=["secret"]
-        )
 
     def tearDown(self) -> None:
         clear_schema_index_cache()
@@ -112,6 +106,9 @@ class ChatSystemPromptTests(SimpleTestCase):
     def test_build_system_prompt_includes_tools_managers_relationships_and_developer_prompt(
         self,
     ) -> None:
+        assert PathMap.mapping == {}
+        assert not hasattr(PathMap, "instance")
+
         prompt = build_system_prompt()
 
         assert "search_managers" in prompt
@@ -123,6 +120,17 @@ class ChatSystemPromptTests(SimpleTestCase):
         assert "MaterialManager: Raw material." in prompt
         assert "PartManager -> MaterialManager" in prompt
         assert "Always cite manager names." in prompt
+
+    def test_build_system_prompt_derives_relationships_without_seeded_path_cache(
+        self,
+    ) -> None:
+        assert PathMap.mapping == {}
+        assert not hasattr(PathMap, "instance")
+
+        prompt = build_system_prompt()
+
+        assert "PartManager -> MaterialManager" in prompt
+        assert "PartManager -> SecretManager" not in prompt
 
     def test_build_system_prompt_excludes_hidden_managers(self) -> None:
         prompt = build_system_prompt()
@@ -222,3 +230,4 @@ class ChatSystemPromptTests(SimpleTestCase):
             not in prompt
         )
         assert "Relationship graph omitted for large schemas" in prompt
+        assert PathMap.mapping == {}

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -532,6 +532,74 @@ class PathMappingUnitTests(SimpleTestCase):
             # Should find a path using either inherited or own property
             self.assertIn(tracer.path[0], ["inherited_end", "own_end"])
 
+    def test_pathmap_finds_inherited_graphql_property_without_derived_edge(self):
+        EndManager = self.EndManager
+
+        class BaseOnlyInterface(BaseTestInterface):
+            pass
+
+        class BaseOnlyManager(GeneralManager):
+            Interface = BaseOnlyInterface
+
+            @GraphQLProperty
+            def inherited_only(self) -> EndManager:  # type: ignore
+                return EndManager()
+
+        class DerivedOnlyInterface(BaseTestInterface):
+            pass
+
+        class DerivedOnlyManager(BaseOnlyManager):
+            Interface = DerivedOnlyInterface
+
+        pm = PathMap(DerivedOnlyManager)
+        tracer = pm.to(EndManager)
+
+        self.assertIsNotNone(tracer)
+        self.assertEqual(tracer.path, ["inherited_only"])  # type: ignore[union-attr]
+        self.assertEqual(pm.get_all_connected(), {EndManager.__name__})
+
+    def test_pathmap_uses_derived_graphql_property_override(self):
+        class BaseTargetInterface(BaseTestInterface):
+            pass
+
+        class BaseTargetManager(GeneralManager):
+            Interface = BaseTargetInterface
+
+        class DerivedTargetInterface(BaseTestInterface):
+            pass
+
+        class DerivedTargetManager(GeneralManager):
+            Interface = DerivedTargetInterface
+
+        class BaseOverrideInterface(BaseTestInterface):
+            pass
+
+        class BaseOverrideManager(GeneralManager):
+            Interface = BaseOverrideInterface
+
+            @GraphQLProperty
+            def shared_edge(self) -> BaseTargetManager:  # type: ignore
+                return BaseTargetManager()
+
+        class DerivedOverrideInterface(BaseTestInterface):
+            pass
+
+        class DerivedOverrideManager(BaseOverrideManager):
+            Interface = DerivedOverrideInterface
+
+            @GraphQLProperty
+            def shared_edge(self) -> DerivedTargetManager:  # type: ignore
+                return DerivedTargetManager()
+
+        pm = PathMap(DerivedOverrideManager)
+        tracer = pm.to(DerivedTargetManager)
+        base_tracer = pm.to(BaseTargetManager)
+
+        self.assertIsNotNone(tracer)
+        self.assertEqual(tracer.path, ["shared_edge"])  # type: ignore[union-attr]
+        self.assertIsNotNone(base_tracer)
+        self.assertIsNone(base_tracer.path)  # type: ignore[union-attr]
+
     def test_pathmap_string_representation(self):
         """
         Test string representation of PathMap and PathTracer objects.

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -1054,6 +1054,52 @@ class PathMappingUnitTests(SimpleTestCase):
             ["dynamic_end"],
         )
 
+    def test_recreated_pathmap_refreshes_after_public_cache_clear(self):
+        """Clearing the pair cache and recreating PathMap refreshes graph metadata."""
+        GeneralManagerMeta.all_classes.clear()
+        PathMap.mapping.clear()
+        PathMap._registry_signature = ()  # type: ignore[attr-defined]
+        PathMap._classes_by_name = {}  # type: ignore[attr-defined]
+        PathMap._adjacency = {}  # type: ignore[attr-defined]
+        PathMap._class_adjacency = {}  # type: ignore[attr-defined]
+        if hasattr(PathMap, "instance"):
+            delattr(PathMap, "instance")
+
+        class DynamicEndInterface(BaseTestInterface):
+            pass
+
+        class DynamicEndManager(GeneralManager):
+            Interface = DynamicEndInterface
+
+        class DynamicStartInterface(BaseTestInterface):
+            pass
+
+        class DynamicStartManager(GeneralManager):
+            Interface = DynamicStartInterface
+
+        GeneralManagerMeta.all_classes[:] = [DynamicStartManager, DynamicEndManager]
+
+        stale_tracer = PathMap(DynamicStartManager).to(DynamicEndManager)
+
+        self.assertIsNotNone(stale_tracer)
+        self.assertIsNone(stale_tracer.path)  # type: ignore[union-attr]
+
+        def dynamic_attribute_types(cls):  # type: ignore[no-untyped-def]
+            return {"dynamic_end": {"type": DynamicEndManager}}
+
+        DynamicStartInterface.get_attribute_types = classmethod(dynamic_attribute_types)  # type: ignore[method-assign]
+
+        PathMap.mapping.clear()
+        delattr(PathMap, "instance")
+
+        refreshed_tracer = PathMap(DynamicStartManager).to(DynamicEndManager)
+
+        self.assertIsNotNone(refreshed_tracer)
+        self.assertEqual(
+            refreshed_tracer.path,  # type: ignore[union-attr]
+            ["dynamic_end"],
+        )
+
     def test_get_all_connected_filters_duplicate_names_by_class_identity(self):
         """Connected destinations must match the registered class object."""
         GeneralManagerMeta.all_classes.clear()

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -846,9 +846,18 @@ class PathMappingUnitTests(SimpleTestCase):
             tracer: PathTracer,
             start_class: type[GeneralManager],
             destination_class: type[GeneralManager],
+            path: list[str] | None = None,
+            *,
+            search: bool = True,
         ) -> None:
             created_pairs.append((start_class.__name__, destination_class.__name__))
-            original_init(tracer, start_class, destination_class)
+            original_init(
+                tracer,
+                start_class,
+                destination_class,
+                path,
+                search=search,
+            )
 
         PathTracer.__init__ = counted_init  # type: ignore[method-assign]
         try:
@@ -876,9 +885,18 @@ class PathMappingUnitTests(SimpleTestCase):
             tracer: PathTracer,
             start_class: type[GeneralManager],
             destination_class: type[GeneralManager],
+            path: list[str] | None = None,
+            *,
+            search: bool = True,
         ) -> None:
             created_pairs.append((start_class.__name__, destination_class.__name__))
-            original_init(tracer, start_class, destination_class)
+            original_init(
+                tracer,
+                start_class,
+                destination_class,
+                path,
+                search=search,
+            )
 
         PathTracer.__init__ = counted_init  # type: ignore[method-assign]
         try:
@@ -991,6 +1009,53 @@ class PathMappingUnitTests(SimpleTestCase):
 
         # Should have no path
         self.assertIsNone(tracer.path)
+
+    def test_path_tracer_uses_precomputed_path_without_search(self):
+        """Direct PathTracer should accept cached paths without searching."""
+        create_path_calls = 0
+
+        class DisconnectedStartInterface(BaseTestInterface):
+            pass
+
+        class DisconnectedStartManager(GeneralManager):
+            Interface = DisconnectedStartInterface
+
+        class DisconnectedDestinationInterface(BaseTestInterface):
+            pass
+
+        class DisconnectedDestinationManager(GeneralManager):
+            Interface = DisconnectedDestinationInterface
+
+        original_create_path = PathTracer.create_path
+
+        def counted_create_path(
+            tracer: PathTracer,
+            current_manager: type[GeneralManager],
+            current_path: list[str],
+            visited_managers: set[type[GeneralManager]] | None = None,
+        ) -> list[str] | None:
+            nonlocal create_path_calls
+            create_path_calls += 1
+            return original_create_path(
+                tracer,
+                current_manager,
+                current_path,
+                visited_managers,
+            )
+
+        PathTracer.create_path = counted_create_path  # type: ignore[method-assign]
+        try:
+            tracer = PathTracer(
+                DisconnectedStartManager,
+                DisconnectedDestinationManager,
+                ["cached"],
+                search=False,
+            )
+        finally:
+            PathTracer.create_path = original_create_path  # type: ignore[method-assign]
+
+        self.assertEqual(tracer.path, ["cached"])
+        self.assertEqual(create_path_calls, 0)
 
     def test_path_tracer_allows_repeated_attribute_names_on_different_managers(self):
         """Direct PathTracer should allow repeated attribute names across managers."""

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -992,6 +992,38 @@ class PathMappingUnitTests(SimpleTestCase):
         # Should have no path
         self.assertIsNone(tracer.path)
 
+    def test_path_tracer_allows_repeated_attribute_names_on_different_managers(self):
+        """Direct PathTracer should allow repeated attribute names across managers."""
+
+        class DestinationInterface(BaseTestInterface):
+            pass
+
+        class DestinationManager(GeneralManager):
+            Interface = DestinationInterface
+
+        class SharedInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):  # type: ignore[no-untyped-def]
+                return {"target_edge": {"type": DestinationManager}}
+
+        class SharedManager(GeneralManager):
+            Interface = SharedInterface
+
+        class RootInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):  # type: ignore[no-untyped-def]
+                return {
+                    "target_edge": {"type": SharedManager},
+                    "alternate_edge": {"type": SharedManager},
+                }
+
+        class RootManager(GeneralManager):
+            Interface = RootInterface
+
+        tracer = PathTracer(RootManager, DestinationManager)
+
+        self.assertEqual(tracer.path, ["target_edge", "target_edge"])
+
     def test_path_tracer_missing_path_visits_each_manager_class_once(self):
         """Direct PathTracer no-path search should not re-expand the same class."""
         call_counts = {"branch": 0}

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -837,6 +837,69 @@ class PathMappingUnitTests(SimpleTestCase):
         # Should be the same tracer instance (cached)
         self.assertIs(tracer1, tracer2)
 
+    def test_pathmap_to_creates_only_requested_tracer(self):
+        """PathMap first use should not build tracers for every registered pair."""
+        created_pairs: list[tuple[str, str]] = []
+        original_init = PathTracer.__init__
+
+        def counted_init(
+            tracer: PathTracer,
+            start_class: type[GeneralManager],
+            destination_class: type[GeneralManager],
+        ) -> None:
+            created_pairs.append((start_class.__name__, destination_class.__name__))
+            original_init(tracer, start_class, destination_class)
+
+        PathTracer.__init__ = counted_init  # type: ignore[method-assign]
+        try:
+            tracer = PathMap(self.StartManager).to(self.EndManager)
+        finally:
+            PathTracer.__init__ = original_init  # type: ignore[method-assign]
+
+        self.assertIsNotNone(tracer)
+        self.assertEqual(tracer.path, ["end"])  # type: ignore[union-attr]
+        self.assertEqual(
+            created_pairs,
+            [(self.StartManager.__name__, self.EndManager.__name__)],
+        )
+        self.assertEqual(
+            set(PathMap.mapping),
+            {(self.StartManager.__name__, self.EndManager.__name__)},
+        )
+
+    def test_pathmap_missing_path_is_cached_without_all_pairs(self):
+        """A failed pair lookup should be cached without warming unrelated pairs."""
+        created_pairs: list[tuple[str, str]] = []
+        original_init = PathTracer.__init__
+
+        def counted_init(
+            tracer: PathTracer,
+            start_class: type[GeneralManager],
+            destination_class: type[GeneralManager],
+        ) -> None:
+            created_pairs.append((start_class.__name__, destination_class.__name__))
+            original_init(tracer, start_class, destination_class)
+
+        PathTracer.__init__ = counted_init  # type: ignore[method-assign]
+        try:
+            path_map = PathMap(self.EndManager)
+            first = path_map.to(self.StartManager)
+            second = path_map.to(self.StartManager)
+        finally:
+            PathTracer.__init__ = original_init  # type: ignore[method-assign]
+
+        self.assertIsNotNone(first)
+        self.assertIs(first, second)
+        self.assertIsNone(first.path)  # type: ignore[union-attr]
+        self.assertEqual(
+            created_pairs,
+            [(self.EndManager.__name__, self.StartManager.__name__)],
+        )
+        self.assertEqual(
+            set(PathMap.mapping),
+            {(self.EndManager.__name__, self.StartManager.__name__)},
+        )
+
     def test_path_map_get_all_connected_empty(self):
         """Test get_all_connected when no connections exist."""
 
@@ -887,6 +950,34 @@ class PathMappingUnitTests(SimpleTestCase):
         self.assertIn(Level2Manager.__name__, connected)
         self.assertIn(Level3Manager.__name__, connected)
 
+    def test_get_all_connected_does_not_populate_pair_cache(self):
+        """Reachability listing should not materialize every pair tracer."""
+
+        class Level2Interface(BaseTestInterface):
+            pass
+
+        class Level2Manager(GeneralManager):
+            Interface = Level2Interface
+
+            @GraphQLProperty
+            def end(self) -> self.EndManager:  # type: ignore
+                return self.EndManager()
+
+        class Level1Interface(BaseTestInterface):
+            pass
+
+        class Level1Manager(GeneralManager):
+            Interface = Level1Interface
+
+            @GraphQLProperty
+            def level2(self) -> Level2Manager:  # type: ignore
+                return Level2Manager()
+
+        connected = PathMap(Level1Manager).get_all_connected()
+
+        self.assertEqual(connected, {"Level2Manager", self.EndManager.__name__})
+        self.assertEqual(PathMap.mapping, {})
+
     def test_path_tracer_with_no_path_available(self):
         """Test PathTracer when no path exists between managers."""
 
@@ -900,6 +991,47 @@ class PathMappingUnitTests(SimpleTestCase):
 
         # Should have no path
         self.assertIsNone(tracer.path)
+
+    def test_path_tracer_missing_path_visits_each_manager_class_once(self):
+        """Direct PathTracer no-path search should not re-expand the same class."""
+        call_counts = {"branch": 0}
+
+        class MissingInterface(BaseTestInterface):
+            pass
+
+        class MissingManager(GeneralManager):
+            Interface = MissingInterface
+
+        class LeafInterface(BaseTestInterface):
+            pass
+
+        class LeafManager(GeneralManager):
+            Interface = LeafInterface
+
+        class BranchInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):  # type: ignore[no-untyped-def]
+                call_counts["branch"] += 1
+                return {"leaf": {"type": LeafManager}}
+
+        class BranchManager(GeneralManager):
+            Interface = BranchInterface
+
+        class RootInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):  # type: ignore[no-untyped-def]
+                return {
+                    "branch_a": {"type": BranchManager},
+                    "branch_b": {"type": BranchManager},
+                }
+
+        class RootManager(GeneralManager):
+            Interface = RootInterface
+
+        tracer = PathTracer(RootManager, MissingManager)
+
+        self.assertIsNone(tracer.path)
+        self.assertEqual(call_counts["branch"], 1)
 
     def test_path_tracer_traverse_path_no_path(self):
         """Test traverse_path when no path exists."""

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -744,6 +744,7 @@ class PathMappingUnitTests(SimpleTestCase):
         PathMap._registry_signature = ()  # type: ignore[attr-defined]
         PathMap._classes_by_name = {}  # type: ignore[attr-defined]
         PathMap._adjacency = {}  # type: ignore[attr-defined]
+        PathMap._class_adjacency = {}  # type: ignore[attr-defined]
 
         # Register test managers
         GeneralManagerMeta.all_classes.append(self.StartManager)
@@ -945,6 +946,51 @@ class PathMappingUnitTests(SimpleTestCase):
         self.assertEqual(
             set(PathMap.mapping),
             {(self.EndManager.__name__, self.StartManager.__name__)},
+        )
+
+    def test_pathmap_traverses_unregistered_intermediate_manager(self):
+        """Lazy PathMap should match PathTracer through unregistered intermediate classes."""
+        GeneralManagerMeta.all_classes.clear()
+        PathMap.mapping.clear()
+        PathMap._registry_signature = ()  # type: ignore[attr-defined]
+        PathMap._classes_by_name = {}  # type: ignore[attr-defined]
+        PathMap._adjacency = {}  # type: ignore[attr-defined]
+        PathMap._class_adjacency = {}  # type: ignore[attr-defined]
+        if hasattr(PathMap, "instance"):
+            delattr(PathMap, "instance")
+
+        class EndInterface(BaseTestInterface):
+            pass
+
+        class EndManager(GeneralManager):
+            Interface = EndInterface
+
+        class IntermediateInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):  # type: ignore[no-untyped-def]
+                return {"end": {"type": EndManager}}
+
+        class IntermediateManager(GeneralManager):
+            Interface = IntermediateInterface
+
+        class StartInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):  # type: ignore[no-untyped-def]
+                return {"intermediate": {"type": IntermediateManager}}
+
+        class StartManager(GeneralManager):
+            Interface = StartInterface
+
+        GeneralManagerMeta.all_classes[:] = [StartManager, EndManager]
+
+        direct_tracer = PathTracer(StartManager, EndManager)
+        path_map_tracer = PathMap(StartManager).to(EndManager)
+
+        self.assertEqual(direct_tracer.path, ["intermediate", "end"])
+        self.assertIsNotNone(path_map_tracer)
+        self.assertEqual(
+            path_map_tracer.path,  # type: ignore[union-attr]
+            ["intermediate", "end"],
         )
 
     def test_path_map_get_all_connected_empty(self):

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -973,10 +973,19 @@ class PathMappingUnitTests(SimpleTestCase):
         class IntermediateManager(GeneralManager):
             Interface = IntermediateInterface
 
+        class UnregisteredTerminalInterface(BaseTestInterface):
+            pass
+
+        class UnregisteredTerminalManager(GeneralManager):
+            Interface = UnregisteredTerminalInterface
+
         class StartInterface(BaseTestInterface):
             @classmethod
             def get_attribute_types(cls):  # type: ignore[no-untyped-def]
-                return {"intermediate": {"type": IntermediateManager}}
+                return {
+                    "intermediate": {"type": IntermediateManager},
+                    "unregistered_terminal": {"type": UnregisteredTerminalManager},
+                }
 
         class StartManager(GeneralManager):
             Interface = StartInterface
@@ -984,13 +993,65 @@ class PathMappingUnitTests(SimpleTestCase):
         GeneralManagerMeta.all_classes[:] = [StartManager, EndManager]
 
         direct_tracer = PathTracer(StartManager, EndManager)
-        path_map_tracer = PathMap(StartManager).to(EndManager)
+        path_map = PathMap(StartManager)
+        path_map_tracer = path_map.to(EndManager)
+        connected = path_map.get_all_connected()
 
         self.assertEqual(direct_tracer.path, ["intermediate", "end"])
         self.assertIsNotNone(path_map_tracer)
         self.assertEqual(
             path_map_tracer.path,  # type: ignore[union-attr]
             ["intermediate", "end"],
+        )
+        self.assertIn(EndManager.__name__, connected)
+        self.assertNotIn(IntermediateManager.__name__, connected)
+        self.assertNotIn(UnregisteredTerminalManager.__name__, connected)
+
+    def test_create_path_mapping_force_refreshes_unchanged_registry(self):
+        """Explicit metadata refresh should clear stale misses for unchanged classes."""
+        GeneralManagerMeta.all_classes.clear()
+        PathMap.mapping.clear()
+        PathMap._registry_signature = ()  # type: ignore[attr-defined]
+        PathMap._classes_by_name = {}  # type: ignore[attr-defined]
+        PathMap._adjacency = {}  # type: ignore[attr-defined]
+        PathMap._class_adjacency = {}  # type: ignore[attr-defined]
+        if hasattr(PathMap, "instance"):
+            delattr(PathMap, "instance")
+
+        class DynamicEndInterface(BaseTestInterface):
+            pass
+
+        class DynamicEndManager(GeneralManager):
+            Interface = DynamicEndInterface
+
+        class DynamicStartInterface(BaseTestInterface):
+            pass
+
+        class DynamicStartManager(GeneralManager):
+            Interface = DynamicStartInterface
+
+        GeneralManagerMeta.all_classes[:] = [DynamicStartManager, DynamicEndManager]
+
+        stale_tracer = PathMap(DynamicStartManager).to(DynamicEndManager)
+
+        self.assertIsNotNone(stale_tracer)
+        self.assertIsNone(stale_tracer.path)  # type: ignore[union-attr]
+
+        def dynamic_attribute_types(cls):  # type: ignore[no-untyped-def]
+            return {"dynamic_end": {"type": DynamicEndManager}}
+
+        DynamicStartInterface.get_attribute_types = classmethod(dynamic_attribute_types)  # type: ignore[method-assign]
+
+        PathMap.create_path_mapping()
+
+        self.assertEqual(PathMap.mapping, {})
+
+        refreshed_tracer = PathMap(DynamicStartManager).to(DynamicEndManager)
+
+        self.assertIsNotNone(refreshed_tracer)
+        self.assertEqual(
+            refreshed_tracer.path,  # type: ignore[union-attr]
+            ["dynamic_end"],
         )
 
     def test_path_map_get_all_connected_empty(self):

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -244,30 +244,44 @@ class PathMappingUnitTests(SimpleTestCase):
 
     def test_pathmap_caching_behavior(self):
         """
-        Test that PathMap properly caches mapping data and rebuilds when cleared.
+        Test that PathMap caches requested path tracers without eager warming.
 
-        Verifies that the mapping cache improves performance by avoiding
-        redundant computation while allowing for cache invalidation.
+        Verifies that graph reachability does not populate the pair cache, while
+        requested tracers are cached and can be recreated after cache clearing.
         """
         pm = PathMap(self.StartManager)
-        initial_mapping = dict(pm.mapping)  # Create copy to avoid reference issues
 
-        # Verify mapping is populated after first access
+        # Verify construction and reachability do not populate pair tracers
+        self.assertEqual(pm.mapping, {})
         connected = pm.get_all_connected()
         self.assertGreater(len(connected), 0)
-        self.assertGreater(len(initial_mapping), 0)
+        self.assertEqual(pm.mapping, {})
 
-        # Clear global mapping cache and singleton
+        # First pair lookup should compute and cache only that path
+        tracer = pm.to(self.EndManager)
+        self.assertIsNotNone(tracer)
+        self.assertEqual(tracer.path, ["end"])  # type: ignore[union-attr]
+        self.assertEqual(
+            set(pm.mapping),
+            {(self.StartManager.__name__, self.EndManager.__name__)},
+        )
+
+        # Clear global pair cache and singleton
         PathMap.mapping.clear()
         if hasattr(PathMap, "instance"):
             delattr(PathMap, "instance")
 
-        # Create new PathMap instance - should rebuild mapping
+        # Create new PathMap instance - graph metadata still supports reachability
         pm_new = PathMap(self.StartManager)
         new_connected = pm_new.get_all_connected()
 
         # Results should be the same even after cache rebuild
         self.assertEqual(connected, new_connected)
+        self.assertEqual(PathMap.mapping, {})
+
+        new_tracer = pm_new.to(self.EndManager)
+        self.assertIsNotNone(new_tracer)
+        self.assertEqual(new_tracer.path, ["end"])  # type: ignore[union-attr]
 
     def test_graphql_property_detection(self):
         """
@@ -727,28 +741,43 @@ class PathMappingUnitTests(SimpleTestCase):
         # Clear existing mappings
         PathMap.mapping.clear()
         GeneralManagerMeta.all_classes.clear()
+        PathMap._registry_signature = ()  # type: ignore[attr-defined]
+        PathMap._classes_by_name = {}  # type: ignore[attr-defined]
+        PathMap._adjacency = {}  # type: ignore[attr-defined]
 
         # Register test managers
         GeneralManagerMeta.all_classes.append(self.StartManager)
         GeneralManagerMeta.all_classes.append(self.EndManager)
 
-        # Manually trigger mapping creation
+        # Manually refresh graph metadata
         PathMap.instance = PathMap.__new__(PathMap)
         PathMap.create_path_mapping()
 
-        # Verify mappings were created
-        start_to_end_key = (self.StartManager.__name__, self.EndManager.__name__)
-        end_to_start_key = (self.EndManager.__name__, self.StartManager.__name__)
+        self.assertEqual(PathMap.mapping, {})
+        self.assertEqual(
+            PathMap._classes_by_name,  # type: ignore[attr-defined]
+            {
+                self.StartManager.__name__: self.StartManager,
+                self.EndManager.__name__: self.EndManager,
+            },
+        )
+        self.assertEqual(
+            PathMap._adjacency[self.StartManager.__name__],  # type: ignore[attr-defined]
+            (("end", self.EndManager.__name__),),
+        )
+        self.assertEqual(
+            PathMap._adjacency[self.EndManager.__name__],  # type: ignore[attr-defined]
+            (),
+        )
 
-        self.assertIn(start_to_end_key, PathMap.mapping)
-        self.assertIn(end_to_start_key, PathMap.mapping)
+        tracer = PathMap(self.StartManager).to(self.EndManager)
 
-        # Verify tracers were created correctly
-        start_to_end_tracer = PathMap.mapping[start_to_end_key]
-        self.assertEqual(start_to_end_tracer.path, ["end"])
-
-        end_to_start_tracer = PathMap.mapping[end_to_start_key]
-        self.assertIsNone(end_to_start_tracer.path)
+        self.assertIsNotNone(tracer)
+        self.assertEqual(tracer.path, ["end"])  # type: ignore[union-attr]
+        self.assertEqual(
+            set(PathMap.mapping),
+            {(self.StartManager.__name__, self.EndManager.__name__)},
+        )
 
     def test_pathtracer_recursive_path_creation(self):
         """

--- a/tests/unit/test_path_mapping.py
+++ b/tests/unit/test_path_mapping.py
@@ -1054,6 +1054,59 @@ class PathMappingUnitTests(SimpleTestCase):
             ["dynamic_end"],
         )
 
+    def test_get_all_connected_filters_duplicate_names_by_class_identity(self):
+        """Connected destinations must match the registered class object."""
+        GeneralManagerMeta.all_classes.clear()
+        PathMap.mapping.clear()
+        PathMap._registry_signature = ()  # type: ignore[attr-defined]
+        PathMap._classes_by_name = {}  # type: ignore[attr-defined]
+        PathMap._adjacency = {}  # type: ignore[attr-defined]
+        PathMap._class_adjacency = {}  # type: ignore[attr-defined]
+        if hasattr(PathMap, "instance"):
+            delattr(PathMap, "instance")
+
+        class RegisteredShadowInterface(BaseTestInterface):
+            pass
+
+        class ShadowManager(GeneralManager):
+            Interface = RegisteredShadowInterface
+
+        registered_shadow = ShadowManager
+
+        class UnregisteredShadowInterface(BaseTestInterface):
+            pass
+
+        unregistered_shadow = type(
+            "ShadowManager",
+            (GeneralManager,),
+            {"Interface": UnregisteredShadowInterface},
+        )
+
+        class StartInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):  # type: ignore[no-untyped-def]
+                return {"shadow": {"type": unregistered_shadow}}
+
+        class StartManager(GeneralManager):
+            Interface = StartInterface
+
+        GeneralManagerMeta.all_classes[:] = [StartManager, registered_shadow]
+
+        path_map = PathMap(StartManager)
+        tracer = path_map.to(registered_shadow)
+        connected = path_map.get_all_connected()
+
+        self.assertIsNotNone(tracer)
+        self.assertIsNone(tracer.path)  # type: ignore[union-attr]
+        self.assertNotIn("ShadowManager", connected)
+        self.assertIs(
+            PathMap.mapping[(StartManager.__name__, registered_shadow.__name__)],
+            tracer,
+        )
+        self.assertIsNone(
+            PathMap.mapping[(StartManager.__name__, registered_shadow.__name__)].path
+        )
+
     def test_path_map_get_all_connected_empty(self):
         """Test get_all_connected when no connections exist."""
 


### PR DESCRIPTION
## Summary
- Replace eager all-pairs `PathMap` initialization with lazy per-pair path resolution and hit/miss memoization.
- Add bounded manager-class traversal, metadata refresh handling, and registered-destination filtering for connected paths.
- Update chat prompt relationship rendering and docs for the new partial-cache model.

## Why
Issue #329 reported request-thread CPU spikes from first-use eager path mapping across all registered manager pairs. The new implementation resolves only the requested path and keeps no-path/cyclic cases bounded.

## Validation
- `python -m pytest tests/unit/test_path_mapping.py tests/integration/test_path_mapping.py -q` -> `47 passed`
- `python -m pytest tests/unit/test_chat_eval_fixtures.py tests/unit/test_chat_evals.py tests/unit/test_chat_schema_index.py tests/unit/test_chat_system_prompt.py tests/unit/test_chat_tools.py -q` -> `164 passed`
- `ruff check src/general_manager/utils/path_mapping.py src/general_manager/chat/system_prompt.py tests/unit/test_path_mapping.py tests/unit/test_chat_system_prompt.py` -> passed
- `ruff format --check src/general_manager/utils/path_mapping.py src/general_manager/chat/system_prompt.py tests/unit/test_path_mapping.py tests/unit/test_chat_system_prompt.py` -> passed
- `mypy src/general_manager/utils/path_mapping.py src/general_manager/chat/system_prompt.py` -> passed
- Synthetic 40-manager chain sanity check -> `created_pairs=1`, `mapping_size=1`, `path_length=39`

Fixes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relationship discovery used in system prompts so only exposed managers are considered, and relationship lines are omitted when paths are same-class, unreachable, or missing.
  * More consistent shortest-path behavior and fewer unnecessary graph expansions, improving reliability and performance of relationship/path lookups.
* **Documentation**
  * Updated developer docs to clarify cached path metadata, traversal rules, and the conditions where lookups return no result.
* **Tests**
  * Strengthened unit coverage for lazy caching, reachability behavior, and correct handling of edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->