### PR TITLE
fix: batch bulk data-change notifications

### DIFF
--- a/docs/concepts/graphql/subscriptions.md
+++ b/docs/concepts/graphql/subscriptions.md
@@ -161,6 +161,45 @@ task errors still propagate from the await.
 - Subscriptions require Django Channels. If `get_channel_layer()` returns `None`, the resolver raises a descriptive GraphQL error explaining that `CHANNEL_LAYERS` must be configured.
 - Managers are automatically decorated with `@data_change` and emit `pre_data_change` and `post_data_change` signals. GraphQL listens to `post_data_change` and forwards the event to the relevant instance channel group (`gm_subscriptions.<Manager>.<digest>`) and class channel group (`gm_subscriptions.<Manager>.__class__`).
 
+### Bulk notification refreshes
+
+Use the public notification context when many writes should produce one refresh
+per affected GraphQL manager class:
+
+```python
+from django.db import transaction
+
+from general_manager.api import bulk_data_change_notifications
+
+
+with bulk_data_change_notifications():
+    with transaction.atomic():
+        for project in projects:
+            project.update(status="archived")
+```
+
+Keep `bulk_data_change_notifications()` outside `transaction.atomic()`. The
+transaction then commits before the notification context flushes. The context is
+not automatically transaction-aware, and it also flushes queued refreshes when
+the body exits exceptionally, after the nested transaction has rolled back and
+before re-raising the exception.
+
+During an explicit batch, row-level events are replaced by one `refresh` event
+for each affected manager class. A detail subscription receives refreshes for
+its own manager and for manager classes in its dependency groups, then
+rehydrates its own item. A class-wide subscription receives `action = refresh`
+with `item = null`; the event contains no row identification. This intentionally
+discloses that a change to the manager class occurred at batch-flush time, but
+not which rows changed, how many changed, or their original actions.
+
+Outside the context, ordinary row events and their timing are unchanged. The
+context batches only GraphQL and RemoteAPI notification delivery:
+`post_data_change`, dependency-cache invalidation, and unrelated signal
+receivers still run immediately for every change. Batching is scoped to the
+current Python `ContextVar` state. Newly created tasks and `asyncio.to_thread()`
+normally copy that state; unrelated threads or execution contexts do not share
+the batch.
+
 ### Identification helpers
 
 The subscription arguments mirror the interface inputs. For nested managers, the schema accepts IDs (e.g. `employeeId`) so the server can reconstruct the full identification dictionary. This results in subscriptions that are consistent with query and mutation signatures.

--- a/docs/concepts/graphql/subscriptions.md
+++ b/docs/concepts/graphql/subscriptions.md
@@ -259,14 +259,24 @@ subscriber actually needs.
 
 - Missing channel layer configuration produces a GraphQL error instructing the operator to configure `CHANNEL_LAYERS`.
 - If instantiating the manager or a dependency fails during an update, the subscription sends an event with `item = null` and the incoming `action`. Clients can use this to show a placeholder while retrying the fetch.
-- Class-wide subscriptions check object-level read permission before yielding each event. If the requesting user cannot read the changed object, the event is suppressed entirely so the stream does not reveal hidden object IDs or change timing.
-- If a class-wide event cannot be rehydrated, such as a hard-deleted object that no longer exists, the event is suppressed rather than sent with `item = null`.
-- Class-wide subscriptions suppress these malformed queued messages before
-  hydration: messages for another manager name, missing or non-string `action`
-  values, and missing or non-object `identification` payloads. The lower-level
-  channel listener only requires `type: "gm.subscription.event"` and a present
-  `action` before queueing a message, so other malformed payloads reach the
-  class-wide stream and are handled there or by the normal hydration error path.
+- Class-wide subscriptions check object-level read permission before yielding
+  each ordinary row-level event. If the requesting user cannot read the changed
+  object, the event is suppressed entirely so the stream does not reveal hidden
+  object IDs or change timing. Aggregate batch `refresh` events are exempt from
+  this object-level check because they contain no row identification, as
+  described under Bulk notification refreshes.
+- If an ordinary class-wide row-level event cannot be rehydrated, such as a
+  hard-deleted object that no longer exists, the event is suppressed rather than
+  sent with `item = null`.
+- Class-wide subscriptions suppress these malformed queued ordinary row-level
+  messages before hydration: messages for another manager name, missing or
+  non-string `action` values, and missing or non-object `identification`
+  payloads. Aggregate batch `refresh` events are handled before identification
+  validation and are therefore exempt from the identification requirement. The
+  lower-level channel listener only requires `type: "gm.subscription.event"`
+  and a present `action` before queueing a message, so other malformed payloads
+  reach the class-wide stream and are handled there or by the normal hydration
+  error path.
 - Data-change dispatch publishes to both the instance group and the class-wide
   group only for registered managers and configured channel layers. A provided
   signal identification mapping is used when available; otherwise the changed

--- a/docs/concepts/graphql/subscriptions.md
+++ b/docs/concepts/graphql/subscriptions.md
@@ -178,19 +178,23 @@ with bulk_data_change_notifications():
             project.update(status="archived")
 ```
 
-Keep `bulk_data_change_notifications()` outside `transaction.atomic()`. The
-transaction then commits before the notification context flushes. The context is
-not automatically transaction-aware, and it also flushes queued refreshes when
-the body exits exceptionally, after the nested transaction has rolled back and
-before re-raising the exception.
+Keep `bulk_data_change_notifications()` outside the true outermost database
+transaction. When the shown `transaction.atomic()` is outermost, it commits
+before the notification context flushes. With `ATOMIC_REQUESTS` or another
+enclosing atomic block, that block may only release a savepoint and the actual
+commit can occur after the refresh; place the notification context outside that
+enclosing boundary instead. The context is not transaction-aware, and it also
+flushes queued refreshes when its body exits exceptionally before re-raising the
+exception.
 
 During an explicit batch, row-level events are replaced by one `refresh` event
 for each affected manager class. A detail subscription receives refreshes for
 its own manager and for manager classes in its dependency groups, then
 rehydrates its own item. A class-wide subscription receives `action = refresh`
 with `item = null`; the event contains no row identification. This intentionally
-discloses that a change to the manager class occurred at batch-flush time, but
-not which rows changed, how many changed, or their original actions.
+discloses that some item changed during the explicit batch, and the client
+observes the aggregate refresh when the batch flushes. It does not disclose
+which rows changed, how many changed, or their original actions.
 
 Outside the context, ordinary row events and their timing are unchanged. The
 context batches only GraphQL and RemoteAPI notification delivery:

--- a/docs/examples/remote_manager_interface_end_to_end.md
+++ b/docs/examples/remote_manager_interface_end_to_end.md
@@ -388,6 +388,29 @@ channel-layer connections with `1011`. Missing `version` is accepted, multiple
 websocket messages are ignored, and client disconnect cleans up the
 channel-layer group subscription.
 
+For bulk writes, use the public notification context outside the transaction so
+the commit completes before refresh delivery:
+
+```python
+from django.db import transaction
+
+from general_manager.api import bulk_data_change_notifications
+
+
+with bulk_data_change_notifications():
+    with transaction.atomic():
+        for project in projects:
+            project.update(status="archived")
+```
+
+The context emits one invalidation per affected RemoteAPI resource with
+`action = "refresh"`, `identification = null`, and a UUID4 `event_id`. Clients
+should treat it as resource-wide invalidation and requery the resource over
+REST. The context is not transaction-aware by itself and flushes even when its
+body exits exceptionally; the nesting above ensures that flush happens after
+the transaction has committed or rolled back. Outside the context, immediate
+row-level events remain unchanged.
+
 ## Usage
 
 ```python

--- a/docs/examples/remote_manager_interface_end_to_end.md
+++ b/docs/examples/remote_manager_interface_end_to_end.md
@@ -388,8 +388,8 @@ channel-layer connections with `1011`. Missing `version` is accepted, multiple
 websocket messages are ignored, and client disconnect cleans up the
 channel-layer group subscription.
 
