### PR TITLE
perf: cache callback invocation plans

### DIFF
--- a/src/general_manager/manager/input.py
+++ b/src/general_manager/manager/input.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import calendar
 import builtins
+import functools
 import inspect
+import threading
+import weakref
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from datetime import date, datetime
+from itertools import islice
+from types import FunctionType, MappingProxyType, MethodType
 from decimal import Decimal
 from typing import TYPE_CHECKING, Generic, Protocol, TypeVar, cast
 
@@ -73,6 +78,172 @@ class InvalidDateRangeError(ValueError):
         super().__init__(messages[reason])
 
 
+@dataclass(frozen=True)
+class _CallableInvocationPlan:
+    """Immutable argument-routing metadata for one callback signature."""
+
+    parameters: tuple[tuple[int, str], ...]
+
+
+@dataclass(frozen=True)
+class _CompiledCallableInvocation:
+    """One reflection result, retained only for the current invocation."""
+
+    plan: _CallableInvocationPlan | None
+    parameters: tuple[inspect.Parameter, ...]
+
+
+_CALLABLE_INVOCATION_PLAN_MISSING = object()
+_callable_invocation_plan_cache: dict[
+    int,
+    tuple[
+        weakref.ReferenceType[Callable[..., object]],
+        _CallableInvocationPlan,
+    ],
+] = {}
+_callable_invocation_plan_cache_lock = threading.Lock()
+
+
+def _remove_stale_callable_invocation_plans_locked() -> None:
+    """Drop a bounded number of dead weak-reference entries."""
+
+    for callback_id, entry in tuple(islice(_callable_invocation_plan_cache.items(), 8)):
+        if (
+            entry[0]() is None
+            and _callable_invocation_plan_cache.get(callback_id) is entry
+        ):
+            del _callable_invocation_plan_cache[callback_id]
+
+
+def _callable_invocation_requires_uncached_plan(func: Callable[..., object]) -> bool:
+    """Reject explicit or mutable decorator metadata from the cache."""
+
+    candidates: list[object] = [func]
+    seen_ids: set[int] = set()
+    for candidate in candidates:
+        if id(candidate) in seen_ids:
+            continue
+        seen_ids.add(id(candidate))
+        try:
+            signature = inspect.getattr_static(
+                candidate,
+                "__signature__",
+                _CALLABLE_INVOCATION_PLAN_MISSING,
+            )
+        except (AttributeError, TypeError, RuntimeError):
+            return True
+        if signature is not _CALLABLE_INVOCATION_PLAN_MISSING:
+            return True
+        try:
+            wrapped = inspect.getattr_static(
+                candidate,
+                "__wrapped__",
+                _CALLABLE_INVOCATION_PLAN_MISSING,
+            )
+        except (AttributeError, TypeError, RuntimeError):
+            return True
+        # ``__wrapped__`` is mutable and may be a descriptor.  Treating every
+        # wrapper as uncached preserves inspect.signature's live semantics.
+        if wrapped is not _CALLABLE_INVOCATION_PLAN_MISSING:
+            return True
+        if type(candidate) is MethodType:
+            candidates.append(candidate.__func__)
+        elif type(candidate) is functools.partial:
+            candidates.append(candidate.func)
+        elif type(candidate) not in (FunctionType, MethodType, functools.partial):
+            try:
+                call_method = inspect.getattr_static(
+                    type(candidate),
+                    "__call__",
+                    _CALLABLE_INVOCATION_PLAN_MISSING,
+                )
+            except (AttributeError, TypeError, RuntimeError):
+                return True
+            if call_method is not _CALLABLE_INVOCATION_PLAN_MISSING:
+                if type(call_method) not in (
+                    FunctionType,
+                    MethodType,
+                    functools.partial,
+                ):
+                    return True
+                candidates.append(call_method)
+    return False
+
+
+def _compile_callable_invocation_plan(
+    func: Callable[..., object],
+) -> _CompiledCallableInvocation:
+    """Compile immutable routing metadata, retaining safe fallback metadata."""
+
+    signature = inspect.signature(func)
+    raw_parameters = tuple(signature.parameters.values())
+    if type(signature) is not inspect.Signature:
+        return _CompiledCallableInvocation(None, raw_parameters)
+    if type(signature.parameters) is not MappingProxyType:
+        return _CompiledCallableInvocation(None, raw_parameters)
+
+    parameter_kind_type = type(inspect.Parameter.POSITIONAL_ONLY)
+    routing_parameters: list[tuple[int, str]] = []
+    for parameter in raw_parameters:
+        if (
+            type(parameter) is not inspect.Parameter
+            or type(parameter.name) is not str
+            or type(parameter.kind) is not parameter_kind_type
+        ):
+            return _CompiledCallableInvocation(None, raw_parameters)
+        routing_parameters.append((int(parameter.kind), parameter.name))
+    return _CompiledCallableInvocation(
+        _CallableInvocationPlan(tuple(routing_parameters)),
+        raw_parameters,
+    )
+
+
+def _get_callable_invocation_plan(
+    func: Callable[..., object],
+) -> _CallableInvocationPlan | _CompiledCallableInvocation:
+    """Return a cached plan when callback identity and metadata are safe."""
+
+    callback_id = id(func)
+    requires_uncached_signature = _callable_invocation_requires_uncached_plan(func)
+
+    with _callable_invocation_plan_cache_lock:
+        _remove_stale_callable_invocation_plans_locked()
+        current_entry = _callable_invocation_plan_cache.get(callback_id)
+        if current_entry is not None:
+            current_callback = current_entry[0]()
+            if current_callback is func and not requires_uncached_signature:
+                return current_entry[1]
+            if _callable_invocation_plan_cache.get(callback_id) is current_entry:
+                del _callable_invocation_plan_cache[callback_id]
+
+    try:
+        weakref.ref(func)
+    except TypeError:
+        return _compile_callable_invocation_plan(func)
+
+    compiled = _compile_callable_invocation_plan(func)
+    if compiled.plan is None or requires_uncached_signature:
+        return compiled
+
+    def remove_dead_entry(
+        reference: weakref.ReferenceType[Callable[..., object]],
+        *,
+        callback_id: int = callback_id,
+    ) -> None:
+        with _callable_invocation_plan_cache_lock:
+            current_entry = _callable_invocation_plan_cache.get(callback_id)
+            if current_entry is not None and current_entry[0] is reference:
+                del _callable_invocation_plan_cache[callback_id]
+
+    reference = weakref.ref(func, remove_dead_entry)
+    with _callable_invocation_plan_cache_lock:
+        current_entry = _callable_invocation_plan_cache.get(callback_id)
+        if current_entry is not None and current_entry[0]() is func:
+            return current_entry[1]
+        _callable_invocation_plan_cache[callback_id] = (reference, compiled.plan)
+    return compiled.plan
+
+
 def _invoke_callable(
     func: Callable[..., object],
     /,
@@ -81,8 +252,61 @@ def _invoke_callable(
 ) -> object:
     """Invoke a callback with only the arguments its signature accepts."""
 
-    signature = inspect.signature(func)
-    parameters = list(signature.parameters.values())
+    compiled = _get_callable_invocation_plan(func)
+    if isinstance(compiled, _CompiledCallableInvocation):
+        if compiled.plan is None:
+            return _invoke_callable_with_parameters(
+                func,
+                compiled.parameters,
+                *args,
+                **kwargs,
+            )
+        plan = compiled.plan
+    else:
+        plan = compiled
+
+    positional_args = list(args)
+    bound_args: list[object] = []
+    bound_kwargs: dict[str, object] = {}
+    remaining_kwargs = dict(kwargs)
+
+    for parameter_kind, parameter_name in plan.parameters:
+        if parameter_kind == inspect.Parameter.POSITIONAL_ONLY:
+            if positional_args:
+                bound_args.append(positional_args.pop(0))
+            continue
+        if parameter_kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
+            if positional_args:
+                bound_args.append(positional_args.pop(0))
+                remaining_kwargs.pop(parameter_name, None)
+                continue
+            if parameter_name in remaining_kwargs:
+                bound_kwargs[parameter_name] = remaining_kwargs.pop(parameter_name)
+            continue
+        if parameter_kind == inspect.Parameter.KEYWORD_ONLY:
+            if parameter_name in remaining_kwargs:
+                bound_kwargs[parameter_name] = remaining_kwargs.pop(parameter_name)
+            continue
+        if parameter_kind == inspect.Parameter.VAR_POSITIONAL:
+            bound_args.extend(positional_args)
+            positional_args.clear()
+            continue
+        if parameter_kind == inspect.Parameter.VAR_KEYWORD:
+            bound_kwargs.update(remaining_kwargs)
+            remaining_kwargs.clear()
+
+    return func(*bound_args, **bound_kwargs)
+
+
+def _invoke_callable_with_parameters(
+    func: Callable[..., object],
+    parameters: tuple[inspect.Parameter, ...],
+    /,
+    *args: object,
+    **kwargs: object,
+) -> object:
+    """Invoke a callback using reflection metadata that cannot be cached."""
+
     positional_args = list(args)
     bound_args: list[object] = []
     bound_kwargs: dict[str, object] = {}

--- a/tests/perf/budgets.py
+++ b/tests/perf/budgets.py
@@ -267,4 +267,29 @@ PERF_CEILINGS: dict[str, int] = {
     "CALC_RESULT_CACHE_10000_SECOND_RUN_PROPERTY_CALLS": 10_000,
     "CALC_RESULT_CACHE_10000_FALLBACK_SOURCE_YIELDS": 20_000,
     "CALC_RESULT_CACHE_10000_FALLBACK_CONSTRUCTORS": 0,
+    # Callback invocation-plan reflection workloads.
+    **{
+        f"INPUT_PLAN_{size}_{form}_{metric}": limit
+        for size, invocation_limit in (
+            (100, 100),
+            (1_000, 1_000),
+            (10_000, 10_000),
+        )
+        for form in (
+            "FUNCTION",
+            "INSTANCE",
+            "PARTIAL",
+            "BOUND_METHOD",
+            "DECORATED",
+            "LAMBDA",
+            "NONWEAK",
+        )
+        for metric, limit in (
+            (
+                "INSPECTIONS",
+                1 if form not in {"DECORATED", "NONWEAK"} else invocation_limit,
+            ),
+            ("INVOCATIONS", invocation_limit),
+        )
+    },
 }

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -15,6 +15,7 @@ REQUIRED_BUDGET_WORKLOAD_MODULES = frozenset(
         "test_calculation_bucket_perf.py",
         "test_database_bucket_perf.py",
         "test_group_bucket_perf.py",
+        "test_input_perf.py",
     }
 )
 

