### PR TITLE
perf: batch run-cache invalidation scans (#355)

### DIFF
--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -48,6 +48,28 @@ logger = get_logger("cache.run_context")
 OrmModelRowKey = tuple[Hashable, Hashable | None]
 CALCULATION_BUCKET_RESULT_MISSING = object()
 
+MUTATION_CACHE_PREFIXES = (
+    ORM_BUCKET_RESULT_PREFIX,
+    ORM_BUCKET_ROW_RESULT_PREFIX,
+    ORM_BUCKET_MANAGER_RESULT_PREFIX,
+    ORM_BUCKET_FIRST_ROW_PREFIX,
+    ORM_BUCKET_COUNT_PREFIX,
+    ORM_BUCKET_LAST_ROW_PREFIX,
+    ORM_BUCKET_GET_PREFIX,
+    ORM_BUCKET_INDEX_PREFIX,
+    ORM_BUCKET_MEMBERSHIP_PREFIX,
+    ORM_MODEL_ROW_INDEX_PREFIX,
+    ORM_MODEL_RELATION_PREFETCH_PREFIX,
+    ORM_DIRECT_RELATION_PREFETCH_PREFIX,
+    ORM_RELATION_MANAGER_PREFIX,
+    ORM_QUERY_BUCKET_PREFIX,
+    ORM_BUCKET_EXISTS_PREFIX,
+    BUCKET_INDEX_PREFIX,
+    TRUSTED_ORM_MANAGER_PREFIX,
+    CALCULATION_BUCKET_RESULT_PREFIX,
+)
+MUTATION_CACHE_KEY_PREFIXES = tuple((prefix,) for prefix in MUTATION_CACHE_PREFIXES)
+
 
 @dataclass(frozen=True)
 class BucketIndexRunCacheEntry:
@@ -311,8 +333,20 @@ class CalculationRunContext:
 
     def discard_prefix(self, prefix: tuple[Hashable, ...]) -> None:
         """Discard cached tuple keys whose leading items equal `prefix`."""
+        self.discard_prefixes((prefix,))
+
+    def discard_prefixes(
+        self,
+        prefixes: Iterable[tuple[Hashable, ...]],
+    ) -> None:
+        """Discard cached tuple keys matching any supplied leading prefix."""
+        prefixes = tuple(prefixes)
+        if not prefixes:
+            return
         for key in list(self._values):
-            if isinstance(key, tuple) and key[: len(prefix)] == prefix:
+            if isinstance(key, tuple) and any(
+                key[: len(prefix)] == prefix for prefix in prefixes
+            ):
                 del self._values[key]
 
     def get_orm_bucket_result(self, key: Hashable) -> object:
@@ -598,21 +632,25 @@ class CalculationRunContext:
 
     def clear_orm_bucket_results(self) -> None:
         """Discard all run-scoped ORM bucket result entries."""
-        self.discard_prefix((ORM_BUCKET_RESULT_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_ROW_RESULT_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_MANAGER_RESULT_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_FIRST_ROW_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_COUNT_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_LAST_ROW_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_GET_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_INDEX_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_MEMBERSHIP_PREFIX,))
-        self.discard_prefix((ORM_MODEL_ROW_INDEX_PREFIX,))
-        self.discard_prefix((ORM_MODEL_RELATION_PREFETCH_PREFIX,))
-        self.discard_prefix((ORM_DIRECT_RELATION_PREFETCH_PREFIX,))
-        self.discard_prefix((ORM_RELATION_MANAGER_PREFIX,))
-        self.discard_prefix((ORM_QUERY_BUCKET_PREFIX,))
-        self.discard_prefix((ORM_BUCKET_EXISTS_PREFIX,))
+        self.discard_prefixes(
+            (
+                (ORM_BUCKET_RESULT_PREFIX,),
+                (ORM_BUCKET_ROW_RESULT_PREFIX,),
+                (ORM_BUCKET_MANAGER_RESULT_PREFIX,),
+                (ORM_BUCKET_FIRST_ROW_PREFIX,),
+                (ORM_BUCKET_COUNT_PREFIX,),
+                (ORM_BUCKET_LAST_ROW_PREFIX,),
+                (ORM_BUCKET_GET_PREFIX,),
+                (ORM_BUCKET_INDEX_PREFIX,),
+                (ORM_BUCKET_MEMBERSHIP_PREFIX,),
+                (ORM_MODEL_ROW_INDEX_PREFIX,),
+                (ORM_MODEL_RELATION_PREFETCH_PREFIX,),
+                (ORM_DIRECT_RELATION_PREFETCH_PREFIX,),
+                (ORM_RELATION_MANAGER_PREFIX,),
+                (ORM_QUERY_BUCKET_PREFIX,),
+                (ORM_BUCKET_EXISTS_PREFIX,),
+            )
+        )
 
     def get_calculation_bucket_result(
         self,
@@ -652,7 +690,7 @@ class CalculationRunContext:
 
     def clear_calculation_bucket_results(self) -> None:
         """Discard all run-scoped calculation bucket result entries."""
-        self.discard_prefix((CALCULATION_BUCKET_RESULT_PREFIX,))
+        self.discard_prefixes(((CALCULATION_BUCKET_RESULT_PREFIX,),))
 
     def _bucket_index_cache_key(
         self,
@@ -711,11 +749,15 @@ class CalculationRunContext:
 
     def clear_bucket_indexes(self) -> None:
         """Discard all run-scoped bucket index entries."""
-        self.discard_prefix((BUCKET_INDEX_PREFIX,))
+        self.discard_prefixes(((BUCKET_INDEX_PREFIX,),))
 
     def clear_trusted_orm_managers(self) -> None:
         """Discard run-scoped manager wrappers built from trusted ORM rows."""
-        self.discard_prefix((TRUSTED_ORM_MANAGER_PREFIX,))
+        self.discard_prefixes(((TRUSTED_ORM_MANAGER_PREFIX,),))
+
+    def clear_mutation_cache(self) -> None:
+        """Discard every run-scoped cache namespace invalidated by mutations."""
+        self.discard_prefixes(MUTATION_CACHE_KEY_PREFIXES)
 
     def has(self, key: Hashable) -> bool:
         """Return whether key has a value in the active run."""

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -91,10 +91,7 @@ def data_change(
         begin_dependency_data_change()
         context = current_calculation_run_context()
         if context is not None:
-            context.clear_orm_bucket_results()
-            context.clear_bucket_indexes()
-            context.clear_trusted_orm_managers()
-            context.clear_calculation_bucket_results()
+            context.clear_mutation_cache()
         try:
             action = func.__name__
             if func.__name__ == "create":
@@ -122,10 +119,7 @@ def data_change(
 
             context = current_calculation_run_context()
             if context is not None:
-                context.clear_orm_bucket_results()
-                context.clear_bucket_indexes()
-                context.clear_trusted_orm_managers()
-                context.clear_calculation_bucket_results()
+                context.clear_mutation_cache()
 
             instance = result
             identification = getattr(instance, "identification", None)

--- a/tests/perf/budgets.py
+++ b/tests/perf/budgets.py
@@ -121,8 +121,8 @@ PERF_CEILINGS: dict[str, int] = {
     "DB_HISTORY_WRITE_100_QUERIES": 600,
     "DB_HISTORY_WRITE_100_CALLBACKS": 100,
     # Calculation run-cache invalidation workloads.
-    "RUN_CACHE_MIXED_500_DISCARD_CALLS": 36,
-    "RUN_CACHE_MIXED_500_KEY_INSPECTIONS": 95_000,
+    "RUN_CACHE_MIXED_500_DISCARD_CALLS": 2,
+    "RUN_CACHE_MIXED_500_KEY_INSPECTIONS": 10_000,
     # Calculation bucket combination workloads.
     "CALC_STATIC_5X10_COLD_A_YIELDS": 5,
     "CALC_STATIC_5X10_COLD_B_YIELDS": 50,

--- a/tests/perf/test_database_bucket_perf.py
+++ b/tests/perf/test_database_bucket_perf.py
@@ -25,6 +25,7 @@ from general_manager.cache.dependency_cache import DependencyCacheHit
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.run_context import (
     BUCKET_INDEX_PREFIX,
+    CALCULATION_BUCKET_RESULT_PREFIX,
     ORM_BUCKET_EXISTS_PREFIX,
     ORM_BUCKET_COUNT_PREFIX,
     ORM_BUCKET_FIRST_ROW_PREFIX,
@@ -92,6 +93,7 @@ RUN_CACHE_PREFIXES = (
     ORM_BUCKET_EXISTS_PREFIX,
     BUCKET_INDEX_PREFIX,
     TRUSTED_ORM_MANAGER_PREFIX,
+    CALCULATION_BUCKET_RESULT_PREFIX,
 )
 
 
@@ -114,20 +116,20 @@ def _assert_mixed_cache_observations(
 def test_mixed_cache_observations_accept_improvements_below_the_ceiling() -> None:
     budgets = PerfBudgets(
         {
-            "RUN_CACHE_MIXED_500_DISCARD_CALLS": 22,
-            "RUN_CACHE_MIXED_500_KEY_INSPECTIONS": 44_000,
+            "RUN_CACHE_MIXED_500_DISCARD_CALLS": 2,
+            "RUN_CACHE_MIXED_500_KEY_INSPECTIONS": 10_000,
         }
     )
 
     _assert_mixed_cache_observations(
         budgets,
-        discard_calls=11,
-        key_inspections=22_000,
+        discard_calls=1,
+        key_inspections=9_000,
     )
 
     assert budgets.observations == {
-        "RUN_CACHE_MIXED_500_DISCARD_CALLS": 11,
-        "RUN_CACHE_MIXED_500_KEY_INSPECTIONS": 22_000,
+        "RUN_CACHE_MIXED_500_DISCARD_CALLS": 1,
+        "RUN_CACHE_MIXED_500_KEY_INSPECTIONS": 9_000,
     }
 
 
@@ -1248,37 +1250,37 @@ def test_data_change_mixed_run_cache_invalidation_work(
             for key in context._values
             if isinstance(key, tuple) and key and key[0] in RUN_CACHE_PREFIXES
         )
-        assert initial_targeted_count == 8_500
-        assert len(context._values) == 9_000
+        assert initial_targeted_count == 9_000
+        assert len(context._values) == 9_500
 
         phase_snapshots: list[dict[Hashable, object]] = []
-        original_discard_prefix = context.discard_prefix
+        original_discard_prefixes = context.discard_prefixes
 
-        def counted_discard_prefix(
+        def counted_discard_prefixes(
             _context: CalculationRunContext,
-            prefix: tuple[Hashable, ...],
+            prefixes: tuple[tuple[Hashable, ...], ...],
         ) -> None:
             discard_calls.increment()
             key_inspections.increment(len(context._values))
-            original_discard_prefix(prefix)
+            original_discard_prefixes(prefixes)
 
         monkeypatch.setattr(
             context,
-            "discard_prefix",
-            MethodType(counted_discard_prefix, context),
+            "discard_prefixes",
+            MethodType(counted_discard_prefixes, context),
         )
-        original_clear_trusted_orm_managers = context.clear_trusted_orm_managers
+        original_clear_mutation_cache = context.clear_mutation_cache
 
-        def observed_clear_trusted_orm_managers(
+        def observed_clear_mutation_cache(
             _context: CalculationRunContext,
         ) -> None:
-            original_clear_trusted_orm_managers()
+            original_clear_mutation_cache()
             phase_snapshots.append(dict(context._values))
 
         monkeypatch.setattr(
             context,
-            "clear_trusted_orm_managers",
-            MethodType(observed_clear_trusted_orm_managers, context),
+            "clear_mutation_cache",
+            MethodType(observed_clear_mutation_cache, context),
         )
 
         if diagnostics_enabled:

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -11,8 +11,26 @@ from general_manager.cache.dependency_publish import (
     PendingDependencyCachePublication,
 )
 from general_manager.cache.run_context import (
+    BUCKET_INDEX_PREFIX,
     CALCULATION_BUCKET_RESULT_MISSING,
+    CALCULATION_BUCKET_RESULT_PREFIX,
     CalculationRunContext,
+    ORM_BUCKET_COUNT_PREFIX,
+    ORM_BUCKET_EXISTS_PREFIX,
+    ORM_BUCKET_FIRST_ROW_PREFIX,
+    ORM_BUCKET_GET_PREFIX,
+    ORM_BUCKET_INDEX_PREFIX,
+    ORM_BUCKET_LAST_ROW_PREFIX,
+    ORM_BUCKET_MANAGER_RESULT_PREFIX,
+    ORM_BUCKET_MEMBERSHIP_PREFIX,
+    ORM_BUCKET_RESULT_PREFIX,
+    ORM_BUCKET_ROW_RESULT_PREFIX,
+    ORM_DIRECT_RELATION_PREFETCH_PREFIX,
+    ORM_MODEL_RELATION_PREFETCH_PREFIX,
+    ORM_MODEL_ROW_INDEX_PREFIX,
+    ORM_QUERY_BUCKET_PREFIX,
+    ORM_RELATION_MANAGER_PREFIX,
+    TRUSTED_ORM_MANAGER_PREFIX,
     current_calculation_run_context,
     ensure_calculation_run_context,
 )
@@ -437,6 +455,114 @@ def test_discard_prefix_removes_matching_tuple_keys_only() -> None:
         assert ctx.get(("orm_instance", "Human", 2, "default")) == "bob"
         assert ctx.get(("other", "Human", 1)) == "other"
         assert ctx.get("plain") == "value"
+
+
+def test_discard_prefixes_scans_all_prefixes_and_preserves_unrelated_values() -> None:
+    with CalculationRunContext() as ctx:
+        ctx.set(("orm", "row", 1), "row")
+        ctx.set(("bucket", "index", 1), "index")
+        ctx.set(("orm", "other", 1), "other")
+        ctx.set(("plain",), "plain")
+        ctx.set("non-tuple", "non-tuple")
+
+        ctx.discard_prefixes((("orm",), ("bucket", "index")))
+
+        assert ctx.get(("orm", "row", 1)) is None
+        assert ctx.get(("bucket", "index", 1)) is None
+        assert ctx.get(("orm", "other", 1)) is None
+        assert ctx.get(("plain",)) == "plain"
+        assert ctx.get("non-tuple") == "non-tuple"
+
+
+def test_discard_prefixes_distinguishes_empty_iterable_from_empty_prefix() -> None:
+    with CalculationRunContext() as ctx:
+        ctx.set(("orm", 1), "orm")
+        ctx.set(("bucket", 1), "bucket")
+        ctx.set("plain", "plain")
+
+        ctx.discard_prefixes(())
+        assert ctx.get(("orm", 1)) == "orm"
+        assert ctx.get(("bucket", 1)) == "bucket"
+
+        ctx.discard_prefixes(((),))
+        assert ctx.get(("orm", 1)) is None
+        assert ctx.get(("bucket", 1)) is None
+        assert ctx.get("plain") == "plain"
+
+
+def test_discard_prefixes_handles_nested_overlapping_and_extra_components() -> None:
+    with CalculationRunContext() as ctx:
+        ctx.set(("orm",), "short")
+        ctx.set(("orm", "row"), "row")
+        ctx.set(("orm", "row", "field"), "field")
+        ctx.set(("ormx", "row"), "other")
+
+        ctx.discard_prefixes((("orm", "row", "field"), ("orm", "row")))
+
+        assert ctx.get(("orm",)) == "short"
+        assert ctx.get(("orm", "row")) is None
+        assert ctx.get(("orm", "row", "field")) is None
+        assert ctx.get(("ormx", "row")) == "other"
+
+
+def test_clear_mutation_cache_clears_all_namespaces_and_preserves_other_state() -> None:
+    prefixes = (
+        ORM_BUCKET_RESULT_PREFIX,
+        ORM_BUCKET_ROW_RESULT_PREFIX,
+        ORM_BUCKET_MANAGER_RESULT_PREFIX,
+        ORM_BUCKET_FIRST_ROW_PREFIX,
+        ORM_BUCKET_COUNT_PREFIX,
+        ORM_BUCKET_LAST_ROW_PREFIX,
+        ORM_BUCKET_GET_PREFIX,
+        ORM_BUCKET_INDEX_PREFIX,
+        ORM_BUCKET_MEMBERSHIP_PREFIX,
+        ORM_MODEL_ROW_INDEX_PREFIX,
+        ORM_MODEL_RELATION_PREFETCH_PREFIX,
+        ORM_DIRECT_RELATION_PREFETCH_PREFIX,
+        ORM_RELATION_MANAGER_PREFIX,
+        ORM_QUERY_BUCKET_PREFIX,
+        ORM_BUCKET_EXISTS_PREFIX,
+        BUCKET_INDEX_PREFIX,
+        TRUSTED_ORM_MANAGER_PREFIX,
+        CALCULATION_BUCKET_RESULT_PREFIX,
+    )
+    entry = make_pending_publication("preserve-publication")
+    hit = DependencyCacheHit(value="prefetched", dependencies=frozenset())
+
+    with (
+        mock.patch(
+            "general_manager.cache.dependency_publish.publish_dependency_cache_entries"
+        ),
+        mock.patch("general_manager.cache.dependency_publish.release_compute_lease"),
+        CalculationRunContext() as ctx,
+    ):
+        for prefix in prefixes:
+            ctx.set((prefix, "key"), "target")
+        ctx.set(("unrelated", "key"), "keep")
+        ctx.set("plain", "keep")
+        ctx.set_dependency_cache_hits({"prefetched": hit})
+        ctx.buffer_dependency_cache_publication(entry)
+
+        ctx.clear_mutation_cache()
+
+        assert all(ctx.get((prefix, "key")) is None for prefix in prefixes)
+        assert ctx.get(("unrelated", "key")) == "keep"
+        assert ctx.get("plain") == "keep"
+        assert ctx.get_dependency_cache_hit("prefetched") is hit
+        assert ctx.get_dependency_cache_hit(entry.cache_key).value == entry.result
+        assert entry.cache_key in ctx._dependency_cache_pending_publications
+
+
+def test_clear_mutation_cache_does_not_touch_nested_context_state() -> None:
+    with CalculationRunContext() as outer:
+        outer.set((ORM_BUCKET_RESULT_PREFIX, "outer"), "outer")
+
+        with CalculationRunContext() as inner:
+            inner.set((ORM_BUCKET_RESULT_PREFIX, "inner"), "inner")
+            inner.clear_mutation_cache()
+            assert inner.get((ORM_BUCKET_RESULT_PREFIX, "inner")) is None
+
+        assert outer.get((ORM_BUCKET_RESULT_PREFIX, "outer")) == "outer"
 
 
 def test_orm_bucket_result_helpers_store_and_clear_entries() -> None:

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -12,6 +12,7 @@ from general_manager.cache.dependency_index import (
     record_invalidated_cache_keys_for_graphql_rewarm,
 )
 from general_manager.cache.signals import data_change, pre_data_change, post_data_change
+from general_manager.cache.run_context import CalculationRunContext
 
 
 @contextmanager
@@ -93,6 +94,10 @@ class RecordingRaisingDummy:
         """Record a pending key and raise from a wrapped method."""
         record_invalidated_cache_keys_for_graphql_rewarm(("stale-key",))
         raise ValueError("boom")
+
+
+class PostSignalError(RuntimeError):
+    """Test-only failure raised by a post-change receiver."""
 
 
 class NestedDataChangeDummy:
@@ -321,6 +326,70 @@ class DataChangeSignalTests(TestCase):
 
         self.assertFalse(is_dependency_data_change_active())
         self.assertEqual(drain_invalidated_cache_keys_for_graphql_rewarm(), ())
+
+    def test_data_change_clears_mutation_cache_before_and_after_success(self):
+        """Successful mutations clear run-cache namespaces in both phases."""
+        with CalculationRunContext() as context:
+            context.set(("orm_bucket_result", "before"), "stale")
+            context.set(("bucket_index", "before"), "stale")
+            context.set(("trusted_orm_manager", "before"), "stale")
+            context.set(("calculation_bucket_result", "before"), "stale")
+            context.set(("unrelated", "before"), "keep")
+
+            with patch.object(
+                context,
+                "clear_mutation_cache",
+                wraps=context.clear_mutation_cache,
+            ) as clear_mutation_cache:
+                Dummy.create("warm")
+
+            self.assertEqual(clear_mutation_cache.call_count, 2)
+            self.assertEqual(context.get(("unrelated", "before")), "keep")
+            self.assertIsNone(context.get(("orm_bucket_result", "before")))
+            self.assertIsNone(context.get(("bucket_index", "before")))
+            self.assertIsNone(context.get(("trusted_orm_manager", "before")))
+            self.assertIsNone(context.get(("calculation_bucket_result", "before")))
+
+    def test_data_change_clears_mutation_cache_only_before_failure(self):
+        """Failed mutations clear stale run-cache state before invoking the body."""
+        with CalculationRunContext() as context:
+            context.set(("orm_bucket_result", "before"), "stale")
+            context.set(("unrelated", "before"), "keep")
+
+            with (
+                patch.object(
+                    context,
+                    "clear_mutation_cache",
+                    wraps=context.clear_mutation_cache,
+                ) as clear_mutation_cache,
+                self.assertRaisesRegex(ValueError, "boom"),
+            ):
+                RaisingDummy().update()
+
+            self.assertEqual(clear_mutation_cache.call_count, 1)
+            self.assertEqual(context.get(("unrelated", "before")), "keep")
+            self.assertIsNone(context.get(("orm_bucket_result", "before")))
+
+    def test_data_change_post_signal_error_keeps_both_cache_clears(self):
+        """Post-signal failures still retain the completed post-mutation clear."""
+
+        def raise_from_post_change(sender, **kwargs):
+            del sender, kwargs
+            raise PostSignalError
+
+        post_data_change.connect(raise_from_post_change, weak=False)
+        with CalculationRunContext() as context:
+            with (
+                patch.object(
+                    context,
+                    "clear_mutation_cache",
+                    wraps=context.clear_mutation_cache,
+                ) as clear_mutation_cache,
+                self.assertRaises(PostSignalError),
+            ):
+                Dummy.create("warm")
+
+            self.assertEqual(clear_mutation_cache.call_count, 2)
 
     def test_cleanup_failure_is_logged_when_wrapped_function_already_failed(self):
         """Cleanup errors are logged when another exception is already active."""


### PR DESCRIPTION
## Problem

Mutation invalidation previously called one prefix scan for each cache namespace in both the pre- and post-mutation phases. With 18 run-cache namespaces, this repeated full `_values` scans and scaled with unrelated cached calculation data.

## Proposed Solution

Add a single-pass multi-prefix invalidation primitive and an internal `clear_mutation_cache()` method covering all 18 mutation-invalidated namespaces. Existing namespace clear methods delegate to the primitive, while dependency-cache hits, pending publications, unrelated values, and nested-context semantics remain unchanged. Data-change signals now use one clear before and one clear after successful mutations.

## Alternatives / Workarounds

Clearing the entire run context would be simpler but would incorrectly discard unrelated calculation/provider state and alter dependency behavior. Retaining one scan per namespace preserves behavior but leaves avoidable repeated work.

## Impact

- Mixed 18-namespace mutation workload: 36 scans -> 2.
- Mixed 18-namespace workload key inspections: 95,000 -> 10,000.
- Targeted entries are invalidated while unrelated entries and dependency state remain.
- Public manager, interface, bucket, and cache APIs are unchanged.

## References

Closes #355. Stacked on #382.

## Verification

- python -m pytest tests/unit/test_calculation_run_context.py tests/unit/test_signals.py tests/perf/test_database_bucket_perf.py -q — 109 passed.
- python -m pytest -q — 5402 passed, 2 skipped, 1 warning, 1984 subtests passed.
- pre-commit run --all-files — passed.
- Ruff, format, mypy, and git diff --check — passed.
- Performance instrumentation recorded exactly 2 discard-prefix scans and 10,000 key inspections after the change.
- Only tracked implementation, tests, and performance-budget files were committed; gitignored files were not staged.