### PR TITLE
fix: preserve failed rule validation

### DIFF
--- a/docs/superpowers/specs/2026-07-13-rule-validation-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-13-rule-validation-fallback-design.md
@@ -1,0 +1,62 @@
+# Rule Validation Fallback Design
+
+## Context
+
+GitHub issue #387 reports that a `Rule` returning `False` can be silently
+accepted when `ignore_if_none=False` unless `custom_error_message` is set. The
+evaluation itself is correct: the failure is lost when automatic AST-based
+message generation returns an empty mapping. ORM and request-backed validation
+only raise `ValidationError` when that mapping is non-empty.
+
+The problem is broader than `None` handling. Any failed expression whose AST
+cannot be mapped back to a referenced variable can reach the same path.
+`ignore_if_none=False` makes the issue visible because it forces predicates to
+evaluate when referenced values are `None`.
+
+## Required Behavior
+
+- A built-in `Rule` that evaluates to `False` always returns a non-empty error
+  mapping from `get_error_message()`.
+- Existing detailed AST-generated messages remain unchanged when generation
+  succeeds.
+- Existing custom messages remain unchanged.
+- When detailed generation fails, every referenced variable receives a generic
+  invalid-combination message.
+- When the rule has no detectable referenced variables, the generic error uses
+  Django's non-field error key.
+- Rules returning `True` or `None` continue to return no error message.
+
+## Design
+
+Keep fallback policy inside `Rule`, which owns both predicate introspection and
+message generation. Add one private helper that builds the generic mapping from
+the rule's extracted variables. Reuse it when comparison-specific generation
+returns no messages and when a custom message has no field keys to attach to.
+
+The fallback message should retain the existing generic wording for referenced
+variables: `"[field] combination is not valid"`. For rules without variables,
+use `NON_FIELD_ERRORS` with `"Rule validation failed"`. Centralizing the
+guarantee means both ORM and request-backed consumers receive a truthy mapping
+without duplicating policy or changing their interfaces.
+
+## Testing
+
+Use test-driven development:
+
+1. Change the existing wrapped-comparison unit test to expect a generic field
+   message and run it to prove the current implementation fails.
+2. Add a no-variable rule test that expects a Django non-field error and prove
+   it fails.
+3. Add ORM regression coverage using a real `Rule` with
+   `ignore_if_none=False`, proving `full_clean` raises without a custom message.
+4. Add request-interface regression coverage proving the same rule failure is
+   raised before a request mutation proceeds.
+5. Run focused rule, ORM-interface, and request-interface tests, followed by
+   formatting, lint, typing, and the full test suite as warranted.
+
+## Compatibility and Scope
+
+This is a behavioral correction to match the documented contract that `False`
+raises `ValidationError`. It does not change successful evaluation, skipped
+`None` evaluation, custom handler dispatch, or detailed message formats. No new
+dependencies or unrelated refactors are required.

--- a/src/general_manager/rule/rule.py
+++ b/src/general_manager/rule/rule.py
@@ -10,6 +10,7 @@ from operator import eq, ge, gt, le, lt, ne
 from typing import Callable, Dict, Generic, List, Optional, Tuple, TypeVar, cast
 from decimal import Decimal
 
