### PR TITLE
perf: batch direct relation hydration

### DIFF
--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -36,6 +36,7 @@ ORM_BUCKET_INDEX_PREFIX = "orm_bucket_index"
 ORM_BUCKET_MEMBERSHIP_PREFIX = "orm_bucket_membership"
 ORM_MODEL_ROW_INDEX_PREFIX = "orm_model_row_index"
 ORM_MODEL_RELATION_PREFETCH_PREFIX = "orm_model_relation_prefetch"
+ORM_DIRECT_RELATION_PREFETCH_PREFIX = "orm_direct_relation_prefetch"
 ORM_RELATION_MANAGER_PREFIX = "orm_relation_manager"
 ORM_QUERY_BUCKET_PREFIX = "orm_query_bucket"
 ORM_BUCKET_EXISTS_PREFIX = "orm_bucket_exists"
@@ -442,6 +443,44 @@ class CalculationRunContext:
         )
         self.set(cache_key, prefetched | frozenset(row_keys))
 
+    def get_orm_direct_relation_prefetched_keys(
+        self,
+        model: type[object],
+        database_alias: Hashable | None,
+        accessor_name: str,
+    ) -> frozenset[OrmModelRowKey]:
+        """Return source rows already processed for direct relation hydration."""
+        prefetched = self.get(
+            (
+                ORM_DIRECT_RELATION_PREFETCH_PREFIX,
+                model,
+                database_alias,
+                accessor_name,
+            )
+        )
+        if isinstance(prefetched, frozenset):
+            return cast(frozenset[OrmModelRowKey], prefetched)
+        return frozenset()
+
+    def add_orm_direct_relation_prefetched_keys(
+        self,
+        model: type[object],
+        database_alias: Hashable | None,
+        accessor_name: str,
+        row_keys: Iterable[OrmModelRowKey],
+    ) -> None:
+        """Mark source rows processed for direct relation hydration."""
+        cache_key = (
+            ORM_DIRECT_RELATION_PREFETCH_PREFIX,
+            model,
+            database_alias,
+            accessor_name,
+        )
+        prefetched = self.get(cache_key)
+        if not isinstance(prefetched, frozenset):
+            prefetched = frozenset()
+        self.set(cache_key, prefetched | frozenset(row_keys))
+
     def get_orm_relation_manager(self, key: Hashable) -> object:
         """Return a cached relation manager for key, or `None` when absent."""
         return self.get((ORM_RELATION_MANAGER_PREFIX, key))
@@ -570,6 +609,7 @@ class CalculationRunContext:
         self.discard_prefix((ORM_BUCKET_MEMBERSHIP_PREFIX,))
         self.discard_prefix((ORM_MODEL_ROW_INDEX_PREFIX,))
         self.discard_prefix((ORM_MODEL_RELATION_PREFETCH_PREFIX,))
+        self.discard_prefix((ORM_DIRECT_RELATION_PREFETCH_PREFIX,))
         self.discard_prefix((ORM_RELATION_MANAGER_PREFIX,))
         self.discard_prefix((ORM_QUERY_BUCKET_PREFIX,))
         self.discard_prefix((ORM_BUCKET_EXISTS_PREFIX,))

--- a/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
+++ b/src/general_manager/interface/capabilities/orm_utils/field_descriptors.py
@@ -298,6 +298,7 @@ class _FieldDescriptorBuilder:
                     field.name,
                     general_manager_class,
                     raw_id_name=raw_id_name,
+                    related_model=related_model,
                 )
                 relation_type = cast(type[object], general_manager_class)
             else:
@@ -347,7 +348,9 @@ class _FieldDescriptorBuilder:
             )
             if general_manager_class:
                 accessor = _general_manager_accessor(
-                    accessor_name, general_manager_class
+                    accessor_name,
+                    general_manager_class,
+                    related_model=related_model,
                 )
                 relation_type = cast(type[object], general_manager_class)
             else:
@@ -795,11 +798,188 @@ _MISSING_RELATED = object()
 _MANY_RELATION_PREFETCH_CHUNK_SIZE = 1000
 
 