-For bulk writes, use the public notification context outside the transaction so
-the commit completes before refresh delivery:
+For bulk writes, use the public notification context outside the true outermost
+database transaction:
 
 ```python
 from django.db import transaction
@@ -407,9 +407,11 @@ The context emits one invalidation per affected RemoteAPI resource with
 `action = "refresh"`, `identification = null`, and a UUID4 `event_id`. Clients
 should treat it as resource-wide invalidation and requery the resource over
 REST. The context is not transaction-aware by itself and flushes even when its
-body exits exceptionally; the nesting above ensures that flush happens after
-the transaction has committed or rolled back. Outside the context, immediate
-row-level events remain unchanged.
+body exits exceptionally. When the shown `transaction.atomic()` is outermost,
+its commit or rollback completes before the flush. With `ATOMIC_REQUESTS` or
+another enclosing atomic block, the actual commit may happen after refresh
+delivery; place the notification context outside that enclosing boundary.
+Outside the context, immediate row-level events remain unchanged.
 
 ## Usage
 

--- a/docs/issue_399_bulk_notification_batching_design.md
+++ b/docs/issue_399_bulk_notification_batching_design.md
@@ -1,0 +1,212 @@
+# Bulk Data-Change Notification Batching Design
+
+## Context
+
+GeneralManager emits `post_data_change` after each successful mutation. The
+GraphQL subscription receiver synchronously bridges into the channel layer once
+for the instance group and once for the class-wide group. RemoteAPI websocket
+invalidation uses the same bridge once for opt-in managers.
+
+When a synchronous import creates thousands of managers row by row, asgiref
+creates a single-worker executor and an event loop for each bridge call. A
+14,265-row import can therefore create roughly 28,530 GraphQL bridge lifecycles,
+or roughly 42,795 when RemoteAPI invalidation is also enabled. This overhead is
+incurred even when no subscribers are connected and can exhaust memory under a
+debugger or other memory pressure.
+
+## Goals
+
+- Provide an explicit, nestable context for batching data-change notifications.
+- Emit one GraphQL refresh per affected manager class at outermost context exit.
+- Emit one RemoteAPI refresh per affected websocket resource at outermost exit.
+- Use one synchronous-to-async bridge for the complete batch flush.
+- Flush accumulated refreshes after both successful and exceptional exits.
+- Preserve immediate cache invalidation and all unrelated signal receivers.
+- Preserve existing row-level notification behavior outside the context.
+- Propagate resource exhaustion rather than reporting a failed dispatch as
+  successful.
+
+## Non-goals
+
+- Automatically detect mutation loops.
+- Delay or coalesce dependency-cache invalidation.
+- Preserve individual row actions or identifications inside an explicit batch.
+- Coordinate a batch collector across unrelated threads or processes.
+- Introduce a persistent background event-loop thread.
+
+## Public API
+
+Expose a synchronous context manager from `general_manager.api`:
+
+```python
+from general_manager.api import bulk_data_change_notifications
+
+with bulk_data_change_notifications():
+    for row in rows:
+        ExampleManager.create(**row)
+```
+
+The context is re-entrant. Only the outermost exit flushes notifications. An
+empty context performs no channel-layer lookup and creates no async bridge.
+
+The collector is scoped with `ContextVar`. Mutations executed in unrelated
+worker threads are outside the batch unless those threads explicitly enter
+their own context.
+
+## Architecture
+
+Add a small notification-batching module under `general_manager.api`. It owns:
+
+- the public context manager;
+- the active batch state;
+- target registration helpers for GraphQL managers and RemoteAPI resources;
+- the single asynchronous flush coroutine; and
+- the synchronous bridge used at outermost exit.
+
+The active state stores a nesting depth and deduplicated notification targets.
+Targets contain only stable routing information needed at flush time. The state
+is detached from the active context before dispatch begins so notification
+callbacks cannot accidentally append to the batch being flushed.
+
+GraphQL and RemoteAPI signal receivers keep their existing eligibility checks.
+When no batch is active, they dispatch immediately. When a batch is active,
+they register a target and return without calling `async_to_sync`.
+
+At outermost exit, the context snapshots the targets and invokes one
+`async_to_sync` wrapper around the flush coroutine. The coroutine dispatches
+targets sequentially to bound concurrency and reports failures with target
+context. Deterministic target ordering makes behavior and tests reproducible.
+
+## GraphQL Refresh Routing
+
+Each registered GraphQL manager receives a dedicated refresh group distinct
+from its existing instance and class-wide change groups. The group uses the
+same stable naming constraints as existing subscription groups.
+
+Detail subscriptions join:
+
+- their existing instance group;
+- existing instance groups for dependency managers; and
+- the refresh group for their own manager class and every dependency manager
+  class represented by those groups.
+
+On a refresh message, a detail subscription rehydrates its own identified item
+and emits:
+
+```text
+action = "refresh"
+item = <fresh item or null>
+```
+
+Class-wide subscriptions join their existing class group and the manager refresh
+group. A refresh message cannot identify one authorized item, so they emit:
+
+```text
+action = "refresh"
+item = null
+```
+
+This intentionally relaxes the existing class-wide timing guarantee: a client
+with an active class subscription can observe that some item in the class
+changed during an explicitly batched operation, but receives no item identity.
+Row-level events outside the batch retain the existing per-object permission
+checks.
+
+The GraphQL refresh channel message contains `type`, `action="refresh"`, and the
+manager name. It does not contain row identification.
+
+## RemoteAPI Refresh Routing
+
+RemoteAPI batching deduplicates by websocket invalidation resource, including
+the configuration fields that determine the group and protocol payload. The
+flush emits the normal invalidation envelope with:
+
+```text
+action = "refresh"
+identification = null
+event_id = <new UUID>
+```
+
+One message is sent per affected resource, regardless of how many rows changed.
+Normal non-bulk RemoteAPI events retain their existing action and identification.
+
+## Failure Semantics
+
+The context flushes accumulated targets in `finally`, including when the batch
+body raises. This prevents stale subscribers when some rows committed before a
+later row failed. A refresh after a fully rolled-back transaction is redundant
+but safe.
+
+Ordinary channel-layer dispatch failures are logged with their target and do
+not stop remaining refreshes. Successful database mutations are not reported as
+failed solely because a best-effort notification could not be delivered.
+
+`MemoryError` is never treated as an ordinary delivery failure. It propagates
+immediately. If the batch body and the flush both fail, both exceptions are
+preserved in an `ExceptionGroup` so neither failure is hidden.
+
+Immediate GraphQL dispatch outside a batch should wrap both group sends in one
+async helper, reducing the normal path from two bridge lifecycles to one while
+preserving independent failure logging for each group. It must not log a
+successful dispatch when every target failed.
+
+## Transactions
+
+The notification context must wrap an explicit database transaction so the
+transaction commits before refresh dispatch:
+
+```python
+with bulk_data_change_notifications():
+    with transaction.atomic():
+        for row in rows:
+            ExampleManager.create(**row)
+```
+
+Reversing the contexts can flush before the outer transaction commits, allowing
+subscribers to rehydrate pre-commit state. The initial implementation documents
+and tests the required ordering instead of attempting implicit multi-database
+`on_commit` coordination.
+
+## Cache Behavior
+
+Dependency-cache invalidation remains immediate. The existing data-change
+barrier prevents unsafe publication during a mutation but does not bypass cache
+reads for the duration of an outer batch. Delaying deletion without a broader
+cache-consistency redesign would therefore expose stale values.
+
+Run-scoped cache clearing, dependency index maintenance, GraphQL cache rewarm,
+and unrelated `post_data_change` receivers retain their current behavior.
+
+## Verification
+
+Test-driven implementation will add coverage for:
+
+- empty, nested, successful, and exceptional batch contexts;
+- target deduplication across many mutations;
+- one bridge invocation per outermost non-empty flush;
+- deterministic sequential dispatch;
+- one GraphQL refresh per affected manager class;
+- detail subscription refresh and rehydration;
+- dependency-class refresh triggering detail subscriptions;
+- class-wide `refresh` events with `item=null`;
+- one RemoteAPI refresh per affected resource;
+- normal row-level behavior outside a batch;
+- ordinary channel-layer failures continuing across targets;
+- `MemoryError` propagation and dual-failure `ExceptionGroup` behavior;
+- transaction ordering; and
+- immediate cache invalidation remaining active inside a notification batch.
+
+Focused tests run first, followed by Ruff, mypy, and the full pytest suite when
+the focused checks pass.
+
+## Documentation
+
+Update the GraphQL subscription guide and RemoteAPI websocket documentation to
+describe:
+
+- the public batching context;
+- `refresh` payload semantics;
+- detail and class subscription behavior;
+- the explicit class-level timing disclosure;
+- transaction context ordering; and
+- the fact that cache invalidation is not batched.

--- a/docs/issue_399_bulk_notification_batching_implementation_plan.md
+++ b/docs/issue_399_bulk_notification_batching_implementation_plan.md
@@ -1,0 +1,677 @@
+# Bulk Data-Change Notification Batching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an explicit, nested notification-batching context that emits one GraphQL refresh per manager class and one RemoteAPI refresh per resource through a single async bridge.
+
+**Architecture:** A focused `notification_batching` module owns `ContextVar` state, target deduplication, flush-on-exit behavior, and the single sync-to-async bridge. Existing GraphQL and RemoteAPI signal receivers retain immediate behavior outside the context but enqueue aggregate refresh targets inside it. GraphQL detail and class subscriptions join dedicated refresh groups without changing ordinary per-row groups.
+
+**Tech Stack:** Python 3.12+, Django signals and transactions, Channels channel layers, asgiref, Graphene subscriptions, pytest/unittest, Ruff, mypy.
+
+---
+
+## File Structure
+
+- Create `src/general_manager/api/notification_batching.py`: public context manager and private generic batching primitives.
+- Create `tests/unit/test_notification_batching.py`: context nesting, deduplication, failure, and bridge-count tests.
+- Modify `src/general_manager/public_api_registry.py`: lazy public export.
+- Modify `src/general_manager/_types/api.py`: type-checker-visible public export.
+- Modify `tests/unit/test_graph_ql.py`: stable public import contract.
+- Modify `src/general_manager/api/graphql_subscriptions.py`: refresh group naming and one-bridge immediate dispatch helper.
+- Modify `src/general_manager/api/graphql.py`: enqueue GraphQL refreshes and subscribe streams to refresh groups.
+- Modify `tests/unit/test_graphql_subscriptions.py`: GraphQL dispatch and class refresh tests.
+- Modify `tests/unit/test_grapql_subscription_helper.py`: immediate dispatch failure tests.
+- Modify `tests/integration/test_graphql_subscriptions.py`: detail and dependency refresh behavior.
+- Modify `src/general_manager/api/remote_invalidation.py`: enqueue RemoteAPI refreshes and share payload construction.
+- Modify `tests/unit/test_remote_invalidation.py`: RemoteAPI aggregation and payload tests.
+- Modify `tests/integration/test_caching.py`: prove cache invalidation remains immediate inside notification batches.
+- Modify `docs/concepts/graphql/subscriptions.md`: public API, refresh semantics, timing disclosure, and transaction ordering.
+- Modify `docs/examples/remote_manager_interface_end_to_end.md`: RemoteAPI refresh payload and batching usage.
+
+### Task 1: Shared Notification Batch Context
+
+**Files:**
+- Create: `tests/unit/test_notification_batching.py`
+- Create: `src/general_manager/api/notification_batching.py`
+- Modify: `src/general_manager/public_api_registry.py`
+- Modify: `src/general_manager/_types/api.py`
+- Modify: `tests/unit/test_graph_ql.py`
+
+- [ ] **Step 1: Write failing context and public-export tests**
+
+Create tests that import `bulk_data_change_notifications` publicly and exercise the private registration seam with an async recording sender:
+
+```python
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from general_manager.api import bulk_data_change_notifications
+from general_manager.api.notification_batching import _queue_notification
+
+
+def test_empty_batch_does_not_create_async_bridge() -> None:
+    with patch("general_manager.api.notification_batching.async_to_sync") as bridge:
+        with bulk_data_change_notifications():
+            pass
+    bridge.assert_not_called()
+
+
+def test_nested_batch_deduplicates_targets_and_flushes_once() -> None:
+    sent: list[tuple[str, dict[str, object]]] = []
+
+    async def group_send(group: str, message: dict[str, object]) -> None:
+        sent.append((group, message))
+
+    with bulk_data_change_notifications():
+        assert _queue_notification(
+            key=("graphql", "Project"),
+            group_send=group_send,
+            group="project-refresh",
+            message={"type": "gm.subscription.event", "action": "refresh"},
+        )
+        with bulk_data_change_notifications():
+            assert _queue_notification(
+                key=("graphql", "Project"),
+                group_send=group_send,
+                group="project-refresh",
+                message={"type": "gm.subscription.event", "action": "refresh"},
+            )
+
+    assert sent == [
+        (
+            "project-refresh",
+            {"type": "gm.subscription.event", "action": "refresh"},
+        )
+    ]
+
+
+def test_batch_flushes_when_body_raises() -> None:
+    sent: list[str] = []
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        sent.append(group)
+
+    with pytest.raises(ValueError, match="row failed"):
+        with bulk_data_change_notifications():
+            _queue_notification(
+                key=("remote", "projects"),
+                group_send=group_send,
+                group="projects-refresh",
+                message={"action": "refresh"},
+            )
+            raise ValueError("row failed")
+
+    assert sent == ["projects-refresh"]
+
+
+def test_body_and_memory_failure_are_preserved() -> None:
+    async def exhausted(_group: str, _message: dict[str, object]) -> None:
+        raise MemoryError("thread startup")
+
+    with pytest.raises(ExceptionGroup) as caught:
+        with bulk_data_change_notifications():
+            _queue_notification(
+                key=("graphql", "Project"),
+                group_send=exhausted,
+                group="project-refresh",
+                message={"action": "refresh"},
+            )
+            raise ValueError("row failed")
+
+    assert [type(exc) for exc in caught.value.exceptions] == [ValueError, MemoryError]
+```
+
+Extend `tests/unit/test_graph_ql.py` to assert the runtime and type-only API exports resolve to the new context manager.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_notification_batching.py tests/unit/test_graph_ql.py::GraphQLTests::test_public_bulk_data_change_notifications_is_importable
+```
+
+Expected: collection fails because `bulk_data_change_notifications` and `notification_batching` do not exist.
+
+- [ ] **Step 3: Implement the minimal batching module and exports**
+
+Implement a private pending-target record, a `ContextVar`, sequential async flush, registration helper, and context manager with this interface:
+
+```python
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+from asgiref.sync import async_to_sync
+
+from general_manager.logging import get_logger
+
+type NotificationKey = tuple[str, ...]
+type NotificationMessage = Mapping[str, object]
+type GroupSend = Callable[[str, NotificationMessage], Awaitable[None]]
+
+logger = get_logger("api.notification_batching")
+
+
+@dataclass(slots=True)
+class _PendingNotification:
+    key: NotificationKey
+    group_send: GroupSend = field(repr=False)
+    group: str
+    message: dict[str, object]
+
+
+@dataclass(slots=True)
+class _BatchState:
+    targets: dict[NotificationKey, _PendingNotification] = field(default_factory=dict)
+
+
+_active_batch: ContextVar[_BatchState | None] = ContextVar(
+    "general_manager_notification_batch",
+    default=None,
+)
+
+
+def _queue_notification(
+    *,
+    key: NotificationKey,
+    group_send: GroupSend,
+    group: str,
+    message: NotificationMessage,
+) -> bool:
+    state = _active_batch.get()
+    if state is None:
+        return False
+    state.targets.setdefault(
+        key,
+        _PendingNotification(key, group_send, group, dict(message)),
+    )
+    return True
+
+
+async def _flush_notifications(state: _BatchState) -> None:
+    for key in sorted(state.targets):
+        target = state.targets[key]
+        try:
+            await target.group_send(target.group, target.message)
+        except MemoryError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "failed to dispatch batched notification",
+                context={"key": key, "group": target.group},
+                exc_info=exc,
+            )
+
+
+def _flush_sync(state: _BatchState) -> None:
+    if state.targets:
+        async_to_sync(_flush_notifications)(state)
+
+
+@contextmanager
+def bulk_data_change_notifications() -> Iterator[None]:
+    current = _active_batch.get()
+    if current is not None:
+        yield
+        return
+
+    state = _BatchState()
+    token = _active_batch.set(state)
+    try:
+        yield
+    except BaseException as body_error:
+        _active_batch.reset(token)
+        try:
+            _flush_sync(state)
+        except BaseException as flush_error:
+            raise BaseExceptionGroup(
+                "bulk data change and notification flush failed",
+                [body_error, flush_error],
+            ) from None
+        raise
+    else:
+        _active_batch.reset(token)
+        _flush_sync(state)
+```
+
+Add `bulk_data_change_notifications` to `API_EXPORTS`, `general_manager._types.api.__all__`, and its type-only imports. Do not add it to the top-level `general_manager` exports because the approved public path is `general_manager.api`.
+
+- [ ] **Step 4: Run focused tests and formatting**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_notification_batching.py tests/unit/test_graph_ql.py
+ruff format src/general_manager/api/notification_batching.py tests/unit/test_notification_batching.py src/general_manager/_types/api.py src/general_manager/public_api_registry.py tests/unit/test_graph_ql.py
+ruff check src/general_manager/api/notification_batching.py tests/unit/test_notification_batching.py src/general_manager/_types/api.py src/general_manager/public_api_registry.py tests/unit/test_graph_ql.py
+```
+
+Expected: all selected tests pass and Ruff reports no errors.
+
+- [ ] **Step 5: Verify and commit only tracked task files**
+
+Run `git check-ignore` on every task file, stage only the five listed files, inspect `git diff --cached --name-only`, then commit:
+
+```bash
+git commit -m "feat: add bulk notification batch context"
+```
+
+### Task 2: GraphQL Dispatch Batching and One-Bridge Immediate Sends
+
+**Files:**
+- Modify: `src/general_manager/api/graphql_subscriptions.py`
+- Modify: `src/general_manager/api/graphql.py`
+- Modify: `tests/unit/test_graphql_subscriptions.py`
+- Modify: `tests/unit/test_grapql_subscription_helper.py`
+
+- [ ] **Step 1: Write failing dispatch tests**
+
+Update the existing `_handle_data_change` tests to use an async `group_send` and assert:
+
+```python
+def test_handle_data_change_uses_one_bridge_for_both_groups(self) -> None:
+    sent: list[str] = []
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        sent.append(group)
+
+    layer = SimpleNamespace(group_send=group_send)
+    with (
+        patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+        patch(
+            "general_manager.api.graphql.async_to_sync",
+            side_effect=lambda fn: lambda *args: asyncio.run(fn(*args)),
+        ) as bridge,
+    ):
+        GraphQL._handle_data_change(
+            sender=RegisteredManager,
+            instance=RegisteredManager(),
+            action="update",
+        )
+
+    bridge.assert_called_once()
+    assert set(sent) == {
+        GraphQL._group_name(RegisteredManager, {"id": 1}),
+        GraphQL._class_group_name(RegisteredManager),
+    }
+```
+
+Add a batching test that performs many `_handle_data_change` calls inside `bulk_data_change_notifications()` and asserts no immediate bridge plus one refresh-group send at exit. Add edge-case tests asserting `MemoryError` propagates without attempting the second group and that ordinary `RuntimeError` logs and continues.
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_graphql_subscriptions.py::GraphQLHandleDataChangeTests tests/unit/test_grapql_subscription_helper.py::GraphQLHandleDataChangeEdgeCasesTests
+```
+
+Expected: failures show two immediate bridge calls remain and no refresh target is queued.
+
+- [ ] **Step 3: Add refresh naming and async dispatch helpers**
+
+In `graphql_subscriptions.py`, add:
+
+```python
+def refresh_group_name(manager_class: type[GeneralManager]) -> str:
+    return f"gm_subscriptions.{manager_class.__name__}.__refresh__"
+
+
+async def dispatch_subscription_event(
+    channel_layer: BaseChannelLayer,
+    group_names: Iterable[str],
+    message: SubscriptionMessage,
+) -> int:
+    dispatched = 0
+    for target_group_name in group_names:
+        try:
+            await channel_layer.group_send(target_group_name, message)
+        except MemoryError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "failed to dispatch subscription event",
+                context={"group": target_group_name, "message": message},
+                exc_info=exc,
+            )
+        else:
+            dispatched += 1
+    return dispatched
+```
+
+Import these helpers into `graphql.py`, add a compatibility wrapper `_refresh_group_name`, and change `_handle_data_change` to:
+
+1. Build the existing row-level message.
+2. Queue a refresh message keyed by `("graphql", refresh_group_name)` when a batch is active.
+3. Otherwise call `async_to_sync(dispatch_subscription_event)` once with both existing groups.
+4. Emit the success debug log only when the returned dispatch count is non-zero.
+
+- [ ] **Step 4: Run focused GraphQL dispatch tests**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_graphql_subscriptions.py::GraphQLHandleDataChangeTests tests/unit/test_grapql_subscription_helper.py::GraphQLHandleDataChangeEdgeCasesTests
+ruff format src/general_manager/api/graphql_subscriptions.py src/general_manager/api/graphql.py tests/unit/test_graphql_subscriptions.py tests/unit/test_grapql_subscription_helper.py
+ruff check src/general_manager/api/graphql_subscriptions.py src/general_manager/api/graphql.py tests/unit/test_graphql_subscriptions.py tests/unit/test_grapql_subscription_helper.py
+```
+
+Expected: all selected tests pass and Ruff reports no errors.
+
+- [ ] **Step 5: Verify and commit only tracked task files**
+
+Check ignored status, stage only the four task files, inspect the staged names, and commit:
+
+```bash
+git commit -m "fix: batch GraphQL subscription dispatch"
+```
+
+### Task 3: GraphQL Refresh Subscription Semantics
+
+**Files:**
+- Modify: `src/general_manager/api/graphql.py`
+- Modify: `tests/unit/test_graphql_subscriptions.py`
+- Modify: `tests/integration/test_graphql_subscriptions.py`
+
+- [ ] **Step 1: Write failing detail, dependency, and class refresh tests**
+
+Add integration tests with actual Channels subscriptions:
+
+```python
+def test_detail_subscription_rehydrates_once_after_bulk_refresh(self) -> None:
+    employee = self.Employee.create(name="Before", creator_id=self.user.id)
+    schema = self._build_schema()
+
+    async def run_subscription() -> tuple[object, object]:
+        generator = await schema.subscribe(
+            DETAIL_SUBSCRIPTION,
+            variable_values={"id": employee.id},
+            context_value=SimpleNamespace(user=self.user),
+        )
+        try:
+            snapshot = await generator.__anext__()
+
+            def mutate() -> None:
+                with bulk_data_change_notifications():
+                    employee.update(name="Middle", creator_id=self.user.id)
+                    employee.update(name="After", creator_id=self.user.id)
+
+            await asyncio.to_thread(mutate)
+            return snapshot, await generator.__anext__()
+        finally:
+            await generator.aclose()
+
+    snapshot, refresh = asyncio.run(run_subscription())
+    assert snapshot.data["onEmployeeChange"]["action"] == "snapshot"
+    assert refresh.data["onEmployeeChange"] == {
+        "action": "refresh",
+        "item": {"id": str(employee.id), "name": "After"},
+    }
+```
+
+Add a calculation/dependency test that batches two changes to a dependency manager and asserts one `refresh` on the calculated manager subscription. Add a class-wide test that batches multiple creates and asserts exactly one `{action: "refresh", item: None}` event.
+
+- [ ] **Step 2: Run tests to verify refresh delivery fails**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_graphql_subscriptions.py -k "class_subscription and refresh" tests/integration/test_graphql_subscriptions.py -k "bulk_refresh"
+```
+
+Expected: subscriptions do not receive refresh messages because they have not joined refresh groups and class streams reject messages without identification.
+
+- [ ] **Step 3: Join refresh groups and handle class refresh messages**
+
+For detail subscriptions, initialize group membership with both the instance group and the manager refresh group. For every resolved dependency, add both its instance group and its manager-class refresh group. The existing action queue can carry `"refresh"`; the event stream rehydrates its own identification as it does for ordinary actions.
+
+For class-wide subscriptions, join both the existing class group and the refresh group. In the event loop, handle the aggregate message before identification validation:
+
+```python
+if action == "refresh":
+    clear_capability_context(info)
+    yield SubscriptionEvent(item=None, action="refresh")
+    continue
+```
+
+Discard every joined group during cleanup.
+
+- [ ] **Step 4: Run focused subscription tests**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_graphql_subscriptions.py tests/integration/test_graphql_subscriptions.py
+ruff format src/general_manager/api/graphql.py tests/unit/test_graphql_subscriptions.py tests/integration/test_graphql_subscriptions.py
+ruff check src/general_manager/api/graphql.py tests/unit/test_graphql_subscriptions.py tests/integration/test_graphql_subscriptions.py
+```
+
+Expected: all GraphQL subscription tests pass, including ordinary row-level permission filtering.
+
+- [ ] **Step 5: Verify and commit only tracked task files**
+
+Check ignored status, stage only the three task files, inspect staged names, and commit:
+
+```bash
+git commit -m "feat: deliver GraphQL batch refresh events"
+```
+
+### Task 4: RemoteAPI Refresh Batching
+
+**Files:**
+- Modify: `src/general_manager/api/remote_invalidation.py`
+- Modify: `tests/unit/test_remote_invalidation.py`
+
+- [ ] **Step 1: Write failing RemoteAPI batching tests**
+
+Add tests that use an async recording channel layer and assert:
+
+```python
+def test_remote_invalidation_batches_one_refresh_per_resource(self) -> None:
+    sent: list[tuple[str, dict[str, object]]] = []
+
+    async def group_send(group: str, payload: dict[str, object]) -> None:
+        sent.append((group, payload))
+
+    layer = SimpleNamespace(group_send=group_send)
+    with (
+        patch(
+            "general_manager.api.remote_invalidation._get_channel_layer_safe",
+            return_value=layer,
+        ),
+        bulk_data_change_notifications(),
+    ):
+        emit_remote_invalidation(Project, instance=first, action="create")
+        emit_remote_invalidation(Project, instance=second, action="create")
+
+    assert len(sent) == 1
+    group, payload = sent[0]
+    assert group == remote_invalidation_group_name(get_remote_api_config(Project))
+    assert payload["action"] == "refresh"
+    assert payload["identification"] is None
+    assert isinstance(payload["event_id"], str)
+```
+
+Add a cross-subsystem test that queues both a GraphQL refresh and a RemoteAPI refresh inside one context and patches `notification_batching.async_to_sync` to assert exactly one bridge invocation.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_remote_invalidation.py -k "batch or refresh"
+```
+
+Expected: two row-level invalidations are sent because RemoteAPI does not yet register batched targets.
+
+- [ ] **Step 3: Share payload construction and enqueue refresh targets**
+
+Extract the payload mapping into a helper accepting `config`, `action`, and optional identification. In `emit_remote_invalidation`:
+
+```python
+refresh_payload = _remote_invalidation_payload(
+    config,
+    action="refresh",
+    identification=None,
+)
+group = remote_invalidation_group_name(config)
+if _queue_notification(
+    key=("remote", group, config.protocol_version),
+    group_send=channel_layer.group_send,
+    group=group,
+    message=refresh_payload,
+):
+    return
+```
+
+When no batch is active, construct and send the existing row-level payload exactly as before.
+
+- [ ] **Step 4: Run focused RemoteAPI and batching tests**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_remote_invalidation.py tests/unit/test_notification_batching.py
+ruff format src/general_manager/api/remote_invalidation.py tests/unit/test_remote_invalidation.py
+ruff check src/general_manager/api/remote_invalidation.py tests/unit/test_remote_invalidation.py
+```
+
+Expected: all selected tests pass and Ruff reports no errors.
+
+- [ ] **Step 5: Verify and commit only tracked task files**
+
+Check ignored status, stage only the two task files, inspect staged names, and commit:
+
+```bash
+git commit -m "feat: batch RemoteAPI refresh invalidation"
+```
+
+### Task 5: Cache Safety, Transaction Contract, and Documentation
+
+**Files:**
+- Modify: `tests/integration/test_caching.py`
+- Modify: `docs/concepts/graphql/subscriptions.md`
+- Modify: `docs/examples/remote_manager_interface_end_to_end.md`
+
+- [ ] **Step 1: Write the cache-safety regression test**
+
+Extend `CachingTestCase` with a test that primes `budget_left`, updates its dependency inside the notification context, and reads it before context exit:
+
+```python
+def test_notification_batch_keeps_dependency_invalidation_immediate(self) -> None:
+    commercials = self.TestCommercials(project=self.project1)
+    assert commercials.budget_left == Measurement(800, "EUR")
+
+    with bulk_data_change_notifications():
+        self.project1 = self.project1.update(
+            actual_costs=Measurement(600, "EUR"),
+            ignore_permission=True,
+        )
+        refreshed = self.TestCommercials(project=self.project1)
+        assert refreshed.budget_left == Measurement(400, "EUR")
+```
+
+- [ ] **Step 2: Run the cache regression test**
+
+Run:
+
+```bash
+python -m pytest -q tests/integration/test_caching.py::CachingTestCase::test_notification_batch_keeps_dependency_invalidation_immediate
+```
+
+Expected: pass without cache implementation changes, proving notification batching does not intercept cache invalidation.
+
+- [ ] **Step 3: Update user-facing documentation**
+
+Document this canonical transaction ordering in both relevant guides:
+
+```python
+from django.db import transaction
+from general_manager.api import bulk_data_change_notifications
+
+with bulk_data_change_notifications():
+    with transaction.atomic():
+        for row in rows:
+            ExampleManager.create(**row)
+```
+
+State that GraphQL detail subscriptions rehydrate on `refresh`, class-wide subscriptions receive `item: null`, RemoteAPI refresh invalidations carry `identification: null`, class-wide refreshes intentionally disclose class-level change timing, exceptional exits flush, and cache invalidation remains immediate.
+
+- [ ] **Step 4: Run documentation-adjacent tests and lint**
+
+Run:
+
+```bash
+python -m pytest -q tests/integration/test_caching.py::CachingTestCase::test_notification_batch_keeps_dependency_invalidation_immediate tests/unit/test_graph_ql.py tests/unit/test_remote_invalidation.py
+ruff check tests/integration/test_caching.py
+```
+
+Expected: all selected tests pass and Ruff reports no errors.
+
+- [ ] **Step 5: Verify and commit only tracked task files**
+
+Check ignored status, stage only the three task files, inspect staged names, and commit:
+
+```bash
+git commit -m "docs: explain bulk notification refreshes"
+```
+
+### Task 6: Full Verification and Final Review
+
+**Files:**
+- Verify all modified implementation, test, and documentation files.
+
+- [ ] **Step 1: Run the complete focused feature suite**
+
+Run:
+
+```bash
+python -m pytest -q tests/unit/test_notification_batching.py tests/unit/test_graphql_subscriptions.py tests/unit/test_grapql_subscription_helper.py tests/integration/test_graphql_subscriptions.py tests/unit/test_remote_invalidation.py tests/integration/test_caching.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run repository formatting, lint, and type checks**
+
+Run:
+
+```bash
+ruff format --check src tests
+ruff check src tests
+mypy src
+```
+
+Expected: all commands exit successfully with no diagnostics.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+
+```bash
+python -m pytest
+```
+
+Expected: the full suite passes.
+
+- [ ] **Step 4: Inspect tracked, ignored, and committed scope**
+
+Run:
+
+```bash
+git status --short --ignored
+git diff --check
+git diff origin/main...HEAD --name-only
+```
+
+Expected: ignored runtime artifacts may appear only with `!!`; no ignored file is staged or committed, no unexpected tracked file is modified, and the diff is limited to issue #399.
+
+- [ ] **Step 5: Perform two-stage code review**
+
+Dispatch one subagent to check spec compliance and a second fresh subagent to review code quality, correctness, concurrency, error handling, public API consistency, and test gaps. Address findings test-first, rerun the narrowest relevant checks, and commit any required fixes with a conventional commit message.

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -5,10 +5,10 @@ ipython==9.0.2
 pytest==9.0.3
 pytest_django==4.11.1
 pytest_cov==4.1.0
-django-types==0.21.0
+django-types==0.24.0
 celery-types==0.23.0
 types-PyYAML==6.0.12.20250915
-mypy==1.19.1
+mypy==1.20.2
 pre-commit==4.3.0
 prometheus-client==0.24.1  # Local metrics collection for development/tests.
 

