### PR TITLE
feat: expose structured GraphQL validation errors

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -145,13 +145,22 @@ are not `GraphQLPermissionCapability` instances are ignored.
 Generated GraphQL resolvers convert handled manager exceptions through the
 shared error mapper. Existing `GraphQLError` instances are returned unchanged,
 preserving object identity and the full existing `extensions` mapping. Converted
-errors use an `extensions` mapping with a single `code` key. `PermissionError`
-becomes `PERMISSION_DENIED`; Django `ValidationError` and plain `ValueError`
-become `BAD_USER_INPUT`; `TypeError`, `AttributeError`, `RuntimeError`,
-`LookupError`, and other handled internal exceptions currently become
-`INTERNAL_SERVER_ERROR`. The original exception text remains the GraphQL error
-message for compatibility. These lower-level helper details document current
-generated-resolver behavior, not stable direct-import guarantees.
+errors always include an `extensions.code` value. `PermissionError` becomes
+`PERMISSION_DENIED`; plain `ValueError` and unstructured Django
+`ValidationError` become `BAD_USER_INPUT`; `TypeError`, `AttributeError`,
+`RuntimeError`, `LookupError`, and other handled internal exceptions currently
+become `INTERNAL_SERVER_ERROR`. Non-structured converted exceptions keep
+`str(error)` as the GraphQL message, preserving current Django
+`ValidationError` message formatting.
+
+When Django `ValidationError` instances have `message_dict`, mutation errors use
+the generic message `Validation failed.` and include structured details in
+`extensions.fieldErrors` and `extensions.nonFieldErrors`. Generated mutations
+use schema-aware input field names, so a Python/Django field such as
+`project_phase_type` is reported as `projectPhaseType`, and relation raw-id
+implementation keys such as `customer_id` are reported as their exposed GraphQL
+input field, such as `customer`. Decorator-created mutations map structured
+validation field keys with `snake_to_camel`.
 
 ::: general_manager.api.graphql_view.GeneralManagerGraphQLView
 

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -69,6 +69,7 @@ from general_manager.api.graphql_errors import (
     EXPECTED_MANAGER_ERRORS,  # noqa: F401  # re-exported
     SUSPICIOUS_MANAGER_ERRORS,  # noqa: F401  # re-exported
     HANDLED_MANAGER_ERRORS as HANDLED_MANAGER_ERRORS,
+    ValidationFieldNameMapper,
     MeasurementType as MeasurementType,
     MeasurementScalar as MeasurementScalar,
     PageInfo,
@@ -1512,9 +1513,13 @@ class GraphQL:
         )
 
     @staticmethod
-    def _handle_graph_ql_error(error: Exception) -> GraphQLError:
+    def _handle_graph_ql_error(
+        error: Exception,
+        *,
+        field_name_mapper: ValidationFieldNameMapper | None = None,
+    ) -> GraphQLError:
         """Thin wrapper - see :func:`general_manager.api.graphql_errors.handle_graph_ql_error`."""
