### PR TITLE
fix: ship chat eval datasets and harden module CLI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,14 @@ jobs:
         name: Build Project
         run: python -m build
 
+      - name: Smoke-test built distribution
+        if: ${{ steps.semantic_release.outputs.released == 'true' }}
+        run: |
+          python -m pip install --force-reinstall dist/*.whl
+          env -u DJANGO_SETTINGS_MODULE python -m general_manager.chat.evals --help
+          env -u DJANGO_SETTINGS_MODULE PYTHONPATH=tests/packaging python -m general_manager.chat.evals --settings chat_eval_smoke_settings --provider builtins.object --fixture toy --dataset basic_queries --tier 999
+          python tests/packaging/smoke_chat_eval_distribution.py dist/*
+
       # 5) Upload nur, wenn wirklich was released wurde
       - name: Publish to PyPI
         if: ${{ steps.semantic_release.outputs.released == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,30 @@ jobs:
           flags: unittests
           version: v11.2.7
           fail_ci_if_error: false
+
+  distribution:
+    name: Package smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distribution
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Install built wheel
+        run: python -m pip install --force-reinstall dist/*.whl
+
+      - name: Smoke-test built distribution
+        run: |
+          env -u DJANGO_SETTINGS_MODULE python -m general_manager.chat.evals --help
+          env -u DJANGO_SETTINGS_MODULE PYTHONPATH=tests/packaging python -m general_manager.chat.evals --settings chat_eval_smoke_settings --provider builtins.object --fixture toy --dataset basic_queries --tier 999
+          python tests/packaging/smoke_chat_eval_distribution.py dist/*

--- a/docs/chat_implementation_plan.md
+++ b/docs/chat_implementation_plan.md
@@ -353,10 +353,16 @@ because phrasing varies across providers and runs.
 
 ```bash
 # Run full eval suite against a provider
-python -m general_manager.chat.evals --provider ollama --model llama3
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --provider general_manager.chat.providers.OllamaProvider \
+  --model llama3
 
 # Run only toy contract cases
-python -m general_manager.chat.evals --fixture toy --tier 0
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --fixture toy \
+  --tier 0
 
 # Run local demo readiness cases with traces
 python scripts/run_chat_evals.py --model glm-4.7-flash:q4_K_M --dataset demo_readiness --tier 1 --trace-jsonl /tmp/chat-demo-eval.jsonl
@@ -365,10 +371,18 @@ python scripts/run_chat_evals.py --model glm-4.7-flash:q4_K_M --dataset demo_rea
 python scripts/run_chat_evals.py --fixture large --dataset large_schema --tier 2
 
 # Run specific dataset
-python -m general_manager.chat.evals --dataset multi_hop
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --dataset multi_hop
 
 # Compare providers side-by-side
-python -m general_manager.chat.evals --compare ollama,anthropic,openai,google
+providers=general_manager.chat.providers.OllamaProvider
+providers+=,general_manager.chat.providers.AnthropicProvider
+providers+=,general_manager.chat.providers.OpenAIProvider
+providers+=,general_manager.chat.providers.GoogleProvider
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --compare "$providers"
 ```
 
 Output: summary table with pass rates per dimension per provider, plus detailed

--- a/docs/concepts/chat_prompting.md
+++ b/docs/concepts/chat_prompting.md
@@ -85,6 +85,31 @@ For debugging a specific dataset, include the transcript:
 PYTHONPATH=src python scripts/run_chat_evals.py --model gemma4:e4b --dataset basic_queries -v --show-chat --trace-jsonl /tmp/chat-basic-eval.jsonl
 ```
 
+### Installed module CLI
+
+The built-in YAML eval datasets ship with GeneralManager. The installed module
+CLI still needs the consuming Django project's settings for Django and provider
+configuration. For `basic_queries`, register its matching built-in toy schema
+and data:
+
+```bash
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --dataset basic_queries \
+  --fixture toy \
+  --provider general_manager.chat.providers.OllamaProvider
+```
+
+Omit a built-in fixture only when the selected dataset's managers and
+expectations match the configured project's schema and data.
+
+You can set `DJANGO_SETTINGS_MODULE` instead of passing `--settings`. Displaying
+the CLI help does not require Django settings:
+
+```bash
+python -m general_manager.chat.evals --help
+```
+
 Treat failures by category:
 
 - **Product contract**: fix unsafe behavior, wrong data, hallucinated fields, or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "general_manager" = ["py.typed"]
+"general_manager.chat.evals" = ["datasets/*.yaml"]
 
 [tool.semantic_release]
 allow_zero_version = true

--- a/src/general_manager/chat/__init__.py
+++ b/src/general_manager/chat/__init__.py
@@ -1,6 +1,36 @@
 """General Manager chat integration."""
 
-from general_manager.chat.bootstrap import initialize_chat
-from general_manager.chat.settings import ChatConfigurationError
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from general_manager.utils.public_api import build_module_dir, resolve_export
 
 __all__ = ["ChatConfigurationError", "initialize_chat"]
+
+_MODULE_MAP = {
+    "ChatConfigurationError": (
+        "general_manager.chat.settings",
+        "ChatConfigurationError",
+    ),
+    "initialize_chat": ("general_manager.chat.bootstrap", "initialize_chat"),
+}
+
+if TYPE_CHECKING:
+    from general_manager.chat.bootstrap import initialize_chat
+    from general_manager.chat.settings import ChatConfigurationError
+
+
+def __getattr__(name: str) -> object:
+    """Resolve and cache a public chat export."""
+    return resolve_export(
+        name,
+        module_all=__all__,
+        module_map=_MODULE_MAP,
+        module_globals=globals(),
+    )
+
+
+def __dir__() -> list[str]:
+    """Return the chat module's available names."""
+    return build_module_dir(module_all=__all__, module_globals=globals())

--- a/src/general_manager/chat/evals/__main__.py
+++ b/src/general_manager/chat/evals/__main__.py
@@ -70,8 +70,11 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.settings:
         os.environ["DJANGO_SETTINGS_MODULE"] = args.settings
-    else:
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_settings")
+    elif not os.environ.get("DJANGO_SETTINGS_MODULE"):
+        parser.error(
+            "Django settings are required; pass --settings or set "
+            "DJANGO_SETTINGS_MODULE."
+        )
 
     import django
 

--- a/tests/packaging/chat_eval_smoke_settings.py
+++ b/tests/packaging/chat_eval_smoke_settings.py
@@ -1,0 +1,4 @@
+"""Minimal Django settings for the installed chat eval CLI smoke test."""
+
+SECRET_KEY = "chat-eval-distribution-smoke"  # noqa: S105
+INSTALLED_APPS: list[str] = []

--- a/tests/packaging/smoke_chat_eval_distribution.py
+++ b/tests/packaging/smoke_chat_eval_distribution.py
@@ -1,0 +1,68 @@
+"""Verify chat eval datasets in distributions and an installed wheel."""
+
+from __future__ import annotations
+
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_DATASETS = ROOT / "src/general_manager/chat/evals/datasets"
+ARCHIVE_MARKER = "general_manager/chat/evals/datasets/"
+
+
+def _archive_dataset_names(artifact: Path) -> set[str]:
+    if artifact.name.endswith(".whl"):
+        with zipfile.ZipFile(artifact) as archive:
+            members = archive.namelist()
+    elif artifact.name.endswith(".tar.gz"):
+        with tarfile.open(artifact, "r:gz") as archive:
+            members = archive.getnames()
+    else:
+        msg = f"Unsupported distribution artifact: {artifact}"
+        raise AssertionError(msg)
+
+    return {
+        Path(member).name
+        for member in members
+        if ARCHIVE_MARKER in member and member.endswith(".yaml")
+    }
+
+
+def main(arguments: list[str]) -> None:
+    assert len(arguments) == 2, "Expected exactly one wheel and one sdist"
+
+    artifacts = [Path(argument).resolve() for argument in arguments]
+    wheels = [artifact for artifact in artifacts if artifact.name.endswith(".whl")]
+    sdists = [artifact for artifact in artifacts if artifact.name.endswith(".tar.gz")]
+    assert len(wheels) == 1, "Expected exactly one wheel"
+    assert len(sdists) == 1, "Expected exactly one sdist"
+
+    source_names = {path.name for path in SOURCE_DATASETS.glob("*.yaml")}
+    assert source_names, "Expected at least one source chat eval dataset"
+    assert _archive_dataset_names(wheels[0]) == source_names
+    assert _archive_dataset_names(sdists[0]) == source_names
+
+    from django.conf import settings
+
+    settings.configure(
+        SECRET_KEY="chat-eval-distribution-smoke",  # noqa: S106
+        INSTALLED_APPS=[],
+    )
+
+    import django
+
+    django.setup()
+
+    import general_manager
+    from general_manager.chat.evals.runner import list_datasets, load_dataset
+
+    installed_package = Path(general_manager.__file__).resolve()
+    assert not installed_package.is_relative_to(ROOT / "src")
+    assert set(list_datasets()) == {Path(name).stem for name in source_names}
+    assert load_dataset("basic_queries")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tests/unit/test_chat_eval_cli.py
+++ b/tests/unit/test_chat_eval_cli.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -8,6 +11,8 @@ import pytest
 
 from general_manager.chat.evals import __main__ as eval_cli
 from general_manager.chat.settings import get_chat_settings
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 class _Provider:
@@ -32,12 +37,12 @@ def test_instantiate_provider_without_model_uses_current_settings() -> None:
     assert isinstance(provider, _Provider)
 
 
-def test_main_defaults_django_settings_module_when_unset(capsys, monkeypatch) -> None:
+def test_main_requires_django_settings_module_when_unset(capsys, monkeypatch) -> None:
     result = SimpleNamespace(passed=True)
     monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
 
     with (
-        patch("django.setup") as django_setup,
+        patch("django.setup"),
         patch(
             "general_manager.chat.settings.import_provider",
             return_value=_Provider,
@@ -51,11 +56,57 @@ def test_main_defaults_django_settings_module_when_unset(capsys, monkeypatch) ->
             return_value="all good",
         ),
     ):
-        eval_cli.main([])
+        with pytest.raises(SystemExit) as exit_info:
+            eval_cli.main([])
 
-    django_setup.assert_called_once_with()
-    assert os.environ["DJANGO_SETTINGS_MODULE"] == "tests.test_settings"
-    assert capsys.readouterr().out == "all good\n"
+    assert exit_info.value.code == 2
+    assert "--settings" in capsys.readouterr().err
+    assert "DJANGO_SETTINGS_MODULE" not in os.environ
+
+
+def test_main_requires_django_settings_module_when_empty(capsys, monkeypatch) -> None:
+    result = SimpleNamespace(passed=True)
+    monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "")
+
+    with (
+        patch("django.setup"),
+        patch(
+            "general_manager.chat.settings.import_provider",
+            return_value=_Provider,
+        ),
+        patch(
+            "general_manager.chat.evals.runner.run_eval_suite_sync",
+            return_value=[result],
+        ),
+        patch(
+            "general_manager.chat.evals.runner.print_report",
+            return_value="all good",
+        ),
+    ):
+        with pytest.raises(SystemExit) as exit_info:
+            eval_cli.main([])
+
+    assert exit_info.value.code == 2
+    assert "--settings" in capsys.readouterr().err
+
+
+def test_module_help_runs_without_django_settings() -> None:
+    env = os.environ.copy()
+    env.pop("DJANGO_SETTINGS_MODULE", None)
+    env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+
+    result = subprocess.run(  # noqa: S603 - trusted current interpreter
+        [sys.executable, "-m", "general_manager.chat.evals", "--help"],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Run the GeneralManager chat evaluation suite." in result.stdout
+    assert "settings are not configured" not in result.stderr
 
 
 def test_main_explicit_settings_overrides_existing_env(capsys, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- ship all built-in chat eval YAML datasets in wheels and sdists
- defer settings-dependent chat imports and require an explicit supported Django settings source
- smoke-test CLI startup and dataset loading from installed artifacts in PR and release CI
- document installed-module usage, settings requirements, fixtures, and provider paths

## Root cause

The package configuration only shipped `py.typed`, while the eval runner loaded adjacent YAML files. In addition, importing the parent `general_manager.chat` package reached Django settings before the module CLI could parse `--help` or `--settings`, and the fallback referenced the repository-only `tests.test_settings` module.

## Testing

- `python -m pytest` — 4,925 passed, 2 skipped
- `ruff check`
- `ruff format --check`
- `mypy --strict`
- `pre-commit run --all-files`
- `mkdocs build --strict`
- clean wheel and sdist build
- fresh virtualenv wheel install
- settings-free module help, explicit `--settings` CLI smoke, exact archive dataset comparison, installed discovery, and `basic_queries` loading

Closes #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat evaluation datasets are now included in Python distributions.
  * The evaluation CLI supports explicit Django settings and clearer setup requirements.
  * CLI help can be viewed without configuring Django.

* **Documentation**
  * Added guidance and updated examples for running chat evaluations, selecting datasets, fixtures, providers, and settings.

* **Bug Fixes**
  * Built packages are now smoke-tested before publishing to help ensure evaluation assets and commands work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->