--- a/src/general_manager/_types/api.py
+++ b/src/general_manager/_types/api.py
@@ -56,6 +56,7 @@ __all__ = [
     "UploadTokenInvalidError",
     "UploadTransferConflictError",
     "UploadTransport",
+    "bulk_data_change_notifications",
     "graph_ql_mutation",
     "graph_ql_property",
     "register_upload_adapter",
@@ -115,5 +116,6 @@ from general_manager.uploads.errors import UploadTokenInvalidError
 from general_manager.uploads.errors import UploadTransferConflictError
 from general_manager.uploads.types import UploadTransport
 from general_manager.api.mutation import graph_ql_mutation
+from general_manager.api.notification_batching import bulk_data_change_notifications
 from general_manager.api.property import graph_ql_property
 from general_manager.uploads.public import register_upload_adapter

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -113,10 +113,13 @@ from general_manager.api.graphql_search import (
     create_filter_options as _create_filter_options_fn,
     normalize_filter_input as _normalize_filter_input_fn,
 )
+from general_manager.api.notification_batching import _queue_notification
 from general_manager.api.graphql_subscriptions import (
     get_channel_layer_safe as _get_channel_layer_fn,
     group_name as _group_name_fn,
     class_group_name as _class_group_name_fn,
+    refresh_group_name as _refresh_group_name_fn,
+    dispatch_subscription_event as _dispatch_subscription_event_fn,
     channel_listener as _channel_listener_fn,
     channel_message_listener as _channel_message_listener_fn,
     prime_graphql_properties as _prime_graphql_properties_fn,
@@ -280,6 +283,15 @@ class GraphQL:
         Returns the deterministic class-wide channel group name.
         """
         return _class_group_name_fn(manager_class)
+
+    @staticmethod
+    def _refresh_group_name(manager_class: type[GeneralManager]) -> str:
+        """
+        Compatibility wrapper for ``graphql_subscriptions.refresh_group_name(manager_class)``.
+
+        Returns the deterministic manager-wide refresh group name.
+        """
+        return _refresh_group_name_fn(manager_class)
 
     @staticmethod
     async def _channel_listener(
@@ -1595,14 +1607,15 @@ class GraphQL:
         Send a "gm.subscription.event" message to the channel group corresponding to a changed GeneralManager instance.
 
         If the provided instance is a registered GeneralManager and a channel
-        layer is configured, publish a message containing the given action to the
-        instance channel group and the class-wide channel group. Identification
-        comes from the provided `identification` mapping when supplied,
-        otherwise from the changed instance, and is deep-copied before dispatch.
-        If the instance is `None`, the manager type is not registered, or no
-        channel layer is available, the function returns without dispatching.
-        Group dispatch failures are logged and do not stop attempts for the
-        remaining target groups.
+        layer is configured, queue one manager-wide refresh while notification
+        batching is active. Outside a batch, publish the row-level message to
+        the instance and class-wide groups through one async bridge.
+        Identification comes from the provided `identification` mapping when
+        supplied, otherwise from the changed instance, and is deep-copied
+        before dispatch. If the instance is `None`, the manager type is not
+        registered, or no channel layer is available, the function returns
+        without dispatching. Ordinary group dispatch failures are logged and
+        do not stop attempts for remaining groups.
 
         Parameters:
             sender (type[GeneralManager] | GeneralManager): The signal sender; either a GeneralManager subclass or an instance.
@@ -1646,35 +1659,40 @@ class GraphQL:
         )
         group_name = cls._group_name(manager_class, event_identification)
         class_group_name = cls._class_group_name(manager_class)
-        message = {
+        message: dict[str, object] = {
             "type": "gm.subscription.event",
             "action": action,
             "manager": manager_class.__name__,
             "identification": event_identification,
         }
-        group_send = async_to_sync(channel_layer.group_send)
-        for target_group_name in (group_name, class_group_name):
-            try:
-                group_send(target_group_name, message)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "failed to dispatch subscription event",
-                    context={
-                        "manager": manager_class.__name__,
-                        "action": action,
-                        "group": target_group_name,
-                        "message": message,
-                    },
-                    exc_info=exc,
-                )
-        logger.debug(
-            "dispatched subscription event",
-            context={
-                "manager": manager_class.__name__,
-                "action": action,
-                "groups": [group_name, class_group_name],
-            },
+        refresh_group_name = cls._refresh_group_name(manager_class)
+        refresh_message: dict[str, object] = {
+            "type": "gm.subscription.event",
+            "action": "refresh",
+            "manager": manager_class.__name__,
+        }
+        if _queue_notification(
+            key=("graphql", refresh_group_name),
+            group_send=channel_layer.group_send,
+            group=refresh_group_name,
+            message=refresh_message,
+        ):
+            return
+
+        dispatched = async_to_sync(_dispatch_subscription_event_fn)(
+            channel_layer,
+            (group_name, class_group_name),
+            message,
         )
+        if dispatched > 0:
+            logger.debug(
+                "dispatched subscription event",
+                context={
+                    "manager": manager_class.__name__,
+                    "action": action,
+                    "groups": [group_name, class_group_name],
+                },
+            )
 
 
 post_data_change.connect(GraphQL._handle_data_change, weak=False)

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -1364,7 +1364,7 @@ class GraphQL:
             """
             Stream subscription events for a specific manager instance identified by the provided arguments.
 
-            Yields an initial `SubscriptionEvent` with `action` set to `"snapshot"` containing the current manager instance, then yields `SubscriptionEvent`s for each subsequent action. For update events, `item` will be the re-instantiated manager instance or `None` if instantiation fails. The subscriber is registered on the manager's channel groups (including dependent managers' groups) and the channel subscriptions and background listener are cleaned up when the iterator is closed or cancelled.
+            Yields an initial `SubscriptionEvent` with `action` set to `"snapshot"` containing the current manager instance, then yields `SubscriptionEvent`s for each subsequent action. For subsequent events, `item` will be the re-instantiated manager instance or `None` if instantiation fails. The subscriber is registered on the manager's channel groups (including dependent managers' groups) and the channel subscriptions and background listener are cleaned up when the iterator is closed or cancelled.
 
             Parameters:
                 identification: Identification fields required to locate the manager instance (maps to the manager's identification signature).
@@ -1398,7 +1398,8 @@ class GraphQL:
                 cls._group_name(
                     generalManagerClass,
                     instance.identification,
-                )
+                ),
+                cls._refresh_group_name(generalManagerClass),
             }
             dependencies = cls._resolve_subscription_dependencies(
                 generalManagerClass,
@@ -1409,6 +1410,7 @@ class GraphQL:
                 group_names.add(
                     cls._group_name(dependency_class, dependency_identification)
                 )
+                group_names.add(cls._refresh_group_name(dependency_class))
 
             for group in group_names:
                 await channel_layer.group_add(group, channel_name)
@@ -1478,9 +1480,9 @@ class GraphQL:
             Stream future authorized change events for any instance of a manager class.
 
             Unlike single-entity subscriptions, class-wide subscriptions do not
-            yield an initial snapshot. Each channel event is hydrated and
-            checked against the request user's object-level read permission
-            before it is yielded.
+            yield an initial snapshot. Aggregate refresh events carry no item;
+            ordinary row events are hydrated and checked against the request
+            user's object-level read permission before they are yielded.
             """
             try:
                 channel_layer = cast(
@@ -1490,8 +1492,12 @@ class GraphQL:
                 raise GraphQLError(str(exc)) from exc
             channel_name = cast(str, await channel_layer.new_channel())
             queue: asyncio.Queue[GraphQLFieldMap] = asyncio.Queue()
-            group_name = cls._class_group_name(generalManagerClass)
-            await channel_layer.group_add(group_name, channel_name)
+            group_names = {
+                cls._class_group_name(generalManagerClass),
+                cls._refresh_group_name(generalManagerClass),
+            }
+            for group in group_names:
+                await channel_layer.group_add(group, channel_name)
             listener_task = asyncio.create_task(
                 cls._channel_message_listener(channel_layer, channel_name, queue)
             )
@@ -1503,10 +1509,14 @@ class GraphQL:
                         if message.get("manager") != generalManagerClass.__name__:
                             continue
                         action = message.get("action")
+                        if not isinstance(action, str):
+                            continue
+                        if action == "refresh":
+                            clear_capability_context(info)
+                            yield SubscriptionEvent(item=None, action=action)
+                            continue
                         identification = message.get("identification")
-                        if not isinstance(action, str) or not isinstance(
-                            identification, dict
-                        ):
+                        if not isinstance(identification, dict):
                             continue
                         identification_copy = deepcopy(identification)
                         try:
@@ -1525,7 +1535,8 @@ class GraphQL:
                     listener_task.cancel()
                     with suppress(asyncio.CancelledError):
                         await listener_task
-                    await channel_layer.group_discard(group_name, channel_name)
+                    for group in group_names:
+                        await channel_layer.group_discard(group, channel_name)
 
             return event_stream()
 

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import suppress
+from contextlib import asynccontextmanager
 from copy import deepcopy
 import re
 from types import UnionType
@@ -158,6 +158,101 @@ GraphQLFilterNormalizer = Callable[
     dict[str, GraphQLFilterMapping],
 ]
 GraphQLMutationMap = dict[str, type[graphene.Mutation]]
+_SUBSCRIPTION_CLEANUP_FAILURE_MESSAGE = "subscription cleanup failed"
+_SUBSCRIPTION_ROLLBACK_FAILURE_MESSAGE = "subscription setup and rollback failed"
+_SUBSCRIPTION_STREAM_CLEANUP_FAILURE_MESSAGE = "subscription stream and cleanup failed"
+
+
+async def _cleanup_subscription_resources(
+    channel_layer: BaseChannelLayer,
+    channel_name: str,
+    joined_groups: Iterable[str],
+    listener_task: asyncio.Task[None] | None = None,
+) -> None:
+    """Stop a listener and attempt to discard every successfully joined group."""
+    cleanup_errors: list[BaseException] = []
+    if listener_task is not None:
+        listener_task.cancel()
+        try:
+            await listener_task
+        except asyncio.CancelledError:
+            pass
+        except BaseException as exc:  # noqa: BLE001
+            cleanup_errors.append(exc)
+
+    for group in joined_groups:
+        try:
+            await channel_layer.group_discard(group, channel_name)
+        except BaseException as exc:  # noqa: BLE001
+            cleanup_errors.append(exc)
+
+    if len(cleanup_errors) == 1:
+        raise cleanup_errors[0]
+    if cleanup_errors:
+        raise BaseExceptionGroup(
+            _SUBSCRIPTION_CLEANUP_FAILURE_MESSAGE,
+            cleanup_errors,
+        )
+
+
+async def _join_subscription_groups(
+    channel_layer: BaseChannelLayer,
+    channel_name: str,
+    group_names: Iterable[str],
+) -> list[str]:
+    """Join groups and roll back every successful join if a later join fails."""
+    joined_groups: list[str] = []
+    try:
+        for group in group_names:
+            await channel_layer.group_add(group, channel_name)
+            joined_groups.append(group)
+    except BaseException as setup_error:
+        try:
+            await _cleanup_subscription_resources(
+                channel_layer,
+                channel_name,
+                joined_groups,
+            )
+        except BaseException as cleanup_error:  # noqa: BLE001
+            raise BaseExceptionGroup(
+                _SUBSCRIPTION_ROLLBACK_FAILURE_MESSAGE,
+                [setup_error, cleanup_error],
+            ) from None
+        raise
+    return joined_groups
+
+
+@asynccontextmanager
+async def _subscription_cleanup_scope(
+    channel_layer: BaseChannelLayer,
+    channel_name: str,
+    joined_groups: Iterable[str],
+    listener_task: asyncio.Task[None],
+) -> AsyncIterator[None]:
+    """Clean subscription resources without masking an active stream failure."""
+    try:
+        yield
+    except BaseException as stream_error:
+        try:
+            await _cleanup_subscription_resources(
+                channel_layer,
+                channel_name,
+                joined_groups,
+                listener_task,
+            )
+        except BaseException as cleanup_error:  # noqa: BLE001
+            raise BaseExceptionGroup(
+                _SUBSCRIPTION_STREAM_CLEANUP_FAILURE_MESSAGE,
+                [stream_error, cleanup_error],
+            ) from None
+        raise
+    else:
+        await _cleanup_subscription_resources(
+            channel_layer,
+            channel_name,
+            joined_groups,
+            listener_task,
+        )
 
 
 class GraphQL:
@@ -1412,8 +1507,11 @@ class GraphQL:
                 )
                 group_names.add(cls._refresh_group_name(dependency_class))
 
-            for group in group_names:
-                await channel_layer.group_add(group, channel_name)
+            joined_groups = await _join_subscription_groups(
+                channel_layer,
+                channel_name,
+                group_names,
+            )
 
             listener_task = asyncio.create_task(
                 cls._channel_listener(channel_layer, channel_name, queue)
@@ -1429,7 +1527,12 @@ class GraphQL:
                 Notes:
                     When the iterator is closed or exits, the background listener task is cancelled and the subscription's channel group memberships are discarded.
                 """
-                try:
+                async with _subscription_cleanup_scope(
+                    channel_layer,
+                    channel_name,
+                    joined_groups,
+                    listener_task,
+                ):
                     clear_capability_context(info)
                     yield SubscriptionEvent(item=instance, action="snapshot")
                     while True:
@@ -1445,12 +1548,6 @@ class GraphQL:
                             item = None
                         clear_capability_context(info)
                         yield SubscriptionEvent(item=item, action=action)
-                finally:
-                    listener_task.cancel()
-                    with suppress(asyncio.CancelledError):
-                        await listener_task
-                    for group in group_names:
-                        await channel_layer.group_discard(group, channel_name)
 
             return event_stream()
 
@@ -1496,14 +1593,22 @@ class GraphQL:
                 cls._class_group_name(generalManagerClass),
                 cls._refresh_group_name(generalManagerClass),
             }
-            for group in group_names:
-                await channel_layer.group_add(group, channel_name)
+            joined_groups = await _join_subscription_groups(
+                channel_layer,
+                channel_name,
+                group_names,
+            )
             listener_task = asyncio.create_task(
                 cls._channel_message_listener(channel_layer, channel_name, queue)
             )
 
             async def event_stream() -> AsyncIterator[SubscriptionEvent]:
-                try:
+                async with _subscription_cleanup_scope(
+                    channel_layer,
+                    channel_name,
+                    joined_groups,
+                    listener_task,
+                ):
                     while True:
                         message = await queue.get()
                         if message.get("manager") != generalManagerClass.__name__:
@@ -1531,12 +1636,6 @@ class GraphQL:
                             continue
                         clear_capability_context(info)
                         yield SubscriptionEvent(item=item, action=action)
-                finally:
-                    listener_task.cancel()
-                    with suppress(asyncio.CancelledError):
-                        await listener_task
-                    for group in group_names:
-                        await channel_layer.group_discard(group, channel_name)
 
             return event_stream()
 

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -1679,18 +1679,35 @@ class GraphQL:
         ):
             return
 
-        dispatched = async_to_sync(_dispatch_subscription_event_fn)(
-            channel_layer,
-            (group_name, class_group_name),
-            message,
-        )
+        target_groups = (group_name, class_group_name)
+        try:
+            dispatched = async_to_sync(_dispatch_subscription_event_fn)(
+                channel_layer,
+                target_groups,
+                message,
+            )
+        except MemoryError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "failed to dispatch subscription event",
+                context={
+                    "manager": manager_class.__name__,
+                    "action": action,
+                    "target_groups": list(target_groups),
+                    "message": message,
+                },
+                exc_info=exc,
+            )
+            return
         if dispatched > 0:
             logger.debug(
                 "dispatched subscription event",
                 context={
                     "manager": manager_class.__name__,
                     "action": action,
-                    "groups": [group_name, class_group_name],
+                    "target_groups": list(target_groups),
+                    "successful_group_count": dispatched,
                 },
             )
 

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -1486,8 +1486,6 @@ class GraphQL:
                 )
             except RuntimeError as exc:
                 raise GraphQLError(str(exc)) from exc