-        return _handle_graph_ql_error_fn(error)
+        return _handle_graph_ql_error_fn(error, field_name_mapper=field_name_mapper)
 
     @classmethod
     def _handle_data_change(

--- a/src/general_manager/api/graphql_errors.py
+++ b/src/general_manager/api/graphql_errors.py
@@ -9,7 +9,7 @@ without introducing circular dependencies.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Protocol, TypeAlias, TypedDict, cast
 
 from graphql import GraphQLError
 from graphql.language import ast
-from django.core.exceptions import ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 
 from general_manager.logging import get_logger
 from general_manager.measurement.measurement import Measurement
@@ -83,6 +83,8 @@ PermissionFilterPlan: TypeAlias = list[PermissionConstraint]
 ReadPermissionPlanMethod: TypeAlias = Callable[[], object]
 BigIntCoercible: TypeAlias = str | bytes | bytearray | int | float | Decimal
 GraphQLSubscriptionAction: TypeAlias = str
+ValidationFieldNameMapper: TypeAlias = Callable[[str], str]
+ValidationFieldErrors: TypeAlias = dict[str, list[str]]
 
 
 class _ReadPermissionProvider(Protocol):
@@ -438,30 +440,76 @@ def map_field_to_graphene_base_type(
         return String
 
 
-def handle_graph_ql_error(error: Exception) -> GraphQLError:
-    """Convert an exception into a GraphQL error with an extensions code.
+def _validation_messages_to_strings(messages: object) -> list[str]:
+    """Convert Django validation message values to plain strings."""
+    if isinstance(messages, ValidationError):
+        return [str(message) for message in messages.messages]
+    if isinstance(messages, str):
+        return [messages]
+    if isinstance(messages, bytes):
+        return [messages.decode()]
+    if isinstance(messages, Iterable):
+        return [str(message) for message in messages]
+    return [str(messages)]
+
+
+def _build_validation_error_extensions(
+    message_dict: Mapping[str, object],
+    *,
+    field_name_mapper: ValidationFieldNameMapper | None,
+) -> dict[str, object]:
+    """Convert validation messages into GraphQL BAD_USER_INPUT extensions.
+
+    Per-field keys are remapped with ``field_name_mapper`` when provided.
+    ``NON_FIELD_ERRORS`` messages are separated into ``nonFieldErrors`` and are
+    not remapped. The returned mapping always includes ``code``,
+    ``fieldErrors``, and ``nonFieldErrors`` keys.
+    """
+    field_errors: ValidationFieldErrors = {}
+    non_field_errors: list[str] = []
+
+    for field_name, messages in message_dict.items():
+        message_list = _validation_messages_to_strings(messages)
+        if field_name == NON_FIELD_ERRORS:
+            non_field_errors.extend(message_list)
+            continue
+
+        schema_field_name = (
+            field_name_mapper(field_name)
+            if field_name_mapper is not None
+            else field_name
+        )
+        field_errors.setdefault(schema_field_name, []).extend(message_list)
+
+    return {
+        "code": "BAD_USER_INPUT",
+        "fieldErrors": field_errors,
+        "nonFieldErrors": non_field_errors,
+    }
+
+
+def handle_graph_ql_error(
+    error: Exception,
+    *,
+    field_name_mapper: ValidationFieldNameMapper | None = None,
+) -> GraphQLError:
+    """Convert a handled exception into a GraphQL error.
 
     This private extracted helper is used by the canonical GraphQL module and is
     not a stable import path. The behavior documented here is a
     generated-resolver compatibility note, not a stable direct-import guarantee.
 
     Explicit ``GraphQLError`` instances are returned as the same object,
-    preserving their message and entire existing ``extensions`` mapping. For
-    converted exceptions, the returned ``GraphQLError.extensions`` mapping
-    contains a single ``"code"`` key. The original exception message is
-    intentionally exposed as the GraphQL error message; this is a stable
-    generated-response compatibility guarantee for
-    ``{"code": "INTERNAL_SERVER_ERROR"}`` responses as well as user-error
-    responses, even though the helper itself remains a private import.
-    ``PermissionError`` uses ``{"code": "PERMISSION_DENIED"}`` and is
-    logged at info level. ``ValueError`` and Django ``ValidationError`` use
-    ``{"code": "BAD_USER_INPUT"}`` and are logged as warnings. ``TypeError``,
-    ``AttributeError``, and ``RuntimeError`` are treated as suspicious handled
-    errors, logged with traceback information, and returned as
-    ``{"code": "INTERNAL_SERVER_ERROR"}``. Exceptions outside those explicit
-    branches are logged as unexpected internal errors and also returned as
-    ``INTERNAL_SERVER_ERROR``. Logging level/category is diagnostic behavior of
-    the internal ``api.graphql`` logger and is not a public API contract.
+    preserving their message and existing ``extensions`` mapping. Converted
+    exceptions always include an ``extensions["code"]`` value. Django
+    ``ValidationError`` instances with ``message_dict`` use
+    ``"Validation failed."`` with ``BAD_USER_INPUT`` plus ``fieldErrors`` and
+    ``nonFieldErrors``. When ``field_name_mapper`` is provided, it maps
+    ``message_dict`` field keys before they are emitted in ``fieldErrors``;
+    non-field errors are not mapped. Other converted exceptions keep their
+    original message and category-specific code. Logging level/category is
+    diagnostic behavior of the internal ``api.graphql`` logger and is not a
+    public API contract.
     """
     message = str(error)
     error_name = type(error).__name__
@@ -477,7 +525,21 @@ def handle_graph_ql_error(error: Exception) -> GraphQLError:
             context={"error": error_name, "message": message},
         )
         return GraphQLError(message, extensions={"code": "PERMISSION_DENIED"})
-    elif isinstance(error, (ValueError, ValidationError)):
+    elif isinstance(error, ValidationError):
+        logger.warning(
+            "graphql user error",
+            context={"error": error_name, "message": message},
+        )
+        if hasattr(error, "error_dict"):
+            return GraphQLError(
+                "Validation failed.",
+                extensions=_build_validation_error_extensions(
+                    error.message_dict,
+                    field_name_mapper=field_name_mapper,
+                ),
+            )
+        return GraphQLError(message, extensions={"code": "BAD_USER_INPUT"})
+    elif isinstance(error, ValueError):
         logger.warning(
             "graphql user error",
             context={"error": error_name, "message": message},

--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -20,6 +20,7 @@ from django.db.models import NOT_PROVIDED
 from general_manager.interface.base_interface import AttributeTypedDict, InterfaceBase
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.utils.type_checks import safe_issubclass
+from general_manager.utils.format_string import snake_to_camel
 from general_manager.api.graphql_errors import (
     HANDLED_MANAGER_ERRORS,
     MissingManagerIdentifierError,
@@ -119,6 +120,35 @@ def _normalize_mutation_kwargs_for_manager(
                 normalized.pop(key, None)
 
     return normalized
+
+
+def _graphql_mutation_field_name(
+    general_manager_class: type[GeneralManager],
+    field_name: str,
+) -> str:
+    interface_cls = getattr(general_manager_class, "Interface", None)
+    if interface_cls is None:
+        return snake_to_camel(field_name)
+
+    attribute_types = interface_cls.get_attribute_types()
+
+    if field_name.endswith("_id_list"):
+        relation_name = f"{field_name.removesuffix('_id_list')}_list"
+        relation_info = attribute_types.get(relation_name)
+        if relation_info is not None and safe_issubclass(
+            relation_info["type"], GeneralManager
+        ):
+            return snake_to_camel(relation_name)
+
+    if field_name.endswith("_id"):
+        relation_name = field_name.removesuffix("_id")
+        relation_info = attribute_types.get(relation_name)
+        if relation_info is not None and safe_issubclass(
+            relation_info["type"], GeneralManager
+        ):
+            return snake_to_camel(relation_name)
+
+    return snake_to_camel(field_name)
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +313,12 @@ def generate_create_mutation_class(
                 create_kwargs["history_comment"] = history_comment
                 instance = create(**create_kwargs)
         except HANDLED_MANAGER_ERRORS as error:
-            raise handle_graph_ql_error(error) from error
+            raise handle_graph_ql_error(
+                error,
+                field_name_mapper=lambda field_name: _graphql_mutation_field_name(
+                    generalManagerClass, field_name
+                ),
+            ) from error
         return {"success": True, generalManagerClass.__name__: instance}
 
     return type(
@@ -361,7 +396,12 @@ def generate_update_mutation_class(
                 update_kwargs["history_comment"] = history_comment
                 instance = update(**update_kwargs)
         except HANDLED_MANAGER_ERRORS as error:
-            raise handle_graph_ql_error(error) from error
+            raise handle_graph_ql_error(
+                error,
+                field_name_mapper=lambda field_name: _graphql_mutation_field_name(
+                    generalManagerClass, field_name
+                ),
+            ) from error
         return {"success": True, generalManagerClass.__name__: instance}
 
     return type(
@@ -440,7 +480,12 @@ def generate_delete_mutation_class(
                     history_comment=history_comment,
                 )
         except HANDLED_MANAGER_ERRORS as error:
-            raise handle_graph_ql_error(error) from error
+            raise handle_graph_ql_error(
+                error,
+                field_name_mapper=lambda field_name: _graphql_mutation_field_name(
+                    generalManagerClass, field_name
+                ),
+            ) from error
         return {"success": True, generalManagerClass.__name__: None}
 
     return type(

--- a/src/general_manager/api/mutation.py
+++ b/src/general_manager/api/mutation.py
@@ -480,7 +480,10 @@ def graph_ql_mutation(
                 data["success"] = True
                 return mutation_class(**data)
             except HANDLED_MANAGER_ERRORS as error:
-                raise GraphQL._handle_graph_ql_error(error) from error
+                raise GraphQL._handle_graph_ql_error(
+                    error,
+                    field_name_mapper=snake_to_camel,
+                ) from error
 
         # Assemble class dict
         class_dict: GrapheneFieldMap = {

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -5,8 +5,9 @@ from unittest import mock
 
 import pytest
 import graphene  # type: ignore[import]
-from graphql import GraphQLError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.test import SimpleTestCase
+from graphql import GraphQLError
 from graphql import parse
 from graphql.language.ast import (
     FragmentDefinitionNode,
@@ -36,6 +37,7 @@ from general_manager.permission.base_permission import (
     BasePermission,
     ReadPermissionPlan,
 )
+from general_manager.utils.format_string import snake_to_camel
 from general_manager.api.graphql_resolvers import (
     apply_grouping,
     apply_pagination,
@@ -458,6 +460,52 @@ class GraphQLHelperTests(SimpleTestCase):
         error = GraphQLError("explicit", extensions={"code": "CUSTOM"})
 
         assert GraphQL._handle_graph_ql_error(error) is error
+
+    def test_handle_graphql_error_structures_validation_message_dict(self) -> None:
+        error = GraphQL._handle_graph_ql_error(
+            ValidationError(
+                {
+                    "project_phase_type": ["This field cannot be null."],
+                    NON_FIELD_ERRORS: ["Project dates overlap."],
+                }
+            ),
+            field_name_mapper=snake_to_camel,
+        )
+
+        assert error.message == "Validation failed."
+        assert error.extensions == {
+            "code": "BAD_USER_INPUT",
+            "fieldErrors": {
+                "projectPhaseType": ["This field cannot be null."],
+            },
+            "nonFieldErrors": ["Project dates overlap."],
+        }
+
+    def test_handle_graphql_error_preserves_field_names_without_mapper(self) -> None:
+        error = GraphQL._handle_graph_ql_error(
+            ValidationError(
+                {
+                    "project_phase_type": ["This field cannot be null."],
+                }
+            ),
+        )
+
+        assert error.message == "Validation failed."
+        assert error.extensions == {
+            "code": "BAD_USER_INPUT",
+            "fieldErrors": {
+                "project_phase_type": ["This field cannot be null."],
+            },
+            "nonFieldErrors": [],
+        }
+
+    def test_handle_graphql_error_preserves_unstructured_validation_behavior(
+        self,
+    ) -> None:
+        error = GraphQL._handle_graph_ql_error(ValidationError("bad data"))
+
+        assert error.extensions == {"code": "BAD_USER_INPUT"}
+        assert error.message == "['bad data']"
 
     def test_apply_permission_filters_enforces_instance_read_gate(self) -> None:
         class AdminOnlyPermission(BasePermission):

--- a/tests/unit/test_mutation.py
+++ b/tests/unit/test_mutation.py
@@ -1,6 +1,7 @@
 from typing import Optional, List, ClassVar
 
 import graphene
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser, User
 
@@ -84,6 +85,76 @@ class SingleInputGM(GeneralManager):
 
 # Required because the dummy handle_interface hook does not attach Interface.
 SingleInputGM.Interface = SingleInputInterface
+
+
+class ValidationInputInterface(DummyInterface):
+    input_fields: ClassVar[dict] = {}
+
+    @classmethod
+    def get_attribute_types(cls):
+        return {
+            "project_phase_type": {
+                "type": str,
+                "is_required": False,
+                "default": None,
+                "is_derived": False,
+                "is_editable": True,
+            },
+            "customer": {
+                "type": SingleInputGM,
+                "is_required": False,
+                "default": None,
+                "is_derived": False,
+                "is_editable": True,
+                "relation_kind": "direct",
+            },
+            "member_list": {
+                "type": SingleInputGM,
+                "is_required": False,
+                "default": None,
+                "is_derived": False,
+                "is_editable": True,
+            },
+        }
+
+
+class ValidationInputGM(GeneralManager):
+    class Interface(ValidationInputInterface):
+        pass
+
+    @classmethod
+    def create(cls, **kwargs):
+        if "member_id_list" in kwargs:
+            raise ValidationError({"member_id_list": ["Members are required."]})
+        raise ValidationError(
+            {
+                "project_phase_type": ["This field cannot be null."],
+                "customer_id": ["Customer is required."],
+                NON_FIELD_ERRORS: ["Project dates overlap."],
+            }
+        )
+
+
+ValidationInputGM.Interface = ValidationInputInterface
+
+
+class ValidationMutationGM(GeneralManager):
+    class Interface(ValidationInputInterface):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        _ = args, kwargs
+
+    def update(self, **kwargs):
+        _ = kwargs
+        raise ValidationError({"customer_id": ["Customer is required."]})
+
+    def delete(self, **kwargs):
+        _ = kwargs
+        raise ValidationError({"customer_id": ["Customer is required."]})
+
+
+ValidationMutationGM.Interface = ValidationInputInterface
 
 
 class MultiInputInterface(DummyInterface):
@@ -270,6 +341,172 @@ class MutationDecoratorTests(TestCase):
             mutation.mutate(None, info, item="not-an-int")
 
         self.assertEqual(ctx.exception.extensions["code"], "BAD_USER_INPUT")
+
+    def test_decorator_mutation_validation_errors_use_schema_argument_names(self):
+        @graph_ql_mutation()
+        def validate_project(info, project_phase_type: str) -> str:
+            _ = info, project_phase_type
+            raise ValidationError(
+                {
+                    "project_phase_type": ["This field cannot be null."],
+                    NON_FIELD_ERRORS: ["Project dates overlap."],
+                }
+            )
+
+        mutation = GraphQL._mutations["validateProject"]
+        info = type("Info", (), {"context": type("Ctx", (), {"user": object()})()})
+
+        with self.assertRaises(GraphQLError) as ctx:
+            mutation.mutate(None, info, project_phase_type="")
+
+        self.assertEqual(ctx.exception.message, "Validation failed.")
+        self.assertEqual(
+            ctx.exception.extensions,
+            {
+                "code": "BAD_USER_INPUT",
+                "fieldErrors": {
+                    "projectPhaseType": ["This field cannot be null."],
+                },
+                "nonFieldErrors": ["Project dates overlap."],
+            },
+        )
+
+    def test_generated_create_mutation_validation_errors_use_schema_field_names(self):
+        mutation = GraphQL.generate_create_mutation_class(ValidationInputGM, {})
+        info = type(
+            "Info",
+            (),
+            {
+                "context": type(
+                    "Ctx",
+                    (),
+                    {"user": type("User", (), {"id": 42})()},
+                )()
+            },
+        )()
+
+        with self.assertRaises(GraphQLError) as ctx:
+            mutation.mutate(
+                None,
+                info,
+                project_phase_type=None,
+                customer="7",
+            )
+
+        self.assertEqual(ctx.exception.message, "Validation failed.")
+        self.assertEqual(
+            ctx.exception.extensions,
+            {
+                "code": "BAD_USER_INPUT",
+                "fieldErrors": {
+                    "projectPhaseType": ["This field cannot be null."],
+                    "customer": ["Customer is required."],
+                },
+                "nonFieldErrors": ["Project dates overlap."],
+            },
+        )
+
+    def test_generated_create_mutation_validation_errors_use_schema_list_field_names(
+        self,
+    ):
+        mutation = GraphQL.generate_create_mutation_class(ValidationInputGM, {})
+        info = type(
+            "Info",
+            (),
+            {
+                "context": type(
+                    "Ctx",
+                    (),
+                    {"user": type("User", (), {"id": 42})()},
+                )()
+            },
+        )()
+
+        with self.assertRaises(GraphQLError) as ctx:
+            mutation.mutate(
+                None,
+                info,
+                member_list=["7"],
+            )
+
+        self.assertEqual(ctx.exception.message, "Validation failed.")
+        self.assertEqual(
+            ctx.exception.extensions,
+            {
+                "code": "BAD_USER_INPUT",
+                "fieldErrors": {
+                    "memberList": ["Members are required."],
+                },
+                "nonFieldErrors": [],
+            },
+        )
+
+    def test_generated_update_mutation_validation_errors_use_schema_field_names(self):
+        mutation = GraphQL.generate_update_mutation_class(ValidationMutationGM, {})
+        info = type(
+            "Info",
+            (),
+            {
+                "context": type(
+                    "Ctx",
+                    (),
+                    {"user": type("User", (), {"id": 42})()},
+                )()
+            },
+        )()
+
+        with self.assertRaises(GraphQLError) as ctx:
+            mutation.mutate(
+                None,
+                info,
+                id="99",
+                customer="7",
+            )
+
+        self.assertEqual(ctx.exception.message, "Validation failed.")
+        self.assertEqual(
+            ctx.exception.extensions,
+            {
+                "code": "BAD_USER_INPUT",
+                "fieldErrors": {
+                    "customer": ["Customer is required."],
+                },
+                "nonFieldErrors": [],
+            },
+        )
+
+    def test_generated_delete_mutation_validation_errors_use_schema_field_names(self):
+        mutation = GraphQL.generate_delete_mutation_class(ValidationMutationGM, {})
+        info = type(
+            "Info",
+            (),
+            {
+                "context": type(
+                    "Ctx",
+                    (),
+                    {"user": type("User", (), {"id": 42})()},
+                )()
+            },
+        )()
+
+        with self.assertRaises(GraphQLError) as ctx:
+            mutation.mutate(
+                None,
+                info,
+                id="99",
+            )
+
+        self.assertEqual(ctx.exception.message, "Validation failed.")
+        self.assertEqual(
+            ctx.exception.extensions,
+            {
+                "code": "BAD_USER_INPUT",
+                "fieldErrors": {
+                    "customer": ["Customer is required."],
+                },
+                "nonFieldErrors": [],
+            },
+        )
 
     def test_list_argument(self):
         @graph_ql_mutation()


### PR DESCRIPTION
## Summary
- Expose Django `ValidationError.message_dict` as structured GraphQL `BAD_USER_INPUT` metadata with `fieldErrors` and `nonFieldErrors`.
- Map validation field keys to schema-facing GraphQL names for generated mutations and `@graph_ql_mutation` handlers.
- Document the new error contract and preserve existing behavior for unstructured validation errors and plain `ValueError`s.

## Test Plan
- `python -m pytest -q`
- `python -m pytest tests/unit/test_graphql_helpers.py tests/unit/test_mutation.py -q`
- `ruff check src/general_manager/api/graphql_errors.py src/general_manager/api/graphql.py src/general_manager/api/graphql_mutations.py src/general_manager/api/mutation.py tests/unit/test_graphql_helpers.py tests/unit/test_mutation.py`
- `ruff format --check src/general_manager/api/graphql_errors.py src/general_manager/api/graphql.py src/general_manager/api/graphql_mutations.py src/general_manager/api/mutation.py tests/unit/test_graphql_helpers.py tests/unit/test_mutation.py`

Closes #333.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL conversion of Django validation errors is now more consistent, returning structured `extensions` with `code`.
  * Field-specific vs. non-field validation details are separated into dedicated `fieldErrors` and `nonFieldErrors`.
  * Mutation validation error field names now align with schema-facing (camelCase) input names, including related and list inputs.
* **Documentation**
  * Updated GraphQL API docs to describe the standardized error shape and validation error behavior.
* **Tests**
  * Expanded test coverage for structured validation errors and schema-based field name mapping in mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->