--- a/tests/perf/test_input_perf.py
+++ b/tests/perf/test_input_perf.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import functools
+import inspect
+from collections.abc import Callable
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from general_manager.manager.input import _invoke_callable
+from tests.perf.support import PerfBudgets
+
+pytestmark = pytest.mark.perf
+
+CALLBACK_FORMS = (
+    "FUNCTION",
+    "INSTANCE",
+    "PARTIAL",
+    "BOUND_METHOD",
+    "DECORATED",
+    "LAMBDA",
+    "NONWEAK",
+)
+
+
+def _measure_callback_form(size: int, form: str) -> dict[str, int]:
+    calls = 0
+    callback: Callable[..., object]
+    invocation_kwargs: dict[str, object]
+
+    def add_call(value: int, offset: int = 1) -> int:
+        nonlocal calls
+        calls += 1
+        return value + offset
+
+    if form == "FUNCTION":
+        callback = add_call
+        invocation_kwargs = {"offset": 1}
+    elif form == "INSTANCE":
+
+        class InstanceCallback:
+            def __call__(self, value: int, *, offset: int = 1) -> int:
+                return add_call(value, offset)
+
+        callback = InstanceCallback()
+        invocation_kwargs = {"offset": 1}
+    elif form == "PARTIAL":
+
+        def add_partial(left: int, right: int, *, offset: int = 1) -> int:
+            return add_call(left + right, offset)
+
+        callback = functools.partial(add_partial, 0)
+        invocation_kwargs = {"offset": 1}
+    elif form == "BOUND_METHOD":
+
+        class BoundCallback:
+            def add(self, value: int, *, offset: int = 1) -> int:
+                return add_call(value, offset)
+
+        callback = BoundCallback().add
+        invocation_kwargs = {"offset": 1}
+    elif form == "DECORATED":
+        callback_target: Callable[..., object] = add_call
+
+        @functools.wraps(callback_target)
+        def decorated_callback(*args: object, **kwargs: object) -> object:
+            return callback_target(*args, **kwargs)
+
+        callback = decorated_callback
+        invocation_kwargs = {"offset": 1}
+    elif form == "LAMBDA":
+        callback = cast(
+            Callable[..., object],
+            {"callback": lambda value, *, offset=1: add_call(value, offset)}[
+                "callback"
+            ],
+        )
+
+        invocation_kwargs = {"offset": 1}
+    elif form == "NONWEAK":
+
+        class NonWeakCallback:
+            __slots__ = ()
+
+            def __call__(self, value: int) -> int:
+                return add_call(value)
+
+        callback = NonWeakCallback()
+        invocation_kwargs = {}
+    else:
+        raise AssertionError
+
+    original_signature = inspect.signature
+    with patch(
+        "general_manager.manager.input.inspect.signature",
+        wraps=original_signature,
+    ) as signature:
+        result = [
+            cast(
+                int,
+                _invoke_callable(callback, value, **invocation_kwargs),
+            )
+            for value in range(size)
+        ]
+
+    assert sum(result) == size * (size - 1) // 2 + size
+    return {"INSPECTIONS": signature.call_count, "INVOCATIONS": calls}
+
+
+@pytest.mark.parametrize("size", [100, 1_000, 10_000])
+def test_callback_invocation_plan_observations_are_stable(
+    size: int,
+    perf_budgets: PerfBudgets,
+) -> None:
+    observations = {
+        form: [_measure_callback_form(size, form) for _ in range(3)]
+        for form in CALLBACK_FORMS
+    }
+    for form, runs in observations.items():
+        assert runs[0] == runs[1] == runs[2]
+        for name, value in runs[0].items():
+            perf_budgets.assert_observation(f"INPUT_PLAN_{size}_{form}_{name}", value)

