### PR TITLE
perf: reuse GroupManager reductions

### DIFF
--- a/src/general_manager/manager/group_manager.py
+++ b/src/general_manager/manager/group_manager.py
@@ -1,7 +1,7 @@
 """Utility manager that aggregates grouped GeneralManager data."""
 
 from __future__ import annotations
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing import Generic, cast, get_args
 from datetime import datetime, date, time
 from general_manager.api.property import GraphQLProperty
@@ -11,6 +11,15 @@ from general_manager.bucket.base_bucket import (
     Bucket,
     GeneralManagerType,
 )
+from general_manager.cache.cache_tracker import DependencyTracker
+from general_manager.cache.dependency_index import Dependency
+
+
+def _is_stable_group_data(data: object) -> bool:
+    """Return whether group entries can be reused across aggregate reads."""
+    return type(data) is tuple or bool(
+        getattr(data, "_group_materialization_safe", False)
+    )
 
 
 def _freeze_manager_value(value: object) -> object:
@@ -84,6 +93,40 @@ class GroupManager(Generic[GeneralManagerType]):
         self._group_by_value = group_by_value
         self._data = data
         self._grouped_data: dict[str, object] = {}
+        self._materialized = _is_stable_group_data(data)
+        self._entries_snapshot: tuple[GeneralManagerType, ...] | None = None
+        self._captured_dependencies: frozenset[Dependency] = frozenset(
+            getattr(data, "_dependencies", ())
+        )
+        self._frozen_entries: frozenset[object] | None = None
+
+    def _replay_dependencies(self) -> None:
+        if self._materialized:
+            DependencyTracker._track_many_validated(self._captured_dependencies)
+
+    def _entries_for_read(self) -> Iterable[GeneralManagerType]:
+        if not self._materialized:
+            return self._data
+        if self._entries_snapshot is None:
+            with DependencyTracker() as captured_dependencies:
+                entries = tuple(self._data)
+            self._entries_snapshot = entries
+            self._captured_dependencies = frozenset(
+                (*self._captured_dependencies, *captured_dependencies)
+            )
+        self._replay_dependencies()
+        return self._entries_snapshot
+
+    def _frozen_entry_values(self) -> frozenset[object]:
+        if self._materialized and self._frozen_entries is not None:
+            self._replay_dependencies()
+            return self._frozen_entries
+        frozen_entries = frozenset(
+            _freeze_manager_value(entry) for entry in self._entries_for_read()
+        )
+        if self._materialized:
+            self._frozen_entries = frozen_entries
+        return frozen_entries
 
     def __hash__(self) -> int:
         """
@@ -104,7 +147,7 @@ class GroupManager(Generic[GeneralManagerType]):
             (
                 self._manager_class,
                 _freeze_manager_value(self._group_by_value),
-                frozenset(_freeze_manager_value(entry) for entry in self._data),
+                self._frozen_entry_values(),
             )
         )
 
@@ -122,8 +165,7 @@ class GroupManager(Generic[GeneralManagerType]):
             isinstance(other, self.__class__)
             and self._manager_class == other._manager_class
             and self._group_by_value == other._group_by_value
-            and frozenset(_freeze_manager_value(entry) for entry in self._data)
-            == frozenset(_freeze_manager_value(entry) for entry in other._data)
+            and self._frozen_entry_values() == other._frozen_entry_values()
         )
 
     def __repr__(self) -> str:
@@ -174,11 +216,19 @@ class GroupManager(Generic[GeneralManagerType]):
             Exception: Exceptions raised while iterating the underlying bucket
                 or reading grouped record attributes propagate unchanged.
         """