+def _direct_relation_prefetch_source_rows(
+    context: object,
+    source_instance: models.Model,
+    database_alias: Hashable | None,
+) -> (
+    tuple[
+        tuple[Hashable, Hashable | None],
+        type[models.Model],
+        list[models.Model],
+    ]
+    | None
+):
+    """Return the indexed source rows eligible for one direct relation batch."""
+    source_identity = _orm_row_identity(source_instance)
+    if source_identity is None:
+        return None
+    get_items = getattr(context, "get_orm_model_row_items", None)
+    if not callable(get_items):
+        return None
+    row_items = get_items(source_instance.__class__)
+    if not row_items:
+        return None
+    rows: list[models.Model] = []
+    for row_key, row in row_items:
+        if row_key[1] != database_alias or not isinstance(
+            row, source_instance.__class__
+        ):
+            continue
+        if getattr(row, "get_deferred_fields", lambda: set())():
+            return None
+        rows.append(row)
+    if not rows:
+        return None
+    return source_identity, source_instance.__class__, rows
+
+
+def _can_prefetch_direct_relation(
+    interface_instance: OrmInterfaceInstance,
+    manager_type: type["GeneralManager"],
+    related_model: type[models.Model] | None,
+    database_alias: Hashable | None,
+) -> bool:
+    """Return whether direct relation hydration can safely use trusted rows."""
+    if (
+        related_model is None
+        or getattr(interface_instance, "_search_date", None) is not None
+    ):
+        return False
+    from general_manager.manager.general_manager import GeneralManager
+    from general_manager.interface.orm_interface import OrmInterfaceBase
+
+    interface_cls = getattr(manager_type, "Interface", None)
+    interface_model = getattr(interface_cls, "_model", None)
+    if interface_model is not related_model:
+        return False
+    configured_database = getattr(interface_cls, "database", None)
+    if configured_database is not None and configured_database != database_alias:
+        return False
+    if bool(getattr(getattr(interface_model, "_meta", None), "use_soft_delete", False)):
+        return False
+    if bool(getattr(interface_cls, "_soft_delete_default", False)):
+        return False
+    if manager_type.__init__ is not GeneralManager.__init__:
+        return False
+    if getattr(interface_cls, "__init__", None) is not OrmInterfaceBase.__init__:
+        return False
+    return callable(getattr(manager_type, "_from_trusted_orm_instance", None))
+
+
+def _prefetch_direct_relation_managers(
+    interface_instance: OrmInterfaceInstance,
+    *,
+    accessor_name: str,
+    manager_type: type["GeneralManager"],
+    related_model: type[models.Model] | None,
+    raw_id_name: str | None,
+) -> bool:
+    """Bulk-hydrate safe direct relations for all indexed source rows."""
+    from general_manager.cache.run_context import current_calculation_run_context
+
+    context = current_calculation_run_context()
+    source_instance = getattr(interface_instance, "_instance", None)
+    if context is None or not isinstance(source_instance, models.Model):
+        return False
+    state = getattr(source_instance, "_state", None)
+    database_alias = getattr(state, "db", None)
+    if not _can_prefetch_direct_relation(
+        interface_instance,
+        manager_type,
+        related_model,
+        database_alias,
+    ):
+        return False
+    if related_model is None:
+        return False
+    source_data = _direct_relation_prefetch_source_rows(
+        context,
+        source_instance,
+        database_alias,
+    )
+    if source_data is None:
+        return False
+    source_identity, source_model, rows = source_data
+    prefetched = context.get_orm_direct_relation_prefetched_keys(
+        source_model,
+        database_alias,
+        accessor_name,
+    )
+    if source_identity in prefetched:
+        return True
+    rows_to_process = [
+        row for row in rows if (_orm_row_identity(row) not in prefetched)
+    ]
+    if not rows_to_process:
+        return True
+    trusted_hydrate = cast(
+        Callable[..., object],
+        manager_type._from_trusted_orm_instance,
+    )
+    relation_cache_keys = []
+    if raw_id_name is not None:
+        related_ids = {
+            getattr(row, raw_id_name, None)
+            for row in rows_to_process
+            if getattr(row, raw_id_name, None) is not None
+        }
+        if related_ids:
+            related_manager = related_model._default_manager
+            if database_alias is not None:
+                related_manager = related_manager.using(database_alias)
+            related_rows = related_manager.in_bulk(related_ids)
+            for related_row in related_rows.values():
+                manager = trusted_hydrate(related_row)
+                related_identity = _orm_row_identity(related_row)
+                if related_identity is None:
+                    continue
+                relation_cache_keys.append(
+                    (manager_type, related_identity[0], related_identity[1])
+                )
+                context.set_orm_relation_manager(
+                    relation_cache_keys[-1],
+                    manager,
+                )
+    else:
+        _prefetch_relation_in_chunks(rows_to_process, accessor_name)
+        for row in rows_to_process:
+            try:
+                related_row = getattr(row, accessor_name)
+            except ObjectDoesNotExist:
+                continue
+            if related_row is None:
+                continue
+            manager = trusted_hydrate(related_row)
+            related_identity = _orm_row_identity(related_row)
+            if related_identity is None:
+                continue
+            relation_cache_keys.append(
+                (manager_type, related_identity[0], related_identity[1])
+            )
+            context.set_orm_relation_manager(
+                relation_cache_keys[-1],
+                manager,
+            )
+    context.add_orm_direct_relation_prefetched_keys(
+        source_model,
+        database_alias,
+        accessor_name,
+        [
+            identity
+            for identity in (_orm_row_identity(row) for row in rows_to_process)
+            if identity is not None
+        ],
+    )
+    return True
+
+
 def _general_manager_accessor(
     field_name: str,
     manager_class: type[object],
     *,
     raw_id_name: str | None = None,
+    related_model: type[models.Model] | None = None,
 ) -> DescriptorAccessor:
     """
     Create an accessor that resolves a related object's manager from an interface.
@@ -814,18 +994,61 @@ def _general_manager_accessor(
         field_name (str): Name of the attribute on the underlying model that holds the related object.
         manager_class (type): Class used to hydrate or construct the related manager.
         raw_id_name (str | None): Optional raw foreign-key attribute name used to avoid loading the relation.
+        related_model (type[models.Model] | None): Related ORM model used for
+            conservative run-scoped bulk hydration.
 
     Returns:
         DescriptorAccessor: A callable that, given a OrmInterfaceBase, returns the manager instance for the related object, or `None` if the related attribute is `None`.
     """
     manager_type = cast("type[GeneralManager]", manager_class)
 