--- a/tests/perf/test_perf_support.py
+++ b/tests/perf/test_perf_support.py
@@ -24,6 +24,7 @@ REQUIRED_BUDGET_WORKLOAD_MODULES = {
     "test_calculation_bucket_perf.py",
     "test_database_bucket_perf.py",
     "test_group_bucket_perf.py",
+    "test_input_perf.py",
 }
 
 

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -1019,6 +1019,57 @@ class TestInput(TestCase):
         self.assertIsNot(plan, stale_plan)
         input_module._callable_invocation_plan_cache.pop(id(first), None)
 
+        signature = inspect.signature(callback)
+        with patch.object(input_module, "MappingProxyType", dict):
+            mutable_metadata = input_module._compile_callable_invocation_plan(callback)
+        self.assertIsNone(mutable_metadata.plan)
+
+        signature._parameters = MappingProxyType({"value": object()})
+        with patch.object(input_module.inspect, "signature", return_value=signature):
+            malformed_parameter = input_module._compile_callable_invocation_plan(
+                callback
+            )
+        self.assertIsNone(malformed_parameter.plan)
+
+        class DeadCallback:
+            def __call__(self, value):
+                return value
+
+        dead = DeadCallback()
+        dead_id = id(dead)
+        dead_reference = weakref.ref(dead)
+        del dead
+        gc.collect()
+        input_module._callable_invocation_plan_cache[dead_id] = (
+            dead_reference,
+            stale_plan,
+        )
+        input_module._get_callable_invocation_plan(callback)
+        self.assertNotIn(dead_id, input_module._callable_invocation_plan_cache)
+
+        winning_plan = input_module._CallableInvocationPlan(())
+        input_module._callable_invocation_plan_cache.pop(id(callback), None)
+        original_compile = input_module._compile_callable_invocation_plan
+
+        def compile_and_publish(func):
+            compiled = original_compile(func)
+            input_module._callable_invocation_plan_cache[id(func)] = (
+                weakref.ref(func),
+                winning_plan,
+            )
+            return compiled
+
+        with patch.object(
+            input_module,
+            "_compile_callable_invocation_plan",
+            side_effect=compile_and_publish,
+        ):
+            self.assertIs(
+                input_module._get_callable_invocation_plan(callback),
+                winning_plan,
+            )
+        input_module._callable_invocation_plan_cache.pop(id(callback), None)
+
     def test_input_from_manager_query_with_filter_dict(self):
         class MockManager:
             @classmethod

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -1035,40 +1035,40 @@ class TestInput(TestCase):
             def __call__(self, value):
                 return value
 
