### PR TITLE
fix: attach release preflight to branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - id: attach_release_branch
+        name: Attach exact commit to the release branch
+        run: |
+          set -euo pipefail
+          git switch -C "$GITHUB_REF_NAME" "$GITHUB_SHA"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -279,6 +279,7 @@ def test_publish_workflow_runs_every_exact_sha_through_quality_and_release() -> 
 def test_publish_artifact_job_builds_once_at_the_exact_commit() -> None:
     workflow = load_workflow("publish.yml")
     job = workflow["jobs"]["artifact"]
+    steps = cast(list[dict[str, Any]], job["steps"])
 
     assert job["permissions"] == {"contents": "read"}
     assert job["outputs"] == {
@@ -286,11 +287,18 @@ def test_publish_artifact_job_builds_once_at_the_exact_commit() -> None:
         "version": "${{ steps.prepare.outputs.version }}",
         "tag": "${{ steps.prepare.outputs.tag }}",
     }
-    assert action_step(job, "actions/checkout@v4")["with"] == {
+    checkout = action_step(job, "actions/checkout@v4")
+    assert checkout["with"] == {
         "ref": "${{ github.sha }}",
         "fetch-depth": "0",
         "persist-credentials": "false",
     }
+    attach_branch = step_by_id(job, "attach_release_branch")
+    assert str(attach_branch["run"]).strip() == (
+        "set -euo pipefail\n"
+        'git switch -C "$GITHUB_REF_NAME" "$GITHUB_SHA"\n'
+        'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"'
+    )
     assert action_step(job, "actions/setup-python@v5")["with"] == {
         "python-version": "3.12"
     }
@@ -301,6 +309,7 @@ def test_publish_artifact_job_builds_once_at_the_exact_commit() -> None:
         "python -m pip install python-semantic-release==10.6.1 build twine==6.0.1"
     ) in commands
     prepare = step_by_id(job, "prepare")
+    assert steps.index(checkout) < steps.index(attach_branch) < steps.index(prepare)
     assert prepare["env"] == {"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}"}
     prepare_command = str(prepare["run"])
     assert "semantic-release version" in prepare_command


### PR DESCRIPTION
## Summary

- attach the exact push SHA to the local release branch before running Python Semantic Release
- assert the attached branch still points to the event SHA
- add a regression test for checkout → branch attachment → release-preflight ordering

## Root cause

The artifact job intentionally checks out `github.sha`, which leaves Git in detached-HEAD state. Python Semantic Release 10.6.1 cannot match detached HEAD to the configured `main` release group, so the publish workflow failed before building artifacts.

Failed run: https://github.com/TimKleindick/general_manager/actions/runs/29405566789/job/87321055655

## Validation

- reproduced the detached-HEAD failure at exact SHA `3618944a`
- the attached exact-SHA reproduction resolves version `0.63.2` and completes the full non-mutating Semantic Release build
- HEAD remains exactly `3618944a`
- release-focused suite: 139 passed
- full suite: 5028 passed, 2 skipped, 1874 subtests passed
- Ruff, formatting, pre-commit, strict MkDocs, and changed-file mypy passed
- independent review approved with no critical or important findings

No tag, release, push, or PyPI mutation was performed during reproduction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by ensuring artifacts are built from the exact release commit.
  * Added verification to prevent packaging from proceeding when the checked-out commit does not match the intended release version.

* **Tests**
  * Expanded automated coverage for release workflow permissions, outputs, step configuration, and execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->