### PR TITLE
perf: query historical rows before live rows (#354)

### DIFF
--- a/src/general_manager/interface/capabilities/orm/support.py
+++ b/src/general_manager/interface/capabilities/orm/support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import re
 from collections.abc import Hashable
 from datetime import date, datetime, time, timedelta
@@ -11,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Type, cast
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models import Subquery
+from django.db.models.manager import ManagerDescriptor
 from django.utils import timezone
 from general_manager.bucket.database_bucket import DatabaseBucket
 from general_manager.cache.run_context import current_calculation_run_context
@@ -28,7 +30,9 @@ from general_manager.interface.capabilities.orm_utils.field_descriptors import (
 from general_manager.interface.capabilities.orm_utils.payload_normalizer import (
     PayloadNormalizer,
 )
+from general_manager.interface.utils.models import ActiveManager
 from simple_history.models import HistoricalChanges
+from simple_history.manager import HistoryDescriptor
 
 from ._compat import call_with_observability
 
@@ -241,6 +245,57 @@ class OrmReadCapability(BaseCapability):
 
     name: ClassVar[CapabilityName] = "read"
 
+    @staticmethod
+    def _supports_history_first(
+        interface_cls: OrmInterfaceClass,
+        model_cls: type[models.Model],
+    ) -> bool:
+        """Admit only the default, static-safe historical read integration."""
+        from .history import OrmHistoryCapability
+
+        if inspect.getattr_static(
+            interface_cls, "get_capability_handler", None
+        ) is not inspect.getattr_static(InterfaceBase, "get_capability_handler"):
+            return False
+        try:
+            history_handler = interface_cls.get_capability_handler("history")
+            support_handler = interface_cls.get_capability_handler("orm_support")
+            soft_delete_handler = interface_cls.get_capability_handler("soft_delete")
+            marker = vars(model_cls._meta).get("simple_history_manager_attribute")
+            if type(marker) is not str:
+                return False
+            descriptor = inspect.getattr_static(model_cls, marker)
+            database_alias = inspect.getattr_static(interface_cls, "database", None)
+        except (AttributeError, TypeError):
+            return False
+        if (
+            type(history_handler) is not OrmHistoryCapability
+            or type(support_handler) is not OrmPersistenceSupportCapability
+            or type(soft_delete_handler) is not SoftDeleteCapability
+            or type(descriptor) is not HistoryDescriptor
+            or not isinstance(descriptor.model, type)
+            or not issubclass(descriptor.model, HistoricalChanges)
+            or (database_alias is not None and type(database_alias) is not str)
+        ):
+            return False
+        try:
+            soft_delete = soft_delete_handler.is_enabled()
+            default_manager = model_cls._meta.default_manager
+            all_objects = inspect.getattr_static(model_cls, "all_objects", None)
+        except (AttributeError, TypeError):
+            return False
+        if soft_delete and all_objects is not None:
+            all_manager = (
+                all_objects.manager
+                if type(all_objects) is ManagerDescriptor
+                else all_objects
+            )
+            return (
+                type(default_manager) is ActiveManager
+                and type(all_manager) is models.Manager
+            )
+        return type(default_manager) is models.Manager
+
     def get_data(self, interface_instance: OrmInterfaceInstance) -> models.Model:
         """
         Retrieve the current model instance or a historical snapshot for the given ORM interface instance.
@@ -265,6 +320,29 @@ class OrmReadCapability(BaseCapability):
             )
             model_cls = interface_cls._model
             pk = interface_instance.pk
+            search_date = interface_instance._search_date
+            now = timezone.now() if search_date is not None else None
+            historical_cutoff = (
+                now - timedelta(seconds=interface_cls.historical_lookup_buffer_seconds)
+                if now is not None
+                else None
+            )
+            if (
+                search_date is not None
+                and historical_cutoff is not None
+                and search_date <= historical_cutoff
+                and self._supports_history_first(interface_cls, model_cls)
+            ):
+                history_handler = _history_capability_for(interface_cls)
+                historical_first = history_handler.get_historical_record_by_pk(
+                    interface_cls,
+                    pk,
+                    search_date,
+                )
+                if historical_first is not None:
+                    return historical_first
+                manager.get(pk=pk)
+                raise model_cls.DoesNotExist
             instance: models.Model | None
             missing_error: Exception | None = None
             try:
@@ -272,11 +350,8 @@ class OrmReadCapability(BaseCapability):
             except model_cls.DoesNotExist as error:
                 instance = None
                 missing_error = error
-            search_date = interface_instance._search_date
             if search_date is not None:
-                if search_date <= timezone.now() - timedelta(
-                    seconds=interface_cls.historical_lookup_buffer_seconds
-                ):
+                if historical_cutoff is not None and search_date <= historical_cutoff:
                     historical: models.Model | None
                     history_handler = _history_capability_for(interface_cls)
                     if instance is not None:

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 from datetime import datetime, timedelta
-from django.db import models
+from django.db import connection, models
 from django.core.exceptions import ValidationError, FieldError
 from django.contrib.auth.models import User
 from django.utils.crypto import get_random_string
 from django.utils import timezone
 from typing import ClassVar
 from unittest.mock import patch
+from django.test.utils import CaptureQueriesContext
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.interface import DatabaseInterface, ReadOnlyInterface
 from general_manager.api.property import graph_ql_property
@@ -25,6 +26,13 @@ from general_manager.manager.meta import (
     GeneralManagerMeta,
     InvalidManagerStateError,
 )
+
+
+HISTORICAL_READ_QUERY_BUDGETS = {
+    "history_hit": 1,
+    "history_miss": 2,
+    "recent_live": 1,
+}
 
 
 class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
@@ -952,9 +960,37 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         with patch(
             "django.utils.timezone.now", return_value=snapshot + timedelta(seconds=10)
         ):
-            historical_view = self.TestHuman(id=human_id, search_date=snapshot)
+            with CaptureQueriesContext(connection) as queries:
+                historical_view = self.TestHuman(id=human_id, search_date=snapshot)
 
         self.assertEqual(historical_view.name, "Historian")
+        self.assertEqual(len(queries), HISTORICAL_READ_QUERY_BUDGETS["history_hit"])
+
+    def test_get_historical_record_for_soft_deleted_manager(self):
+        base_time = timezone.now() - timedelta(days=10)
+        with patch("django.utils.timezone.now", return_value=base_time):
+            historical_family = self.TestFamily.create(
+                creator_id=None,
+                name="Historical Family",
+                ignore_permission=True,
+            )
+
+        family_id = historical_family.identification["id"]
+        search_date = base_time + timedelta(hours=1)
+        historical_family.delete(ignore_permission=True)
+
+        with patch(
+            "django.utils.timezone.now",
+            return_value=search_date + timedelta(seconds=10),
+        ):
+            with CaptureQueriesContext(connection) as queries:
+                historical_view = self.TestFamily(
+                    id=family_id,
+                    search_date=search_date,
+                )
+
+        self.assertEqual(historical_view.name, "Historical Family")
+        self.assertEqual(len(queries), HISTORICAL_READ_QUERY_BUDGETS["history_hit"])
 
     def test_get_historical_record_after_delete_with_manager_lookup(self):
         historical_human = self.TestHuman.create(
@@ -1016,10 +1052,15 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             "django.utils.timezone.now",
             return_value=search_date + timedelta(seconds=10),
         ):
-            historical_view = self.TestHuman(id=human_a_id, search_date=search_date)
+            with CaptureQueriesContext(connection) as queries:
+                historical_view = self.TestHuman(
+                    id=human_a_id,
+                    search_date=search_date,
+                )
 
         self.assertEqual(historical_view.name, "Alice Updated")
         self.assertEqual(historical_view.identification["id"], human_a_id)
+        self.assertEqual(len(queries), HISTORICAL_READ_QUERY_BUDGETS["history_hit"])
 
     def test_get_data_raises_when_historical_missing_for_active_instance(self):
         base_time = timezone.now() - timedelta(days=10)
@@ -1037,11 +1078,168 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
             "django.utils.timezone.now",
             return_value=base_time + timedelta(seconds=10),
         ):
-            with self.assertRaises(self.TestHuman.Interface._model.DoesNotExist):  # type: ignore[attr-defined]
-                self.TestHuman(
+            with CaptureQueriesContext(connection) as queries:
+                with self.assertRaises(self.TestHuman.Interface._model.DoesNotExist):  # type: ignore[attr-defined]
+                    self.TestHuman(
+                        id=human.identification["id"],
+                        search_date=search_date,
+                    )
+        self.assertEqual(len(queries), HISTORICAL_READ_QUERY_BUDGETS["history_miss"])
+
+    def test_get_data_history_miss_for_missing_live_row_keeps_two_queries(self):
+        search_date = timezone.now() - timedelta(days=10)
+        missing_pk = 987654321
+
+        with patch(
+            "django.utils.timezone.now",
+            return_value=search_date + timedelta(seconds=10),
+        ):
+            with CaptureQueriesContext(connection) as queries:
+                with self.assertRaises(self.TestHuman.Interface._model.DoesNotExist):  # type: ignore[attr-defined]
+                    self.TestHuman(id=missing_pk, search_date=search_date)
+
+        self.assertEqual(len(queries), HISTORICAL_READ_QUERY_BUDGETS["history_miss"])
+
+    def test_recent_search_date_keeps_one_live_query(self):
+        human = self.TestHuman.create(
+            creator_id=None,
+            name="Recent",
+            ignore_permission=True,
+        )
+        search_date = timezone.now()
+
+        with patch(
+            "django.utils.timezone.now",
+            return_value=search_date + timedelta(seconds=1),
+        ):
+            with CaptureQueriesContext(connection) as queries:
+                manager = self.TestHuman(
                     id=human.identification["id"],
                     search_date=search_date,
                 )
+
+        self.assertEqual(manager.name, "Recent")
+        self.assertEqual(len(queries), HISTORICAL_READ_QUERY_BUDGETS["recent_live"])
+
+    def test_custom_interface_dispatch_keeps_live_first_fallback(self):
+        base_time = timezone.now() - timedelta(days=1)
+        with patch("django.utils.timezone.now", return_value=base_time):
+            human = self.TestHuman.create(
+                creator_id=None,
+                name="Custom History",
+                ignore_permission=True,
+            )
+        search_date = base_time + timedelta(hours=1)
+        interface_cls = self.TestHuman.Interface
+        original_get_capability_handler = interface_cls.get_capability_handler
+
+        def custom_get_capability_handler(_cls, name):
+            return original_get_capability_handler(name)
+
+        with patch.object(
+            interface_cls,
+            "get_capability_handler",
+            classmethod(custom_get_capability_handler),
+        ):
+            with patch(
+                "django.utils.timezone.now",
+                return_value=search_date + timedelta(seconds=10),
+            ):
+                with CaptureQueriesContext(connection) as queries:
+                    manager = self.TestHuman(
+                        id=human.identification["id"],
+                        search_date=search_date,
+                    )
+
+        self.assertEqual(manager.name, "Custom History")
+        self.assertEqual(len(queries), 2)
+
+    def test_old_history_hit_honors_configured_database_alias(self):
+        human = self.TestHuman.create(
+            creator_id=None,
+            name="Aliased History",
+            ignore_permission=True,
+        )
+        search_date = timezone.now()
+        human.delete(ignore_permission=True)
+        interface_cls = self.TestHuman.Interface
+        original_database = interface_cls.database
+        interface_cls.database = "default"
+        try:
+            with patch(
+                "django.utils.timezone.now",
+                return_value=search_date + timedelta(seconds=10),
+            ):
+                with CaptureQueriesContext(connection) as queries:
+                    manager = self.TestHuman(
+                        id=human.identification["id"],
+                        search_date=search_date,
+                    )
+        finally:
+            interface_cls.database = original_database
+
+        self.assertEqual(manager.name, "Aliased History")
+        self.assertEqual(len(queries), 1)
+
+    def test_old_history_read_reuses_run_context_cache(self):
+        base_time = timezone.now() - timedelta(days=10)
+        with patch("django.utils.timezone.now", return_value=base_time):
+            human = self.TestHuman.create(
+                creator_id=None,
+                name="Cached History",
+                ignore_permission=True,
+            )
+        search_date = base_time + timedelta(hours=1)
+
+        with patch(
+            "django.utils.timezone.now",
+            return_value=search_date + timedelta(seconds=10),
+        ):
+            with CalculationRunContext(), CaptureQueriesContext(connection) as queries:
+                first = self.TestHuman(
+                    id=human.identification["id"],
+                    search_date=search_date,
+                )
+                second = self.TestHuman(
+                    id=human.identification["id"],
+                    search_date=search_date,
+                )
+
+        self.assertEqual(first.name, "Cached History")
+        self.assertEqual(second.name, "Cached History")
+        self.assertEqual(len(queries), 1)
+
+    def test_history_read_cache_clears_after_mutation(self):
+        base_time = timezone.now() - timedelta(days=10)
+        with patch("django.utils.timezone.now", return_value=base_time):
+            human = self.TestHuman.create(
+                creator_id=None,
+                name="Before Mutation",
+                ignore_permission=True,
+            )
+        search_date = base_time + timedelta(hours=1)
+
+        with (
+            patch(
+                "django.utils.timezone.now",
+                return_value=search_date + timedelta(seconds=10),
+            ),
+            CalculationRunContext(),
+            CaptureQueriesContext(connection) as queries,
+        ):
+            first = self.TestHuman(
+                id=human.identification["id"],
+                search_date=search_date,
+            )
+            human.update(name="After Mutation", ignore_permission=True)
+            second = self.TestHuman(
+                id=human.identification["id"],
+                search_date=search_date,
+            )
+
+        self.assertEqual(first.name, "Before Mutation")
+        self.assertEqual(second.name, "Before Mutation")
+        self.assertGreaterEqual(len(queries), 2)
 
     def test_bucket_operations(self):
         """


### PR DESCRIPTION
## Problem

Point-in-time ORM reads queried the live manager before the history table. Successful historical reads therefore paid for two SQL queries, even when the historical row could be resolved directly. Soft-deleted models were not admitted to the optimized path.

## Proposed Solution

For the default, framework-managed history integration, query the historical row by primary key first for dates outside the recent lookup buffer. Return immediately on a history hit, and preserve the existing live-first fallback for misses and custom/overridden integrations. The admission checks are static-safe and cover default capability handlers, history descriptors, manager shapes, soft-delete managers, and configured database aliases.

## Alternatives / Workarounds

Keep the existing live-first ordering. This preserves behavior but retains the avoidable query for every successful historical read.

## Impact

- Successful historical reads: 2 SQL queries -> 1.
- Soft-deleted historical reads: 2 SQL queries -> 1.
- Historical misses remain at 2 queries and preserve exception semantics.
- Recent live reads, custom dispatch, aliases, run-cache reuse, and mutation invalidation remain covered.
- No public API changes.

## References

Closes #354. Stacked on #381.

## Verification

- python -m pytest tests/integration/test_database_manager.py -q — 73 passed.
- python -m pytest tests/unit/test_database_based_interface.py tests/unit/test_orm_capabilities_comprehensive.py -q — 172 passed, 1 warning.
- python -m pytest -q — 5394 passed, 2 skipped, 1 warning, 1984 subtests passed.
- pre-commit run --all-files — passed.
- Ruff, format, mypy, and git diff --check — passed.
- Only tracked implementation and test files were committed; gitignored files were not staged.