-        dead = DeadCallback()
-        dead_id = id(dead)
-        dead_reference = weakref.ref(dead)
-        del dead
-        gc.collect()
-        input_module._callable_invocation_plan_cache[dead_id] = (
-            dead_reference,
-            stale_plan,
-        )
-        input_module._get_callable_invocation_plan(callback)
-        self.assertNotIn(dead_id, input_module._callable_invocation_plan_cache)
+        cache = input_module._callable_invocation_plan_cache
+        saved_cache = dict(cache)
+        cache.clear()
+        try:
+            dead = DeadCallback()
+            dead_id = id(dead)
+            dead_reference = weakref.ref(dead)
+            del dead
+            gc.collect()
+            cache[dead_id] = (dead_reference, stale_plan)
+            input_module._get_callable_invocation_plan(callback)
+            self.assertNotIn(dead_id, cache)
 
-        winning_plan = input_module._CallableInvocationPlan(())
-        input_module._callable_invocation_plan_cache.pop(id(callback), None)
-        original_compile = input_module._compile_callable_invocation_plan
+            winning_plan = input_module._CallableInvocationPlan(())
+            cache.pop(id(callback), None)
+            original_compile = input_module._compile_callable_invocation_plan
 
-        def compile_and_publish(func):
-            compiled = original_compile(func)
-            input_module._callable_invocation_plan_cache[id(func)] = (
-                weakref.ref(func),
-                winning_plan,
-            )
-            return compiled
+            def compile_and_publish(func):
+                compiled = original_compile(func)
+                cache[id(func)] = (weakref.ref(func), winning_plan)
+                return compiled
 