+from django.core.exceptions import NON_FIELD_ERRORS
 from django.utils.module_loading import import_string
 
 from general_manager.rule.handler import (
@@ -289,6 +290,20 @@ class Rule(Generic[GeneralManagerType]):
         if missing:
             raise MissingErrorTemplateVariableError(missing)
 
+    def _generate_fallback_error_messages(
+        self,
+        message: str | None = None,
+    ) -> Dict[str, str]:
+        """Attach a generic failed-rule message to fields or non-field errors."""
+        variables = self._variables or [NON_FIELD_ERRORS]
+        if message is None:
+            if self._variables:
+                combo = ", ".join(f"[{variable}]" for variable in self._variables)
+                message = f"{combo} combination is not valid"
+            else:
+                message = "Rule validation failed"
+        return {variable: message for variable in variables}
+
     def get_error_message(self) -> Optional[Dict[str, str]]:
         """
         Constructs error messages for the last failed evaluation and returns them keyed by variable name.
@@ -330,7 +345,7 @@ class Rule(Generic[GeneralManagerType]):
                     "variables": self._variables,
                 },
             )
-            return {v: formatted for v in self._variables}
+            return self._generate_fallback_error_messages(formatted)
 
         errors = self._generate_error_messages(vals)
         if errors:
@@ -350,7 +365,7 @@ class Rule(Generic[GeneralManagerType]):
                     "manager": manager_class,
                 },
             )
-        return errors or None
+        return errors or self._generate_fallback_error_messages()
 
     def _extract_variables(self) -> List[str]:
         """

--- a/src/general_manager/rule/rule.py
+++ b/src/general_manager/rule/rule.py
@@ -306,10 +306,12 @@ class Rule(Generic[GeneralManagerType]):
 
     def get_error_message(self) -> Optional[Dict[str, str]]:
         """
-        Constructs error messages for the last failed evaluation and returns them keyed by variable name.
+        Construct error messages for the last failed evaluation.
 
         Returns:
-            dict[str, str] | None: Mapping from each referenced variable name to its error message, or `None` if the predicate passed or was not evaluated.
+            dict[str, str] | None: Mapping keyed by referenced variables or
+            Django's `NON_FIELD_ERRORS` fallback when no variables are available;
+            `None` if the predicate passed or was not evaluated.
 
         Raises:
             ErrorMessageGenerationError: If called before any input has been evaluated.

--- a/tests/integration/test_request_transport.py
+++ b/tests/integration/test_request_transport.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pickle
 from datetime import datetime
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from unittest import mock
 
 from django.core.exceptions import ValidationError
@@ -463,8 +463,8 @@ class RuleProtectedProject(GeneralManager):
             auth_provider = FakeBearerAuth()
             rules: ClassVar[list[Rule]] = [
                 Rule(
-                    lambda project: bool(project.name),
-                    custom_error_message="Name is required: {name}",
+                    lambda project: cast(str, project.name) != "",
+                    ignore_if_none=False,
                 ),
                 Rule(
                     lambda project: project.status in {"active", "inactive"},
@@ -646,13 +646,17 @@ class RequestTransportIntegrationTest(SimpleTestCase):
         self.assertEqual(request.headers["Authorization"], "Bearer good-token")
 
     def test_request_rules_block_invalid_create_mutations(self) -> None:
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as context:
             RuleProtectedProject.create(
                 name="",
                 status="active",
                 ignore_permission=True,
             )
 
+        self.assertEqual(
+            context.exception.message_dict["name"],
+            ["[name] combination is not valid"],
+        )
         self.assertEqual(RuleProtectedProject.Interface.transport.requests, [])
 
     def test_request_rules_block_invalid_update_mutations(self) -> None:

--- a/tests/unit/test_database_based_interface.py
+++ b/tests/unit/test_database_based_interface.py
@@ -1,6 +1,6 @@
 # type: ignore
 
-from typing import ClassVar
+from typing import ClassVar, cast
 from uuid import UUID
 
 from django.test import TransactionTestCase
@@ -30,6 +30,7 @@ from general_manager.interface.utils.errors import (
     UnknownFieldError,
 )
 from general_manager.manager.input import Input
+from general_manager.rule import Rule
 from general_manager.bucket.database_bucket import DatabaseBucket
 from general_manager.interface.capabilities.orm_utils.payload_normalizer import (
     PayloadNormalizer,
@@ -328,6 +329,31 @@ class OrmInterfaceBaseTestCase(TransactionTestCase):
             cleaner(self.person)
         self.assertTrue(PersonModel._meta.rules[0].called)
         delattr(PersonModel._meta, "rules")
+
+    def test_rules_and_full_clean_false_without_custom_message(self):
+        """A failed real Rule cannot pass when message inference needs fallback."""
+
+        def positive_age(person: PersonModel) -> bool:
+            return cast(int, person.age) > 0
+
+        PersonModel._meta.rules = [Rule(positive_age, ignore_if_none=False)]
+        cleaner = get_full_clean_methode(PersonModel)
+        invalid = PersonModel(
+            name="Invalid Age",
+            age=0,
+            owner=self.user,
+            changed_by=self.user,
+        )
+
+        try:
+            with self.assertRaises(ValidationError) as context:
+                cleaner(invalid)
+            self.assertEqual(
+                context.exception.message_dict["age"],
+                ["[age] combination is not valid"],
+            )
+        finally:
+            delattr(PersonModel._meta, "rules")
 
     def test_rules_and_full_clean_merges_errors_for_same_field(self):
         """

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import NON_FIELD_ERRORS
 from django.test import TestCase, override_settings
 from datetime import datetime
 import ast
@@ -631,7 +632,7 @@ class RuleTests(TestCase):
     def test_rule_with_type_hint(self):
         """
         Verifies a Rule correctly evaluates a predicate that uses a type hint cast.
-        Creates a Rule whose predicate casts item.price to float and compares it to 100.0, asserts the evaluation is False for price 150.75, and asserts no error message is produced.
+        Creates a Rule whose predicate casts item.price to float and compares it to 100.0, asserts the evaluation is False for price 150.75, and asserts a fallback error message is produced.
         """
 
         def func(item: DummyObject) -> bool:
@@ -651,7 +652,24 @@ class RuleTests(TestCase):
         result = rule.evaluate(x)
         self.assertFalse(result)
         error_message = rule.get_error_message()
-        self.assertIsNone(error_message)
+        self.assertEqual(
+            error_message,
+            {"price": "[price] combination is not valid"},
+        )
+
+    def test_failed_rule_without_variables_uses_non_field_error(self):
+        """A failed rule always returns an attachable validation message."""
+
+        def func(_item: DummyObject) -> bool:
+            return False
+
+        rule = Rule(func, ignore_if_none=False)
+
+        self.assertFalse(rule.evaluate(DummyObject()))
+        self.assertEqual(
+            rule.get_error_message(),
+            {NON_FIELD_ERRORS: "Rule validation failed"},
+        )
 
     def test_rule_with_none_value(self):
         """Ensure Rules handle None values correctly when ignore_if_none is enabled."""

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -671,6 +671,24 @@ class RuleTests(TestCase):
             {NON_FIELD_ERRORS: "Rule validation failed"},
         )
 