-            channel_name = cast(str, await channel_layer.new_channel())
-            queue: asyncio.Queue[str] = asyncio.Queue[str]()
 
             group_names = {
                 cls._group_name(
@@ -1507,16 +1505,6 @@ class GraphQL:
                 )
                 group_names.add(cls._refresh_group_name(dependency_class))
 
-            joined_groups = await _join_subscription_groups(
-                channel_layer,
-                channel_name,
-                group_names,
-            )
-
-            listener_task = asyncio.create_task(
-                cls._channel_listener(channel_layer, channel_name, queue)
-            )
-
             async def event_stream() -> AsyncIterator[SubscriptionEvent]:
                 """
                 Yield subscription events for a manager instance, starting with an initial snapshot followed by subsequent updates.
@@ -1527,6 +1515,16 @@ class GraphQL:
                 Notes:
                     When the iterator is closed or exits, the background listener task is cancelled and the subscription's channel group memberships are discarded.
                 """
+                channel_name = cast(str, await channel_layer.new_channel())
+                queue: asyncio.Queue[str] = asyncio.Queue[str]()
+                joined_groups = await _join_subscription_groups(
+                    channel_layer,
+                    channel_name,
+                    group_names,
+                )
+                listener_task = asyncio.create_task(
+                    cls._channel_listener(channel_layer, channel_name, queue)
+                )
                 async with _subscription_cleanup_scope(
                     channel_layer,
                     channel_name,
@@ -1577,9 +1575,10 @@ class GraphQL:
             Stream future authorized change events for any instance of a manager class.
 
             Unlike single-entity subscriptions, class-wide subscriptions do not
-            yield an initial snapshot. Aggregate refresh events carry no item;
-            ordinary row events are hydrated and checked against the request
-            user's object-level read permission before they are yielded.
+            yield an initial snapshot. Aggregate refresh events without an
+            identification carry no item; identified row events, including
+            row-level refresh actions, are hydrated and checked against the
+            request user's object-level read permission before they are yielded.
             """
             try:
                 channel_layer = cast(
@@ -1587,22 +1586,22 @@ class GraphQL:
                 )
             except RuntimeError as exc:
                 raise GraphQLError(str(exc)) from exc
-            channel_name = cast(str, await channel_layer.new_channel())
-            queue: asyncio.Queue[GraphQLFieldMap] = asyncio.Queue()
             group_names = {
                 cls._class_group_name(generalManagerClass),
                 cls._refresh_group_name(generalManagerClass),
             }
-            joined_groups = await _join_subscription_groups(
-                channel_layer,
-                channel_name,
-                group_names,
-            )
-            listener_task = asyncio.create_task(
-                cls._channel_message_listener(channel_layer, channel_name, queue)
-            )
 
             async def event_stream() -> AsyncIterator[SubscriptionEvent]:
+                channel_name = cast(str, await channel_layer.new_channel())
+                queue: asyncio.Queue[GraphQLFieldMap] = asyncio.Queue()
+                joined_groups = await _join_subscription_groups(
+                    channel_layer,
+                    channel_name,
+                    group_names,
+                )
+                listener_task = asyncio.create_task(
+                    cls._channel_message_listener(channel_layer, channel_name, queue)
+                )
                 async with _subscription_cleanup_scope(
                     channel_layer,
                     channel_name,
@@ -1616,11 +1615,11 @@ class GraphQL:
                         action = message.get("action")
                         if not isinstance(action, str):
                             continue
-                        if action == "refresh":
+                        identification = message.get("identification")
+                        if action == "refresh" and identification is None:
                             clear_capability_context(info)
                             yield SubscriptionEvent(item=None, action=action)
                             continue
-                        identification = message.get("identification")
                         if not isinstance(identification, dict):
                             continue
                         identification_copy = deepcopy(identification)

--- a/src/general_manager/api/graphql_subscriptions.py
+++ b/src/general_manager/api/graphql_subscriptions.py
@@ -110,6 +110,51 @@ def class_group_name(manager_class: type[GeneralManager]) -> str:
     return f"gm_subscriptions.{manager_class.__name__}.__class__"
 
 
+def refresh_group_name(manager_class: type[GeneralManager]) -> str:
+    """
+    Build the channel-group name for batched refreshes of a manager class.
+
+    Parameters:
+        manager_class: Manager class used to namespace the refresh group.
+
+    Returns:
+        A stable group identifier for aggregate manager refresh events.
+    """
+    return f"gm_subscriptions.{manager_class.__name__}.__refresh__"
+
+
+async def dispatch_subscription_event(
+    channel_layer: BaseChannelLayer,
+    group_names: Iterable[str],
+    message: SubscriptionMessage,
+) -> int:
+    """
+    Send one subscription event sequentially to each requested group.
+
+    Ordinary dispatch failures are logged for their target and do not prevent
+    later sends. ``MemoryError`` propagates immediately because continuing
+    dispatch during memory exhaustion is unsafe.
+
+    Returns:
+        The number of groups that accepted the event successfully.
+    """
+    dispatched = 0
+    for target_group_name in group_names:
+        try:
+            await channel_layer.group_send(target_group_name, message)
+        except MemoryError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "failed to dispatch subscription event",
+                context={"group": target_group_name, "message": message},
+                exc_info=exc,
+            )
+        else:
+            dispatched += 1
+    return dispatched
+
+
 async def channel_listener(
     channel_layer: BaseChannelLayer,
     channel_name: str,

--- a/src/general_manager/api/graphql_subscriptions.py
+++ b/src/general_manager/api/graphql_subscriptions.py
@@ -147,7 +147,12 @@ async def dispatch_subscription_event(
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "failed to dispatch subscription event",
-                context={"group": target_group_name, "message": message},
+                context={
+                    "group": target_group_name,
+                    "event_type": message.get("type"),
+                    "action": message.get("action"),
+                    "manager": message.get("manager"),
+                },
                 exc_info=exc,
             )
         else:

--- a/src/general_manager/api/notification_batching.py
+++ b/src/general_manager/api/notification_batching.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+from _thread import LockType
 from collections.abc import Awaitable, Callable, Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -30,6 +32,8 @@ class _PendingNotification:
 @dataclass(slots=True)
 class _BatchState:
     targets: dict[NotificationKey, _PendingNotification] = field(default_factory=dict)
+    accepting: bool = True
+    lock: LockType = field(default_factory=threading.Lock, repr=False)
 
 
 _active_batch: ContextVar[_BatchState | None] = ContextVar(
@@ -49,15 +53,23 @@ def _queue_notification(
     state = _active_batch.get()
     if state is None:
         return False
-    if key in state.targets:
+    with state.lock:
+        if not state.accepting:
+            return False
+        if key in state.targets:
+            return True
+        state.targets[key] = _PendingNotification(
+            key,
+            group_send,
+            group,
+            dict(message),
+        )
         return True
-    state.targets[key] = _PendingNotification(
-        key,
-        group_send,
-        group,
-        dict(message),
-    )
-    return True
+
+
+def _close_batch(state: _BatchState) -> None:
+    with state.lock:
+        state.accepting = False
 
 
 async def _flush_notifications(state: _BatchState) -> None:
@@ -93,6 +105,7 @@ def bulk_data_change_notifications() -> Iterator[None]:
     try:
         yield
     except BaseException as body_error:
+        _close_batch(state)
         _active_batch.reset(token)
         try:
             _flush_sync(state)
@@ -103,5 +116,6 @@ def bulk_data_change_notifications() -> Iterator[None]:
             ) from None
         raise
     else:
+        _close_batch(state)
         _active_batch.reset(token)
         _flush_sync(state)

--- a/src/general_manager/api/notification_batching.py
+++ b/src/general_manager/api/notification_batching.py
@@ -1,0 +1,103 @@
+"""Batch data-change notifications across synchronous bulk operations."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+from asgiref.sync import async_to_sync
+
+from general_manager.logging import get_logger
+
+type NotificationKey = tuple[str, ...]
+type NotificationMessage = Mapping[str, object]
+type GroupSend = Callable[[str, dict[str, object]], Awaitable[None]]
+
+logger = get_logger("api.notification_batching")
+_COMBINED_FAILURE_MESSAGE = "bulk data change and notification flush failed"
+
+
+@dataclass(slots=True)
+class _PendingNotification:
+    key: NotificationKey
+    group_send: GroupSend = field(repr=False)
+    group: str
+    message: dict[str, object]
+
+
+@dataclass(slots=True)
+class _BatchState:
+    targets: dict[NotificationKey, _PendingNotification] = field(default_factory=dict)
+
+
+_active_batch: ContextVar[_BatchState | None] = ContextVar(
+    "general_manager_notification_batch",
+    default=None,
+)
+
+
+def _queue_notification(
+    *,
+    key: NotificationKey,
+    group_send: GroupSend,
+    group: str,
+    message: NotificationMessage,
+) -> bool:
+    """Queue a target when batching is active."""
+    state = _active_batch.get()
+    if state is None:
+        return False
+    state.targets.setdefault(
+        key,
+        _PendingNotification(key, group_send, group, dict(message)),
+    )
+    return True
+
+
+async def _flush_notifications(state: _BatchState) -> None:
+    for key in sorted(state.targets):
+        target = state.targets[key]
+        try:
+            await target.group_send(target.group, target.message)
+        except MemoryError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "failed to dispatch batched notification",
+                context={"key": key, "group": target.group},
+                exc_info=exc,
+            )
+
+
+def _flush_sync(state: _BatchState) -> None:
+    if state.targets:
+        async_to_sync(_flush_notifications)(state)
+
+
+@contextmanager
+def bulk_data_change_notifications() -> Iterator[None]:
+    """Collect and flush data-change notifications for a bulk operation."""
+    current = _active_batch.get()
+    if current is not None:
+        yield
+        return
+
+    state = _BatchState()
+    token = _active_batch.set(state)
+    try:
+        yield
+    except BaseException as body_error:
+        _active_batch.reset(token)
+        try:
+            _flush_sync(state)
+        except BaseException as flush_error:  # noqa: BLE001
+            raise BaseExceptionGroup(
+                _COMBINED_FAILURE_MESSAGE,
+                [body_error, flush_error],
+            ) from None
+        raise
+    else:
+        _active_batch.reset(token)
+        _flush_sync(state)

--- a/src/general_manager/api/notification_batching.py
+++ b/src/general_manager/api/notification_batching.py
@@ -49,9 +49,13 @@ def _queue_notification(
     state = _active_batch.get()
     if state is None:
         return False
-    state.targets.setdefault(
+    if key in state.targets:
+        return True
+    state.targets[key] = _PendingNotification(
         key,
-        _PendingNotification(key, group_send, group, dict(message)),
+        group_send,
+        group,
+        dict(message),
     )
     return True
 

--- a/src/general_manager/api/remote_invalidation.py
+++ b/src/general_manager/api/remote_invalidation.py
@@ -22,6 +22,7 @@ from general_manager.api.remote_api import (
     build_remote_api_registry,
     get_remote_api_config,
 )
+from general_manager.api.notification_batching import _queue_notification
 from general_manager.cache.signals import post_data_change
 from general_manager.logging import get_logger
 
@@ -84,6 +85,27 @@ def _json_safe_identification(
     }
 
 
+def _build_remote_invalidation_payload(
+    config: RemoteAPIConfig,
+    *,
+    action: str,
+    identification: IdentificationPayload | None,
+    event_id: str,
+) -> RemoteInvalidationPayload:
+    """Build one protocol-complete RemoteAPI invalidation payload."""
+    return {
+        "type": "gm.remote.invalidation",
+        "protocol_version": config.protocol_version,
+        "base_path": config.base_path,
+        "resource_name": config.resource_name,
+        "action": action,
+        "identification": _json_safe_identification(identification)
+        if identification is not None
+        else None,
+        "event_id": event_id,
+    }
+
+
 def remote_invalidation_group_name(config: RemoteAPIConfig) -> str:
     """
     Return the channel-layer group name for a RemoteAPI websocket resource.
@@ -117,7 +139,7 @@ def emit_remote_invalidation(
     **_: object,
 ) -> None:
     """
-    Emit one websocket invalidation event for a RemoteAPI-enabled manager.
+    Emit or queue a websocket invalidation for a RemoteAPI-enabled manager.
 
     Returns without sending when the manager has no RemoteAPI config, websocket
     invalidation is disabled, or Channels has no configured channel layer.
@@ -127,9 +149,11 @@ def emit_remote_invalidation(
     validation. UUID, date, and datetime identification values are serialized to
     strings, and other non-JSON values fall back to `str(value)`.
 
-    The synchronous signal receiver sends one channel-layer payload through
-    `async_to_sync(channel_layer.group_send)`. Payload fields are `type`
-    (`"gm.remote.invalidation"`), `protocol_version`, `base_path`,
+    During a bulk notification batch, the receiver queues one resource-wide
+    `refresh` payload and returns without resolving row identification or
+    creating an immediate async bridge. Outside a batch, it sends one row-level
+    payload through `async_to_sync(channel_layer.group_send)`. Payload fields
+    are `type` (`"gm.remote.invalidation"`), `protocol_version`, `base_path`,
     `resource_name`, `action`, `identification`, and `event_id` as a UUID4
     string. Identification serialization is shallow; nested lists or mappings
     fall back to `str(value)`. Missing `instance.identification`, pathological
@@ -141,22 +165,33 @@ def emit_remote_invalidation(
     channel_layer = _get_channel_layer_safe()
     if channel_layer is None:
         return
+    group_name = remote_invalidation_group_name(config)
+    event_id = str(uuid4())
+    refresh_payload = _build_remote_invalidation_payload(
+        config,
+        action="refresh",
+        identification=None,
+        event_id=event_id,
+    )
+    if _queue_notification(
+        key=("remote", group_name, config.protocol_version),
+        group_send=channel_layer.group_send,
+        group=group_name,
+        message=refresh_payload,
+    ):
+        return
+
     event_identification = identification
     if event_identification is None and instance is not None:
         event_identification = dict(instance.identification)
-    payload: RemoteInvalidationPayload = {
-        "type": "gm.remote.invalidation",
-        "protocol_version": config.protocol_version,
-        "base_path": config.base_path,
-        "resource_name": config.resource_name,
-        "action": action,
-        "identification": _json_safe_identification(event_identification)
-        if event_identification is not None
-        else None,
-        "event_id": str(uuid4()),
-    }
+    payload = _build_remote_invalidation_payload(
+        config,
+        action=action,
+        identification=event_identification,
+        event_id=event_id,
+    )
     async_to_sync(channel_layer.group_send)(
-        remote_invalidation_group_name(config),
+        group_name,
         payload,
     )
 

--- a/src/general_manager/bootstrap.py
+++ b/src/general_manager/bootstrap.py
@@ -179,7 +179,7 @@ def install_startup_hook_runner() -> None:
 
     def run_from_argv_with_startup_hooks(
         self: BaseCommand,
-        argv: list[str],
+        argv: Sequence[str],
     ) -> None:
         run_main = os.environ.get("RUN_MAIN") == "true"
         command = argv[1] if len(argv) > 1 else None

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -365,7 +365,7 @@ def _record_dependencies_locked(
     """Mutate an already-loaded dependency index for one cache key."""
     for model_name, action, identifier in set(dependencies):
         if action in ("filter", "exclude"):
-            action_key = cast(Literal["filter", "exclude"], action)
+            action_key = action
             params = parse_dependency_identifier(identifier)
             if not isinstance(params, dict):
                 continue

--- a/src/general_manager/migrations/0007_upload_intent.py
+++ b/src/general_manager/migrations/0007_upload_intent.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 "constraints": (
-                    models.CheckConstraint(  # type: ignore[call-arg]
+                    models.CheckConstraint(
                         condition=models.Q(("id", 1)),
                         name="gm_upload_quota_lock_singleton",
                     ),
@@ -153,11 +153,11 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 "constraints": (
-                    models.CheckConstraint(  # type: ignore[call-arg]
+                    models.CheckConstraint(
                         condition=models.Q(("declared_size__gte", 0)),
                         name="gm_upload_declared_size_gte_0",
                     ),
-                    models.CheckConstraint(  # type: ignore[call-arg]
+                    models.CheckConstraint(
                         condition=models.Q(
                             ("verified_size__isnull", True),
                             ("verified_size__gte", 0),
@@ -165,11 +165,11 @@ class Migration(migrations.Migration):
                         ),
                         name="gm_upload_verified_size_gte_0",
                     ),
-                    models.CheckConstraint(  # type: ignore[call-arg]
+                    models.CheckConstraint(
                         condition=models.Q(("finalization_attempt_count__gte", 0)),
                         name="gm_upload_attempt_count_gte_0",
                     ),
-                    models.CheckConstraint(  # type: ignore[call-arg]
+                    models.CheckConstraint(
                         condition=models.Q(("transfer_attempt_count__gte", 0)),
                         name="gm_upload_transfer_attempt_gte_0",
                     ),

--- a/src/general_manager/public_api_registry.py
+++ b/src/general_manager/public_api_registry.py
@@ -92,6 +92,10 @@ GENERAL_MANAGER_EXPORTS: LazyExportMap = {
 
 API_EXPORTS: LazyExportMap = {
     "GraphQL": ("general_manager.api.graphql", "GraphQL"),
+    "bulk_data_change_notifications": (
+        "general_manager.api.notification_batching",
+        "bulk_data_change_notifications",
+    ),
     "PublicGraphQLError": (
         "general_manager.api.graphql_errors",
         "PublicGraphQLError",

--- a/src/general_manager/search/backends/meilisearch.py
+++ b/src/general_manager/search/backends/meilisearch.py
@@ -447,7 +447,7 @@ class MeilisearchBackend:
             )
             clauses.append(f"({type_clause})")
         if filters:
-            filter_groups = filters if isinstance(filters, (list, tuple)) else [filters]
+            filter_groups = [filters] if isinstance(filters, Mapping) else filters
             group_clauses: list[str] = []
             for group in filter_groups:
                 parts: list[str] = []

--- a/src/general_manager/uploads/finalization.py
+++ b/src/general_manager/uploads/finalization.py
@@ -2218,10 +2218,10 @@ def _has_unsafe_sqlite_outer_atomic(alias: str) -> bool:
     connection = connections[alias]
     if connection.vendor != "sqlite":
         return False
-    return any(
-        not getattr(block, "_from_testcase", False)
-        for block in connection.atomic_blocks
-    )
+    blocks = services._connection_atomic_blocks(connection)
+    if blocks is None or not blocks:
+        return bool(getattr(connection, "in_atomic_block", False))
+    return any(not services._atomic_block_is_from_testcase(block) for block in blocks)
 
 
 def _parse_target_pk(value: str | None, model: type[models.Model]) -> object:

--- a/src/general_manager/uploads/models.py
+++ b/src/general_manager/uploads/models.py
@@ -44,7 +44,7 @@ class UploadQuotaLock(models.Model):
 
     class Meta:
         constraints: ClassVar[tuple[models.BaseConstraint, ...]] = (
-            models.CheckConstraint(  # type: ignore[call-arg]
+            models.CheckConstraint(
                 condition=models.Q(id=1),
                 name="gm_upload_quota_lock_singleton",
             ),
@@ -202,22 +202,22 @@ class UploadIntent(models.Model):
             ),
         )
         constraints: ClassVar[tuple[models.BaseConstraint, ...]] = (
-            models.CheckConstraint(  # type: ignore[call-arg]
+            models.CheckConstraint(
                 condition=models.Q(declared_size__gte=0),
                 name="gm_upload_declared_size_gte_0",
             ),
-            models.CheckConstraint(  # type: ignore[call-arg]
+            models.CheckConstraint(
                 condition=(
                     models.Q(verified_size__isnull=True)
                     | models.Q(verified_size__gte=0)
                 ),
                 name="gm_upload_verified_size_gte_0",
             ),
-            models.CheckConstraint(  # type: ignore[call-arg]
+            models.CheckConstraint(
                 condition=models.Q(finalization_attempt_count__gte=0),
                 name="gm_upload_attempt_count_gte_0",
             ),
-            models.CheckConstraint(  # type: ignore[call-arg]
+            models.CheckConstraint(
                 condition=models.Q(transfer_attempt_count__gte=0),
                 name="gm_upload_transfer_attempt_gte_0",
             ),

--- a/src/general_manager/utils/filter_parser.py
+++ b/src/general_manager/utils/filter_parser.py
@@ -192,7 +192,7 @@ def create_filter_function(lookup_str: str, value: object) -> FilterFunction:
     parts = lookup_str.split("__") if lookup_str else []
     lookup: LookupName
     if parts and parts[-1] in _SUPPORTED_LOOKUPS:
-        lookup = cast(LookupName, parts[-1])
+        lookup = parts[-1]
         attr_path = parts[:-1]
     else:
         lookup = "exact"

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -10,6 +10,7 @@ from general_manager.cache.run_context import CalculationRunContext
 from general_manager.utils.testing import GeneralManagerTransactionTestCase
 from general_manager.utils.make_cache_key import make_cache_key
 from general_manager.manager import GeneralManager, Input
+from general_manager.api import bulk_data_change_notifications
 from django.db.models.fields import CharField, IntegerField, DateField, DateTimeField
 from typing import ClassVar
 from general_manager.measurement import MeasurementField, Measurement
@@ -629,6 +630,23 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
 
         self.assertEqual(commercials2.budget_left, Measurement(1500, "EUR"))
         self.assert_cache_hit()
+
+    def test_bulk_notifications_preserve_dependency_cache_invalidation(self):
+        """Characterize immediate cache invalidation inside a notification batch."""
+        commercials = self.TestCommercials(project=self.project1)
+        self.assertEqual(commercials.budget_left, Measurement(800, "EUR"))
+
+        with bulk_data_change_notifications():
+            self.project1 = self.project1.update(
+                actual_costs=Measurement(600, "EUR"),
+                ignore_permission=True,
+            )
+
+            refreshed_commercials = self.TestCommercials(project=self.project1)
+            self.assertEqual(
+                refreshed_commercials.budget_left,
+                Measurement(400, "EUR"),
+            )
 
     def test_filter_dependency_invalidation(self):
         """

--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -635,6 +635,9 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
         """Characterize immediate cache invalidation inside a notification batch."""
         commercials = self.TestCommercials(project=self.project1)
         self.assertEqual(commercials.budget_left, Measurement(800, "EUR"))
+        self.assert_cache_miss()
+        self.assertEqual(commercials.budget_left, Measurement(800, "EUR"))
+        self.assert_cache_hit()
 
         with bulk_data_change_notifications():
             self.project1 = self.project1.update(
@@ -647,6 +650,7 @@ class CachingTestCase(GeneralManagerTransactionTestCase):
                 refreshed_commercials.budget_left,
                 Measurement(400, "EUR"),
             )
+            self.assert_cache_miss()
 
     def test_filter_dependency_invalidation(self):
         """

--- a/tests/integration/test_graphql_subscriptions.py
+++ b/tests/integration/test_graphql_subscriptions.py
@@ -10,6 +10,7 @@ from django.db.models import CharField, FloatField
 from django.utils.crypto import get_random_string
 from typing import ClassVar
 
+from general_manager.api import bulk_data_change_notifications
 from general_manager.api.graphql import GraphQL
 from general_manager.api.property import graph_ql_property
 from general_manager.interface import CalculationInterface, DatabaseInterface
@@ -389,6 +390,88 @@ class TestGraphQLCalculationSubscriptions(GeneralManagerTransactionTestCase):
         self.assertEqual(update["item"]["configuredTax"]["unit"], "EUR")
         self.assertIn("configuredTax", self.TaxCalculation.access_log)
         self.assertNotIn("unusedTax", self.TaxCalculation.access_log)
+
+    def test_calculation_subscription_batches_dependency_refreshes(self) -> None:
+        employee = self.Employee.create(
+            name="Alice",
+            salary=Measurement(3000, "EUR"),
+            creator_id=self.user.id,
+        )
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription ($employeeId: ID!) {
+                onTaxCalculationChange(employeeId: $employeeId) {
+                    action
+                    item {
+                        configuredTax {
+                            value
+                            unit
+                        }
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> tuple[object, object, object]:
+            generator = await schema.subscribe(
+                subscription,
+                variable_values={"employeeId": employee.id},
+                context_value=context,
+            )
+            if hasattr(generator, "errors"):
+                raise AssertionError(generator.errors)
+            try:
+                snapshot = await generator.__anext__()
+
+                def update_batch() -> None:
+                    with bulk_data_change_notifications():
+                        self.tax_rule.update(
+                            multiplier=0.25,
+                            creator_id=self.user.id,
+                            ignore_permission=True,
+                        )
+                        self.tax_rule.update(
+                            multiplier=0.3,
+                            creator_id=self.user.id,
+                            ignore_permission=True,
+                        )
+
+                await asyncio.to_thread(update_batch)
+                refresh = await asyncio.wait_for(generator.__anext__(), timeout=1)
+
+                next_event = asyncio.create_task(generator.__anext__())
+                await asyncio.to_thread(
+                    lambda: self.tax_rule.update(
+                        multiplier=0.35,
+                        creator_id=self.user.id,
+                        ignore_permission=True,
+                    )
+                )
+                ordinary_update = await asyncio.wait_for(next_event, timeout=1)
+            finally:
+                await generator.aclose()
+            return snapshot, refresh, ordinary_update
+
+        snapshot_event, refresh_event, update_event = asyncio.run(run_subscription())
+
+        self.assertIsNone(snapshot_event.errors)
+        self.assertAlmostEqual(
+            snapshot_event.data["onTaxCalculationChange"]["item"]["configuredTax"][
+                "value"
+            ],
+            600,
+        )
+
+        self.assertIsNone(refresh_event.errors)
+        refresh = refresh_event.data["onTaxCalculationChange"]
+        self.assertEqual(refresh["action"], "refresh")
+        self.assertAlmostEqual(refresh["item"]["configuredTax"]["value"], 900)
+
+        self.assertIsNone(update_event.errors)
+        update = update_event.data["onTaxCalculationChange"]
+        self.assertEqual(update["action"], "update")
+        self.assertAlmostEqual(update["item"]["configuredTax"]["value"], 1050)
 
     def test_calculation_subscription_handles_property_aliases(self) -> None:
         """

--- a/tests/snapshots/public_api_exports.json
+++ b/tests/snapshots/public_api_exports.json
@@ -330,6 +330,10 @@
       "general_manager.uploads.types",
       "UploadTransport"
     ],
+    "bulk_data_change_notifications": [
+      "general_manager.api.notification_batching",
+      "bulk_data_change_notifications"
+    ],
     "graph_ql_mutation": [
       "general_manager.api.mutation",
       "graph_ql_mutation"

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -251,6 +251,25 @@ class MeasurementTypeTests(TestCase):
 
 
 class GraphQLTests(TestCase):
+    def test_public_bulk_data_change_notifications_is_importable(self):
+        """Bulk notification batching is exposed only through the API module."""
+        import general_manager
+        import general_manager._types.api as type_api
+        from general_manager._types.api import (
+            bulk_data_change_notifications as typed_bulk_notifications,
+        )
+        from general_manager.api import (
+            bulk_data_change_notifications as public_bulk_notifications,
+        )
+        from general_manager.api.notification_batching import (
+            bulk_data_change_notifications,
+        )
+
+        self.assertIs(public_bulk_notifications, bulk_data_change_notifications)
+        self.assertIs(typed_bulk_notifications, bulk_data_change_notifications)
+        self.assertIn("bulk_data_change_notifications", type_api.__all__)
+        self.assertNotIn("bulk_data_change_notifications", general_manager.__all__)
+
     def setUp(self):
         self.general_manager_class = MagicMock(spec=GeneralManagerMeta)
         self.general_manager_class.__name__ = "TestManager"

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -383,6 +383,7 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         async def run_subscription() -> None:
             successfully_added: list[str] = []
             discard_attempts: list[str] = []
+            stream: Any = None
 
             async def failing_group_add(group: str, channel: str) -> None:
                 if successfully_added:
@@ -394,19 +395,116 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
                 discard_attempts.append(group)
                 await original_group_discard(group, channel)
 
+            try:
+                with (
+                    patch.object(channel_layer, "group_add", new=failing_group_add),
+                    patch.object(
+                        channel_layer,
+                        "group_discard",
+                        new=tracking_group_discard,
+                    ),
+                    self.assertRaises(RuntimeError) as caught,
+                ):
+                    stream = await subscribe(None, info, id=employee.id)
+                    await stream.__anext__()
+            finally:
+                if stream is not None:
+                    await stream.aclose()
+
+            self.assertIs(caught.exception, setup_error)
+            self.assertEqual(discard_attempts, successfully_added)
+
+        asyncio.run(run_subscription())
+
+    def test_unstarted_detail_subscription_allocates_no_channel_resources(self) -> None:
+        employee = self.Employee.create(name="Alice", creator_id=self.user.id)
+        context = SimpleNamespace(user=self.user)
+        info = SimpleNamespace(field_nodes=[], fragments={}, context=context)
+        subscribe = GraphQL._subscription_fields["subscribe_on_employee_change"]
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+
+        async def run_subscription() -> None:
             with (
-                patch.object(channel_layer, "group_add", new=failing_group_add),
+                patch.object(
+                    channel_layer,
+                    "new_channel",
+                    new=AsyncMock(return_value="detail.test.channel"),
+                ) as new_channel,
+                patch.object(
+                    channel_layer,
+                    "group_add",
+                    new=AsyncMock(),
+                ) as group_add,
+                patch.object(
+                    GraphQL,
+                    "_channel_listener",
+                    new=AsyncMock(),
+                ) as listener,
+            ):
+                stream = await subscribe(None, info, id=employee.id)
+                await stream.aclose()
+                new_channel.assert_not_awaited()
+                group_add.assert_not_awaited()
+                listener.assert_not_called()
+
+        asyncio.run(run_subscription())
+
+    def test_cancelled_detail_first_pull_rolls_back_joined_groups(self) -> None:
+        employee = self.Employee.create(name="Alice", creator_id=self.user.id)
+        context = SimpleNamespace(user=self.user)
+        info = SimpleNamespace(field_nodes=[], fragments={}, context=context)
+        subscribe = GraphQL._subscription_fields["subscribe_on_employee_change"]
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+
+        async def run_subscription() -> None:
+            successfully_added: list[str] = []
+            discard_attempts: list[str] = []
+            second_add_started = asyncio.Event()
+            never_finish_add = asyncio.Event()
+
+            async def blocking_group_add(group: str, _channel: str) -> None:
+                if not successfully_added:
+                    successfully_added.append(group)
+                    return
+                second_add_started.set()
+                await never_finish_add.wait()
+
+            async def tracking_group_discard(group: str, _channel: str) -> None:
+                discard_attempts.append(group)
+
+            with (
+                patch.object(
+                    channel_layer,
+                    "new_channel",
+                    new=AsyncMock(return_value="detail.cancel.channel"),
+                ),
+                patch.object(channel_layer, "group_add", new=blocking_group_add),
                 patch.object(
                     channel_layer,
                     "group_discard",
                     new=tracking_group_discard,
                 ),
-                self.assertRaises(RuntimeError) as caught,
+                patch.object(GraphQL, "_channel_listener") as listener,
             ):
-                await subscribe(None, info, id=employee.id)
+                stream = await asyncio.wait_for(
+                    subscribe(None, info, id=employee.id),
+                    timeout=1,
+                )
+                first_pull = asyncio.create_task(stream.__anext__())
+                try:
+                    await asyncio.wait_for(second_add_started.wait(), timeout=1)
+                    first_pull.cancel()
+                    with self.assertRaises(asyncio.CancelledError):
+                        await first_pull
+                finally:
+                    if not first_pull.done():
+                        first_pull.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await first_pull
+                    await stream.aclose()
 
-            self.assertIs(caught.exception, setup_error)
-            self.assertEqual(discard_attempts, successfully_added)
+                self.assertEqual(discard_attempts, successfully_added)
+                listener.assert_not_called()
 
         asyncio.run(run_subscription())
 
@@ -695,6 +793,7 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         async def run_subscription() -> None:
             successfully_added: list[str] = []
             discard_attempts: list[str] = []
+            stream: Any = None
 
             async def failing_group_add(group: str, channel: str) -> None:
                 if successfully_added:
@@ -707,21 +806,113 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
                 await original_group_discard(group, channel)
                 raise discard_error
 
-            with (
-                patch.object(channel_layer, "group_add", new=failing_group_add),
-                patch.object(
-                    channel_layer,
-                    "group_discard",
-                    new=failing_group_discard,
-                ),
-                self.assertRaises(BaseExceptionGroup) as caught,
-            ):
-                await subscribe(None, info)
+            try:
+                with (
+                    patch.object(channel_layer, "group_add", new=failing_group_add),
+                    patch.object(
+                        channel_layer,
+                        "group_discard",
+                        new=failing_group_discard,
+                    ),
+                    self.assertRaises(BaseExceptionGroup) as caught,
+                ):
+                    stream = await subscribe(None, info)
+                    await stream.__anext__()
+            finally:
+                if stream is not None:
+                    await stream.aclose()
 
             leaves = _exception_group_leaves(caught.exception)
             self.assertIn(setup_error, leaves)
             self.assertIn(discard_error, leaves)
             self.assertEqual(discard_attempts, successfully_added)
+
+        asyncio.run(run_subscription())
+
+    def test_unstarted_class_subscription_allocates_no_channel_resources(self) -> None:
+        context = SimpleNamespace(user=self.user)
+        info = SimpleNamespace(context=context)
+        subscribe = GraphQL._subscription_fields["subscribe_on_employee_class_change"]
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+
+        async def run_subscription() -> None:
+            with (
+                patch.object(
+                    channel_layer,
+                    "new_channel",
+                    new=AsyncMock(return_value="class.test.channel"),
+                ) as new_channel,
+                patch.object(
+                    channel_layer,
+                    "group_add",
+                    new=AsyncMock(),
+                ) as group_add,
+                patch.object(
+                    GraphQL,
+                    "_channel_message_listener",
+                    new=AsyncMock(),
+                ) as listener,
+            ):
+                stream = await subscribe(None, info)
+                await stream.aclose()
+                new_channel.assert_not_awaited()
+                group_add.assert_not_awaited()
+                listener.assert_not_called()
+
+        asyncio.run(run_subscription())
+
+    def test_cancelled_class_first_pull_rolls_back_joined_groups(self) -> None:
+        context = SimpleNamespace(user=self.user)
+        info = SimpleNamespace(context=context)
+        subscribe = GraphQL._subscription_fields["subscribe_on_employee_class_change"]
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+
+        async def run_subscription() -> None:
+            successfully_added: list[str] = []
+            discard_attempts: list[str] = []
+            second_add_started = asyncio.Event()
+            never_finish_add = asyncio.Event()
+
+            async def blocking_group_add(group: str, _channel: str) -> None:
+                if not successfully_added:
+                    successfully_added.append(group)
+                    return
+                second_add_started.set()
+                await never_finish_add.wait()
+
+            async def tracking_group_discard(group: str, _channel: str) -> None:
+                discard_attempts.append(group)
+
+            with (
+                patch.object(
+                    channel_layer,
+                    "new_channel",
+                    new=AsyncMock(return_value="class.cancel.channel"),
+                ),
+                patch.object(channel_layer, "group_add", new=blocking_group_add),
+                patch.object(
+                    channel_layer,
+                    "group_discard",
+                    new=tracking_group_discard,
+                ),
+                patch.object(GraphQL, "_channel_message_listener") as listener,
+            ):
+                stream = await asyncio.wait_for(subscribe(None, info), timeout=1)
+                first_pull = asyncio.create_task(stream.__anext__())
+                try:
+                    await asyncio.wait_for(second_add_started.wait(), timeout=1)
+                    first_pull.cancel()
+                    with self.assertRaises(asyncio.CancelledError):
+                        await first_pull
+                finally:
+                    if not first_pull.done():
+                        first_pull.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await first_pull
+                    await stream.aclose()
+
+                self.assertEqual(discard_attempts, successfully_added)
+                listener.assert_not_called()
 
         asyncio.run(run_subscription())
 
@@ -783,16 +974,24 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
             ):
                 stream = await subscribe(None, info)
                 try:
-                    await asyncio.wait_for(listener_finished.wait(), timeout=1)
-                    with (
-                        patch.object(
-                            GraphQL,
-                            "_instantiate_manager",
-                            side_effect=stream_error,
-                        ),
-                        self.assertRaises(BaseExceptionGroup) as caught,
+                    with patch.object(
+                        GraphQL,
+                        "_instantiate_manager",
+                        side_effect=stream_error,
                     ):
-                        await stream.__anext__()
+                        next_event = asyncio.create_task(stream.__anext__())
+                        try:
+                            await asyncio.wait_for(
+                                listener_finished.wait(),
+                                timeout=1,
+                            )
+                            with self.assertRaises(BaseExceptionGroup) as caught:
+                                await next_event
+                        finally:
+                            if not next_event.done():
+                                next_event.cancel()
+                                with contextlib.suppress(asyncio.CancelledError):
+                                    await next_event
                 finally:
                     await stream.aclose()
 
@@ -848,6 +1047,112 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         self.assertIsNone(event.errors)
         payload = event.data["onEmployeeClassChange"]
         self.assertEqual(payload["action"], "create")
+        self.assertEqual(payload["item"]["name"], "Visible")
+
+    def test_class_subscription_hydrates_authorized_row_refresh(self) -> None:
+        employee = self.Employee.create(name="Visible", creator_id=self.user.id)
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+
+        async def fake_listener(
+            _channel_layer: object,
+            _channel_name: str,
+            queue: asyncio.Queue[dict[str, object]],
+        ) -> None:
+            await queue.put(
+                {
+                    "type": "gm.subscription.event",
+                    "manager": "Employee",
+                    "action": "refresh",
+                    "identification": employee.identification,
+                }
+            )
+            await asyncio.Event().wait()
+
+        async def run_subscription() -> object:
+            with patch.object(
+                GraphQL,
+                "_channel_message_listener",
+                new=fake_listener,
+            ):
+                generator = await schema.subscribe(subscription, context_value=context)
+                if hasattr(generator, "errors"):
+                    raise AssertionError(generator.errors)
+                try:
+                    return await asyncio.wait_for(generator.__anext__(), timeout=1)
+                finally:
+                    await generator.aclose()
+
+        event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        payload = event.data["onEmployeeClassChange"]
+        self.assertEqual(payload["action"], "refresh")
+        self.assertEqual(payload["item"]["name"], "Visible")
+
+    def test_class_subscription_suppresses_unreadable_row_refresh(self) -> None:
+        hidden = self.Employee.create(name="Hidden", creator_id=self.user.id)
+        visible = self.Employee.create(name="Visible", creator_id=self.user.id)
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+
+        async def fake_listener(
+            _channel_layer: object,
+            _channel_name: str,
+            queue: asyncio.Queue[dict[str, object]],
+        ) -> None:
+            for employee in (hidden, visible):
+                await queue.put(
+                    {
+                        "type": "gm.subscription.event",
+                        "manager": "Employee",
+                        "action": "refresh",
+                        "identification": employee.identification,
+                    }
+                )
+            await asyncio.Event().wait()
+
+        async def run_subscription() -> object:
+            with patch.object(
+                GraphQL,
+                "_channel_message_listener",
+                new=fake_listener,
+            ):
+                generator = await schema.subscribe(subscription, context_value=context)
+                if hasattr(generator, "errors"):
+                    raise AssertionError(generator.errors)
+                try:
+                    return await asyncio.wait_for(generator.__anext__(), timeout=1)
+                finally:
+                    await generator.aclose()
+
+        event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        payload = event.data["onEmployeeClassChange"]
+        self.assertEqual(payload["action"], "refresh")
         self.assertEqual(payload["item"]["name"], "Visible")
 
     def test_class_subscription_suppresses_non_string_actions(self) -> None:

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -6,7 +6,7 @@ import contextlib
 import os
 from types import SimpleNamespace
 from typing import Any, ClassVar
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import graphene
 from django.contrib.auth import get_user_model
@@ -234,6 +234,132 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
             second_event.data["onEmployeeChange"]["item"]["capabilities"]["canKeepName"]
         )
 
+    def test_detail_subscription_batches_updates_into_one_refresh(self) -> None:
+        employee = self.Employee.create(name="Alice", creator_id=self.user.id)
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription ($id: ID!) {
+                onEmployeeChange(id: $id) {
+                    action
+                    item {
+                        id
+                        name
+                        capabilities {
+                            canKeepName
+                        }
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> tuple[object, object, object]:
+            generator = await schema.subscribe(
+                subscription,
+                variable_values={"id": employee.id},
+                context_value=context,
+            )
+            try:
+                snapshot = await generator.__anext__()
+
+                def update_batch() -> None:
+                    with bulk_data_change_notifications():
+                        employee.update(name="Bob", creator_id=self.user.id)
+                        employee.update(name="Carol", creator_id=self.user.id)
+
+                await asyncio.to_thread(update_batch)
+                refresh = await asyncio.wait_for(generator.__anext__(), timeout=1)
+
+                next_event = asyncio.create_task(generator.__anext__())
+                await asyncio.to_thread(
+                    lambda: employee.update(name="Dave", creator_id=self.user.id)
+                )
+                ordinary_update = await asyncio.wait_for(next_event, timeout=1)
+            finally:
+                await generator.aclose()
+            return snapshot, refresh, ordinary_update
+
+        snapshot_event, refresh_event, update_event = asyncio.run(run_subscription())
+
+        self.assertIsNone(snapshot_event.errors)
+        self.assertEqual(snapshot_event.data["onEmployeeChange"]["action"], "snapshot")
+
+        self.assertIsNone(refresh_event.errors)
+        refresh = refresh_event.data["onEmployeeChange"]
+        self.assertEqual(refresh["action"], "refresh")
+        self.assertEqual(refresh["item"]["name"], "Carol")
+        self.assertFalse(refresh["item"]["capabilities"]["canKeepName"])
+
+        self.assertIsNone(update_event.errors)
+        update = update_event.data["onEmployeeChange"]
+        self.assertEqual(update["action"], "update")
+        self.assertEqual(update["item"]["name"], "Dave")
+
+    def test_detail_subscription_joins_and_discards_refresh_groups(self) -> None:
+        employee = self.Employee.create(name="Alice", creator_id=self.user.id)
+        dependency_identification = {"id": 42}
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription ($id: ID!) {
+                onEmployeeChange(id: $id) {
+                    action
+                }
+            }
+        """
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+        original_group_add = channel_layer.group_add
+        original_group_discard = channel_layer.group_discard
+
+        async def run_subscription() -> None:
+            with (
+                patch.object(
+                    GraphQL,
+                    "_resolve_subscription_dependencies",
+                    return_value=[
+                        (self.SoftEmployee, dependency_identification),
+                        (self.SoftEmployee, dependency_identification),
+                    ],
+                ),
+                patch.object(
+                    channel_layer,
+                    "group_add",
+                    new=AsyncMock(wraps=original_group_add),
+                ) as group_add,
+                patch.object(
+                    channel_layer,
+                    "group_discard",
+                    new=AsyncMock(wraps=original_group_discard),
+                ) as group_discard,
+            ):
+                generator = await schema.subscribe(
+                    subscription,
+                    variable_values={"id": employee.id},
+                    context_value=context,
+                )
+                try:
+                    await generator.__anext__()
+                finally:
+                    await generator.aclose()
+
+                expected_groups = {
+                    GraphQL._group_name(self.Employee, employee.identification),
+                    GraphQL._refresh_group_name(self.Employee),
+                    GraphQL._group_name(
+                        self.SoftEmployee,
+                        dependency_identification,
+                    ),
+                    GraphQL._refresh_group_name(self.SoftEmployee),
+                }
+                added_groups = {args.args[0] for args in group_add.await_args_list}
+                discarded_groups = {
+                    args.args[0] for args in group_discard.await_args_list
+                }
+                self.assertEqual(added_groups, expected_groups)
+                self.assertEqual(discarded_groups, expected_groups)
+
+        asyncio.run(run_subscription())
+
     def test_class_subscription_emits_create_without_initial_snapshot(self) -> None:
         schema = self._build_schema()
         context = SimpleNamespace(user=self.user)
@@ -273,6 +399,123 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         payload = event.data["onEmployeeClassChange"]
         self.assertEqual(payload["action"], "create")
         self.assertEqual(payload["item"]["name"], "Class Alice")
+
+    def test_class_subscription_batches_creates_into_one_refresh(self) -> None:
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+
+        async def run_subscription() -> tuple[object, object]:
+            generator = await schema.subscribe(subscription, context_value=context)
+            if hasattr(generator, "errors"):
+                raise AssertionError(generator.errors)
+            try:
+                refresh_task = asyncio.create_task(generator.__anext__())
+                await asyncio.sleep(0.02)
+
+                def create_batch() -> None:
+                    with bulk_data_change_notifications():
+                        self.Employee.create(
+                            name="Batch One",
+                            creator_id=self.user.id,
+                        )
+                        self.Employee.create(
+                            name="Batch Two",
+                            creator_id=self.user.id,
+                        )
+
+                await asyncio.to_thread(create_batch)
+                refresh = await asyncio.wait_for(refresh_task, timeout=1)
+
+                next_event = asyncio.create_task(generator.__anext__())
+                await asyncio.to_thread(
+                    lambda: self.Employee.create(
+                        name="Ordinary",
+                        creator_id=self.user.id,
+                    )
+                )
+                ordinary_create = await asyncio.wait_for(next_event, timeout=1)
+            finally:
+                await generator.aclose()
+            return refresh, ordinary_create
+
+        refresh_event, create_event = asyncio.run(run_subscription())
+
+        self.assertIsNone(refresh_event.errors)
+        refresh = refresh_event.data["onEmployeeClassChange"]
+        self.assertEqual(refresh["action"], "refresh")
+        self.assertIsNone(refresh["item"])
+
+        self.assertIsNone(create_event.errors)
+        create = create_event.data["onEmployeeClassChange"]
+        self.assertEqual(create["action"], "create")
+        self.assertEqual(create["item"]["name"], "Ordinary")
+
+    def test_class_subscription_joins_and_discards_refresh_group(self) -> None:
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                }
+            }
+        """
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+        original_group_add = channel_layer.group_add
+        original_group_discard = channel_layer.group_discard
+
+        async def run_subscription() -> None:
+            with (
+                patch.object(
+                    channel_layer,
+                    "group_add",
+                    new=AsyncMock(wraps=original_group_add),
+                ) as group_add,
+                patch.object(
+                    channel_layer,
+                    "group_discard",
+                    new=AsyncMock(wraps=original_group_discard),
+                ) as group_discard,
+            ):
+                generator = await schema.subscribe(subscription, context_value=context)
+                if hasattr(generator, "errors"):
+                    raise AssertionError(generator.errors)
+                next_event = asyncio.create_task(generator.__anext__())
+                try:
+                    await asyncio.sleep(0.02)
+                    await asyncio.to_thread(
+                        lambda: self.Employee.create(
+                            name="Cleanup",
+                            creator_id=self.user.id,
+                        )
+                    )
+                    await asyncio.wait_for(next_event, timeout=1)
+                finally:
+                    await generator.aclose()
+
+                expected_groups = {
+                    GraphQL._class_group_name(self.Employee),
+                    GraphQL._refresh_group_name(self.Employee),
+                }
+                added_groups = {args.args[0] for args in group_add.await_args_list}
+                discarded_groups = {
+                    args.args[0] for args in group_discard.await_args_list
+                }
+                self.assertEqual(added_groups, expected_groups)
+                self.assertEqual(discarded_groups, expected_groups)
+
+        asyncio.run(run_subscription())
 
     def test_class_subscription_suppresses_unreadable_events(self) -> None:
         schema = self._build_schema()
@@ -344,6 +587,13 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
             await queue.put(
                 {
                     "type": "gm.subscription.event",
+                    "manager": "OtherManager",
+                    "action": "refresh",
+                }
+            )
+            await queue.put(
+                {
+                    "type": "gm.subscription.event",
                     "manager": "Employee",
                     "action": 123,
                     "identification": employee.identification,
@@ -402,6 +652,14 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
                 raise AssertionError(generator.errors)
             try:
                 next_event = asyncio.create_task(generator.__anext__())
+                await asyncio.sleep(0.02)
+                self.assertFalse(next_event.done())
+                await asyncio.to_thread(
+                    lambda: employee.update(
+                        name="Hidden",
+                        creator_id=self.user.id,
+                    )
+                )
                 await asyncio.sleep(0.02)
                 self.assertFalse(next_event.done())
                 await asyncio.to_thread(

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -1659,7 +1659,12 @@ class GraphQLSubscriptionDispatchTests(unittest.IsolatedAsyncioTestCase):
                 raise RuntimeError(failure_message)
 
         layer = SimpleNamespace(group_send=group_send)
-        message: dict[str, object] = {"action": "update"}
+        message: dict[str, object] = {
+            "type": "gm.subscription.event",
+            "action": "update",
+            "manager": "Project",
+            "identification": {"secret": "sensitive-value"},
+        }
 
         with patch.object(graphql_subscriptions, "logger") as mock_logger:
             success_count = await graphql_subscriptions.dispatch_subscription_event(
@@ -1675,11 +1680,21 @@ class GraphQLSubscriptionDispatchTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(success_count, 1)
         self.assertEqual(mock_logger.warning.call_count, 2)
         self.assertEqual(
+            [call.kwargs["context"] for call in mock_logger.warning.call_args_list],
             [
-                call.kwargs["context"]["group"]
-                for call in mock_logger.warning.call_args_list
+                {
+                    "group": "first-failure",
+                    "event_type": "gm.subscription.event",
+                    "action": "update",
+                    "manager": "Project",
+                },
+                {
+                    "group": "second-failure",
+                    "event_type": "gm.subscription.event",
+                    "action": "update",
+                    "manager": "Project",
+                },
             ],
-            ["first-failure", "second-failure"],
         )
 
     async def test_memory_error_stops_dispatch_immediately(self) -> None:

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -49,6 +49,16 @@ class _DummyManager:
 _DummyInterface._parent_class = _DummyManager
 
 
+def _exception_group_leaves(error: BaseException) -> list[BaseException]:
+    if not isinstance(error, BaseExceptionGroup):
+        return [error]
+    return [
+        leaf
+        for nested_error in error.exceptions
+        for leaf in _exception_group_leaves(nested_error)
+    ]
+
+
 class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -360,6 +370,115 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
 
         asyncio.run(run_subscription())
 
+    def test_detail_subscription_rolls_back_groups_when_setup_fails(self) -> None:
+        employee = self.Employee.create(name="Alice", creator_id=self.user.id)
+        context = SimpleNamespace(user=self.user)
+        info = SimpleNamespace(field_nodes=[], fragments={}, context=context)
+        subscribe = GraphQL._subscription_fields["subscribe_on_employee_change"]
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+        original_group_add = channel_layer.group_add
+        original_group_discard = channel_layer.group_discard
+        setup_error = RuntimeError("detail group setup failed")
+
+        async def run_subscription() -> None:
+            successfully_added: list[str] = []
+            discard_attempts: list[str] = []
+
+            async def failing_group_add(group: str, channel: str) -> None:
+                if successfully_added:
+                    raise setup_error
+                await original_group_add(group, channel)
+                successfully_added.append(group)
+
+            async def tracking_group_discard(group: str, channel: str) -> None:
+                discard_attempts.append(group)
+                await original_group_discard(group, channel)
+
+            with (
+                patch.object(channel_layer, "group_add", new=failing_group_add),
+                patch.object(
+                    channel_layer,
+                    "group_discard",
+                    new=tracking_group_discard,
+                ),
+                self.assertRaises(RuntimeError) as caught,
+            ):
+                await subscribe(None, info, id=employee.id)
+
+            self.assertIs(caught.exception, setup_error)
+            self.assertEqual(discard_attempts, successfully_added)
+
+        asyncio.run(run_subscription())
+
+    def test_detail_subscription_preserves_stream_and_cleanup_failures(self) -> None:
+        employee = self.Employee.create(name="Alice", creator_id=self.user.id)
+        context = SimpleNamespace(user=self.user)
+        info = SimpleNamespace(field_nodes=[], fragments={}, context=context)
+        subscribe = GraphQL._subscription_fields["subscribe_on_employee_change"]
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+        original_group_add = channel_layer.group_add
+        original_group_discard = channel_layer.group_discard
+        stream_error = OSError("detail stream failed")
+        listener_error = RuntimeError("detail listener failed")
+        discard_error = RuntimeError("detail discard failed")
+        listener_finished = asyncio.Event()
+
+        async def failing_listener(
+            _channel_layer: object,
+            _channel_name: str,
+            queue: asyncio.Queue[str],
+        ) -> None:
+            await queue.put("update")
+            listener_finished.set()
+            raise listener_error
+
+        async def run_subscription() -> None:
+            successfully_added: list[str] = []
+            discard_attempts: list[str] = []
+
+            async def tracking_group_add(group: str, channel: str) -> None:
+                await original_group_add(group, channel)
+                successfully_added.append(group)
+
+            async def failing_group_discard(group: str, channel: str) -> None:
+                discard_attempts.append(group)
+                await original_group_discard(group, channel)
+                if len(discard_attempts) == 1:
+                    raise discard_error
+
+            with (
+                patch.object(channel_layer, "group_add", new=tracking_group_add),
+                patch.object(
+                    channel_layer,
+                    "group_discard",
+                    new=failing_group_discard,
+                ),
+                patch.object(GraphQL, "_channel_listener", new=failing_listener),
+            ):
+                stream = await subscribe(None, info, id=employee.id)
+                try:
+                    await stream.__anext__()
+                    await asyncio.wait_for(listener_finished.wait(), timeout=1)
+                    with (
+                        patch.object(
+                            GraphQL,
+                            "_instantiate_manager",
+                            side_effect=stream_error,
+                        ),
+                        self.assertRaises(BaseExceptionGroup) as caught,
+                    ):
+                        await stream.__anext__()
+                finally:
+                    await stream.aclose()
+
+            leaves = _exception_group_leaves(caught.exception)
+            self.assertIn(stream_error, leaves)
+            self.assertIn(listener_error, leaves)
+            self.assertIn(discard_error, leaves)
+            self.assertCountEqual(discard_attempts, successfully_added)
+
+        asyncio.run(run_subscription())
+
     def test_class_subscription_emits_create_without_initial_snapshot(self) -> None:
         schema = self._build_schema()
         context = SimpleNamespace(user=self.user)
@@ -415,38 +534,65 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
             }
         """
 
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+        original_group_add = channel_layer.group_add
+
         async def run_subscription() -> tuple[object, object]:
-            generator = await schema.subscribe(subscription, context_value=context)
-            if hasattr(generator, "errors"):
-                raise AssertionError(generator.errors)
-            try:
+            required_groups = {
+                GraphQL._class_group_name(self.Employee),
+                GraphQL._refresh_group_name(self.Employee),
+            }
+            registered_groups: set[str] = set()
+            registration_ready = asyncio.Event()
+
+            async def tracking_group_add(group: str, channel: str) -> None:
+                await original_group_add(group, channel)
+                registered_groups.add(group)
+                if required_groups <= registered_groups:
+                    registration_ready.set()
+
+            with patch.object(
+                channel_layer,
+                "group_add",
+                new=tracking_group_add,
+            ):
+                generator = await schema.subscribe(subscription, context_value=context)
+                if hasattr(generator, "errors"):
+                    raise AssertionError(generator.errors)
                 refresh_task = asyncio.create_task(generator.__anext__())
-                await asyncio.sleep(0.02)
+                next_event: asyncio.Task[object] | None = None
+                try:
+                    await asyncio.wait_for(registration_ready.wait(), timeout=1)
 
-                def create_batch() -> None:
-                    with bulk_data_change_notifications():
-                        self.Employee.create(
-                            name="Batch One",
+                    def create_batch() -> None:
+                        with bulk_data_change_notifications():
+                            self.Employee.create(
+                                name="Batch One",
+                                creator_id=self.user.id,
+                            )
+                            self.Employee.create(
+                                name="Batch Two",
+                                creator_id=self.user.id,
+                            )
+
+                    await asyncio.to_thread(create_batch)
+                    refresh = await asyncio.wait_for(refresh_task, timeout=1)
+
+                    next_event = asyncio.create_task(generator.__anext__())
+                    await asyncio.to_thread(
+                        lambda: self.Employee.create(
+                            name="Ordinary",
                             creator_id=self.user.id,
                         )
-                        self.Employee.create(
-                            name="Batch Two",
-                            creator_id=self.user.id,
-                        )
-
-                await asyncio.to_thread(create_batch)
-                refresh = await asyncio.wait_for(refresh_task, timeout=1)
-
-                next_event = asyncio.create_task(generator.__anext__())
-                await asyncio.to_thread(
-                    lambda: self.Employee.create(
-                        name="Ordinary",
-                        creator_id=self.user.id,
                     )
-                )
-                ordinary_create = await asyncio.wait_for(next_event, timeout=1)
-            finally:
-                await generator.aclose()
+                    ordinary_create = await asyncio.wait_for(next_event, timeout=1)
+                finally:
+                    for task in (refresh_task, next_event):
+                        if task is not None and not task.done():
+                            task.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await task
+                    await generator.aclose()
             return refresh, ordinary_create
 
         refresh_event, create_event = asyncio.run(run_subscription())
@@ -476,11 +622,24 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         original_group_discard = channel_layer.group_discard
 
         async def run_subscription() -> None:
+            required_groups = {
+                GraphQL._class_group_name(self.Employee),
+                GraphQL._refresh_group_name(self.Employee),
+            }
+            registered_groups: set[str] = set()
+            registration_ready = asyncio.Event()
+
+            async def tracking_group_add(group: str, channel: str) -> None:
+                await original_group_add(group, channel)
+                registered_groups.add(group)
+                if required_groups <= registered_groups:
+                    registration_ready.set()
+
             with (
                 patch.object(
                     channel_layer,
                     "group_add",
-                    new=AsyncMock(wraps=original_group_add),
+                    new=AsyncMock(side_effect=tracking_group_add),
                 ) as group_add,
                 patch.object(
                     channel_layer,
@@ -493,7 +652,7 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
                     raise AssertionError(generator.errors)
                 next_event = asyncio.create_task(generator.__anext__())
                 try:
-                    await asyncio.sleep(0.02)
+                    await asyncio.wait_for(registration_ready.wait(), timeout=1)
                     await asyncio.to_thread(
                         lambda: self.Employee.create(
                             name="Cleanup",
@@ -502,6 +661,10 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
                     )
                     await asyncio.wait_for(next_event, timeout=1)
                 finally:
+                    if not next_event.done():
+                        next_event.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await next_event
                     await generator.aclose()
 
                 expected_groups = {
@@ -514,6 +677,130 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
                 }
                 self.assertEqual(added_groups, expected_groups)
                 self.assertEqual(discarded_groups, expected_groups)
+
+        asyncio.run(run_subscription())
+
+    def test_class_subscription_rolls_back_groups_and_preserves_failures(
+        self,
+    ) -> None:
+        context = SimpleNamespace(user=self.user)
+        info = SimpleNamespace(context=context)
+        subscribe = GraphQL._subscription_fields["subscribe_on_employee_class_change"]
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+        original_group_add = channel_layer.group_add
+        original_group_discard = channel_layer.group_discard
+        setup_error = RuntimeError("class group setup failed")
+        discard_error = RuntimeError("class setup rollback failed")
+
+        async def run_subscription() -> None:
+            successfully_added: list[str] = []
+            discard_attempts: list[str] = []
+
+            async def failing_group_add(group: str, channel: str) -> None:
+                if successfully_added:
+                    raise setup_error
+                await original_group_add(group, channel)
+                successfully_added.append(group)
+
+            async def failing_group_discard(group: str, channel: str) -> None:
+                discard_attempts.append(group)
+                await original_group_discard(group, channel)
+                raise discard_error
+
+            with (
+                patch.object(channel_layer, "group_add", new=failing_group_add),
+                patch.object(
+                    channel_layer,
+                    "group_discard",
+                    new=failing_group_discard,
+                ),
+                self.assertRaises(BaseExceptionGroup) as caught,
+            ):
+                await subscribe(None, info)
+
+            leaves = _exception_group_leaves(caught.exception)
+            self.assertIn(setup_error, leaves)
+            self.assertIn(discard_error, leaves)
+            self.assertEqual(discard_attempts, successfully_added)
+
+        asyncio.run(run_subscription())
+
+    def test_class_subscription_preserves_stream_and_cleanup_failures(self) -> None:
+        employee = self.Employee.create(name="Alice", creator_id=self.user.id)
+        context = SimpleNamespace(user=self.user)
+        info = SimpleNamespace(context=context)
+        subscribe = GraphQL._subscription_fields["subscribe_on_employee_class_change"]
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+        original_group_add = channel_layer.group_add
+        original_group_discard = channel_layer.group_discard
+        stream_error = OSError("class stream failed")
+        listener_error = RuntimeError("class listener failed")
+        discard_error = RuntimeError("class discard failed")
+        listener_finished = asyncio.Event()
+
+        async def failing_listener(
+            _channel_layer: object,
+            _channel_name: str,
+            queue: asyncio.Queue[dict[str, object]],
+        ) -> None:
+            await queue.put(
+                {
+                    "type": "gm.subscription.event",
+                    "manager": "Employee",
+                    "action": "update",
+                    "identification": employee.identification,
+                }
+            )
+            listener_finished.set()
+            raise listener_error
+
+        async def run_subscription() -> None:
+            successfully_added: list[str] = []
+            discard_attempts: list[str] = []
+
+            async def tracking_group_add(group: str, channel: str) -> None:
+                await original_group_add(group, channel)
+                successfully_added.append(group)
+
+            async def failing_group_discard(group: str, channel: str) -> None:
+                discard_attempts.append(group)
+                await original_group_discard(group, channel)
+                if len(discard_attempts) == 1:
+                    raise discard_error
+
+            with (
+                patch.object(channel_layer, "group_add", new=tracking_group_add),
+                patch.object(
+                    channel_layer,
+                    "group_discard",
+                    new=failing_group_discard,
+                ),
+                patch.object(
+                    GraphQL,
+                    "_channel_message_listener",
+                    new=failing_listener,
+                ),
+            ):
+                stream = await subscribe(None, info)
+                try:
+                    await asyncio.wait_for(listener_finished.wait(), timeout=1)
+                    with (
+                        patch.object(
+                            GraphQL,
+                            "_instantiate_manager",
+                            side_effect=stream_error,
+                        ),
+                        self.assertRaises(BaseExceptionGroup) as caught,
+                    ):
+                        await stream.__anext__()
+                finally:
+                    await stream.aclose()
+
+            leaves = _exception_group_leaves(caught.exception)
+            self.assertIn(stream_error, leaves)
+            self.assertIn(listener_error, leaves)
+            self.assertIn(discard_error, leaves)
+            self.assertCountEqual(discard_attempts, successfully_added)
 
         asyncio.run(run_subscription())
 

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -1427,6 +1427,45 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
             ],
         )
 
+    def test_handle_data_change_deep_copies_nested_identification(self) -> None:
+        """Verify dispatched row identification is detached from the source."""
+        source_identification: dict[str, object] = {
+            "id": 1,
+            "nested": {"labels": ["alpha", "beta"]},
+        }
+
+        class RegisteredManager(GeneralManager):
+            identification: ClassVar = source_identification
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {"RegisteredManager": RegisteredManager}
+        sent: list[dict[str, object]] = []
+
+        async def group_send(_group: str, message: dict[str, object]) -> None:
+            sent.append(message)
+
+        layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch(
+                "general_manager.api.graphql.async_to_sync",
+                side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
+            ),
+        ):
+            GraphQL._handle_data_change(
+                sender=RegisteredManager,
+                instance=RegisteredManager(),
+                action="update",
+            )
+
+        dispatched_identification = sent[0]["identification"]
+        self.assertEqual(dispatched_identification, source_identification)
+        self.assertIsNot(dispatched_identification, source_identification)
+        self.assertIsNot(
+            dispatched_identification["nested"],  # type: ignore[index]
+            source_identification["nested"],
+        )
+
     def test_bulk_changes_queue_one_manager_refresh(self) -> None:
         """Many changes for one manager flush one aggregate refresh event."""
 

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -16,6 +16,8 @@ from graphql import parse
 from graphql.language.ast import FragmentDefinitionNode, OperationDefinitionNode
 import unittest
 
+from general_manager.api import bulk_data_change_notifications
+from general_manager.api import graphql_subscriptions
 from general_manager.api.graphql import GraphQL
 from general_manager.interface import DatabaseInterface
 from general_manager.manager.general_manager import GeneralManager
@@ -793,6 +795,63 @@ class GraphQLChannelLayerTests(unittest.TestCase):
             self.assertIs(layer, mock_layer)
 
 
+class GraphQLSubscriptionDispatchTests(unittest.IsolatedAsyncioTestCase):
+    """Test sequential subscription event dispatch."""
+
+    async def test_runtime_errors_log_per_target_and_count_successes(self) -> None:
+        """Ordinary send failures do not prevent later target attempts."""
+        sent: list[str] = []
+        failure_message = "dispatch failed"
+
+        async def group_send(group: str, _message: dict[str, object]) -> None:
+            sent.append(group)
+            if group != "successful":
+                raise RuntimeError(failure_message)
+
+        layer = SimpleNamespace(group_send=group_send)
+        message: dict[str, object] = {"action": "update"}
+
+        with patch.object(graphql_subscriptions, "logger") as mock_logger:
+            success_count = await graphql_subscriptions.dispatch_subscription_event(
+                layer,  # type: ignore[arg-type]
+                ("first-failure", "successful", "second-failure"),
+                message,
+            )
+
+        self.assertEqual(
+            sent,
+            ["first-failure", "successful", "second-failure"],
+        )
+        self.assertEqual(success_count, 1)
+        self.assertEqual(mock_logger.warning.call_count, 2)
+        self.assertEqual(
+            [
+                call.kwargs["context"]["group"]
+                for call in mock_logger.warning.call_args_list
+            ],
+            ["first-failure", "second-failure"],
+        )
+
+    async def test_memory_error_stops_dispatch_immediately(self) -> None:
+        """Memory exhaustion propagates without attempting later targets."""
+        sent: list[str] = []
+
+        async def group_send(group: str, _message: dict[str, object]) -> None:
+            sent.append(group)
+            raise MemoryError
+
+        layer = SimpleNamespace(group_send=group_send)
+
+        with self.assertRaises(MemoryError):
+            await graphql_subscriptions.dispatch_subscription_event(
+                layer,  # type: ignore[arg-type]
+                ("first", "second"),
+                {"action": "update"},
+            )
+
+        self.assertEqual(sent, ["first"])
+
+
 class GraphQLGroupNameTests(unittest.TestCase):
     """Test subscription group name generation."""
 
@@ -856,6 +915,17 @@ class GraphQLGroupNameTests(unittest.TestCase):
         name2 = GraphQL._class_group_name(TestManager)
         self.assertEqual(name1, name2)
         self.assertEqual(name1, "gm_subscriptions.TestManager.__class__")
+
+    def test_refresh_group_name_identifies_manager_refreshes(self) -> None:
+        """Verify _refresh_group_name produces the manager refresh group."""
+
+        class TestManager(GeneralManager):
+            pass
+
+        self.assertEqual(
+            GraphQL._refresh_group_name(TestManager),
+            "gm_subscriptions.TestManager.__refresh__",
+        )
 
 
 class GraphQLPrimePropertiesEdgeCaseTests(unittest.TestCase):
@@ -1303,8 +1373,8 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
                 sender=RegisteredManager, instance=instance, action="test"
             )
 
-    def test_handle_data_change_sends_to_instance_and_class_groups(self) -> None:
-        """Verify _handle_data_change sends a rich message to both groups."""
+    def test_handle_data_change_uses_one_bridge_for_both_groups(self) -> None:
+        """Verify one bridge sends the unchanged row payload to both groups."""
 
         class RegisteredManager(GeneralManager):
             identification: ClassVar[dict[str, int]] = {"id": 1}
@@ -1313,38 +1383,156 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
         GraphQL.manager_registry = {"RegisteredManager": RegisteredManager}
         instance = RegisteredManager()
 
-        mock_layer = MagicMock()
-        with patch(
-            "general_manager.api.graphql.GraphQL._get_channel_layer",
-            return_value=mock_layer,
+        sent: list[tuple[str, dict[str, object]]] = []
+
+        async def group_send(group: str, message: dict[str, object]) -> None:
+            sent.append((group, message))
+
+        layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch(
+                "general_manager.api.graphql.async_to_sync",
+                side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
+            ) as bridge,
         ):
-            with patch(
-                "general_manager.api.graphql.async_to_sync"
-            ) as mock_async_to_sync:
-                mock_send = MagicMock()
-                mock_async_to_sync.return_value = mock_send
+            GraphQL._handle_data_change(
+                sender=RegisteredManager, instance=instance, action="update"
+            )
 
+        bridge.assert_called_once_with(
+            graphql_subscriptions.dispatch_subscription_event
+        )
+        instance_group = GraphQL._group_name(RegisteredManager, instance.identification)
+        class_group = GraphQL._class_group_name(RegisteredManager)
+        self.assertEqual(
+            [group for group, _message in sent],
+            [instance_group, class_group],
+        )
+        self.assertEqual(
+            [message for _group, message in sent],
+            [
+                {
+                    "type": "gm.subscription.event",
+                    "action": "update",
+                    "manager": "RegisteredManager",
+                    "identification": {"id": 1},
+                },
+                {
+                    "type": "gm.subscription.event",
+                    "action": "update",
+                    "manager": "RegisteredManager",
+                    "identification": {"id": 1},
+                },
+            ],
+        )
+
+    def test_bulk_changes_queue_one_manager_refresh(self) -> None:
+        """Many changes for one manager flush one aggregate refresh event."""
+
+        class RegisteredManager(GeneralManager):
+            identification: ClassVar[dict[str, int]] = {"id": 1}
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {"RegisteredManager": RegisteredManager}
+        sent: list[tuple[str, dict[str, object]]] = []
+
+        async def group_send(group: str, message: dict[str, object]) -> None:
+            sent.append((group, message))
+
+        layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch("general_manager.api.graphql.async_to_sync") as immediate_bridge,
+        ):
+            with bulk_data_change_notifications():
+                for _ in range(5):
+                    GraphQL._handle_data_change(
+                        sender=RegisteredManager,
+                        instance=RegisteredManager(),
+                        action="update",
+                    )
+                self.assertEqual(sent, [])
+                immediate_bridge.assert_not_called()
+
+        self.assertEqual(
+            sent,
+            [
+                (
+                    GraphQL._refresh_group_name(RegisteredManager),
+                    {
+                        "type": "gm.subscription.event",
+                        "action": "refresh",
+                        "manager": "RegisteredManager",
+                    },
+                )
+            ],
+        )
+
+    def test_bulk_changes_queue_distinct_manager_refreshes(self) -> None:
+        """A batch flushes one refresh target for each changed manager."""
+
+        class AlphaManager(GeneralManager):
+            identification: ClassVar[dict[str, int]] = {"id": 1}
+            Interface = BaseTestInterface
+
+        class BetaManager(GeneralManager):
+            identification: ClassVar[dict[str, int]] = {"id": 2}
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {
+            "AlphaManager": AlphaManager,
+            "BetaManager": BetaManager,
+        }
+        sent: list[tuple[str, dict[str, object]]] = []
+
+        async def group_send(group: str, message: dict[str, object]) -> None:
+            sent.append((group, message))
+
+        layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch("general_manager.api.graphql.async_to_sync") as immediate_bridge,
+        ):
+            with bulk_data_change_notifications():
                 GraphQL._handle_data_change(
-                    sender=RegisteredManager, instance=instance, action="update"
+                    sender=BetaManager,
+                    instance=BetaManager(),
+                    action="delete",
                 )
-
-                # Verify group_send was wrapped with async_to_sync
-                mock_async_to_sync.assert_called_once_with(mock_layer.group_send)
-
-                self.assertEqual(mock_send.call_count, 2)
-                sent_groups = {call.args[0] for call in mock_send.call_args_list}
-                instance_group = GraphQL._group_name(
-                    RegisteredManager, instance.identification
+                GraphQL._handle_data_change(
+                    sender=AlphaManager,
+                    instance=AlphaManager(),
+                    action="create",
                 )
-                class_group = GraphQL._class_group_name(RegisteredManager)
-                self.assertEqual(sent_groups, {instance_group, class_group})
+                GraphQL._handle_data_change(
+                    sender=BetaManager,
+                    instance=BetaManager(),
+                    action="update",
+                )
+                immediate_bridge.assert_not_called()
 
-                for call in mock_send.call_args_list:
-                    message = call.args[1]
-                    self.assertEqual(message["type"], "gm.subscription.event")
-                    self.assertEqual(message["action"], "update")
-                    self.assertEqual(message["manager"], "RegisteredManager")
-                    self.assertEqual(message["identification"], {"id": 1})
+        self.assertEqual(
+            sent,
+            [
+                (
+                    GraphQL._refresh_group_name(AlphaManager),
+                    {
+                        "type": "gm.subscription.event",
+                        "action": "refresh",
+                        "manager": "AlphaManager",
+                    },
+                ),
+                (
+                    GraphQL._refresh_group_name(BetaManager),
+                    {
+                        "type": "gm.subscription.event",
+                        "action": "refresh",
+                        "manager": "BetaManager",
+                    },
+                ),
+            ],
+        )
 
 
 class GraphQLInstantiateManagerTests(GeneralManagerTransactionTestCase):

--- a/tests/unit/test_grapql_subscription_helper.py
+++ b/tests/unit/test_grapql_subscription_helper.py
@@ -10,6 +10,7 @@ import unittest
 from graphql import parse
 from graphql.language.ast import FragmentDefinitionNode, OperationDefinitionNode
 
+from general_manager.api import graphql_subscriptions
 from general_manager.api.graphql import GraphQL, SubscriptionEvent
 from general_manager.manager.general_manager import GeneralManager
 from tests.utils.simple_manager_interface import BaseTestInterface
@@ -646,29 +647,33 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
         GraphQL.manager_registry = {"TestManager": TestManager}
         instance = TestManager()
 
-        mock_layer = MagicMock()
-        with patch(
-            "general_manager.api.graphql.GraphQL._get_channel_layer",
-            return_value=mock_layer,
+        sent: list[str] = []
+
+        async def group_send(group: str, _message: dict[str, object]) -> None:
+            sent.append(group)
+
+        layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch(
+                "general_manager.api.graphql.async_to_sync",
+                side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
+            ) as bridge,
         ):
-            with patch("general_manager.api.graphql.async_to_sync") as mock_async:
-                mock_send = MagicMock()
-                mock_async.return_value = mock_send
+            GraphQL._handle_data_change(
+                sender=instance, instance=instance, action="test"
+            )
 
-                # Pass instance as both sender and instance
-                GraphQL._handle_data_change(
-                    sender=instance, instance=instance, action="test"
-                )
-
-                # Should send to the instance and class-level groups.
-                self.assertEqual(mock_send.call_count, 2)
-                self.assertEqual(
-                    {call.args[0] for call in mock_send.call_args_list},
-                    {
-                        GraphQL._group_name(TestManager, instance.identification),
-                        GraphQL._class_group_name(TestManager),
-                    },
-                )
+        bridge.assert_called_once_with(
+            graphql_subscriptions.dispatch_subscription_event
+        )
+        self.assertEqual(
+            sent,
+            [
+                GraphQL._group_name(TestManager, instance.identification),
+                GraphQL._class_group_name(TestManager),
+            ],
+        )
 
     def test_handle_data_change_with_subclass(self) -> None:
         """Verify _handle_data_change works with GeneralManager subclasses."""
@@ -683,20 +688,33 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
         GraphQL.manager_registry = {"DerivedManager": DerivedManager}
         instance = DerivedManager()
 
-        mock_layer = MagicMock()
-        with patch(
-            "general_manager.api.graphql.GraphQL._get_channel_layer",
-            return_value=mock_layer,
+        sent: list[str] = []
+
+        async def group_send(group: str, _message: dict[str, object]) -> None:
+            sent.append(group)
+
+        layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch(
+                "general_manager.api.graphql.async_to_sync",
+                side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
+            ) as bridge,
         ):
-            with patch("general_manager.api.graphql.async_to_sync") as mock_async:
-                mock_send = MagicMock()
-                mock_async.return_value = mock_send
+            GraphQL._handle_data_change(
+                sender=DerivedManager, instance=instance, action="test"
+            )
 
-                GraphQL._handle_data_change(
-                    sender=DerivedManager, instance=instance, action="test"
-                )
-
-                self.assertEqual(mock_send.call_count, 2)
+        bridge.assert_called_once_with(
+            graphql_subscriptions.dispatch_subscription_event
+        )
+        self.assertEqual(
+            sent,
+            [
+                GraphQL._group_name(DerivedManager, instance.identification),
+                GraphQL._class_group_name(DerivedManager),
+            ],
+        )
 
     def test_handle_data_change_continues_when_instance_group_send_fails(
         self,
@@ -709,19 +727,27 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
 
         GraphQL.manager_registry = {"TestManager": TestManager}
         instance = TestManager()
-        mock_layer = MagicMock()
+        instance_group = GraphQL._group_name(TestManager, instance.identification)
+        class_group = GraphQL._class_group_name(TestManager)
+        sent: list[str] = []
+        failure_message = "send failed"
+
+        async def group_send(group: str, _message: dict[str, object]) -> None:
+            sent.append(group)
+            if group == instance_group:
+                raise RuntimeError(failure_message)
+
+        layer = SimpleNamespace(group_send=group_send)
 
         with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
             patch(
-                "general_manager.api.graphql.GraphQL._get_channel_layer",
-                return_value=mock_layer,
-            ),
-            patch("general_manager.api.graphql.async_to_sync") as mock_async,
-            patch("general_manager.api.graphql.logger") as mock_logger,
+                "general_manager.api.graphql.async_to_sync",
+                side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
+            ) as bridge,
+            patch.object(graphql_subscriptions, "logger") as dispatch_logger,
+            patch("general_manager.api.graphql.logger") as handler_logger,
         ):
-            mock_send = MagicMock(side_effect=[RuntimeError("send failed"), None])
-            mock_async.return_value = mock_send
-
             GraphQL._handle_data_change(
                 sender=TestManager,
                 instance=instance,
@@ -729,10 +755,55 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             )
 
         self.assertEqual(
-            [call.args[0] for call in mock_send.call_args_list],
+            sent,
+            [instance_group, class_group],
+        )
+        bridge.assert_called_once_with(
+            graphql_subscriptions.dispatch_subscription_event
+        )
+        dispatch_logger.warning.assert_called_once()
+        handler_logger.debug.assert_called_once()
+
+    def test_handle_data_change_does_not_log_success_when_all_sends_fail(
+        self,
+    ) -> None:
+        """Verify the handler does not claim success when no group accepted it."""
+
+        class TestManager(GeneralManager):
+            identification: ClassVar = {"id": 1}
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {"TestManager": TestManager}
+        instance = TestManager()
+        sent: list[str] = []
+        failure_message = "send failed"
+
+        async def group_send(group: str, _message: dict[str, object]) -> None:
+            sent.append(group)
+            raise RuntimeError(failure_message)
+
+        layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch(
+                "general_manager.api.graphql.async_to_sync",
+                side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
+            ),
+            patch.object(graphql_subscriptions, "logger") as dispatch_logger,
+            patch("general_manager.api.graphql.logger") as handler_logger,
+        ):
+            GraphQL._handle_data_change(
+                sender=TestManager,
+                instance=instance,
+                action="test",
+            )
+
+        self.assertEqual(
+            sent,
             [
                 GraphQL._group_name(TestManager, instance.identification),
                 GraphQL._class_group_name(TestManager),
             ],
         )
-        mock_logger.warning.assert_called_once()
+        self.assertEqual(dispatch_logger.warning.call_count, 2)
+        handler_logger.debug.assert_not_called()

--- a/tests/unit/test_grapql_subscription_helper.py
+++ b/tests/unit/test_grapql_subscription_helper.py
@@ -762,7 +762,15 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             graphql_subscriptions.dispatch_subscription_event
         )
         dispatch_logger.warning.assert_called_once()
-        handler_logger.debug.assert_called_once()
+        handler_logger.debug.assert_called_once_with(
+            "dispatched subscription event",
+            context={
+                "manager": "TestManager",
+                "action": "test",
+                "target_groups": [instance_group, class_group],
+                "successful_group_count": 1,
+            },
+        )
 
     def test_handle_data_change_does_not_log_success_when_all_sends_fail(
         self,
@@ -806,4 +814,98 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             ],
         )
         self.assertEqual(dispatch_logger.warning.call_count, 2)
+        handler_logger.debug.assert_not_called()
+
+    def test_handle_data_change_logs_bridge_construction_failure(self) -> None:
+        """Verify ordinary bridge-construction errors are suppressed and logged."""
+
+        class TestManager(GeneralManager):
+            identification: ClassVar = {"id": 1}
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {"TestManager": TestManager}
+        instance = TestManager()
+        layer = SimpleNamespace(group_send=MagicMock())
+        failure_message = "bridge construction failed"
+        bridge_error = RuntimeError(failure_message)
+
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch(
+                "general_manager.api.graphql.async_to_sync",
+                side_effect=bridge_error,
+            ),
+            patch("general_manager.api.graphql.logger") as handler_logger,
+        ):
+            GraphQL._handle_data_change(
+                sender=TestManager,
+                instance=instance,
+                action="test",
+            )
+
+        handler_logger.warning.assert_called_once()
+        handler_logger.debug.assert_not_called()
+
+    def test_handle_data_change_logs_bridge_invocation_failure(self) -> None:
+        """Verify ordinary bridge-invocation errors are suppressed and logged."""
+
+        class TestManager(GeneralManager):
+            identification: ClassVar = {"id": 1}
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {"TestManager": TestManager}
+        instance = TestManager()
+        layer = SimpleNamespace(group_send=MagicMock())
+        failure_message = "bridge invocation failed"
+
+        def failing_bridge(*_args: object) -> int:
+            raise RuntimeError(failure_message)
+
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch(
+                "general_manager.api.graphql.async_to_sync",
+                return_value=failing_bridge,
+            ),
+            patch("general_manager.api.graphql.logger") as handler_logger,
+        ):
+            GraphQL._handle_data_change(
+                sender=TestManager,
+                instance=instance,
+                action="test",
+            )
+
+        handler_logger.warning.assert_called_once()
+        handler_logger.debug.assert_not_called()
+
+    def test_handle_data_change_propagates_bridge_memory_error(self) -> None:
+        """Verify bridge memory exhaustion propagates to the signal caller."""
+
+        class TestManager(GeneralManager):
+            identification: ClassVar = {"id": 1}
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {"TestManager": TestManager}
+        instance = TestManager()
+        layer = SimpleNamespace(group_send=MagicMock())
+
+        def exhausted_bridge(*_args: object) -> int:
+            raise MemoryError
+
+        with (
+            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
+            patch(
+                "general_manager.api.graphql.async_to_sync",
+                return_value=exhausted_bridge,
+            ),
+            patch("general_manager.api.graphql.logger") as handler_logger,
+            self.assertRaises(MemoryError),
+        ):
+            GraphQL._handle_data_change(
+                sender=TestManager,
+                instance=instance,
+                action="test",
+            )
+
+        handler_logger.warning.assert_not_called()
         handler_logger.debug.assert_not_called()

--- a/tests/unit/test_meilisearch_backend.py
+++ b/tests/unit/test_meilisearch_backend.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections import UserList
+from collections.abc import Mapping, Sequence
+
 import pytest
 
 from general_manager.search.backend import SearchBackendError, SearchDocument
@@ -667,6 +670,17 @@ def test_meilisearch_backend_build_filter_expression_groups() -> None:
     assert 'type = "TypeB"' in expr
     assert 'status = "ready"' in expr
     assert 'status = "paused"' in expr
+
+
+def test_meilisearch_backend_build_filter_expression_accepts_general_sequence() -> None:
+    """Build grouped filters from sequences other than lists and tuples."""
+    filters: Sequence[Mapping[str, object]] = UserList(
+        [{"status": "ready"}, {"status": "paused"}]
+    )
+
+    expr = MeilisearchBackend._build_filter_expression(filters, types=None)
+
+    assert expr == '(status = "ready") OR (status = "paused")'
 
 
 def test_meilisearch_backend_build_filter_expression_empty() -> None:

--- a/tests/unit/test_notification_batching.py
+++ b/tests/unit/test_notification_batching.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Iterator, Mapping
+from threading import Thread
 from unittest.mock import patch
 
 import pytest
@@ -164,6 +165,78 @@ def test_batch_is_inactive_while_notifications_are_flushed() -> None:
         )
 
     assert reentrant_queue_results == [False]
+
+
+def test_child_asyncio_task_participates_in_active_batch() -> None:
+    sent: list[str] = []
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        sent.append(group)
+
+    async def queue_from_child_task() -> bool:
+        async def queue_notification() -> bool:
+            return _queue_notification(
+                key=("graphql", "TaskProject"),
+                group_send=group_send,
+                group="task-project-refresh",
+                message={"action": "refresh"},
+            )
+
+        return await asyncio.create_task(queue_notification())
+
+    with bulk_data_change_notifications():
+        queued = asyncio.run(queue_from_child_task())
+
+    assert queued
+    assert sent == ["task-project-refresh"]
+
+
+def test_asyncio_to_thread_participates_in_active_batch() -> None:
+    sent: list[str] = []
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        sent.append(group)
+
+    async def queue_from_thread() -> bool:
+        return await asyncio.to_thread(
+            _queue_notification,
+            key=("graphql", "ThreadProject"),
+            group_send=group_send,
+            group="thread-project-refresh",
+            message={"action": "refresh"},
+        )
+
+    with bulk_data_change_notifications():
+        queued = asyncio.run(queue_from_thread())
+
+    assert queued
+    assert sent == ["thread-project-refresh"]
+
+
+def test_raw_thread_does_not_inherit_active_batch() -> None:
+    sent: list[str] = []
+    queue_results: list[bool] = []
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        sent.append(group)
+
+    def queue_from_thread() -> None:
+        queue_results.append(
+            _queue_notification(
+                key=("graphql", "RawThreadProject"),
+                group_send=group_send,
+                group="raw-thread-project-refresh",
+                message={"action": "refresh"},
+            )
+        )
+
+    with bulk_data_change_notifications():
+        thread = Thread(target=queue_from_thread)
+        thread.start()
+        thread.join()
+
+    assert queue_results == [False]
+    assert sent == []
 
 
 def test_ordinary_dispatch_failure_is_logged_and_remaining_targets_continue(

--- a/tests/unit/test_notification_batching.py
+++ b/tests/unit/test_notification_batching.py
@@ -1,0 +1,227 @@
+"""Tests for batching data-change notifications."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+from asgiref.sync import async_to_sync
+
+from general_manager.api import bulk_data_change_notifications
+from general_manager.api.notification_batching import _queue_notification
+
+
+def test_queue_notification_returns_false_outside_batch() -> None:
+    async def group_send(_group: str, _message: dict[str, object]) -> None:
+        raise AssertionError
+
+    assert not _queue_notification(
+        key=("graphql", "Project"),
+        group_send=group_send,
+        group="project-refresh",
+        message={"action": "refresh"},
+    )
+
+
+def test_empty_batch_does_not_create_async_bridge() -> None:
+    with patch("general_manager.api.notification_batching.async_to_sync") as bridge:
+        with bulk_data_change_notifications():
+            pass
+
+    bridge.assert_not_called()
+
+
+def test_nested_batch_deduplicates_first_target_and_flushes_once() -> None:
+    sent: list[tuple[str, dict[str, object]]] = []
+
+    async def group_send(group: str, message: dict[str, object]) -> None:
+        sent.append((group, message))
+
+    message: dict[str, object] = {
+        "type": "gm.subscription.event",
+        "action": "refresh",
+    }
+    with patch(
+        "general_manager.api.notification_batching.async_to_sync",
+        side_effect=async_to_sync,
+    ) as bridge:
+        with bulk_data_change_notifications():
+            assert _queue_notification(
+                key=("graphql", "Project"),
+                group_send=group_send,
+                group="project-refresh",
+                message=message,
+            )
+            message["action"] = "changed-after-queue"
+            with bulk_data_change_notifications():
+                assert _queue_notification(
+                    key=("graphql", "Project"),
+                    group_send=group_send,
+                    group="ignored-duplicate",
+                    message={"action": "ignored"},
+                )
+
+    bridge.assert_called_once()
+    assert sent == [
+        (
+            "project-refresh",
+            {"type": "gm.subscription.event", "action": "refresh"},
+        )
+    ]
+
+
+def test_batch_dispatches_sequentially_in_sorted_key_order() -> None:
+    sent: list[str] = []
+    active_sends = 0
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        nonlocal active_sends
+        assert active_sends == 0
+        active_sends += 1
+        await asyncio.sleep(0)
+        sent.append(group)
+        active_sends -= 1
+
+    with bulk_data_change_notifications():
+        for key, group in [
+            (("remote", "zeta"), "zeta-refresh"),
+            (("graphql", "Alpha"), "alpha-refresh"),
+            (("remote", "middle"), "middle-refresh"),
+        ]:
+            assert _queue_notification(
+                key=key,
+                group_send=group_send,
+                group=group,
+                message={"action": "refresh"},
+            )
+
+    assert sent == ["alpha-refresh", "middle-refresh", "zeta-refresh"]
+
+
+def test_batch_is_inactive_while_notifications_are_flushed() -> None:
+    reentrant_queue_results: list[bool] = []
+
+    async def group_send(_group: str, _message: dict[str, object]) -> None:
+        reentrant_queue_results.append(
+            _queue_notification(
+                key=("remote", "reentrant"),
+                group_send=group_send,
+                group="reentrant-refresh",
+                message={"action": "refresh"},
+            )
+        )
+
+    with bulk_data_change_notifications():
+        assert _queue_notification(
+            key=("graphql", "Project"),
+            group_send=group_send,
+            group="project-refresh",
+            message={"action": "refresh"},
+        )
+
+    assert reentrant_queue_results == [False]
+
+
+def test_ordinary_dispatch_failure_is_logged_and_remaining_targets_continue(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sent: list[str] = []
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        if group == "alpha-refresh":
+            raise RuntimeError
+        sent.append(group)
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="general_manager.api.notification_batching",
+    ):
+        with bulk_data_change_notifications():
+            for key, group in [
+                (("graphql", "Alpha"), "alpha-refresh"),
+                (("graphql", "Beta"), "beta-refresh"),
+            ]:
+                assert _queue_notification(
+                    key=key,
+                    group_send=group_send,
+                    group=group,
+                    message={"action": "refresh"},
+                )
+
+    assert sent == ["beta-refresh"]
+    failure_record = next(
+        record
+        for record in caplog.records
+        if record.message == "failed to dispatch batched notification"
+    )
+    assert failure_record.__dict__["context"] == {
+        "key": ("graphql", "Alpha"),
+        "group": "alpha-refresh",
+    }
+
+
+def test_memory_error_propagates_without_dispatching_remaining_targets() -> None:
+    attempted: list[str] = []
+    memory_error = MemoryError("thread startup")
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        attempted.append(group)
+        if group == "alpha-refresh":
+            raise memory_error
+
+    with pytest.raises(MemoryError, match="thread startup"):
+        with bulk_data_change_notifications():
+            for key, group in [
+                (("graphql", "Alpha"), "alpha-refresh"),
+                (("graphql", "Beta"), "beta-refresh"),
+            ]:
+                assert _queue_notification(
+                    key=key,
+                    group_send=group_send,
+                    group=group,
+                    message={"action": "refresh"},
+                )
+
+    assert attempted == ["alpha-refresh"]
+
+
+def test_batch_flushes_when_body_raises() -> None:
+    sent: list[str] = []
+    body_error = ValueError("row failed")
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        sent.append(group)
+
+    with pytest.raises(ValueError, match="row failed"):
+        with bulk_data_change_notifications():
+            assert _queue_notification(
+                key=("remote", "projects"),
+                group_send=group_send,
+                group="projects-refresh",
+                message={"action": "refresh"},
+            )
+            raise body_error
+
+    assert sent == ["projects-refresh"]
+
+
+def test_body_and_memory_failure_are_preserved() -> None:
+    async def exhausted(_group: str, _message: dict[str, object]) -> None:
+        raise MemoryError
+
+    with pytest.raises(ExceptionGroup) as caught:
+        with bulk_data_change_notifications():
+            assert _queue_notification(
+                key=("graphql", "Project"),
+                group_send=exhausted,
+                group="project-refresh",
+                message={"action": "refresh"},
+            )
+            raise ValueError
+
+    assert [type(exc) for exc in caught.value.exceptions] == [
+        ValueError,
+        MemoryError,
+    ]

--- a/tests/unit/test_notification_batching.py
+++ b/tests/unit/test_notification_batching.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Iterator, Mapping
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +12,27 @@ from asgiref.sync import async_to_sync
 
 from general_manager.api import bulk_data_change_notifications
 from general_manager.api.notification_batching import _queue_notification
+
+
+class _SingleUseMapping(Mapping[str, object]):
+    """Expose a payload that fails if batching copies it more than once."""
+
+    def __init__(self) -> None:
+        self.iterations = 0
+
+    def __getitem__(self, key: str) -> object:
+        if key != "action":
+            raise KeyError(key)
+        return "refresh"
+
+    def __iter__(self) -> Iterator[str]:
+        self.iterations += 1
+        if self.iterations > 1:
+            raise AssertionError("duplicate payload was copied")  # noqa: TRY003
+        return iter(("action",))
+
+    def __len__(self) -> int:
+        return 1
 
 
 def test_queue_notification_returns_false_outside_batch() -> None:
@@ -70,6 +92,26 @@ def test_nested_batch_deduplicates_first_target_and_flushes_once() -> None:
             {"type": "gm.subscription.event", "action": "refresh"},
         )
     ]
+
+
+def test_duplicate_registration_does_not_copy_payload_again() -> None:
+    sent: list[dict[str, object]] = []
+    message = _SingleUseMapping()
+
+    async def group_send(_group: str, payload: dict[str, object]) -> None:
+        sent.append(payload)
+
+    with bulk_data_change_notifications():
+        for _ in range(2):
+            assert _queue_notification(
+                key=("graphql", "Project"),
+                group_send=group_send,
+                group="project-refresh",
+                message=message,
+            )
+
+    assert message.iterations == 1
+    assert sent == [{"action": "refresh"}]
 
 
 def test_batch_dispatches_sequentially_in_sorted_key_order() -> None:
@@ -223,5 +265,26 @@ def test_body_and_memory_failure_are_preserved() -> None:
 
     assert [type(exc) for exc in caught.value.exceptions] == [
         ValueError,
+        MemoryError,
+    ]
+
+
+def test_base_exception_body_and_memory_failure_are_preserved() -> None:
+    async def exhausted(_group: str, _message: dict[str, object]) -> None:
+        raise MemoryError
+
+    with pytest.raises(BaseExceptionGroup) as caught:
+        with bulk_data_change_notifications():
+            assert _queue_notification(
+                key=("graphql", "Project"),
+                group_send=exhausted,
+                group="project-refresh",
+                message={"action": "refresh"},
+            )
+            raise KeyboardInterrupt
+
+    assert type(caught.value) is BaseExceptionGroup
+    assert [type(exc) for exc in caught.value.exceptions] == [
+        KeyboardInterrupt,
         MemoryError,
     ]

--- a/tests/unit/test_notification_batching.py
+++ b/tests/unit/test_notification_batching.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Iterator, Mapping
-from threading import Thread
+from contextvars import copy_context
+from threading import Event, Thread
 from unittest.mock import patch
 
 import pytest
@@ -211,6 +212,51 @@ def test_asyncio_to_thread_participates_in_active_batch() -> None:
 
     assert queued
     assert sent == ["thread-project-refresh"]
+
+
+def test_child_context_outliving_batch_falls_back_to_immediate_dispatch() -> None:
+    sent: list[str] = []
+    queue_results: list[bool] = []
+    child_ready = Event()
+    release_child = Event()
+
+    async def group_send(group: str, _message: dict[str, object]) -> None:
+        sent.append(group)
+
+    def queue_after_parent_exit() -> None:
+        child_ready.set()
+        assert release_child.wait(timeout=1)
+        queued = _queue_notification(
+            key=("graphql", "LateChildProject"),
+            group_send=group_send,
+            group="late-child-project-refresh",
+            message={"action": "refresh"},
+        )
+        queue_results.append(queued)
+        if not queued:
+            async_to_sync(group_send)(
+                "late-child-project-refresh",
+                {"action": "refresh"},
+            )
+
+    with bulk_data_change_notifications():
+        assert _queue_notification(
+            key=("graphql", "ParentProject"),
+            group_send=group_send,
+            group="parent-project-refresh",
+            message={"action": "refresh"},
+        )
+        child_context = copy_context()
+        thread = Thread(target=child_context.run, args=(queue_after_parent_exit,))
+        thread.start()
+        assert child_ready.wait(timeout=1)
+
+    release_child.set()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert queue_results == [False]
+    assert sent == ["parent-project-refresh", "late-child-project-refresh"]
 
 
 def test_raw_thread_does_not_inherit_active_batch() -> None:

--- a/tests/unit/test_remote_invalidation.py
+++ b/tests/unit/test_remote_invalidation.py
@@ -1,23 +1,30 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import date, datetime
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
+from asgiref.sync import async_to_sync
+from channels.auth import AuthMiddlewareStack  # type: ignore[import-untyped]
+from channels.routing import ProtocolTypeRouter, URLRouter  # type: ignore[import-untyped]
 from django.test import SimpleTestCase
 from django.test import override_settings
 from django.urls import re_path
-from channels.auth import AuthMiddlewareStack  # type: ignore[import-untyped]
-from channels.routing import ProtocolTypeRouter, URLRouter  # type: ignore[import-untyped]
 
+from general_manager.api import bulk_data_change_notifications
+from general_manager.api.graphql import GraphQL
 from general_manager.api.remote_invalidation import (
     clear_remote_invalidation_routes,
     emit_remote_invalidation,
     ensure_remote_invalidation_route,
 )
+from general_manager.manager.general_manager import GeneralManager
 
 from tests import testing_asgi
+from tests.utils.simple_manager_interface import BaseTestInterface
 
 
 def _unwrap_websocket_router():
@@ -242,4 +249,216 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
         self.assertEqual(
             payload["identification"],
             {"id": "12345678-1234-5678-1234-567812345678"},
+        )
+
+
+class RemoteInvalidationBatchTests(SimpleTestCase):
+    def test_batch_deduplicates_rows_into_one_resource_refresh(self) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+                protocol_version = "v2"
+
+        sent: list[tuple[str, dict[str, object]]] = []
+
+        async def group_send(group: str, message: dict[str, object]) -> None:
+            sent.append((group, message))
+
+        channel_layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe",
+                return_value=channel_layer,
+            ),
+            patch(
+                "general_manager.api.remote_invalidation.async_to_sync"
+            ) as immediate_bridge,
+        ):
+            with bulk_data_change_notifications():
+                for identification in ({"id": 1}, {"id": 2}, {"id": 3}):
+                    emit_remote_invalidation(
+                        Project,
+                        identification=identification,
+                        action="update",
+                    )
+                self.assertEqual(sent, [])
+                immediate_bridge.assert_not_called()
+
+        self.assertEqual(len(sent), 1)
+        group, payload = sent[0]
+        self.assertEqual(group, "gm.remote.remote.projects")
+        event_id = payload.pop("event_id")
+        self.assertEqual(
+            payload,
+            {
+                "type": "gm.remote.invalidation",
+                "protocol_version": "v2",
+                "base_path": "/remote",
+                "resource_name": "projects",
+                "action": "refresh",
+                "identification": None,
+            },
+        )
+        self.assertEqual(UUID(str(event_id)).version, 4)
+
+    def test_batch_queues_one_refresh_for_each_remote_resource(self) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        class Task:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "tasks"
+                allow_delete = True
+                websocket_invalidation = True
+
+        sent: list[tuple[str, dict[str, object]]] = []
+
+        async def group_send(group: str, message: dict[str, object]) -> None:
+            sent.append((group, message))
+
+        channel_layer = SimpleNamespace(group_send=group_send)
+        with patch(
+            "general_manager.api.remote_invalidation._get_channel_layer_safe",
+            return_value=channel_layer,
+        ):
+            with bulk_data_change_notifications():
+                emit_remote_invalidation(
+                    Task, identification={"id": 2}, action="delete"
+                )
+                emit_remote_invalidation(Project, instance=None, action="update")
+
+        self.assertEqual(
+            [
+                (group, message["resource_name"], message["action"])
+                for group, message in sent
+            ],
+            [
+                ("gm.remote.remote.projects", "projects", "refresh"),
+                ("gm.remote.remote.tasks", "tasks", "refresh"),
+            ],
+        )
+        self.assertTrue(all(message["identification"] is None for _, message in sent))
+
+    def test_batch_skips_managers_without_enabled_websocket_config(self) -> None:
+        class NoRemoteAPI:
+            pass
+
+        class WebsocketDisabled:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "disabled"
+                allow_update = True
+                websocket_invalidation = False
+
+        with (
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe"
+            ) as get_channel_layer,
+            patch("general_manager.api.notification_batching.async_to_sync") as bridge,
+        ):
+            with bulk_data_change_notifications():
+                emit_remote_invalidation(NoRemoteAPI, action="update")
+                emit_remote_invalidation(WebsocketDisabled, action="update")
+
+        get_channel_layer.assert_not_called()
+        bridge.assert_not_called()
+
+    def test_batch_skips_remote_resource_without_channel_layer(self) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        with (
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe",
+                return_value=None,
+            ),
+            patch("general_manager.api.notification_batching.async_to_sync") as bridge,
+        ):
+            with bulk_data_change_notifications():
+                emit_remote_invalidation(Project, action="update")
+
+        bridge.assert_not_called()
+
+    def test_graphql_and_remote_refreshes_share_one_batch_bridge(self) -> None:
+        class Project(GeneralManager):
+            identification: ClassVar[dict[str, object]] = {"id": 1}
+            Interface = BaseTestInterface
+
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        sent: list[tuple[str, str, dict[str, object]]] = []
+
+        async def graphql_group_send(group: str, message: dict[str, object]) -> None:
+            await asyncio.sleep(0)
+            sent.append(("graphql", group, message))
+
+        async def remote_group_send(group: str, message: dict[str, object]) -> None:
+            await asyncio.sleep(0)
+            sent.append(("remote", group, message))
+
+        graphql_layer = SimpleNamespace(group_send=graphql_group_send)
+        remote_layer = SimpleNamespace(group_send=remote_group_send)
+        project = Project()
+        with (
+            patch.object(GraphQL, "manager_registry", {"Project": Project}),
+            patch.object(GraphQL, "_get_channel_layer", return_value=graphql_layer),
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe",
+                return_value=remote_layer,
+            ),
+            patch("general_manager.api.graphql.async_to_sync") as graphql_bridge,
+            patch(
+                "general_manager.api.remote_invalidation.async_to_sync"
+            ) as remote_bridge,
+            patch(
+                "general_manager.api.notification_batching.async_to_sync",
+                side_effect=async_to_sync,
+            ) as batch_bridge,
+        ):
+            with bulk_data_change_notifications():
+                GraphQL._handle_data_change(
+                    sender=Project,
+                    instance=project,
+                    action="update",
+                )
+                emit_remote_invalidation(
+                    Project,
+                    instance=project,
+                    action="update",
+                )
+
+        batch_bridge.assert_called_once()
+        graphql_bridge.assert_not_called()
+        remote_bridge.assert_not_called()
+        self.assertEqual(
+            [
+                (subsystem, group, message["action"])
+                for subsystem, group, message in sent
+            ],
+            [
+                ("graphql", GraphQL._refresh_group_name(Project), "refresh"),
+                ("remote", "gm.remote.remote.projects", "refresh"),
+            ],
         )

--- a/tests/unit/test_startup_hooks.py
+++ b/tests/unit/test_startup_hooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Sequence
 from typing import Callable, ClassVar
 from unittest.mock import patch
 
@@ -272,6 +273,23 @@ class StartupHookRunnerTests(SimpleTestCase):
         result = BaseCommand().run_from_argv(["manage.py", "custom"])
         self.assertEqual(result, "ok")
         self.assertEqual(calls, ["ran"])
+
+    def test_runner_preserves_tuple_argv_for_original_runner(self) -> None:
+        received_argv: list[Sequence[str]] = []
+
+        def fake_run(self: BaseCommand, argv: Sequence[str]) -> str:
+            received_argv.append(argv)
+            return "ok"
+
+        BaseCommand.run_from_argv = fake_run  # type: ignore[assignment]
+        gm_bootstrap.install_startup_hook_runner()
+        argv = ("manage.py", "custom")
+
+        result = BaseCommand().run_from_argv(argv)
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(received_argv, [argv])
+        self.assertIs(received_argv[0], argv)
 
     def test_runner_skips_runserver_autoreload(self) -> None:
         """

--- a/tests/unit/test_upload_config.py
+++ b/tests/unit/test_upload_config.py
@@ -26,7 +26,7 @@ def test_image_upload_dependencies_match_development_type_check_environment() ->
         "Pillow>=12.2.0"
     ]
     assert "-e .[file-upload-image]" in development
-    assert "django-types==0.21.0" in development
+    assert "django-types==0.24.0" in development
     assert "django-stubs" not in development
     assert 'pip install -e ".[file-upload-image]"' in quality_workflow
 

--- a/tests/unit/test_upload_finalization.py
+++ b/tests/unit/test_upload_finalization.py
@@ -1212,6 +1212,47 @@ def test_sqlite_application_atomic_fails_before_inspection_or_claim(
     assert FinalizationAdapter.materialize_calls == 0
 
 
+def test_sqlite_atomic_check_fails_closed_without_block_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_alias = "missing-atomic-blocks"
+    connection = SimpleNamespace(vendor="sqlite", in_atomic_block=True)
+    monkeypatch.setattr(finalization, "connections", {database_alias: connection})
+
+    assert finalization._has_unsafe_sqlite_outer_atomic(database_alias) is True
+
+
+def test_sqlite_atomic_check_allows_testcase_only_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_alias = "testcase-only-atomic-blocks"
+    connection = SimpleNamespace(
+        vendor="sqlite",
+        in_atomic_block=True,
+        atomic_blocks=[SimpleNamespace(_from_testcase=True)],
+    )
+    monkeypatch.setattr(finalization, "connections", {database_alias: connection})
+
+    assert finalization._has_unsafe_sqlite_outer_atomic(database_alias) is False
+
+
+def test_sqlite_atomic_check_rejects_application_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_alias = "application-atomic-blocks"
+    connection = SimpleNamespace(
+        vendor="sqlite",
+        in_atomic_block=True,
+        atomic_blocks=[
+            SimpleNamespace(_from_testcase=True),
+            SimpleNamespace(_from_testcase=False),
+        ],
+    )
+    monkeypatch.setattr(finalization, "connections", {database_alias: connection})
+
+    assert finalization._has_unsafe_sqlite_outer_atomic(database_alias) is True
+
+
 @pytest.mark.django_db(transaction=True)
 @override_settings(GENERAL_MANAGER={"FILE_UPLOADS": {"ENABLED": True}})
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add an explicit, nested `bulk_data_change_notifications()` context that coalesces GraphQL and RemoteAPI events into one refresh per manager or resource through a single async bridge
- preserve immediate cache invalidation and ordinary row-level subscription semantics while hardening GraphQL group lifecycle, refresh hydration, permission handling, late-child batch cleanup, and log safety
- document refresh payloads and transaction ordering, with regression coverage for batching, failures, context propagation, cache behavior, and the strict-mypy cleanup uncovered during review

## Why

Bulk operations currently pay the notification and async-bridge cost for every changed row. This keeps cache correctness immediate while delaying only external notification delivery until the outer batch exits, reducing redundant work without changing non-batched behavior.

## Validation

- `python -m pytest -q` — 5,081 passed, 2 skipped, 1 pre-existing warning, 1,874 subtests passed
- `mypy src` — success across 267 source files
- `ruff format --check src tests`
- `ruff check src tests`
- `mkdocs build --strict`

Closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `bulk_data_change_notifications()` to batch data-change notifications.
  - GraphQL subscriptions now consolidate manager refresh events during batching.
  - Remote API websocket invalidations now emit one resource-level `refresh` per affected resource.
  - Exposed the batching context manager via the public API.
- **Bug Fixes**
  - Improved SQLite outer-atomic detection to better raise upload storage errors in unsafe contexts.
- **Documentation**
  - Documented batching, flush/exception semantics, and class-wide subscription error handling behavior.
- **Tests**
  - Added unit/integration coverage for batching deduplication, refresh payload semantics, cache invalidation, and failure/cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->