-        with patch.object(
-            input_module,
-            "_compile_callable_invocation_plan",
-            side_effect=compile_and_publish,
-        ):
-            self.assertIs(
-                input_module._get_callable_invocation_plan(callback),
-                winning_plan,
-            )
-        input_module._callable_invocation_plan_cache.pop(id(callback), None)
+            with patch.object(
+                input_module,
+                "_compile_callable_invocation_plan",
+                side_effect=compile_and_publish,
+            ):
+                self.assertIs(
+                    input_module._get_callable_invocation_plan(callback),
+                    winning_plan,
+                )
+        finally:
+            cache.clear()
+            cache.update(saved_cache)
 
     def test_input_from_manager_query_with_filter_dict(self):
         class MockManager:

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -6,7 +6,7 @@ import gc
 import inspect
 import weakref
 from concurrent.futures import ThreadPoolExecutor
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 from unittest.mock import patch
 
 from general_manager.manager import input as input_module
@@ -967,6 +967,57 @@ class TestInput(TestCase):
         )
         del second
         gc.collect()
+
+    def test_invocation_plan_guards_cover_dynamic_metadata_and_stale_entries(self):
+        def callback(value):
+            return value
+
+        with patch.object(
+            input_module.inspect,
+            "getattr_static",
+            side_effect=RuntimeError("metadata unavailable"),
+        ):
+            self.assertTrue(
+                input_module._callable_invocation_requires_uncached_plan(callback)
+            )
+
+        class NonWeakCallback:
+            __slots__ = ()
+
+            def __call__(self, value):
+                return value
+
+        non_weak = NonWeakCallback()
+        self.assertFalse(
+            input_module._callable_invocation_requires_uncached_plan(non_weak)
+        )
+        self.assertEqual(input_module._invoke_callable(non_weak, 3), 3)
+
+        fake_signature = SimpleNamespace(parameters=MappingProxyType({}))
+        with patch.object(
+            input_module.inspect,
+            "signature",
+            return_value=fake_signature,
+        ):
+            compiled = input_module._compile_callable_invocation_plan(callback)
+        self.assertIsNone(compiled.plan)
+        self.assertEqual(compiled.parameters, ())
+
+        def first(value):
+            return value
+
+        def second(value):
+            return value + 1
+
+        stale_plan = input_module._CallableInvocationPlan(())
+        input_module._callable_invocation_plan_cache[id(first)] = (
+            weakref.ref(second),
+            stale_plan,
+        )
+        plan = input_module._get_callable_invocation_plan(first)
+        self.assertIsInstance(plan, input_module._CallableInvocationPlan)
+        self.assertIsNot(plan, stale_plan)
+        input_module._callable_invocation_plan_cache.pop(id(first), None)
 
     def test_input_from_manager_query_with_filter_dict(self):
         class MockManager:

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -1,8 +1,15 @@
 from django.test import TestCase
 from decimal import Decimal
 from datetime import timedelta