+    def test_failed_rule_without_variables_preserves_custom_non_field_error(self):
+        """A variable-free custom message is attached as a non-field error."""
+
+        def func(_item: DummyObject) -> bool:
+            return False
+
+        rule = Rule(
+            func,
+            custom_error_message="Custom failure",
+            ignore_if_none=False,
+        )
+
+        self.assertFalse(rule.evaluate(DummyObject()))
+        self.assertEqual(
+            rule.get_error_message(),
+            {NON_FIELD_ERRORS: "Custom failure"},
+        )
+
     def test_rule_with_none_value(self):
         """Ensure Rules handle None values correctly when ignore_if_none is enabled."""
 


### PR DESCRIPTION
## Summary

- guarantee that every failed built-in `Rule` returns a non-empty validation error mapping
- attach generic fallback messages to referenced fields, or Django's non-field error key when no fields can be inferred
- add direct, ORM, and request-interface regression coverage for failures without `custom_error_message`

## Root cause and impact

`Rule.evaluate()` correctly returned `False`, but AST-based error-message inference could return an empty mapping for wrapped comparisons. ORM and request validation only raised `ValidationError` when that mapping was truthy, allowing invalid mutations to proceed silently. The fallback is now centralized in `Rule.get_error_message()`, preserving existing detailed and custom messages.

Fixes #387.

## Validation

- `python -m pytest -q` — 4,922 passed, 2 skipped, 1 pre-existing warning, 1,867 subtests passed
- focused rule/ORM/request suites — 171 passed, 22 subtests passed
- `ruff check src tests`
- `mypy` — no issues in 265 source files
- independent specification, code-quality, and final whole-branch reviews found no critical or important issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors now consistently return a meaningful message, including cases where rules produce no field-specific details (using non-field errors when needed).
  * Improved fallback handling when rule-derived message mappings are empty, preventing “no message” outcomes.
  * Request validation for empty project names now surfaces the expected `ValidationError` message details.

* **Tests**
  * Added and updated unit/integration tests to assert fallback and non-field error message behavior.

* **Documentation**
  * Added a design specification for rule validation fallback behavior and testing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->