### PR TITLE
[codex] Preserve count measurement units

### DIFF
--- a/docs/howto/add_model_with_measurement.md
+++ b/docs/howto/add_model_with_measurement.md
@@ -64,6 +64,15 @@ discounted_price = price * Measurement(10, "percent")
 discounted_price.to("EUR") # returns Measurement(19.9, 'EUR')
 ```
 
+Use `"count"` for discrete item quantities. Counts keep their unit through
+scalar operations such as weighted averages and are separate from plain
+dimensionless ratios:
+
+```python
+units = (Measurement(2, "count") + Measurement(4, "count")) / 2
+units.to("count") # returns Measurement(3, 'count')
+```
+
 Addition and subtraction require compatible units. Currency values must use the
 same currency code for arithmetic, and converting between currencies requires an
 explicit exchange rate. The exchange rate is target currency per one source
@@ -82,9 +91,10 @@ canonical unit `"dimensionless"`. Invalid text raises
 `InvalidMeasurementStringError` or
 `InvalidDimensionlessValueError`; incompatible arithmetic raises one of the
 measurement-specific `TypeError` or `ValueError` subclasses. Equivalent
-measurements compare and hash by their canonical unit value, so
+measurements compare and hash by normalized base-unit value, so
 `Measurement(1, "kg")` and `Measurement(1000, "gram")` can be used
-interchangeably as dictionary keys.
+interchangeably as dictionary keys. Count measurements use the public unit
+`"count"` while Pint stores their internal base unit as `"piece"`.
 
 ## Step 5: Expose via GraphQL
 

--- a/docs/howto/dataframe_measurements.md
+++ b/docs/howto/dataframe_measurements.md
@@ -30,7 +30,9 @@ from decimal import Decimal
 ]
 ```
 
-Units use Pint's canonical unit names through `Measurement.unit`.
+Units use `Measurement.unit`, which exposes GeneralManager's public unit names.
+Most aliases canonicalize through Pint; discrete item counts are emitted as
+`"count"`.
 
 ## Parse Strings Intentionally
 