+import functools
+import gc
+import inspect
+import weakref
+from concurrent.futures import ThreadPoolExecutor
 from types import MappingProxyType
 from unittest.mock import patch
+
+from general_manager.manager import input as input_module
 from general_manager.cache.run_context import CalculationRunContext
 from general_manager.manager.input import (
     DateRangeDomain,
@@ -641,6 +648,325 @@ class TestInput(TestCase):
         result_arg, result_kwargs = _invoke_callable(capture, 1, a=1, b=2)
         self.assertEqual(result_arg, 1)
         self.assertEqual(result_kwargs, {"b": 2})
+
+    def test_invoke_callable_routes_every_parameter_kind_and_defaults(self):
+        def capture(
+            positional_only,
+            positional_or_keyword=2,
+            /,
+            *values,
+            keyword_only,
+            optional=7,
+            **keywords,
+        ):
+            return (
+                positional_only,
+                positional_or_keyword,
+                values,
+                keyword_only,
+                optional,
+                keywords,
+            )
+
+        self.assertEqual(
+            _invoke_callable(
+                capture,
+                1,
+                3,
+                4,
+                5,
+                keyword_only=6,
+                optional=8,
+                extra=9,
+            ),
+            (1, 3, (4, 5), 6, 8, {"extra": 9}),
+        )
+        self.assertEqual(
+            _invoke_callable(capture, 1, keyword_only=6),
+            (1, 2, (), 6, 7, {}),
+        )
+
+    def test_invoke_callable_preserves_missing_argument_and_exception_behavior(self):
+        def requires_value(value):
+            return value
+
+        with self.assertRaises(TypeError):
+            _invoke_callable(requires_value)
+
+        def raises(value):
+            raise ValueError(value)
+
+        with self.assertRaisesRegex(ValueError, "boom"):
+            _invoke_callable(raises, "boom")
+
+    def test_invoke_callable_does_not_cache_mutable_wrapped_callbacks(self):
+        def first_target(value):
+            return value
+
+        target = first_target
+
+        def wrapper(*args, **kwargs):
+            return target(*args, **kwargs)
+
+        wrapper.__wrapped__ = target
+        self.assertEqual(_invoke_callable(wrapper, 1), 1)
+
+        def second_target(value, extra):
+            return value + extra
+
+        target = second_target
+        wrapper.__wrapped__ = target
+        self.assertEqual(_invoke_callable(wrapper, 1, 2), 3)
+
+    def test_invoke_callable_descriptor_wrapped_metadata_is_uncached(self):
+        def first_target(value):
+            return value
+
+        def second_target(value, extra):
+            return value + extra
+
+        class Callback:
+            target = staticmethod(first_target)
+
+            @property
+            def __wrapped__(self):
+                return self.target
+
+            def __call__(self, *args, **kwargs):
+                return self.target(*args, **kwargs)
+
+        callback = Callback()
+        self.assertEqual(_invoke_callable(callback, 1), 1)
+        callback.target = second_target
+        self.assertEqual(_invoke_callable(callback, 1, 2), 3)
+
+    def test_invoke_callable_reuses_compiled_signature_plan(self):
+        def capture(value, *, suffix="!"):
+            return f"{value}{suffix}"
+
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            wraps=__import__("inspect").signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(capture, "ok"), "ok!")
+            self.assertEqual(_invoke_callable(capture, "ready", suffix="?"), "ready?")
+
+        self.assertEqual(signature.call_count, 1)
+
+    def test_invoke_callable_caches_callable_instances_without_hashing(self):
+        class Callback:
+            __hash__ = None
+
+            def __eq__(self, other):
+                raise AssertionError
+
+            def __call__(self, value):
+                return value + 1
+
+        callback = Callback()
+        original_signature = inspect.signature
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            wraps=original_signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(callback, 1), 2)
+            self.assertEqual(_invoke_callable(callback, 2), 3)
+
+        self.assertEqual(signature.call_count, 1)
+
+    def test_invoke_callable_caches_partial_and_bound_method_callbacks(self):
+        def add(left, right):
+            return left + right
+
+        partial = functools.partial(add, 2)
+
+        class Callback:
+            def add(self, left, right):
+                return left + right
+
+        bound_method = Callback().add
+        original_signature = inspect.signature
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            wraps=original_signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(partial, 3), 5)
+            self.assertEqual(_invoke_callable(partial, 4), 6)
+            self.assertEqual(_invoke_callable(bound_method, 3, right=4), 7)
+            self.assertEqual(_invoke_callable(bound_method, 4, right=5), 9)
+
+        self.assertEqual(signature.call_count, 2)
+
+    def test_invoke_callable_explicit_signature_is_always_reflected(self):
+        def capture(value):
+            return value
+
+        capture.__signature__ = inspect.signature(capture)
+        original_signature = inspect.signature
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            wraps=original_signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(capture, "first"), "first")
+            self.assertEqual(_invoke_callable(capture, "second"), "second")
+
+        self.assertEqual(signature.call_count, 2)
+
+    def test_invoke_callable_decorator_with_explicit_wrapped_signature_is_uncached(
+        self,
+    ):
+        def original(value):
+            return value
+
+        original.__signature__ = inspect.signature(original)
+
+        @functools.wraps(original)
+        def decorated(value):
+            return original(value)
+
+        original_signature = inspect.signature
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            wraps=original_signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(decorated, "first"), "first")
+            self.assertEqual(_invoke_callable(decorated, "second"), "second")
+
+        self.assertEqual(signature.call_count, 2)
+
+    def test_invoke_callable_bound_method_underlying_signature_is_uncached(self):
+        class Callback:
+            def capture(self, value):
+                return value
+
+        Callback.capture.__signature__ = inspect.signature(Callback.capture)
+        callback = Callback().capture
+        original_signature = inspect.signature
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            wraps=original_signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(callback, "first"), "first")
+            self.assertEqual(_invoke_callable(callback, "second"), "second")
+
+        self.assertEqual(signature.call_count, 2)
+
+    def test_invoke_callable_partial_underlying_signature_is_uncached(self):
+        def capture(prefix, value):
+            return f"{prefix}{value}"
+
+        capture.__signature__ = inspect.signature(capture)
+        callback = functools.partial(capture, "item:")
+        original_signature = inspect.signature
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            wraps=original_signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(callback, 1), "item:1")
+            self.assertEqual(_invoke_callable(callback, 2), "item:2")
+
+        self.assertEqual(signature.call_count, 2)
+
+    def test_invoke_callable_custom_signature_metadata_is_uncached(self):
+        def callback(value):
+            return value
+
+        class CustomSignature(inspect.Signature):
+            pass
+
+        standard_signature = inspect.signature(callback)
+        custom_signature = CustomSignature(
+            parameters=tuple(standard_signature.parameters.values())
+        )
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            return_value=custom_signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(callback, "first"), "first")
+            self.assertEqual(_invoke_callable(callback, "second"), "second")
+
+        self.assertEqual(signature.call_count, 2)
+
+    def test_invoke_callable_non_weak_callback_is_not_cached(self):
+        class Callback:
+            __slots__ = ()
+
+            def __call__(self, value):
+                return value * 2
+
+        callback = Callback()
+        original_signature = inspect.signature
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            wraps=original_signature,
+        ) as signature:
+            self.assertEqual(_invoke_callable(callback, 2), 4)
+            self.assertEqual(_invoke_callable(callback, 3), 6)
+
+        self.assertEqual(signature.call_count, 2)
+
+    def test_invoke_callable_signature_failure_is_not_cached(self):
+        def callback(value):
+            return value
+
+        with patch(
+            "general_manager.manager.input.inspect.signature",
+            side_effect=RuntimeError("signature unavailable"),
+        ) as signature:
+            with self.assertRaisesRegex(RuntimeError, "signature unavailable"):
+                _invoke_callable(callback, 1)
+            with self.assertRaisesRegex(RuntimeError, "signature unavailable"):
+                _invoke_callable(callback, 2)
+
+        self.assertEqual(signature.call_count, 2)
+
+    def test_invoke_callable_concurrent_cache_access_keeps_results_correct(self):
+        def callback(value):
+            return value * 2
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(
+                executor.map(lambda value: _invoke_callable(callback, value), range(20))
+            )
+
+        self.assertEqual(results, [value * 2 for value in range(20)])
+
+    def test_dead_callable_plan_entry_is_removed_after_collection(self):
+        def callback(value):
+            return value
+
+        callback_id = id(callback)
+        _invoke_callable(callback, 1)
+        self.assertIn(callback_id, input_module._callable_invocation_plan_cache)
+        del callback
+        gc.collect()
+        self.assertNotIn(callback_id, input_module._callable_invocation_plan_cache)
+
+    def test_dead_callable_cleanup_does_not_remove_replacement_entry(self):
+        class Callback:
+            def __call__(self, value):
+                return value
+
+        first = Callback()
+        _invoke_callable(first, 1)
+        first_id = id(first)
+        first_entry = input_module._callable_invocation_plan_cache[first_id]
+
+        second = Callback()
+        second_reference = weakref.ref(second)
+        input_module._callable_invocation_plan_cache[first_id] = (
+            second_reference,
+            first_entry[1],
+        )
+        del first
+        gc.collect()
+
+        self.assertIs(
+            input_module._callable_invocation_plan_cache[first_id][0],
+            second_reference,
+        )
+        del second
+        gc.collect()
 
     def test_input_from_manager_query_with_filter_dict(self):
         class MockManager:


### PR DESCRIPTION
## Summary
Cache compiled private invocation plans for `Input._invoke_callable()` so repeated provider, normalizer, validator, range, and manager-query callbacks avoid repeated signature reflection without changing the public API.

## Motivation
Dynamic calculation domains can invoke the same callback once per dependency combination. Rebuilding `inspect.signature()` metadata and the routing loop on every call adds avoidable hot-path overhead.

## Proposed implementation
- Compile immutable positional/keyword parameter metadata on safe callback identities.
- Use an id-keyed weak-reference cache with identity-only matching, dead-entry cleanup, bounded stale sweeping, and a lock limited to map operations.
- Fail closed for non-weak callbacks, explicit or mutable signature metadata, mutable `__wrapped__` decorators/descriptors, unsupported/custom metadata, and inspection failures; these paths retain live uncached `inspect.signature()` behavior.
- Preserve positional-only, positional-or-keyword, keyword-only, variadic, duplicate-removal, defaults, missing-value, and exception behavior.

## Verification
- Focused callback unit/performance/manifest suite: `131 passed`.
- Full suite: `5308 passed, 2 skipped, 1 warning`.
- `ruff check`, `ruff format --check`, `mypy`, `pre-commit run --all-files`, and `git diff --check` passed.
- Deterministic perf gates at 100/1,000/10,000 calls cover functions, callable instances, partials, bound methods, decorated fallback callbacks, lambdas, and non-weak fallback callbacks. Cacheable forms inspect once per run; fallback forms preserve one inspection per invocation; three-run maps are identical.

## Scope and follow-up
This PR is intentionally limited to private callback reflection metadata. No public API or callback result caching changes are included.

Closes #342
References #336, #341