-        if item in self._group_by_value:
-            return self._group_by_value[item]
-        if item not in self._grouped_data:
-            self._grouped_data[item] = self.combine_value(item)
-        return self._grouped_data[item]
+        group_by_value = self.__dict__.get("_group_by_value")
+        if group_by_value is None:
+            raise AttributeError(item)
+        if item in group_by_value:
+            return group_by_value[item]
+        grouped_data = self.__dict__.get("_grouped_data")
+        if grouped_data is None:
+            raise AttributeError(item)
+        if item not in grouped_data:
+            grouped_data[item] = self.combine_value(item)
+        else:
+            self._replay_dependencies()
+        return grouped_data[item]
 
     def combine_value(self, item: str) -> object:
         """
@@ -228,43 +278,77 @@ class GroupManager(Generic[GeneralManagerType]):
         if data_type is None or not isinstance(data_type, type):
             raise MissingGroupAttributeError(self.__class__.__name__, item)
 
-        total_data: list[object] = []
-        for entry in self._data:
-            total_data.append(getattr(entry, item))
-
-        new_data: object = None
-        if all(i is None for i in total_data):
-            return new_data
-        total_data = [i for i in total_data if i is not None]
-
+        entries = self._entries_for_read()
         if issubclass(data_type, (Bucket, GeneralManager)):
-            for value in total_data:
+            new_data: object = None
+            for entry in entries:
+                value = getattr(entry, item)
+                if value is None:
+                    continue
                 if new_data is None:
                     new_data = value
                 else:
-                    new_data = value | new_data  # type: ignore[operator]
-        elif issubclass(data_type, list):
+                    new_data = value | new_data
+            return new_data
+        if issubclass(data_type, list):
             list_data: list[object] = []
-            for value in total_data:
-                list_data.extend(cast(list[object], value))
-            new_data = list_data
-        elif issubclass(data_type, dict):
+            saw_value = False
+            for entry in entries:
+                value = getattr(entry, item)
+                if value is not None:
+                    saw_value = True
+                    list_data.extend(cast(list[object], value))
+            return list_data if saw_value else None
+        if issubclass(data_type, dict):
             dict_data: dict[object, object] = {}
-            for value in total_data:
-                dict_data.update(cast(dict[object, object], value))
-            new_data = dict_data
-        elif issubclass(data_type, str):
+            saw_value = False
+            for entry in entries:
+                value = getattr(entry, item)
+                if value is not None:
+                    saw_value = True
+                    dict_data.update(cast(dict[object, object], value))
+            return dict_data if saw_value else None
+        if issubclass(data_type, str):
             text_data: list[str] = []
-            for value in total_data:
+            seen_text: set[str] = set()
+            saw_value = False
+            for entry in entries:
+                value = getattr(entry, item)
+                if value is None:
+                    continue
+                saw_value = True
                 text_value = str(value)
-                if text_value not in text_data:
+                if text_value not in seen_text:
+                    seen_text.add(text_value)
                     text_data.append(text_value)
-            new_data = ", ".join(text_data)
-        elif issubclass(data_type, bool):
-            new_data = any(total_data)
-        elif issubclass(data_type, (int, float, Measurement)):
-            new_data = sum(cast(list[int | float | Measurement], total_data))
-        elif issubclass(data_type, (datetime, date, time)):
-            new_data = max(cast(list[datetime | date | time], total_data))
-
-        return new_data
+            return ", ".join(text_data) if saw_value else None
+        if issubclass(data_type, bool):
+            saw_value = False
+            result = False
+            for entry in entries:
+                value = getattr(entry, item)
+                if value is not None:
+                    saw_value = True
+                    result = result or bool(value)
+            return result if saw_value else None
+        if issubclass(data_type, (int, float, Measurement)):
+            saw_value = False
+            numeric_result: object = 0
+            for entry in entries:
+                value = getattr(entry, item)
+                if value is not None:
+                    saw_value = True
+                    numeric_result = numeric_result + value
+            return numeric_result if saw_value else None
+        if issubclass(data_type, (datetime, date, time)):
+            temporal_result: object = None
+            for entry in entries:
+                value = getattr(entry, item)
+                if value is not None and (
+                    temporal_result is None or value > temporal_result
+                ):
+                    temporal_result = value
+            return temporal_result
+        for entry in entries:
+            getattr(entry, item)
+        return None

--- a/tests/perf/budgets.py
+++ b/tests/perf/budgets.py
@@ -20,6 +20,7 @@ PERF_CEILINGS: dict[str, int] = {
     "GROUP_10000_YIELDS": 10_000,
     "GROUP_10000_CONSTRUCTORS": 10_000,
     "GROUP_10000_FILTER_CALLS": 0,
+    "GROUP_MANAGER_10000_SOURCE_YIELDS": 1,
     # Database bucket terminal-operation workloads.
     "DB_FIRST_999_COLD_QUERIES": 1,
     "DB_FIRST_999_COLD_CONSTRUCTORS": 1,

--- a/tests/perf/test_group_manager_perf.py
+++ b/tests/perf/test_group_manager_perf.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+from general_manager.manager.group_manager import GroupManager
+from tests.perf.support import Counter, PerfBudgets
+
+pytestmark = pytest.mark.perf
+
+ROW_COUNT = 10_000
+
+
+class AggregateInterface:
+    @classmethod
+    def get_attributes(cls) -> dict[str, object]:
+        return {"label": {}, "amount": {}}
+
+    @classmethod
+    def get_attribute_types(cls) -> dict[str, dict[str, object]]:
+        return {"label": {"type": str}, "amount": {"type": int}}
+
+
+class AggregateManager:
+    Interface = AggregateInterface
+
+    def __init__(self, label: str, amount: int) -> None:
+        self.label = label
+        self.amount = amount
+
+
+class CountingMaterializedBucket(list[AggregateManager]):
+    _group_materialization_safe = True
+
+    def __init__(
+        self,
+        values: list[AggregateManager],
+        source_yields: Counter,
+    ) -> None:
+        super().__init__(values)
+        self._source_yields = source_yields
+
+    def __iter__(self) -> Generator[AggregateManager, None, None]:
+        self._source_yields.increment()
+        yield from list.__iter__(self)
+
+
+def test_group_manager_reuses_snapshot_for_aggregates_and_identity(
+    perf_budgets: PerfBudgets,
+) -> None:
+    source_yields = Counter()
+    source = CountingMaterializedBucket(
+        [AggregateManager(f"label-{index % 100}", index) for index in range(ROW_COUNT)],
+        source_yields,
+    )
+    manager = GroupManager(AggregateManager, {}, source)
+
+    labels = manager.label
+    amount = manager.amount
+    hash(manager)
+    hash(manager)
+
+    assert isinstance(labels, str)
+    assert labels.startswith("label-0")
+    assert amount == sum(range(ROW_COUNT))
+    assert source_yields.value == 1
+    perf_budgets.assert_observation(
+        "GROUP_MANAGER_10000_SOURCE_YIELDS", source_yields.value
+    )

--- a/tests/unit/test_group_manager.py
+++ b/tests/unit/test_group_manager.py
@@ -7,7 +7,9 @@ from unittest.mock import patch
 from django.test import TestCase
 from general_manager.api.property import GraphQLProperty
 from general_manager.manager.group_manager import (
+    _freeze_manager_value,
     GroupManager,
+    MissingGroupAttributeError,
 )
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.bucket.base_bucket import Bucket
@@ -601,6 +603,67 @@ class GroupManagerCombineValueTests(TestCase):
 
     def tearDown(self) -> None:
         DummyInterface.attr_types = self.original_attr_types
+
+    def test_group_manager_snapshots_none_values_and_nested_frozen_shapes(self):
+        self.assertEqual(
+            _freeze_manager_value([{"items": {1, 2}}, ("x", None)]),
+            ((("items", frozenset({1, 2})),), ("x", None)),
+        )
+        entries = [
+            DummyManager(
+                bucket=None,
+                field_list=None,
+                field_dict=None,
+                field_text=None,
+                field_bool=None,
+                field_number=None,
+                field_date=None,
+            ),
+            DummyManager(
+                bucket=ListBucket([DummyManager(a=1)]),
+                field_list=[1],
+                field_dict={"x": 1},
+                field_text="ready",
+                field_bool=True,
+                field_number=2,
+                field_date=date(2024, 1, 1),
+            ),
+        ]
+        DummyInterface.attr_types.update(
+            {
+                "bucket": {"type": Bucket},
+                "field_list": {"type": list},
+                "field_dict": {"type": dict},
+                "field_text": {"type": str},
+                "field_bool": {"type": bool},
+                "field_number": {"type": int},
+                "field_date": {"type": date},
+            }
+        )
+        manager = GroupManager(DummyManager, {}, ListBucket(entries))
+        self.assertEqual(manager.combine_value("field_list"), [1])
+        self.assertEqual(manager.combine_value("field_dict"), {"x": 1})
+        self.assertEqual(manager.combine_value("field_text"), "ready")
+        self.assertTrue(manager.combine_value("field_bool"))
+        self.assertEqual(manager.combine_value("field_number"), 2)
+        self.assertEqual(manager.combine_value("field_date"), date(2024, 1, 1))
+        self.assertEqual(len(manager.combine_value("bucket")), 1)
+        self.assertEqual(manager.field_number, 2)
+        self.assertIn("field_number", manager.__dict__["_grouped_data"])
+        self.assertIn("GroupManager", repr(manager))
+
+        stable = GroupManager(DummyManager, {}, tuple(entries))
+        self.assertEqual(hash(stable), hash(stable))
+        stable._replay_dependencies()
+
+        broken = object.__new__(GroupManager)
+        with self.assertRaises(AttributeError):
+            broken.__getattr__("missing")
+        broken._group_by_value = {}
+        with self.assertRaises(AttributeError):
+            broken.__getattr__("missing")
+        with self.assertRaises(MissingGroupAttributeError):
+            manager.combine_value("missing")
 
     # Parametrized tests for combine_value on various data types
     def helper_make_group_manager(self, values, value_type):

--- a/tests/unit/test_group_manager.py
+++ b/tests/unit/test_group_manager.py
@@ -2,15 +2,19 @@
 from datetime import date
 import pickle
 from typing import ClassVar
+from unittest.mock import patch
 from django.test import TestCase
 from general_manager.api.property import GraphQLProperty
 from general_manager.manager.group_manager import (
     GroupManager,
 )
+from general_manager.manager.general_manager import GeneralManager
 from general_manager.bucket.group_bucket import GroupBucket
 from general_manager.bucket.group_bucket import GroupBucketKeysMismatchError
+from general_manager.bucket.base_bucket import Bucket
 from general_manager.measurement import Measurement
 from general_manager.cache.cache_tracker import DependencyTracker
+import general_manager.manager.group_manager as group_manager_module
 
 
 # Stub Interface to simulate attribute definitions
@@ -81,9 +85,50 @@ class ListBucket(list):
 
 
 class DependencyListBucket(ListBucket):
+    _group_materialization_safe = True
+
     def __iter__(self):
         DependencyTracker.track("DummyManager", "all", "snapshot")
         yield from super().__iter__()
+
+
+class IterationCounter:
+    value = 0
+
+
+class CountingMaterializedBucket(ListBucket):
+    _group_materialization_safe = True
+
+    def __init__(self, items, counter):
+        super().__init__(items)
+        self.counter = counter
+
+    def __iter__(self):
+        self.counter.value += 1
+        yield from super().__iter__()
+
+
+class CountingLiveBucket(ListBucket):
+    def __init__(self, items, counter):
+        super().__init__(items)
+        self.counter = counter
+
+    def __iter__(self):
+        self.counter.value += 1
+        yield from super().__iter__()
+
+
+class FailingMaterializedBucket(CountingMaterializedBucket):
+    def __init__(self, items, counter):
+        super().__init__(items, counter)
+        self.fail = True
+
+    def __iter__(self):
+        self.counter.value += 1
+        for index, item in enumerate(list.__iter__(self)):
+            if self.fail and index == 1:
+                raise RuntimeError
+            yield item
 
 
 class GroupBucketTests(TestCase):
@@ -342,6 +387,17 @@ class GroupManagerCombineValueTests(TestCase):
         gm = self.helper_make_group_manager([None, None], type(None))
         self.assertIsNone(gm.combine_value("field"))
 
+    def test_combine_empty_containers_preserves_non_none_values(self):
+        self.assertEqual(
+            self.helper_make_group_manager([[]], list).combine_value("field"), []
+        )
+        self.assertEqual(
+            self.helper_make_group_manager([{}], dict).combine_value("field"), {}
+        )
+        self.assertEqual(
+            self.helper_make_group_manager([""], str).combine_value("field"), ""
+        )
+
     def test_combine_none_and_value(self):
         gm = self.helper_make_group_manager([None, 1], int)
         self.assertEqual(gm.combine_value("field"), 1)
@@ -365,6 +421,173 @@ class GroupManagerCombineValueTests(TestCase):
         )
         result = gm.combine_value("field")
         self.assertEqual(result, Measurement(3, "m"))
+
+    def test_materialized_snapshot_reuses_source_for_multiple_aggregates(self):
+        DummyInterface.attr_types.update(
+            {
+                "field": {"type": int},
+                "label": {"type": str},
+            }
+        )
+        counter = IterationCounter()
+        entries = [
+            DummyManager(field=1, label="a"),
+            DummyManager(field=2, label="b"),
+            DummyManager(field=3, label="a"),
+        ]
+        manager = GroupManager(
+            DummyManager,
+            {},
+            CountingMaterializedBucket(entries, counter),
+        )
+
+        self.assertEqual(manager.combine_value("field"), 6)
+        self.assertEqual(manager.combine_value("label"), "a, b")
+        self.assertIsNone(manager.combine_value("id"))
+        self.assertEqual(counter.value, 1)
+
+    def test_live_snapshot_fallback_observes_mutations_for_aggregate_and_identity(self):
+        DummyInterface.attr_types["field"] = {"type": int}
+        counter = IterationCounter()
+        entries = [DummyManager(field=1)]
+        source = CountingLiveBucket(entries, counter)
+        manager = GroupManager(DummyManager, {}, source)
+        other = GroupManager(
+            DummyManager, {}, CountingLiveBucket(list(entries), counter)
+        )
+
+        self.assertEqual(manager.combine_value("field"), 1)
+        source.append(DummyManager(field=2))
+        self.assertEqual(manager.combine_value("field"), 3)
+        self.assertNotEqual(hash(manager), hash(other))
+        self.assertNotEqual(manager, other)
+        self.assertGreaterEqual(counter.value, 4)
+
+    def test_materialized_cache_hit_replays_dependencies_in_nested_trackers(self):
+        DummyInterface.attr_types["label"] = {"type": str}
+        manager = GroupManager(
+            DummyManager,
+            {},
+            DependencyListBucket([DummyManager(label="a")]),
+        )
+
+        with DependencyTracker() as outer:
+            with DependencyTracker() as inner:
+                self.assertEqual(manager.label, "a")
+
+        with DependencyTracker() as cache_hit:
+            self.assertEqual(manager.label, "a")
+
+        dependency = ("DummyManager", "all", "snapshot")
+        self.assertIn(dependency, outer)
+        self.assertIn(dependency, inner)
+        self.assertIn(dependency, cache_hit)
+
+    def test_materialized_identity_cache_hits_replay_dependencies(self):
+        DummyInterface.attr_types["label"] = {"type": str}
+        manager = GroupManager(
+            DummyManager,
+            {},
+            DependencyListBucket([DummyManager(label="a")]),
+        )
+
+        with DependencyTracker() as first_hash:
+            hash(manager)
+        with DependencyTracker() as second_hash:
+            hash(manager)
+        with DependencyTracker() as equality_hit:
+            _ = manager == manager
+
+        dependency = ("DummyManager", "all", "snapshot")
+        self.assertIn(dependency, first_hash)
+        self.assertIn(dependency, second_hash)
+        self.assertIn(dependency, equality_hit)
+
+    def test_materialized_identity_reuses_frozen_entries(self):
+        DummyInterface.attr_types["field"] = {"type": int}
+        counter = IterationCounter()
+        entry = object.__new__(GeneralManager)
+        entry._GeneralManager__id = {"id": 1}
+        source = CountingMaterializedBucket([entry], counter)
+        manager = GroupManager(DummyManager, {}, source)
+
+        with patch(
+            "general_manager.manager.group_manager._freeze_manager_value",
+            wraps=group_manager_module._freeze_manager_value,
+        ) as freeze:
+            hash(manager)
+            _ = manager == manager
+            first_manager_freezes = sum(
+                isinstance(call.args[0], GeneralManager)
+                for call in freeze.call_args_list
+            )
+            hash(manager)
+            _ = manager == manager
+            second_manager_freezes = sum(
+                isinstance(call.args[0], GeneralManager)
+                for call in freeze.call_args_list
+            )
+
+        self.assertEqual(first_manager_freezes, second_manager_freezes)
+        self.assertEqual(counter.value, 1)
+
+    def test_materialized_group_manager_pickle_preserves_cached_aggregate(self):
+        DummyInterface.attr_types["field"] = {"type": int}
+        manager = GroupManager(
+            DummyManager,
+            {},
+            CountingMaterializedBucket([DummyManager(field=3)], IterationCounter()),
+        )
+        self.assertEqual(manager.field, 3)
+
+        restored = pickle.loads(pickle.dumps(manager))  # noqa: S301 - local test data
+
+        self.assertEqual(restored.field, 3)
+
+    def test_identity_reflects_mutated_group_mapping(self):
+        DummyInterface.attr_types["field"] = {"type": int}
+        entry = DummyManager(field=1)
+        source = CountingMaterializedBucket([entry], IterationCounter())
+        manager = GroupManager(DummyManager, {}, source)
+        other = GroupManager(
+            DummyManager,
+            {},
+            CountingMaterializedBucket([entry], IterationCounter()),
+        )
+        self.assertEqual(manager, other)
+
+        manager._group_by_value["group"] = "new"
+
+        self.assertNotEqual(manager, other)
+
+    def test_failed_materialized_iteration_does_not_publish_partial_snapshot(self):
+        DummyInterface.attr_types["field"] = {"type": int}
+        counter = IterationCounter()
+        source = FailingMaterializedBucket(
+            [DummyManager(field=1), DummyManager(field=2)], counter
+        )
+        manager = GroupManager(DummyManager, {}, source)
+
+        with self.assertRaises(RuntimeError):
+            manager.combine_value("field")
+        source.fail = False
+
+        self.assertEqual(manager.combine_value("field"), 3)
+        self.assertEqual(counter.value, 2)
+
+    def test_manager_bucket_union_preserves_existing_order(self):
+        DummyInterface.attr_types["field"] = {"type": Bucket}
+        first = ListBucket([DummyManager(field=1)])
+        second = ListBucket([DummyManager(field=2)])
+        manager = GroupManager(
+            DummyManager,
+            {},
+            ListBucket([DummyManager(field=first), DummyManager(field=second)]),
+        )
+
+        combined = manager.combine_value("field")
+
+        self.assertEqual([entry.field for entry in combined], [2, 1])
 
     def test_iterate_group_manager(self):
         # Test that iterating over GroupManager yields correct items


### PR DESCRIPTION
## Problem

Each uncached grouped attribute re-iterates the group bucket and materializes temporary values. String aggregation uses list membership for deduplication, while hash and equality repeatedly enumerate and freeze the full group data.

## Proposed Solution

- Capture one private entry snapshot and dependency set for explicitly stable/materialized group buckets.
- Replay dependencies on aggregate cache hits, hash/equality reads, and nested tracker scopes.
- Stream all aggregate branches while preserving current `None`, ordering, metadata, union, and exception semantics.
- Deduplicate strings with an insertion-ordered set instead of list membership.
- Reuse frozen entry identities for stable hash/equality reads while keeping mutable/live buckets uncached.
- Preserve pickle behavior and live mutation fallback without changing public APIs.

## Alternatives / Workarounds

Callers can cache aggregate properties themselves, but that duplicates framework behavior and cannot optimize GroupManager hash/equality or dependency replay. No public API change is proposed.

## Impact

⚙️ Important – significant productivity gain

## References

- Closes #351
- Stacked on `codex/perf-350-partition-group-buckets`
- Feature issue: #351

## Verification

- `python -m pytest -q` → 5,367 passed, 2 skipped, 1 warning, 1,984 subtests.
- Focused GroupManager unit/performance checks → 40 tests; affected integration suite → 176 tests and 40 subtests.
- Stable 10,000-entry aggregate/hash workload performs one source traversal; marker-free mutable buckets re-read after mutation.
- Coverage includes every aggregate branch, empty/all-None values, duplicate-string order, union order, dependency replay, pickle, no-partial snapshots, and dynamic hash/equality semantics.
- Ruff, format, mypy, pre-commit, and `git diff --check` all pass.