-    def raw_id_manager(raw_id: object, database_alias: object) -> object:
+    def related_manager_from_instance(related: models.Model) -> object:
+        from general_manager.cache.run_context import current_calculation_run_context
+
+        context = current_calculation_run_context()
+        identity = _orm_row_identity(related)
+        if context is not None and identity is not None:
+            cache_key = (manager_type, identity[0], identity[1])
+            cached = context.get_orm_relation_manager(cast(Hashable, cache_key))
+            if isinstance(cached, manager_type):
+                track_own = getattr(
+                    cached,
+                    "_track_own_identification_dependency_active",
+                    None,
+                )
+                if callable(track_own) and DependencyTracker.is_active():
+                    track_own()
+                return cached
+        trusted_hydrate = getattr(manager_type, "_from_trusted_orm_instance", None)
+        if callable(trusted_hydrate):
+            manager = trusted_hydrate(related)
+        else:
+            manager = manager_type(related.pk)
+        if context is not None and identity is not None:
+            context.set_orm_relation_manager(
+                cast(Hashable, (manager_type, identity[0], identity[1])),
+                manager,
+            )
+        return manager
+
+    def raw_id_manager(
+        raw_id: object,
+        database_alias: object,
+        interface_instance: OrmInterfaceInstance,
+    ) -> object:
         from general_manager.cache.run_context import current_calculation_run_context
 
         context = current_calculation_run_context()
         if context is None:
             return manager_type(raw_id)
+
+        _prefetch_direct_relation_managers(
+            interface_instance,
+            accessor_name=field_name,
+            manager_type=manager_type,
+            related_model=related_model,
+            raw_id_name=raw_id_name,
+        )
 
         cache_key = (manager_type, raw_id, database_alias)
         try:
@@ -868,24 +1091,25 @@ def _general_manager_accessor(
             fields_cache = getattr(state, "fields_cache", {})
             related = fields_cache.get(field_name, _MISSING_RELATED)
             if related is _MISSING_RELATED:
-                return raw_id_manager(raw_id, database_alias)
+                return raw_id_manager(raw_id, database_alias, self)
             if related is None:
                 return None
-            trusted_hydrate = getattr(manager_type, "_from_trusted_orm_instance", None)
-            if callable(trusted_hydrate):
-                return trusted_hydrate(related)
-            return manager_type(raw_id)
+            return related_manager_from_instance(related)
 
+        _prefetch_direct_relation_managers(
+            self,
+            accessor_name=field_name,
+            manager_type=manager_type,
+            related_model=related_model,
+            raw_id_name=None,
+        )
         try:
             related = getattr(self._instance, field_name)
         except ObjectDoesNotExist:
             return None
         if related is None:
             return None
-        trusted_hydrate = getattr(manager_type, "_from_trusted_orm_instance", None)
-        if callable(trusted_hydrate):
-            return trusted_hydrate(related)
-        return manager_type(related.pk)
+        return related_manager_from_instance(related)
 
     return getter
 

--- a/tests/perf/budgets.py
+++ b/tests/perf/budgets.py
@@ -116,8 +116,8 @@ PERF_CEILINGS: dict[str, int] = {
     "DB_HISTORY_WRITE_100_QUERIES": 600,
     "DB_HISTORY_WRITE_100_CALLBACKS": 100,
     # Calculation run-cache invalidation workloads.
-    "RUN_CACHE_MIXED_500_DISCARD_CALLS": 34,
-    "RUN_CACHE_MIXED_500_KEY_INSPECTIONS": 85_000,
+    "RUN_CACHE_MIXED_500_DISCARD_CALLS": 36,
+    "RUN_CACHE_MIXED_500_KEY_INSPECTIONS": 95_000,
     # Calculation bucket combination workloads.
     "CALC_STATIC_5X10_COLD_A_YIELDS": 5,
     "CALC_STATIC_5X10_COLD_B_YIELDS": 50,

--- a/tests/perf/test_database_bucket_perf.py
+++ b/tests/perf/test_database_bucket_perf.py
@@ -35,6 +35,7 @@ from general_manager.cache.run_context import (
     ORM_BUCKET_LAST_ROW_PREFIX,
     ORM_BUCKET_RESULT_PREFIX,
     ORM_BUCKET_ROW_RESULT_PREFIX,
+    ORM_DIRECT_RELATION_PREFETCH_PREFIX,
     ORM_MODEL_RELATION_PREFETCH_PREFIX,
     ORM_MODEL_ROW_INDEX_PREFIX,
     ORM_QUERY_BUCKET_PREFIX,
@@ -83,6 +84,7 @@ RUN_CACHE_PREFIXES = (
     ORM_BUCKET_GET_PREFIX,
     ORM_BUCKET_INDEX_PREFIX,
     ORM_BUCKET_MEMBERSHIP_PREFIX,
+    ORM_DIRECT_RELATION_PREFETCH_PREFIX,
     ORM_MODEL_ROW_INDEX_PREFIX,
     ORM_MODEL_RELATION_PREFETCH_PREFIX,
     ORM_RELATION_MANAGER_PREFIX,
@@ -1246,8 +1248,8 @@ def test_data_change_mixed_run_cache_invalidation_work(
             for key in context._values
             if isinstance(key, tuple) and key and key[0] in RUN_CACHE_PREFIXES
         )
-        assert initial_targeted_count == 8_000
-        assert len(context._values) == 8_500
+        assert initial_targeted_count == 8_500
+        assert len(context._values) == 9_000
 
         phase_snapshots: list[dict[Hashable, object]] = []
         original_discard_prefix = context.discard_prefix

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -494,6 +494,41 @@ def test_orm_bucket_scalar_terminal_helpers_preserve_false_and_clear_entries() -
         )
 
 
+def test_direct_relation_prefetch_keys_are_stored_and_cleared() -> None:
+    with CalculationRunContext() as ctx:
+        assert (
+            ctx.get_orm_direct_relation_prefetched_keys(
+                object,
+                "default",
+                "owner",
+            )
+            == frozenset()
+        )
+        ctx.add_orm_direct_relation_prefetched_keys(
+            object,
+            "default",
+            "owner",
+            [(1, "default")],
+        )
+
+        assert ctx.get_orm_direct_relation_prefetched_keys(
+            object,
+            "default",
+            "owner",
+        ) == frozenset({(1, "default")})
+
+        ctx.clear_orm_bucket_results()
+
+        assert (
+            ctx.get_orm_direct_relation_prefetched_keys(
+                object,
+                "default",
+                "owner",
+            )
+            == frozenset()
+        )
+
+
 def test_orm_bucket_row_results_are_stored_and_cleared() -> None:
     rows = (object(), object())
 

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -18,6 +18,7 @@ from general_manager.interface.capabilities.orm_utils.field_descriptors import (
 )
 from general_manager.bootstrap import initialize_general_manager_classes
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.interface.orm_interface import OrmInterfaceBase
 
 
 def test_general_manager_many_accessor_uses_explicit_relation_field_name() -> None:
@@ -319,6 +320,145 @@ def test_general_manager_fk_accessor_reuses_raw_id_manager_in_run_context() -> N
 
     assert first is second
     assert calls == [7]
+
+
+def test_general_manager_fk_accessor_batches_indexed_related_rows() -> None:
+    class DirectSourceModel(models.Model):
+        owner_id = models.IntegerField(null=True)
+
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class DirectRelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_tests"
+
+    class DirectRelatedInterface:
+        __init__ = OrmInterfaceBase.__init__
+        _model = DirectRelatedModel
+        database = None
+        _soft_delete_default = False
+
+    class DirectRelatedManager:
+        __init__ = GeneralManager.__init__
+        Interface = DirectRelatedInterface
+
+    trusted_managers: list[object] = []
+
+    def trusted_hydrate(
+        cls: type[DirectRelatedManager],
+        instance: DirectRelatedModel,
+        *,
+        search_date: object | None = None,
+    ) -> object:
+        del search_date
+        manager = cls.__new__(cls)
+        trusted_managers.append((instance.pk, manager))
+        return manager
+
+    DirectRelatedManager._from_trusted_orm_instance = classmethod(trusted_hydrate)  # type: ignore[method-assign]
+    source_rows = (
+        DirectSourceModel(id=1, owner_id=7),
+        DirectSourceModel(id=2, owner_id=7),
+    )
+    related_row = DirectRelatedModel(id=7)
+
+    class RelatedObjects:
+        def __init__(self) -> None:
+            self.calls: list[set[object]] = []
+
+        def in_bulk(self, ids: set[object]) -> dict[object, DirectRelatedModel]:
+            self.calls.append(ids)
+            return {7: related_row}
+
+    related_objects = RelatedObjects()
+
+    class RunContext:
+        def __init__(self) -> None:
+            self.relation_managers: dict[object, object] = {}
+            self.prefetched: frozenset[tuple[object, object | None]] = frozenset()
+
+        def get_orm_model_row_items(
+            self,
+            model: type[object],
+        ) -> tuple[tuple[tuple[object, object | None], object], ...]:
+            assert model is DirectSourceModel
+            return tuple(((row.pk, None), row) for row in source_rows)
+
+        def get_orm_direct_relation_prefetched_keys(
+            self,
+            _model: type[object],
+            _database_alias: object | None,
+            _accessor_name: str,
+        ) -> frozenset[tuple[object, object | None]]:
+            return self.prefetched
+
+        def add_orm_direct_relation_prefetched_keys(
+            self,
+            _model: type[object],
+            _database_alias: object | None,
+            _accessor_name: str,
+            row_keys: list[tuple[object, object | None]],
+        ) -> None:
+            self.prefetched = frozenset(row_keys)
+
+        def get_orm_relation_manager(self, key: object) -> object:
+            return self.relation_managers.get(key)
+
+        def set_orm_relation_manager(self, key: object, value: object) -> None:
+            self.relation_managers[key] = value
+
+    run_context = RunContext()
+    accessor = _general_manager_accessor(
+        "owner",
+        DirectRelatedManager,
+        raw_id_name="owner_id",
+        related_model=DirectRelatedModel,
+    )
+
+    with (
+        patch(
+            "general_manager.cache.run_context.current_calculation_run_context",
+            return_value=run_context,
+        ),
+        patch.object(DirectRelatedModel._meta, "default_manager", related_objects),
+    ):
+        first = accessor(SimpleNamespace(_instance=source_rows[0]))
+        second = accessor(SimpleNamespace(_instance=source_rows[1]))
+
+    assert first is second
+    assert related_objects.calls == [{7}]
+    assert len(trusted_managers) == 1
+
+    for row in source_rows:
+        row.profile = related_row
+    run_context.prefetched = frozenset()
+
+    reverse_accessor = _general_manager_accessor(
+        "profile",
+        DirectRelatedManager,
+        related_model=DirectRelatedModel,
+    )
+
+    def fake_prefetch(rows: list[models.Model], _accessor_name: str) -> None:
+        for row in rows:
+            row.profile = related_row
+
+    with (
+        patch(
+            "general_manager.cache.run_context.current_calculation_run_context",
+            return_value=run_context,
+        ),
+        patch(
+            "general_manager.interface.capabilities.orm_utils.field_descriptors._prefetch_relation_in_chunks",
+            side_effect=fake_prefetch,
+        ) as prefetch,
+    ):
+        reverse_first = reverse_accessor(SimpleNamespace(_instance=source_rows[0]))
+        reverse_second = reverse_accessor(SimpleNamespace(_instance=source_rows[1]))
+
+    assert reverse_first is reverse_second
+    prefetch.assert_called_once()
 
 
 def test_general_manager_fk_accessor_clears_raw_id_cache_on_data_change() -> None:

--- a/tests/unit/test_field_descriptors.py
+++ b/tests/unit/test_field_descriptors.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 from unittest.mock import Mock, patch
 
 from django.apps import apps
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from general_manager.cache.cache_tracker import DependencyTracker
@@ -12,8 +13,11 @@ from general_manager.cache.run_context import CalculationRunContext
 from general_manager.cache.signals import data_change
 from general_manager.interface.capabilities.orm_utils.field_descriptors import (
     _FieldDescriptorBuilder,
+    _can_prefetch_direct_relation,
+    _direct_relation_prefetch_source_rows,
     _general_manager_accessor,
     _general_manager_many_accessor,
+    _prefetch_direct_relation_managers,
     build_field_descriptors,
 )
 from general_manager.bootstrap import initialize_general_manager_classes
@@ -459,6 +463,517 @@ def test_general_manager_fk_accessor_batches_indexed_related_rows() -> None:
 
     assert reverse_first is reverse_second
     prefetch.assert_called_once()
+
+
+def test_direct_relation_prefetch_helpers_fail_closed_for_unsafe_rows() -> None:
+    class SourceModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_guard_tests"
+
+    class RelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_guard_tests"
+
+    source = SourceModel(id=1)
+
+    class NoRowIndex:
+        pass
+
+    assert _direct_relation_prefetch_source_rows(NoRowIndex(), source, None) is None
+
+    class NonCallableRowIndex:
+        get_orm_model_row_items = 1
+
+    assert (
+        _direct_relation_prefetch_source_rows(NonCallableRowIndex(), source, None)
+        is None
+    )
+
+    class EmptyRowIndex:
+        def get_orm_model_row_items(self, _model: type[object]) -> tuple[object, ...]:
+            return ()
+
+    assert _direct_relation_prefetch_source_rows(EmptyRowIndex(), source, None) is None
+
+    class MismatchedRowIndex:
+        def get_orm_model_row_items(
+            self, _model: type[object]
+        ) -> tuple[tuple[tuple[object, object], object], ...]:
+            return (((1, "replica"), source), ((2, None), object()))
+
+    assert (
+        _direct_relation_prefetch_source_rows(MismatchedRowIndex(), source, None)
+        is None
+    )
+
+    deferred = SourceModel(id=2)
+    deferred.get_deferred_fields = lambda: {"name"}  # type: ignore[method-assign]
+
+    class DeferredRowIndex:
+        def get_orm_model_row_items(
+            self, _model: type[object]
+        ) -> tuple[tuple[tuple[object, object], object], ...]:
+            return (((2, None), deferred),)
+
+    assert (
+        _direct_relation_prefetch_source_rows(DeferredRowIndex(), source, None) is None
+    )
+
+    class RelatedInterface:
+        __init__ = OrmInterfaceBase.__init__
+        _model = RelatedModel
+        database = None
+        _soft_delete_default = False
+
+    class RelatedManager:
+        __init__ = GeneralManager.__init__
+        Interface = RelatedInterface
+
+    RelatedManager._from_trusted_orm_instance = staticmethod(lambda row: row)  # type: ignore[attr-defined]
+    interface_instance = SimpleNamespace(_search_date=None)
+
+    assert not _can_prefetch_direct_relation(
+        interface_instance,
+        RelatedManager,
+        None,
+        None,
+    )
+    interface_instance._search_date = object()
+    assert not _can_prefetch_direct_relation(
+        interface_instance,
+        RelatedManager,
+        RelatedModel,
+        None,
+    )
+    interface_instance._search_date = None
+
+    RelatedManager.Interface._model = SourceModel
+    assert not _can_prefetch_direct_relation(
+        interface_instance,
+        RelatedManager,
+        RelatedModel,
+        None,
+    )
+    RelatedManager.Interface._model = RelatedModel
+    RelatedManager.Interface.database = "replica"
+    assert not _can_prefetch_direct_relation(
+        interface_instance,
+        RelatedManager,
+        RelatedModel,
+        "default",
+    )
+    RelatedManager.Interface.database = None
+
+    with patch.object(RelatedModel._meta, "use_soft_delete", True, create=True):
+        assert not _can_prefetch_direct_relation(
+            interface_instance,
+            RelatedManager,
+            RelatedModel,
+            None,
+        )
+    RelatedManager.Interface._soft_delete_default = True
+    assert not _can_prefetch_direct_relation(
+        interface_instance,
+        RelatedManager,
+        RelatedModel,
+        None,
+    )
+    RelatedManager.Interface._soft_delete_default = False
+
+    class CustomInitManager:
+        Interface = RelatedInterface
+
+        def __init__(self, _pk: object) -> None:
+            pass
+
+    CustomInitManager._from_trusted_orm_instance = staticmethod(lambda row: row)  # type: ignore[attr-defined]
+    assert not _can_prefetch_direct_relation(
+        interface_instance,
+        CustomInitManager,
+        RelatedModel,
+        None,
+    )
+
+    class CustomInterface:
+        def __init__(self) -> None:
+            pass
+
+        _model = RelatedModel
+        database = None
+        _soft_delete_default = False
+
+    class CustomInterfaceManager:
+        __init__ = GeneralManager.__init__
+        Interface = CustomInterface
+
+    CustomInterfaceManager._from_trusted_orm_instance = staticmethod(lambda row: row)  # type: ignore[attr-defined]
+    assert not _can_prefetch_direct_relation(
+        interface_instance,
+        CustomInterfaceManager,
+        RelatedModel,
+        None,
+    )
+
+    class NoTrustedManager:
+        __init__ = GeneralManager.__init__
+        Interface = RelatedInterface
+
+    assert not _can_prefetch_direct_relation(
+        interface_instance,
+        NoTrustedManager,
+        RelatedModel,
+        None,
+    )
+
+    assert _can_prefetch_direct_relation(
+        interface_instance,
+        RelatedManager,
+        RelatedModel,
+        None,
+    )
+
+
+def test_direct_relation_prefetch_handles_cached_and_missing_related_rows() -> None:
+    class SourceModel(models.Model):
+        target_id = models.IntegerField(null=True)
+
+        class Meta:
+            app_label = "field_descriptor_branch_tests"
+
+    class RelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_branch_tests"
+
+    class RelatedInterface:
+        __init__ = OrmInterfaceBase.__init__
+        _model = RelatedModel
+        database = None
+        _soft_delete_default = False
+
+    class RelatedManager:
+        __init__ = GeneralManager.__init__
+        Interface = RelatedInterface
+
+    hydrated: list[object] = []
+
+    def trusted_hydrate(row: RelatedModel) -> object:
+        hydrated.append(row)
+        return object()
+
+    RelatedManager._from_trusted_orm_instance = staticmethod(trusted_hydrate)  # type: ignore[attr-defined]
+    source_rows = (
+        SourceModel(id=1, target_id=7),
+        SourceModel(id=2, target_id=None),
+        SourceModel(id=3, target_id=8),
+    )
+    for row in source_rows:
+        row._state.db = "replica"
+    good_related = RelatedModel(id=7)
+    invalid_related = RelatedModel(id=8)
+    invalid_related.pk = []
+
+    class RelatedObjects:
+        def __init__(self) -> None:
+            self.aliases: list[str] = []
+            self.ids: list[set[object]] = []
+
+        def using(self, alias: str) -> "RelatedObjects":
+            self.aliases.append(alias)
+            return self
+
+        def in_bulk(self, ids: set[object]) -> dict[object, RelatedModel]:
+            self.ids.append(ids)
+            return {7: good_related, 8: invalid_related}
+
+    related_objects = RelatedObjects()
+
+    class RunContext:
+        def __init__(self) -> None:
+            self.prefetched: frozenset[tuple[object, object | None]] = frozenset()
+            self.relation_managers: dict[object, object] = {}
+
+        def get_orm_model_row_items(
+            self, _model: type[object]
+        ) -> tuple[tuple[tuple[object, object | None], SourceModel], ...]:
+            return tuple(((row.pk, row._state.db), row) for row in source_rows)
+
+        def get_orm_direct_relation_prefetched_keys(
+            self,
+            _model: type[object],
+            _database_alias: object | None,
+            _accessor_name: str,
+        ) -> frozenset[tuple[object, object | None]]:
+            return self.prefetched
+
+        def add_orm_direct_relation_prefetched_keys(
+            self,
+            _model: type[object],
+            _database_alias: object | None,
+            _accessor_name: str,
+            row_keys: list[tuple[object, object | None]],
+        ) -> None:
+            self.prefetched = frozenset(row_keys)
+
+        def get_orm_relation_manager(self, key: object) -> object:
+            return self.relation_managers.get(key)
+
+        def set_orm_relation_manager(self, key: object, value: object) -> None:
+            self.relation_managers[key] = value
+
+    context = RunContext()
+    source_interface = SimpleNamespace(_instance=source_rows[0])
+    with (
+        patch(
+            "general_manager.cache.run_context.current_calculation_run_context",
+            return_value=context,
+        ),
+        patch.object(RelatedModel._meta, "default_manager", related_objects),
+    ):
+        assert _prefetch_direct_relation_managers(
+            source_interface,
+            accessor_name="target",
+            manager_type=RelatedManager,
+            related_model=RelatedModel,
+            raw_id_name="target_id",
+        )
+        assert _prefetch_direct_relation_managers(
+            source_interface,
+            accessor_name="target",
+            manager_type=RelatedManager,
+            related_model=RelatedModel,
+            raw_id_name="target_id",
+        )
+
+    assert related_objects.aliases == ["replica"]
+    assert related_objects.ids == [{7, 8}]
+    assert hydrated == [good_related, invalid_related]
+
+    class ReverseSourceModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_branch_tests"
+
+        @property
+        def profile(self) -> object:
+            state = getattr(self, "_profile_state", "missing")
+            if state == "missing":
+                raise ObjectDoesNotExist
+            return getattr(self, "_profile_value", None)
+
+    reverse_rows = (
+        ReverseSourceModel(id=1),
+        ReverseSourceModel(id=2),
+        ReverseSourceModel(id=3),
+        ReverseSourceModel(id=4),
+    )
+    for row in reverse_rows:
+        row._state.db = "replica"
+    reverse_rows[1]._profile_state = "empty"
+    reverse_rows[2]._profile_state = "invalid"
+    invalid_profile = RelatedModel(id=9)
+    invalid_profile.pk = []
+    reverse_rows[2]._profile_value = invalid_profile
+    reverse_rows[3]._profile_state = "good"
+    reverse_rows[3]._profile_value = good_related
+
+    class ReverseContext(RunContext):
+        def get_orm_model_row_items(
+            self, _model: type[object]
+        ) -> tuple[tuple[tuple[object, object | None], ReverseSourceModel], ...]:
+            return tuple(((row.pk, row._state.db), row) for row in reverse_rows)
+
+    reverse_context = ReverseContext()
+    with (
+        patch(
+            "general_manager.cache.run_context.current_calculation_run_context",
+            return_value=reverse_context,
+        ),
+        patch(
+            "general_manager.interface.capabilities.orm_utils.field_descriptors._prefetch_relation_in_chunks"
+        ) as prefetch,
+    ):
+        assert _prefetch_direct_relation_managers(
+            SimpleNamespace(_instance=reverse_rows[0]),
+            accessor_name="profile",
+            manager_type=RelatedManager,
+            related_model=RelatedModel,
+            raw_id_name=None,
+        )
+
+    prefetch.assert_called_once()
+
+
+def test_direct_relation_accessor_preserves_loaded_and_fallback_paths() -> None:
+    class RelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_accessor_tests"
+
+    related = RelatedModel(id=7)
+    tracked: list[bool] = []
+
+    class RelatedManager:
+        def __init__(self, pk: object) -> None:
+            self.pk = pk
+
+        def _track_own_identification_dependency_active(self) -> None:
+            tracked.append(True)
+
+    class Context:
+        def __init__(self) -> None:
+            self.values: dict[object, object] = {}
+
+        def get_orm_relation_manager(self, key: object) -> object:
+            return self.values.get(key)
+
+        def set_orm_relation_manager(self, key: object, value: object) -> None:
+            self.values[key] = value
+
+    context = Context()
+    loaded_accessor = _general_manager_accessor(
+        "owner",
+        RelatedManager,
+        raw_id_name="owner_id",
+    )
+    loaded_source = SimpleNamespace(
+        owner_id=7,
+        _state=SimpleNamespace(db=None, fields_cache={"owner": related}),
+    )
+    with patch(
+        "general_manager.cache.run_context.current_calculation_run_context",
+        return_value=context,
+    ):
+        first = loaded_accessor(SimpleNamespace(_instance=loaded_source))
+        with DependencyTracker():
+            second = loaded_accessor(SimpleNamespace(_instance=loaded_source))
+
+    assert isinstance(first, RelatedManager)
+    assert second is first
+    assert first.pk == 7
+    assert tracked == [True]
+
+    class UnhashableContext(Context):
+        def get_orm_relation_manager(self, _key: object) -> object:
+            raise TypeError
+
+    fallback_accessor = _general_manager_accessor(
+        "owner",
+        RelatedManager,
+        raw_id_name="owner_id",
+    )
+    unhashable_source = SimpleNamespace(
+        owner_id=[],
+        _state=SimpleNamespace(db=None, fields_cache={}),
+    )
+    with patch(
+        "general_manager.cache.run_context.current_calculation_run_context",
+        return_value=UnhashableContext(),
+    ):
+        fallback = fallback_accessor(SimpleNamespace(_instance=unhashable_source))
+
+    assert isinstance(fallback, RelatedManager)
+    assert fallback.pk == []
+
+    assert (
+        loaded_accessor(
+            SimpleNamespace(
+                _instance=SimpleNamespace(
+                    owner_id=None,
+                    _state=SimpleNamespace(fields_cache={}),
+                )
+            )
+        )
+        is None
+    )
+    assert (
+        loaded_accessor(
+            SimpleNamespace(
+                _instance=SimpleNamespace(
+                    owner_id=7,
+                    _state=SimpleNamespace(fields_cache={"owner": None}),
+                )
+            )
+        )
+        is None
+    )
+
+    class MissingReverse:
+        @property
+        def profile(self) -> object:
+            raise ObjectDoesNotExist
+
+    reverse_accessor = _general_manager_accessor("profile", RelatedManager)
+    assert reverse_accessor(SimpleNamespace(_instance=MissingReverse())) is None
+    assert (
+        reverse_accessor(SimpleNamespace(_instance=SimpleNamespace(profile=None)))
+        is None
+    )
+
+
+def test_direct_relation_prefetch_returns_false_without_safe_context_or_admission() -> (
+    None
+):
+    class SourceModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_context_tests"
+
+    class RelatedModel(models.Model):
+        class Meta:
+            app_label = "field_descriptor_context_tests"
+
+    class RelatedManager:
+        def __init__(self, _pk: object) -> None:
+            pass
+
+    interface_instance = SimpleNamespace(_instance=SourceModel(id=1))
+    with patch(
+        "general_manager.cache.run_context.current_calculation_run_context",
+        return_value=None,
+    ):
+        assert not _prefetch_direct_relation_managers(
+            interface_instance,
+            accessor_name="owner",
+            manager_type=RelatedManager,
+            related_model=RelatedModel,
+            raw_id_name="owner_id",
+        )
+
+    with patch(
+        "general_manager.cache.run_context.current_calculation_run_context",
+        return_value=object(),
+    ):
+        assert not _prefetch_direct_relation_managers(
+            SimpleNamespace(_instance=object()),
+            accessor_name="owner",
+            manager_type=RelatedManager,
+            related_model=RelatedModel,
+            raw_id_name="owner_id",
+        )
+
+    class EmptyContext:
+        def get_orm_model_row_items(self, _model: type[object]) -> tuple[object, ...]:
+            return ()
+
+    class SafeInterface:
+        __init__ = OrmInterfaceBase.__init__
+        _model = RelatedModel
+        database = None
+        _soft_delete_default = False
+
+    class SafeManager:
+        __init__ = GeneralManager.__init__
+        Interface = SafeInterface
+
+    SafeManager._from_trusted_orm_instance = staticmethod(lambda row: row)  # type: ignore[attr-defined]
+    with patch(
+        "general_manager.cache.run_context.current_calculation_run_context",
+        return_value=EmptyContext(),
+    ):
+        assert not _prefetch_direct_relation_managers(
+            SimpleNamespace(_instance=SourceModel(id=1)),
+            accessor_name="owner",
+            manager_type=SafeManager,
+            related_model=RelatedModel,
+            raw_id_name="owner_id",
+        )
 
 
 def test_general_manager_fk_accessor_clears_raw_id_cache_on_data_change() -> None:

--- a/tests/unit/test_trusted_enumeration.py
+++ b/tests/unit/test_trusted_enumeration.py
@@ -788,9 +788,9 @@ def test_domain_hostile_state_key_prevents_evidence_without_running_hooks(
     candidate: object,
 ) -> None:
     hostile_key = _HostileStateKey()
-    hostile_key.hash_value = hash("kind")
     source.__dict__.pop("kind")
     cast(dict[object, object], source.__dict__)[hostile_key] = None
+    hostile_key.hash_value = hash("kind")
     hostile_key.callbacks.clear()
     input_field = cast(
         Input[type[object]], Input(type(candidate), possible_values=source)
@@ -819,9 +819,9 @@ def test_domain_hostile_state_key_revokes_evidence_without_running_hooks(
     )
     evidence = _static_evidence(input_field, source, candidate)
     hostile_key = _HostileStateKey()
-    hostile_key.hash_value = hash("kind")
     source.__dict__.pop("kind")
     cast(dict[object, object], source.__dict__)[hostile_key] = None
+    hostile_key.hash_value = hash("kind")
     hostile_key.callbacks.clear()
 
     assert not evidence.authorizes(input_field, candidate, {})


### PR DESCRIPTION
## Problem

Direct foreign-key and reverse one-to-one manager relations can construct one related manager per source row and then issue one related-row query per unique ID. Repeated source rows and repeated accesses amplify the same N+1 work.

## Proposed Solution

- Add a run-scoped direct-relation prefetch marker namespace cleared with ORM mutation caches.
- For trusted, non-history, non-soft-delete, non-deferred source rows, gather indexed rows by database alias and bulk-load forward FK targets with `in_bulk()`.
- Prefetch reverse one-to-one relations in chunks, trusted-hydrate related managers, and seed the existing relation-manager cache.
- Reuse cached related managers and replay identification dependencies on hits.
- Retain lazy fallback behavior for custom constructors/interfaces, historical rows, soft-delete managers, incompatible aliases, missing indexes, and unsupported shapes.

## Alternatives / Workarounds

Callers can add `select_related()` manually, but that over-fetches unused relations and does not cover reverse one-to-one or historical cases consistently. No public API change is proposed.

## Impact

⚙️ Important – significant productivity gain

## References

- Closes #349
- Stacked on `codex/perf-348-scalar-terminal-caches`
- Feature issue: #349

## Verification

- `python -m pytest -q` → 5,354 passed, 2 skipped, 1 warning, 1,984 subtests.
- Focused relation/context/performance suite → 173 passed.
- Ruff, format, mypy, pre-commit, and `git diff --check` all pass.