--- a/src/general_manager/api/graphql_errors.py
+++ b/src/general_manager/api/graphql_errors.py
@@ -239,10 +239,10 @@ HANDLED_MANAGER_ERRORS: tuple[type[Exception], ...] = (
 
 
 class MeasurementType(ObjectType):
-    """GraphQL object wrapper exposing measurement magnitude and Pint unit text.
+    """GraphQL object wrapper exposing measurement magnitude and unit text.
 
     ``value`` is emitted through Graphene ``Float`` and may lose Decimal
-    precision. ``unit`` is the measurement's canonical Pint unit string.
+    precision. ``unit`` is the measurement's GeneralManager public unit string.
     """
 
     value = Float()
@@ -259,7 +259,7 @@ class MeasurementScalar(Scalar):
     are outside the documented user API.
 
     ``serialize()`` accepts only ``Measurement`` instances and returns their
-    canonical string representation; it raises ``InvalidMeasurementValueError``
+    public string representation; it raises ``InvalidMeasurementValueError``
     for every other value. ``parse_value()`` is the public variable-input parser,
     accepts a string, and returns a ``Measurement``. Type checkers should reject
     non-string direct calls. Runtime non-string calls are unsupported; their

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -588,7 +588,7 @@ def create_measurement_resolver(field_name: str) -> Resolver:
             result = result.to(target_unit)
         return {
             "value": result.quantity.magnitude,
-            "unit": str(result.quantity.units),
+            "unit": result.unit,
         }
 
     return resolver

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -19,11 +19,20 @@ ComparisonOperation: TypeAlias = Callable[[QuantityMagnitude, QuantityMagnitude]
 # Set precision for Decimal
 getcontext().prec = 28
 _PERCENT_SCALE = Decimal("100")
+_COUNT_PUBLIC_UNIT = "count"
+_PIECE_COUNT_CANONICAL_UNIT = "piece"
 
 # Create a new UnitRegistry
 ureg: pint.UnitRegistry[QuantityMagnitude] = pint.UnitRegistry(
     auto_reduce_dimensions=True
 )
+
+# Pint defines "count" as dimensionless. GeneralManager treats discrete item
+# counts as their own unit family so scalar arithmetic cannot silently erase it.
+ureg.define(
+    f"{_PIECE_COUNT_CANONICAL_UNIT} = [piece_count] = pc = {_COUNT_PUBLIC_UNIT}"
+)
+_PIECE_COUNT_UNIT = ureg.parse_units(_COUNT_PUBLIC_UNIT)
 
 # Define currency units
 currency_units = ["EUR", "USD", "GBP", "JPY", "CHF", "AUD", "CAD"]
@@ -43,7 +52,10 @@ def _parse_unit(unit: str) -> pint.Unit:
 def _canonical_unit_string(unit: str) -> str:
     """Return Pint's canonical unit string for one unit expression."""
 
-    return str(_parse_unit(unit))
+    parsed_unit = _parse_unit(unit)
+    if parsed_unit == _PIECE_COUNT_UNIT:
+        return _COUNT_PUBLIC_UNIT
+    return str(parsed_unit)
 
 
 def _format_decimal(value: Decimal) -> Decimal:
@@ -496,8 +508,11 @@ class Measurement:
     comparison, string parsing, pickling, and explicit currency conversion.
     Currency conversions never use implicit rates; callers must pass an
     ``exchange_rate`` when converting between different configured currencies.
-    Pint canonicalizes unit names, so ``unit`` and string/repr output may use
-    canonical names such as ``"kilogram"`` rather than the caller's spelling.
+    Pint canonicalizes most unit names, so ``unit`` and string/repr output may
+    use canonical names such as ``"kilogram"`` rather than the caller's
+    spelling. GeneralManager keeps the public ``"count"`` spelling for discrete
+    piece-count measurements even though Pint represents that base unit
+    internally as ``"piece"``.
     Exact Pint exception subclasses/messages, canonical compound-unit ordering,
     aliases, and offset-unit internals are delegated to the installed Pint
     version and are not a stable GeneralManager API contract.
@@ -515,8 +530,10 @@ class Measurement:
         Converts the provided numeric-like value to a Decimal through
         ``Decimal(str(value))`` and constructs the internal quantity using the
         given Pint unit expression. ``unit`` may be ``"dimensionless"`` or an
-        empty string for dimensionless measurements. Invalid units are reported
-        by Pint and are not wrapped by this constructor. String values are
+        empty string for dimensionless measurements. Discrete item quantities
+        should use ``"count"``, which belongs to its own unit family rather than
+        Pint's plain dimensionless family. Invalid units are reported by Pint and
+        are not wrapped by this constructor. String values are
         numeric magnitudes only; use ``from_string()`` for combined
         ``"<value> <unit>"`` text. ``bool`` is rejected even though it is an
         ``int`` subclass in Python.
@@ -531,7 +548,8 @@ class Measurement:
             value (Decimal | float | int | str): Numeric value to use as the measurement magnitude; strings and numeric types are coerced to Decimal.
             unit (str): Unit label registered in the module's unit registry,
                 including configured currency codes, physical unit names,
-                compound Pint expressions such as ``"kg / m^2"``, or
+                ``"count"`` for discrete item quantities, compound Pint
+                expressions such as ``"kg / m^2"``, or
                 dimensionless units.
 
         Raises:
@@ -585,7 +603,9 @@ class Measurement:
 
         self.__quantity = quantity
         self.__magnitude = _decimal_from_magnitude(quantity.magnitude)
-        self.__unit = unit if unit is not None else str(quantity.units)
+        self.__unit = (
+            unit if unit is not None else _canonical_unit_string(str(quantity.units))
+        )
         self.__quantity_exposed = False
 
     def __current_quantity(self) -> MeasurementQuantity:
@@ -605,7 +625,7 @@ class Measurement:
 
     def __current_unit(self) -> str:
         if self.__quantity_exposed:
-            return str(self.__current_quantity().units)
+            return _canonical_unit_string(str(self.__current_quantity().units))
         return self.__unit
 
     def __getstate__(self) -> dict[str, str]:
@@ -671,12 +691,15 @@ class Measurement:
         """
         Retrieve the unit label associated with the measurement.
 
-        The returned value is Pint's canonical unit string, not necessarily the
-        spelling passed to the constructor. Empty-string and ``"dimensionless"``
-        inputs both expose ``"dimensionless"``.
+        The returned value is GeneralManager's public unit string, usually
+        Pint's canonical unit string and not necessarily the spelling passed to
+        the constructor. Empty-string and ``"dimensionless"`` inputs both expose
+        ``"dimensionless"``. Discrete piece-count inputs such as ``"count"``,
+        ``"pc"``, and ``"piece"`` expose ``"count"`` while Pint's internal
+        quantity uses ``"piece"``.
 
         Returns:
-            str: Canonical unit string as provided by the unit registry.
+            str: Public unit string used by GeneralManager.
         """
         return self.__current_unit()
 
@@ -1118,8 +1141,8 @@ class Measurement:
         Return a detailed representation suitable for debugging.
 
         The magnitude is read through the ``magnitude`` property, and the unit
-        is Pint's canonical unit string. The GeneralManager-owned shape is
-        ``Measurement(<magnitude>, '<canonical unit>')``; exact magnitude and
+        is GeneralManager's public unit string. The GeneralManager-owned shape is
+        ``Measurement(<magnitude>, '<unit>')``; exact magnitude and
         compound-unit spelling follow the documented Decimal/Pint boundaries.
 
         Returns:

--- a/src/general_manager/measurement/measurement.py
+++ b/src/general_manager/measurement/measurement.py
@@ -29,9 +29,7 @@ ureg: pint.UnitRegistry[QuantityMagnitude] = pint.UnitRegistry(
 
 # Pint defines "count" as dimensionless. GeneralManager treats discrete item
 # counts as their own unit family so scalar arithmetic cannot silently erase it.
-ureg.define(
-    f"{_PIECE_COUNT_CANONICAL_UNIT} = [piece_count] = pc = {_COUNT_PUBLIC_UNIT}"
-)
+ureg.define(f"{_PIECE_COUNT_CANONICAL_UNIT} = [piece_count] = {_COUNT_PUBLIC_UNIT}")
 _PIECE_COUNT_UNIT = ureg.parse_units(_COUNT_PUBLIC_UNIT)
 
 # Define currency units
@@ -694,9 +692,9 @@ class Measurement:
         The returned value is GeneralManager's public unit string, usually
         Pint's canonical unit string and not necessarily the spelling passed to
         the constructor. Empty-string and ``"dimensionless"`` inputs both expose
-        ``"dimensionless"``. Discrete piece-count inputs such as ``"count"``,
-        ``"pc"``, and ``"piece"`` expose ``"count"`` while Pint's internal
-        quantity uses ``"piece"``.
+        ``"dimensionless"``. Discrete piece-count inputs such as ``"count"``
+        and ``"piece"`` expose ``"count"`` while Pint's internal quantity uses
+        ``"piece"``. The Pint ``"pc"`` alias remains parsec, not piece count.
 
         Returns:
             str: Public unit string used by GeneralManager.

--- a/src/general_manager/measurement/measurement_field.py
+++ b/src/general_manager/measurement/measurement_field.py
@@ -73,10 +73,10 @@ class MeasurementField(MeasurementFieldBase):
         """
         Create a MeasurementField configured with a canonical base unit and paired backing columns.
 
-        Initializes the field's canonical base unit and derived dimensionality, records the editable flag, constructs a Decimal-backed value column (`<name>_value`) and Char-backed unit column (`<name>_unit`), and forwards remaining arguments to the base Field constructor. Stored magnitudes are converted to `base_unit` and rounded to the backing `DecimalField(max_digits=30, decimal_places=10)` precision; the unit column stores Pint's canonical spelling for the assigned unit, such as `gram` for `g`.
+        Initializes the field's canonical base unit and derived dimensionality, records the editable flag, constructs a Decimal-backed value column (`<name>_value`) and Char-backed unit column (`<name>_unit`), and forwards remaining arguments to the base Field constructor. Stored magnitudes are converted to `base_unit` and rounded to the backing `DecimalField(max_digits=30, decimal_places=10)` precision; the unit column stores the Measurement's public unit spelling, such as `gram` for `g` and `count` for discrete item counts.
 
         Parameters:
-            base_unit (str): Multiplicative Pint unit used to normalize and store measurements. Currency units must be one of `currency_units`; each configured currency is treated as its own Pint dimension.
+            base_unit (str): Multiplicative Pint unit used to normalize and store measurements. Currency units must be one of `currency_units`; each configured currency is treated as its own Pint dimension. Use `count` for discrete item quantities.
             *args (object): Positional arguments forwarded to the base Field implementation.
             null (bool): If True, the backing columns may be NULL in the database.
             blank (bool): If True, forms may accept an empty value for this field.
@@ -536,7 +536,7 @@ class MeasurementField(MeasurementFieldBase):
         Resolve the field value on an instance, reconstructing the measurement when possible.
 
         The descriptor reads `<name>_value` as a base-unit magnitude and
-        `<name>_unit` as Pint's canonical spelling for the unit originally assigned. It converts the
+        `<name>_unit` as the Measurement public spelling for the unit originally assigned. It converts the
         base magnitude back to that stored unit for display. If stored data has
         drifted and the unit is no longer parseable or dimensionally compatible with the base
         unit, reconstruction falls back to a Measurement in `base_unit` rather
@@ -655,7 +655,7 @@ class MeasurementField(MeasurementFieldBase):
             ) from e
 
         setattr(instance, self.value_attr, self._normalize_base_magnitude(base_mag))
-        setattr(instance, self.unit_attr, str(value.quantity.units))
+        setattr(instance, self.unit_attr, str(value.unit))
 
     def validate(
         self,

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -345,6 +345,21 @@ class GraphQLTests(TestCase):
         result = resolver(mock_instance, self.info, target_unit="cm")
         self.assertEqual(result, {"value": Decimal(100), "unit": "centimeter"})
 
+    def test_create_resolver_measurement_count_uses_public_unit(self):
+        mock_instance = MagicMock()
+        mock_instance.measurement_field = Measurement(Decimal("1"), "count")
+
+        resolver = GraphQL._create_resolver("measurement_field", Measurement)
+
+        self.assertEqual(
+            resolver(mock_instance, self.info),
+            {"value": Decimal("1"), "unit": "count"},
+        )
+        self.assertEqual(
+            resolver(mock_instance, self.info, target_unit="count"),
+            {"value": Decimal("1"), "unit": "count"},
+        )
+
     def test_create_resolver_list_case(self):
         mock_instance = MagicMock()
         mock_queryset = MagicMock()

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -471,6 +471,56 @@ class MeasurementTestCase(TestCase):
         self.assertEqual(str(divided), "4 meter")
         mocked.assert_not_called()
 
+    def test_count_scalar_arithmetic_preserves_public_count_unit(self):
+        measurement = Measurement(Decimal("1.123"), "count")
+
+        divided = measurement / Decimal("1")
+        multiplied = measurement * Decimal("2")
+
+        self.assertEqual(divided.magnitude, Decimal("1.123"))
+        self.assertEqual(divided.unit, "count")
+        self.assertEqual(multiplied.magnitude, Decimal("2.246"))
+        self.assertEqual(multiplied.unit, "count")
+
+    def test_count_weighted_average_preserves_public_count_unit(self):
+        result = sum(
+            [
+                Measurement(Decimal("2"), "count"),
+                Measurement(Decimal("4"), "count"),
+            ]
+        ) / Decimal("2")
+
+        self.assertEqual(result.magnitude, Decimal("3"))
+        self.assertEqual(result.unit, "count")
+        self.assertEqual(result.to("count").magnitude, Decimal("3"))
+
+    def test_count_uses_dedicated_piece_count_dimension(self):
+        count = Measurement(Decimal("1"), "count")
+
+        self.assertEqual(count.to("count").magnitude, Decimal("1"))
+        with self.assertRaises(DimensionalityError):
+            count.to("dimensionless")
+        with self.assertRaises(DimensionalityError):
+            Measurement(Decimal("1"), "dimensionless").to("count")
+
+    def test_count_public_unit_survives_quantity_exposure(self):
+        measurement = Measurement(Decimal("1"), "count")
+
+        self.assertEqual(str(measurement.quantity.units), "piece")
+
+        self.assertEqual(measurement.unit, "count")
+        self.assertEqual(str(measurement), "1 count")
+        self.assertEqual(repr(measurement), "Measurement(1, 'count')")
+
+    def test_count_public_unit_survives_pickle_after_quantity_exposure(self):
+        measurement = Measurement(Decimal("1"), "count")
+        _ = measurement.quantity
+
+        restored = _trusted_pickle_loads(pickle.dumps(measurement))
+
+        self.assertEqual(restored.unit, "count")
+        self.assertEqual(str(restored), "1 count")
+
     def test_multiplication_different_units(self):
         m1 = Measurement(2, "meter")
         m2 = Measurement(3, "second")

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -503,6 +503,12 @@ class MeasurementTestCase(TestCase):
         with self.assertRaises(DimensionalityError):
             Measurement(Decimal("1"), "dimensionless").to("count")
 
+    def test_pc_remains_parsec_alias_not_piece_count_alias(self):
+        measurement = Measurement(Decimal("1"), "pc")
+
+        self.assertEqual(measurement.unit, "parsec")
+        self.assertEqual(measurement.quantity.units, ureg.parse_units("parsec"))
+
     def test_count_public_unit_survives_quantity_exposure(self):
         measurement = Measurement(Decimal("1"), "count")
 

--- a/tests/unit/test_measurement_field.py
+++ b/tests/unit/test_measurement_field.py
@@ -170,6 +170,24 @@ class MeasurementFieldTests(TestCase):
         self.assertEqual(temperature.unit, "degree_Celsius")  # type: ignore[union-attr]
         self.assertAlmostEqual(float(temperature.magnitude), 25.0)  # type: ignore[union-attr]
 
+    @isolate_apps("tests")
+    def test_count_measurement_field_preserves_count_after_scalar_arithmetic(self):
+        class Inventory(models.Model):
+            quantity = MeasurementField(base_unit="count", null=True, blank=True)
+
+            class Meta:
+                app_label = "tests"
+
+        instance = Inventory()
+        instance.quantity = Measurement(Decimal("6"), "count") / Decimal("2")
+        instance.full_clean()
+
+        self.assertEqual(instance.quantity_value, Decimal("3"))  # type: ignore
+        self.assertEqual(instance.quantity_unit, "count")  # type: ignore
+        self.assertIsNotNone(instance.quantity)
+        self.assertEqual(instance.quantity.unit, "count")  # type: ignore[union-attr]
+        self.assertEqual(instance.quantity.to("count").magnitude, Decimal("3"))  # type: ignore[union-attr]
+
     def test_descriptor_falls_back_to_base_unit_for_unknown_stored_unit(self):
         self.instance.length_value = Decimal("5")  # type: ignore
         self.instance.length_unit = "not_a_unit"  # type: ignore


### PR DESCRIPTION
## Summary
- Add a dedicated piece-count unit family so `Measurement(..., "count")` no longer collapses to `dimensionless` during scalar arithmetic.
- Preserve `count` as GeneralManager's public unit spelling across `Measurement`, `MeasurementField`, dataframe docs, and GraphQL measurement resolvers.
- Add regression coverage for scalar operations, weighted averages, field round trips, quantity exposure, pickling, and GraphQL output.

## Root Cause
Pint treats its built-in `count` unit as dimensionless. With `auto_reduce_dimensions=True`, scalar multiplication/division could reduce `Measurement(..., "count")` to `dimensionless`, unlike custom currency units.

## Validation
- `python -m pytest tests/unit/test_measurement.py tests/unit/test_measurement_field.py tests/unit/test_dataframe_measurements.py tests/unit/test_graph_ql.py::MeasurementTypeTests tests/unit/test_graph_ql.py::GraphQLTests::test_create_resolver_measurement_case tests/unit/test_graph_ql.py::GraphQLTests::test_create_resolver_measurement_count_uses_public_unit -q`
- `ruff check src/general_manager/measurement/measurement.py src/general_manager/measurement/measurement_field.py src/general_manager/api/graphql_errors.py src/general_manager/api/graphql_resolvers.py tests/unit/test_measurement.py tests/unit/test_measurement_field.py tests/unit/test_graph_ql.py`
- `mypy src/general_manager/measurement/measurement.py src/general_manager/measurement/measurement_field.py src/general_manager/api/graphql_errors.py src/general_manager/api/graphql_resolvers.py`

Fixes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discrete item quantities now consistently display as **`count`** across measurements, storage, and GraphQL responses.
  * Arithmetic on count-based values now preserves the count unit, including averaging and scalar operations.
  * Measurement comparisons and hashing behavior are clarified to better match equivalent base units.

* **Documentation**
  * Updated guides to explain count handling, unit normalization, and how measurement units are shown in exports and API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->