### PR TITLE
docs: cover seven-day public API changes

### DIFF
--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -1,0 +1,59 @@
+# Chat API
+
+## Installed evaluation CLI
+
+```text
+python -m general_manager.chat.evals [OPTIONS]
+```
+
+The module command configures Django, optionally registers a built-in schema
+fixture, loads packaged YAML datasets, constructs one or more providers, runs
+the selected cases synchronously, prints a report, and returns no Python value.
+`python -m general_manager.chat.evals --help` can run without Django settings;
+every evaluation run requires either `--settings MODULE` or a nonempty
+`DJANGO_SETTINGS_MODULE`.
+
+| Option | Value and behavior |
+| --- | --- |
+| `--settings` | Import path for the Django settings module. Overrides an existing `DJANGO_SETTINGS_MODULE` for this process. |
+| `--provider` | Provider class import path. When omitted, GeneralManager imports the provider configured in `GENERAL_MANAGER["CHAT"]`. |
+| `--model` | Model name merged into the selected provider configuration before provider construction. |
+| `--dataset` | One packaged dataset name. When omitted, the runner selects all datasets. |
+| `--fixture` | `toy` or `large`; registers the matching built-in eval schema before the run. |
+| `--tier` | Integer tier filter. |
+| `--tag` | Required tag filter; repeat the option to pass multiple tags. |
+| `--compare` | Comma-separated provider class import paths. Runs each provider and prints a comparison report instead of the single-provider report. |
+| `--verbose`, `-v` | Includes detailed failure information in a single-provider report. |
+| `--trace-jsonl` | File path that receives per-case JSONL traces. |
+
+The packaged dataset names are `basic_queries`, `demo_readiness`, `edge_cases`,
+`follow_ups`, `large_schema`, and `multi_hop`. Dataset resources are part of the
+wheel and source distribution as of GeneralManager 0.62.3.
+
+### Exit status and failures
+
+- Status 0: argument help was displayed, or every selected result passed.
+- Status 1: at least one selected result failed.
+- Status 2: argument parsing failed, including a run without Django settings.
+- Other nonzero termination: Django setup, provider import/construction,
+  fixture registration, dataset loading, trace writing, or evaluation raised an
+  exception. Those exceptions are not converted into a CLI-specific error type.
+
+`--settings` takes precedence over `DJANGO_SETTINGS_MODULE`; `--provider` takes
+precedence over the configured provider; and `--compare` takes precedence over
+the single-provider selection. `--model` applies to every constructed provider
+by temporarily overriding the `GENERAL_MANAGER["CHAT"]` provider configuration.
+
+### Compatibility
+
+GeneralManager 0.62.3 stopped defaulting the installed command to
+`tests.test_settings` and began shipping the built-in YAML datasets as package
+data. Existing automation must now pass `--settings` or set
+`DJANGO_SETTINGS_MODULE`. The help command remains settings-free.
+
+The Python modules below implement the harness but are not registered stable
+package exports. Application automation should prefer the module CLI documented
+above rather than import runner internals directly.
+
+See the [task guide](../howto/run_chat_evals.md) and
+[command cookbook](../examples/chat_eval_cli.md).

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -28,6 +28,16 @@ returns the same manager instance. `manager.delete(...)` checks delete
 permission unless skipped, delegates to the interface, invalidates the manager
 for later field reads, and returns `None`.
 
+For writable ORM interfaces as of GeneralManager 0.63.1, ordinary
+`create()`/`update()` calls commit the row save, history actor/reason, and
+many-to-many `<relation>_id_list` changes in one transaction on the configured
+database alias. Validation, save, history, relation, and transaction exceptions
+propagate and roll back that complete unit. Upload-aware writes retain their
+separate atomic upload/finalization contract. After a caller-owned transaction
+rolls back, discard an in-place-updated manager and reconstruct it from its ID;
+materialized values on that Python object may reflect the failed transaction.
+The [ORM transaction guide](../howto/orm_atomic_writes.md) shows the pattern.
+
 `GeneralManager.filter(**lookups)` and `exclude(**lookups)` forward lookup
 expressions to the interface and return `Bucket[Self]`. Lookup values may be
 manager instances or lists/tuples containing manager instances; those values are
@@ -668,6 +678,22 @@ so it uses normal manager equality/identity rather than request lookup
 semantics.
 
 ::: general_manager.rule.rule.Rule
+
+`Rule(func, custom_error_message=None, ignore_if_none=True)` returns the
+predicate result from `evaluate(manager)` as `True`, `False`, or `None` when a
+referenced value is skipped. After `False`, `get_error_message()` returns a
+non-empty `dict[str, str]`: handler-derived messages when available, a
+variable-keyed combination fallback otherwise, or Django's `"__all__"` key for
+a variable-free predicate. A custom message is retained by the fallback.
+Calling `get_error_message()` before evaluation or after a passing/skipped
+evaluation returns `None`. For a failed rule, missing custom-message
+placeholders raise `MissingErrorTemplateVariableError`, and documented custom or
+built-in handler exceptions propagate unchanged. The defensive
+`ErrorMessageGenerationError` applies only if internal state records failure
+without retaining the evaluated input. The non-empty failed-rule fallback is
+guaranteed from 0.62.2.
+See the [task guide](../howto/write_validation_rules.md) and
+[cookbook recipe](../examples/rule_validation.md).
 
 `BaseRuleHandler.handle(node, left, right, op, var_values, rule)` is called by
 `Rule` while explaining a failed predicate. It returns `{variable: message}` and

--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -10,6 +10,26 @@
 
 ::: general_manager.api.graphql_errors.PublicGraphQLError
 
+`PublicGraphQLError(message: str, *, code: str)` constructs a GraphQL error for
+an intentionally public application failure. `message` is exposed unchanged to
+the client. The required keyword-only `code` is stored as the complete
+`extensions` mapping: `{"code": code}`. Construction returns a
+`PublicGraphQLError` instance, which is also a `graphql.GraphQLError`; it does
+not perform code-format validation or sanitize the supplied message. Callers
+are responsible for ensuring both values are safe and stable. Import the class
+from `general_manager.api`, not its implementation module.
+
+The constructor has no GeneralManager-specific failure path. Normal Python and
+`GraphQLError` constructor errors propagate if callers pass incompatible values.
+When raised inside a GeneralManager-generated mutation or a mutation registered
+with `@graph_ql_mutation`, the same error instance, message, and extensions are
+preserved.
+
+Compatibility: this stable export was added in GeneralManager 0.63.0. In the
+same release, plain `ValueError` stopped producing public `BAD_USER_INPUT`
+messages at GeneralManager mutation boundaries; use `PublicGraphQLError` for an
+application code or Django `ValidationError` for validation details.
+
 Stable imports from `general_manager.api` include `GraphQL`,
 `MeasurementType`, `MeasurementScalar`, `PublicGraphQLError`, and the file-upload
 contracts documented below. Stable imports from
@@ -30,9 +50,15 @@ import promises.
 
 Configuration and inspection:
 
-- `FileUploadPolicy` configures one manager file field.
+- `FileUploadPolicy(max_bytes=None, allowed_content_types=None,
+  allowed_extensions=None, public=None, content_inspector=None)` configures one
+  manager file field. Invalid limits, allowlists, booleans, or inspectors raise
+  `FileUploadConfigurationError` during construction.
 - `FileInspection` is the credential-free bounded value passed to a
   `FileContentInspector`.
+- `FileContentInspector` has the callable signature
+  `(inspection: FileInspection) -> str | None`; a returned string rejects the
+  file with that reason and `None` accepts it.
 - `FileUploadConfigurationError` reports invalid policy/settings construction.
 
 GraphQL contracts:
@@ -44,8 +70,12 @@ GraphQL contracts:
 
 Custom storage extension contracts:
 
-- `register_upload_adapter(storage_class, factory)` registers one global
-  `UploadAdapterFactory` before upload use.
+- `register_upload_adapter(storage_class: type[Storage], factory:
+  UploadAdapterFactory) -> None` registers one global factory before upload
+  use. Invalid arguments raise `TypeError`; duplicate or ambiguous registration
+  raises `ValueError`.
+- `UploadAdapterFactory` has the callable signature
+  `(storage: Storage) -> UploadAdapter`.
 - `UploadAdapter` is the complete transfer/inspect/download protocol.
 - `UploadFinalizationAdapter` is the exact post-commit and replacement cleanup
   protocol.
@@ -58,9 +88,16 @@ Custom storage extension contracts:
   do not log it.
 
 See [the setup and custom-adapter guide](../howto/graphql_file_uploads.md) for
-method semantics and contract testing. Persistence models, token/digest helpers,
+method semantics and contract testing, or use the
+[end-to-end upload recipe](../examples/graphql_file_upload.md). Persistence models, token/digest helpers,
 the registry instance, local capability codecs, and finalization functions are
 not public API.
+
+The file-upload surface was introduced in GeneralManager 0.62.0. The current
+contract includes the same-release hardening for Unicode-safe paths,
+no-overwrite storage behavior, deterministic admission, single-use token
+preflight, post-commit finalization, secure downloads, and cleanup. Callers must
+not depend on the intermediate behavior of earlier commits in that release.
 
 Expected failures derive from `UploadError` and carry stable `code` class
 attributes. Public exception classes are:
@@ -101,6 +138,8 @@ an adapter with a backend-native atomic exact-delete operation.
 
 ::: general_manager.uploads.config.FileInspection
 
+::: general_manager.uploads.config.FileUploadConfigurationError
+
 ::: general_manager.uploads.public.register_upload_adapter
 
 ::: general_manager.uploads.adapters.UploadAdapter
@@ -111,11 +150,29 @@ an adapter with a backend-native atomic exact-delete operation.
 
 ::: general_manager.uploads.adapters.ProxyUploadSink
 
+::: general_manager.uploads.adapters.UploadInstructions
+
+::: general_manager.uploads.adapters.ClaimedObject
+
+::: general_manager.uploads.types.ObjectVersion
+
+::: general_manager.uploads.types.UploadTransport
+
+::: general_manager.uploads.types.StoredFileStatus
+
 ::: general_manager.uploads.graphql_types.UploadToken
 
 ::: general_manager.uploads.graphql_types.StoredFile
 
 ::: general_manager.uploads.graphql_types.StoredImage
+
+::: general_manager.uploads.errors.UploadError
+
+Every public upload exception listed above inherits
+`UploadError(message: str | None = None)`, returns no value when raised, and
+exposes its stable `code` plus a safe default message. Passing a message changes
+the local exception text, but GraphQL and HTTP boundaries sanitize arbitrary
+messages and non-framework subclasses.
 
 `MeasurementScalar` parses string inputs such as `"12.5 m/s"` into
 `Measurement` values and serializes stored measurements with the canonical
@@ -278,6 +335,9 @@ while rendering the original exception are also kept out of the client response.
 Migrate client-facing `ValueError` uses to `PublicGraphQLError`, or to Django
 `ValidationError` for validation (use structured validation errors for field
 details). Public messages must never contain secrets or other internal details.
+
+See the [safe mutation error recipe](../examples/graphql_error_handling.md) for
+a directly usable resolver and client-handling pattern.
 
 ::: general_manager.api.graphql_view.GeneralManagerGraphQLView
 

--- a/docs/api/interface.md
+++ b/docs/api/interface.md
@@ -75,14 +75,16 @@ model that already exists outside GeneralManager. Direct subclasses set
 app registry, such as `settings.AUTH_USER_MODEL` or `"app_label.ModelName"`.
 The `existing_model_resolution` lifecycle capability resolves that reference
 during manager class creation, stores the resolved class on the concrete
-interface as `_model` and `model`, registers simple-history when needed,
-applies interface rules, and builds a factory for the existing table. Missing
+interface as `_model` and `model`, registers database-aware simple-history when
+needed, applies interface rules, and builds a factory for the existing table. Missing
 model declarations raise `MissingModelConfigurationError`; invalid strings,
 non-model classes, and other invalid references raise
-`InvalidModelReferenceError`. History registration is skipped when the legacy
-model already exposes the simple-history manager marker; otherwise local
-many-to-many fields are included in the registration. Soft delete is enabled
-when the resolved model exposes an `is_active` attribute. The simple-history
+`InvalidModelReferenceError`. Auto-registration includes local many-to-many
+fields and routes base and relation history to the live row's database alias. A
+pre-existing tracker is accepted on the default alias. On a configured
+non-default alias its history model must carry GeneralManager's database-aware
+marker or manager creation raises `UnsafeHistoryConfigurationError`. Soft
+delete is enabled when the resolved model exposes an `is_active` attribute. The simple-history
 marker is `model._meta.simple_history_manager_attribute`; interface rules are
 the optional `Meta.rules` sequence on the interface. This shell class does not
 declare separate create/update/delete signatures. Those public operations are
@@ -621,14 +623,20 @@ metadata keys `creator_id` and `history_comment`; other keys are validated as
 model fields/attributes or many-to-many aliases such as `<relation>_id_list`.
 The capability removes the metadata keys, validates and normalizes the remaining
 payload through the validation/support normalizer, creates the model instance,
-saves it, applies many-to-many updates, and returns `{"id": pk}`. The
+saves it, and applies many-to-many updates in one alias-aware transaction before
+returning `{"id": pk}`. Validation, save, history-reason, relation, and
+transaction errors propagate and roll back that unit. The
 GeneralManager layer consumes that result and returns the public manager
 instance from `Manager.create(...)`.
 
 `OrmUpdateCapability.update()` loads the target row by `pk` with inactive rows
 included, ignores positional arguments, applies the same
-normalization/save/many-to-many path, discards the run-scoped ORM read cache for
-the saved primary key, and returns the capability result `{"id": pk}`. The
+normalization/save/many-to-many transaction, discards the run-scoped ORM read
+cache only after that transaction succeeds, and returns the capability result
+`{"id": pk}`. Inside a caller-owned transaction on the same alias, ORM reads
+bypass the run-scoped identity cache so uncommitted rows are not published into
+it. After rollback, callers should reconstruct any in-place-updated manager from
+its ID. The
 GeneralManager layer consumes that result, refreshes the public manager state,
 and returns the same manager instance from `manager.update(...)`.
 
@@ -979,10 +987,18 @@ references, malformed strings, and non-model objects are invalid. Missing model
 configuration raises `MissingModelConfigurationError`; invalid strings or
 non-model references raise `InvalidModelReferenceError`.
 
-`ensure_history(model, interface_cls=None)` registers django-simple-history for
-the model unless the model metadata already has a simple-history manager
-attribute. Local many-to-many field names are passed to simple-history
-registration. Registration errors from django-simple-history propagate.
+`ensure_history(model, interface_cls=None)` registers database-aware
+django-simple-history for an untracked model and includes local many-to-many
+field names. A pre-existing tracker is accepted for the default alias. For a
+non-default interface alias, its generated history model must have
+GeneralManager's database-aware marker; otherwise
+`UnsafeHistoryConfigurationError(model_name, interface_name, alias)` is raised.
+The exception message is
+`<model> must use DatabaseAwareHistoricalRecords before <interface> configures non-default database alias '<alias>'.`.
+The records class and exception currently live in implementation modules and are
+not stable exports from `general_manager.interface`; this is a compatibility
+limitation of 0.63.1, not a promise of those direct import paths. Other
+registration errors from django-simple-history propagate.
 `apply_rules(interface_cls, model)` appends `interface_cls.Meta.rules` after any
 existing `model._meta.rules` and replaces `model.full_clean` with the
 GeneralManager rules-aware implementation. If no interface rules are declared,
@@ -1038,6 +1054,8 @@ manager wiring, ORM support lookup, and observability hooks propagate unchanged.
 ::: general_manager.interface.utils.errors.MissingReadOnlyBindingError
 
 ::: general_manager.interface.utils.errors.MissingModelConfigurationError
+
+::: general_manager.interface.utils.errors.UnsafeHistoryConfigurationError
 
 ::: general_manager.interface.utils.errors.InvalidModelReferenceError
 

--- a/docs/concepts/graphql/custom_mutations.md
+++ b/docs/concepts/graphql/custom_mutations.md
@@ -214,3 +214,8 @@ Structured field errors should use a Django `ValidationError` with a message
 dictionary, as above. Public error and validation messages must never contain
 secrets. Keep business logic in manager methods where possible so validation,
 permissions, history, and other framework behavior remain consistent.
+
+For a complete resolver and client response handler, use the
+[safe GraphQL mutation error recipe](../../examples/graphql_error_handling.md).
+The [GraphQL API reference](../../api/graphql.md) records the constructor
+signature and the compatibility change from public `ValueError` messages.

--- a/docs/concepts/graphql/file_uploads.md
+++ b/docs/concepts/graphql/file_uploads.md
@@ -166,4 +166,8 @@ fail closed with `downloadUrl: null`. Public URLs have no expiry.
   uploaded through this workflow.
 
 See [the local-storage guide](../../howto/graphql_file_uploads.md) and
-[the S3 guide](../../howto/graphql_file_uploads_s3.md) for complete setup.
+[the S3 guide](../../howto/graphql_file_uploads_s3.md) for complete setup. For a
+directly usable client flow, see the
+[GraphQL upload cookbook entry](../../examples/graphql_file_upload.md). The
+[GraphQL API reference](../../api/graphql.md#file-uploads) lists the stable
+Python extension contracts and failure types.

--- a/docs/concepts/interfaces/db_based_interface.md
+++ b/docs/concepts/interfaces/db_based_interface.md
@@ -110,6 +110,11 @@ place may retain transactional values if they were materialized before that
 rollback; discard it and construct a fresh manager from its ID before
 continuing.
 
+For a task-oriented rollback pattern, see
+[Keep ORM writes and history on one database](../../howto/orm_atomic_writes.md).
+The [existing-model cookbook](../../examples/existing_model_interface.md#route-atomic-writes-and-history-to-another-database)
+contains a directly usable multi-database example.
+
 History-capable managers expose `manager.history` as the audit trail for that object's ID. The returned queryset lets you inspect or filter raw history entries directly:
 
 ```python

--- a/docs/concepts/interfaces/existing_model_interface.md
+++ b/docs/concepts/interfaces/existing_model_interface.md
@@ -110,6 +110,12 @@ connected signal receivers. It therefore raises
 pre-registered tracker lacks the database-aware marker on a non-default alias.
 Existing trackers remain compatible for the default alias.
 
+`DatabaseAwareHistoricalRecords` and `UnsafeHistoryConfigurationError` are
+required implementation contracts for this non-default-alias case in 0.63.1,
+but they are not stable `general_manager.interface` exports. Use the documented
+setup below without treating their implementation-module paths as a broader
+compatibility promise.
+
 ## Auditing and validation
 
 - `create` and `update` assign `changed_by_id` when the model exposes that column and record `history_comment` values using `django-simple-history`.
@@ -127,6 +133,9 @@ Existing trackers remain compatible for the default alias.
 ## Writing data through the manager
 
 `ExistingModelInterface` reuses the same write helpers as `DatabaseInterface`:
+
+See [Keep ORM writes and history on one database](../../howto/orm_atomic_writes.md)
+for the complete configuration and rollback workflow.
 
 - `create()` and `update()` share the
   [`DatabaseInterface` atomic write contract](db_based_interface.md#atomic-writes),

--- a/docs/concepts/rules_validation.md
+++ b/docs/concepts/rules_validation.md
@@ -63,6 +63,14 @@ if not result:
     print(positive_price.get_error_message())
 ```
 
+Since GeneralManager 0.62.2, a failed rule always returns an error mapping even
+when AST-specific message generation cannot explain the predicate. Referenced
+variables receive a combination error; a variable-free predicate uses Django's
+`NON_FIELD_ERRORS` key (`"__all__"`). A custom message is preserved in both
+cases. See [the validation-rule guide](../howto/write_validation_rules.md), the
+[cookbook recipe](../examples/rule_validation.md), and the
+[API reference](../api/core.md#general_manager.rule.rule.Rule).
+
 ## Custom rule handlers
 
 For advanced scenarios, register additional rule handlers via the

--- a/docs/examples/chat_eval_cli.md
+++ b/docs/examples/chat_eval_cli.md
@@ -1,0 +1,50 @@
+# Installed Chat Eval Commands
+
+These commands use datasets packaged with GeneralManager. Replace
+`myproject.settings` and provider paths with importable modules from the Django
+project where the command runs.
+
+## Smoke-test the installed wheel
+
+```bash
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --provider general_manager.chat.providers.OllamaProvider \
+  --fixture toy \
+  --dataset basic_queries \
+  --tier 0
+```
+
+This is the smallest directly usable installed-package check: it configures
+Django, registers the toy managers expected by `basic_queries`, loads the YAML
+dataset from package data, constructs the provider, and returns status 1 if any
+case fails.
+
+## Use project data and the configured provider
+
+```bash
+DJANGO_SETTINGS_MODULE=myproject.settings \
+python -m general_manager.chat.evals \
+  --dataset follow_ups \
+  --tag grounding \
+  --verbose \
+  --trace-jsonl /tmp/follow-ups.jsonl
+```
+
+No fixture is registered in this version, so the dataset must match managers
+and data exposed by `myproject.settings`. Because `--provider` is absent, the
+command imports the provider from `GENERAL_MANAGER["CHAT"]`.
+
+## Compare two provider classes
+
+```bash
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --fixture toy \
+  --dataset basic_queries \
+  --compare general_manager.chat.providers.OllamaProvider,myproject.chat.CandidateProvider
+```
+
+The comparison succeeds only if every result from both providers passes. See
+the [task guide](../howto/run_chat_evals.md) for setup and the
+[CLI reference](../api/chat.md) for every option and exit status.

--- a/docs/examples/existing_model_interface.md
+++ b/docs/examples/existing_model_interface.md
@@ -82,3 +82,59 @@ class Project(GeneralManager):
 tracking and activation semantics continue to flow through to `LegacyProject`.
 If Django's field validation also reports `name`, GeneralManager keeps both the
 Django message and the rule message in the final `ValidationError`.
+
+## Route atomic writes and history to another database
+
+For a legacy model that already uses simple-history, select the same database
+alias for the interface and a database-aware history tracker:
+
+```python
+# models.py
+from django.db import models
+
+from general_manager.interface.utils.history import DatabaseAwareHistoricalRecords
+
+
+class LegacyContract(models.Model):
+    title = models.CharField(max_length=120)
+    reviewers = models.ManyToManyField("auth.User", blank=True)
+    history = DatabaseAwareHistoricalRecords(m2m_fields=["reviewers"])
+
+
+# managers.py
+from general_manager.interface import ExistingModelInterface
+from general_manager.manager import GeneralManager
+from contracts.models import LegacyContract
+
+
+class Contract(GeneralManager):
+    class Interface(ExistingModelInterface):
+        model = LegacyContract
+        database = "archive"
+```
+
+With an `archive` entry in `DATABASES`, this directly usable write commits the
+row, audit reason, and relation table together on that alias:
+
+```python
+contract = Contract.create(
+    title="Supply agreement",
+    reviewers_id_list=[reviewer.id],
+    history_comment="imported",
+    ignore_permission=True,
+)
+contract.update(
+    title="Supply agreement v2",
+    reviewers_id_list=[lead_reviewer.id],
+    history_comment="review reassigned",
+    ignore_permission=True,
+)
+```
+
+Any validation, save, history-reason, or many-to-many exception rolls the whole
+ordinary mutation back. Models without pre-existing history are registered
+automatically. `DatabaseAwareHistoricalRecords` is the required 0.63.1 helper
+for a pre-tracked model on a non-default alias, but its implementation-module
+import is not part of the stable `general_manager.interface` export registry;
+pin and test the dependency when using it. See the
+[task guide](../howto/orm_atomic_writes.md) for rollback handling.

--- a/docs/examples/existing_model_interface.md
+++ b/docs/examples/existing_model_interface.md
@@ -90,6 +90,7 @@ alias for the interface and a database-aware history tracker:
 
 ```python
 # models.py
+from django.conf import settings
 from django.db import models
 
 from general_manager.interface.utils.history import DatabaseAwareHistoricalRecords
@@ -97,7 +98,7 @@ from general_manager.interface.utils.history import DatabaseAwareHistoricalRecor
 
 class LegacyContract(models.Model):
     title = models.CharField(max_length=120)
-    reviewers = models.ManyToManyField("auth.User", blank=True)
+    reviewers = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True)
     history = DatabaseAwareHistoricalRecords(m2m_fields=["reviewers"])
 
 
@@ -117,6 +118,12 @@ With an `archive` entry in `DATABASES`, this directly usable write commits the
 row, audit reason, and relation table together on that alias:
 
 ```python
+from django.contrib.auth import get_user_model
+
+users = get_user_model().objects.using("archive")
+reviewer = users.get(pk=41)  # Pre-existing user on the archive database.
+lead_reviewer = users.get(pk=42)  # Pre-existing user on the archive database.
+
 contract = Contract.create(
     title="Supply agreement",
     reviewers_id_list=[reviewer.id],

--- a/docs/examples/graphql_error_handling.md
+++ b/docs/examples/graphql_error_handling.md
@@ -53,21 +53,67 @@ entries. A `PermissionError` uses only `Permission denied.` and
 ## Handle the stable client contract
 
 ```javascript
+export class GraphQLRequestError extends Error {
+  constructor(failures) {
+    super("GraphQL request failed.");
+    this.name = "GraphQLRequestError";
+    this.failures = failures;
+  }
+}
+
+export function mapGraphQLErrors(errors, {isPublicCode = () => false} = {}) {
+  return errors.map((error) => {
+    const extensions = error.extensions ?? {};
+    const code = typeof extensions.code === "string"
+      ? extensions.code
+      : "GRAPHQL_ERROR";
+
+    if (code === "BAD_USER_INPUT") {
+      return {
+        code,
+        message: "Validation failed.",
+        fieldErrors: extensions.fieldErrors ?? {},
+        nonFieldErrors: extensions.nonFieldErrors ?? [],
+      };
+    }
+    if (code === "INTERNAL_SERVER_ERROR") {
+      return {
+        code,
+        message: "An internal server error occurred.",
+        errorId: typeof extensions.errorId === "string"
+          ? extensions.errorId
+          : null,
+      };
+    }
+    if (code === "PERMISSION_DENIED") {
+      return {code, message: "Permission denied."};
+    }
+    if (isPublicCode(code)) {
+      return {code, message: error.message};
+    }
+    return {code: "GRAPHQL_ERROR", message: "The request failed."};
+  });
+}
+
 const result = await graphqlClient.mutate({
   mutation: ARCHIVE_PROJECT,
   variables: {projectId, reason},
 });
 
-for (const error of result.errors ?? []) {
-  switch (error.extensions?.code) {
+const failures = mapGraphQLErrors(result.errors ?? [], {
+  isPublicCode: (code) => code === "PROJECT_ALREADY_ARCHIVED",
+});
+for (const failure of failures) {
+  switch (failure.code) {
     case "PROJECT_ALREADY_ARCHIVED":
-      showNotice(error.message);
+      showNotice(failure.message);
       break;
     case "BAD_USER_INPUT":
-      showFieldErrors(error.extensions.fieldErrors ?? []);
+      showFieldErrors(failure.fieldErrors);
+      showNonFieldErrors(failure.nonFieldErrors);
       break;
     case "INTERNAL_SERVER_ERROR":
-      reportSupportId(error.extensions.errorId);
+      if (failure.errorId) reportSupportId(failure.errorId);
       break;
     default:
       showGenericFailure();
@@ -79,6 +125,8 @@ Do not display or branch on the text of an internal error. Its public message is
 always `An internal server error occurred.`; `extensions.errorId` correlates the
 response with server logs. Since GeneralManager 0.63.0, plain `ValueError` and
 other unexpected exceptions are internal errors rather than `BAD_USER_INPUT`.
+Keep `mapGraphQLErrors` in a shared client module so every GraphQL caller uses
+the same allowlist for intentionally public codes.
 
 See the [custom-mutation concept](../concepts/graphql/custom_mutations.md), the
 [GraphQL task guide](../howto/expose_via_graphql.md), and the

--- a/docs/examples/graphql_error_handling.md
+++ b/docs/examples/graphql_error_handling.md
@@ -1,0 +1,85 @@
+# Safe GraphQL Mutation Errors
+
+Use `PublicGraphQLError` only for messages and codes that are intentionally part
+of the client contract. Use Django `ValidationError` for input validation, and
+let unexpected exceptions reach GeneralManager's mutation boundary so their
+details are replaced with a correlated internal error.
+
+## Define a mutation with explicit client failures
+
+```python
+from django.core.exceptions import ValidationError
+
+from general_manager.api import PublicGraphQLError, graph_ql_mutation
+from projects.managers import Project
+
+
+@graph_ql_mutation
+def archive_project(info, project_id: int, reason: str) -> Project:
+    project = Project(id=project_id)
+    if project.status == "archived":
+        raise PublicGraphQLError(
+            "The project is already archived.",
+            code="PROJECT_ALREADY_ARCHIVED",
+        )
+    if not reason.strip():
+        raise ValidationError({"reason": ["An archive reason is required."]})
+    return project.update(
+        status="archived",
+        archive_reason=reason,
+        creator_id=getattr(info.context.user, "id", None),
+    )
+```
+
+The explicit public failure appears in GraphQL's top-level `errors` list:
+
+```json
+{
+  "data": {"archiveProject": null},
+  "errors": [
+    {
+      "message": "The project is already archived.",
+      "extensions": {"code": "PROJECT_ALREADY_ARCHIVED"}
+    }
+  ]
+}
+```
+
+A structured `ValidationError` uses code `BAD_USER_INPUT`, the message
+`Validation failed.`, and schema-named `fieldErrors`/`nonFieldErrors` extension
+entries. A `PermissionError` uses only `Permission denied.` and
+`PERMISSION_DENIED`.
+
+## Handle the stable client contract
+
+```javascript
+const result = await graphqlClient.mutate({
+  mutation: ARCHIVE_PROJECT,
+  variables: {projectId, reason},
+});
+
+for (const error of result.errors ?? []) {
+  switch (error.extensions?.code) {
+    case "PROJECT_ALREADY_ARCHIVED":
+      showNotice(error.message);
+      break;
+    case "BAD_USER_INPUT":
+      showFieldErrors(error.extensions.fieldErrors ?? []);
+      break;
+    case "INTERNAL_SERVER_ERROR":
+      reportSupportId(error.extensions.errorId);
+      break;
+    default:
+      showGenericFailure();
+  }
+}
+```
+
+Do not display or branch on the text of an internal error. Its public message is
+always `An internal server error occurred.`; `extensions.errorId` correlates the
+response with server logs. Since GeneralManager 0.63.0, plain `ValueError` and
+other unexpected exceptions are internal errors rather than `BAD_USER_INPUT`.
+
+See the [custom-mutation concept](../concepts/graphql/custom_mutations.md), the
+[GraphQL task guide](../howto/expose_via_graphql.md), and the
+[GraphQL API reference](../api/graphql.md).

--- a/docs/examples/graphql_file_upload.md
+++ b/docs/examples/graphql_file_upload.md
@@ -1,0 +1,82 @@
+# Upload a file through GraphQL
+
+This browser-side recipe assumes the server is configured with the
+[local upload guide](../howto/graphql_file_uploads.md). It calculates the exact
+SHA-256 expected by `beginFileUpload`, performs the returned transfer, and then
+consumes the one-time token in a generated update mutation.
+
+```javascript
+async function sha256Hex(file) {
+  const bytes = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function graphql(query, variables) {
+  const response = await fetch("/graphql", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({query, variables}),
+  });
+  const payload = await response.json();
+  if (payload.errors) throw new Error(payload.errors[0].message);
+  return payload.data;
+}
+
+async function uploadAvatar(profileId, file) {
+  const begin = await graphql(`
+    mutation Begin($id: ID!, $name: String!, $size: BigIntScalar!,
+                   $type: String!, $digest: String!) {
+      beginFileUpload(
+        manager: "Profile", field: "avatar", operation: UPDATE,
+        objectId: $id, filename: $name, size: $size,
+        contentType: $type,
+        checksum: {algorithm: SHA256, digest: $digest}
+      ) {
+        token transport uploadUrl method
+        headers { name value }
+      }
+    }
+  `, {
+    id: String(profileId),
+    name: file.name,
+    size: String(file.size),
+    type: file.type || "application/octet-stream",
+    digest: await sha256Hex(file),
+  });
+
+  const instructions = begin.beginFileUpload;
+  const headers = Object.fromEntries(
+    instructions.headers
+      .filter(({name}) => name.toLowerCase() !== "content-length")
+      .map(({name, value}) => [name, value]),
+  );
+  const transfer = await fetch(instructions.uploadUrl, {
+    method: instructions.method,
+    credentials: instructions.transport === "PROXY" ? "same-origin" : "omit",
+    headers,
+    body: file,
+  });
+  if (!transfer.ok) throw new Error(`upload failed: ${transfer.status}`);
+
+  return graphql(`
+    mutation Finish($id: Int!, $token: UploadToken!) {
+      updateProfile(id: $id, avatar: $token) {
+        Profile { avatar { name status downloadUrl expiresAt } }
+      }
+    }
+  `, {id: profileId, token: instructions.token});
+}
+```
+
+Do not retry the final mutation with the same token once the intent reaches
+`FINALIZING`. Poll the normal profile query while the returned status is
+`PROCESSING`; begin a new upload after a terminal token error. This workflow and
+its stable Python extension contracts were introduced in 0.62.0.
+
+See the [concept page](../concepts/graphql/file_uploads.md), the
+[S3 task guide](../howto/graphql_file_uploads_s3.md), and the
+[API reference](../api/graphql.md#file-uploads).

--- a/docs/examples/graphql_file_upload.md
+++ b/docs/examples/graphql_file_upload.md
@@ -6,7 +6,19 @@ SHA-256 expected by `beginFileUpload`, performs the returned transfer, and then
 consumes the one-time token in a generated update mutation.
 
 ```javascript
+import {
+  GraphQLRequestError,
+  mapGraphQLErrors,
+} from "./graphql-errors.js";
+
+// Web Crypto does not expose incremental SHA-256. Keep this limit no higher
+// than the server's upload policy, or use a reviewed streaming hash library.
+const MAX_CLIENT_HASH_BYTES = 25_000_000;
+
 async function sha256Hex(file) {
+  if (file.size > MAX_CLIENT_HASH_BYTES) {
+    throw new RangeError("The file is too large to hash in this browser flow.");
+  }
   const bytes = await file.arrayBuffer();
   const digest = await crypto.subtle.digest("SHA-256", bytes);
   return [...new Uint8Array(digest)]
@@ -22,7 +34,16 @@ async function graphql(query, variables) {
     body: JSON.stringify({query, variables}),
   });
   const payload = await response.json();
-  if (payload.errors) throw new Error(payload.errors[0].message);
+  const failures = mapGraphQLErrors(payload.errors ?? [], {
+    isPublicCode: (code) => (
+      code === "UNAUTHENTICATED"
+      || code === "INVALID_FILE_TYPE"
+      || code === "INVALID_IMAGE"
+      || code.startsWith("UPLOAD_")
+      || code.startsWith("INVALID_UPLOAD_")
+    ),
+  });
+  if (failures.length) throw new GraphQLRequestError(failures);
   return payload.data;
 }
 
@@ -60,7 +81,15 @@ async function uploadAvatar(profileId, file) {
     headers,
     body: file,
   });
-  if (!transfer.ok) throw new Error(`upload failed: ${transfer.status}`);
+  if (!transfer.ok) {
+    const payload = await transfer.json().catch(() => null);
+    const code = typeof payload?.error?.code === "string"
+      ? payload.error.code
+      : "UPLOAD_FAILED";
+    throw new GraphQLRequestError([
+      {code, message: "The upload transfer failed."},
+    ]);
+  }
 
   return graphql(`
     mutation Finish($id: Int!, $token: UploadToken!) {
@@ -76,6 +105,11 @@ Do not retry the final mutation with the same token once the intent reaches
 `FINALIZING`. Poll the normal profile query while the returned status is
 `PROCESSING`; begin a new upload after a terminal token error. This workflow and
 its stable Python extension contracts were introduced in 0.62.0.
+
+The 25 MB browser hashing limit matches GeneralManager's default `MAX_BYTES`.
+Lower it when the field policy is smaller. For larger configured uploads, use a
+reviewed incremental SHA-256 implementation instead of increasing the buffered
+limit without considering client memory.
 
 See the [concept page](../concepts/graphql/file_uploads.md), the
 [S3 task guide](../howto/graphql_file_uploads_s3.md), and the

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -6,6 +6,10 @@ The cookbook collects self-contained snippets that demonstrate how to solve doma
 <!-- - [Nested set bill of materials](nested_set_bom.md) -->
 - [Derivative aggregation](derivatives_groups.md)
 - [GraphQL query patterns](graphql_queries.md)
+- [Safe GraphQL mutation errors](graphql_error_handling.md)
+- [Upload a file through GraphQL](graphql_file_upload.md)
+- [Validate a manager with field and non-field rule errors](rule_validation.md)
+- [Installed chat eval commands](chat_eval_cli.md)
 - [Permission patterns](permission_patterns.md)
 - [Permission cookbook](permission_cookbook.md)
 - [Custom audit logger](audit_logger_custom.md)

--- a/docs/examples/rule_validation.md
+++ b/docs/examples/rule_validation.md
@@ -1,0 +1,57 @@
+# Validate a manager with field and non-field rule errors
+
+This recipe exercises the public `Rule` API directly and is suitable for a unit
+test. Defining named functions keeps their source available to `inspect`.
+
+```python
+from dataclasses import dataclass
+
+from django.core.exceptions import NON_FIELD_ERRORS
+
+from general_manager.rule import Rule
+
+
+@dataclass
+class Booking:
+    starts_at: int
+    ends_at: int
+
+
+def ordered(booking: Booking) -> bool:
+    return booking.starts_at < booking.ends_at
+
+
+field_rule = Rule(
+    ordered,
+    custom_error_message="Start {starts_at} must be before end {ends_at}.",
+)
+
+assert field_rule.evaluate(Booking(starts_at=20, ends_at=10)) is False
+assert field_rule.get_error_message() == {
+    "starts_at": "Start 20 must be before end 10.",
+    "ends_at": "Start 20 must be before end 10.",
+}
+
+
+def maintenance_window_closed(_booking: Booking) -> bool:
+    return False
+
+
+non_field_rule = Rule(
+    maintenance_window_closed,
+    custom_error_message="Bookings are temporarily disabled.",
+    ignore_if_none=False,
+)
+
+assert non_field_rule.evaluate(Booking(starts_at=1, ends_at=2)) is False
+assert non_field_rule.get_error_message() == {
+    NON_FIELD_ERRORS: "Bookings are temporarily disabled."
+}
+```
+
+The guaranteed non-empty fallback was added in 0.62.2. Earlier versions could
+return `None` after a failed predicate when no AST handler produced a message.
+
+See the [concept page](../concepts/rules_validation.md),
+[task guide](../howto/write_validation_rules.md), and
+[API reference](../api/core.md#general_manager.rule.rule.Rule).

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -150,3 +150,8 @@ Return one type for a single output field, or a tuple of types for multiple outp
 At execution time the wrapper normalizes GeneralManager arguments before permission checks and before calling the original function. A configured permission class receives `permission.check(normalized_kwargs, info.context.user)`. Registration is first-writer-wins for duplicate generated mutation class names. Generated names use `snake_to_camel`: the first underscore-delimited segment stays unchanged and later segments are title-cased. Missing parameter annotations raise `MissingParameterTypeHintError`, missing return annotations raise `MissingMutationReturnAnnotationError`, invalid return annotations raise `InvalidMutationReturnTypeError`, and duplicate output field names raise `DuplicateMutationOutputNameError`.
 
 At the decorator boundary, explicit `GraphQLError` instances are preserved, while `ValidationError` and `PublicGraphQLError` retain their intended public behavior. `PermissionError` returns only `Permission denied.` with code `PERMISSION_DENIED`. Every other ordinary `Exception`, including `ValueError`, returns `An internal server error occurred.` with code `INTERNAL_SERVER_ERROR` and an opaque `errorId`; server logs retain the original details and matching `error_id` for correlation. Migrate client-facing `ValueError` uses to `PublicGraphQLError`, or to `ValidationError` for validation.
+
+Use the [safe GraphQL mutation error recipe](../examples/graphql_error_handling.md)
+for a copy-ready resolver and client handler. The
+[GraphQL API reference](../api/graphql.md) documents the exact error signatures,
+extensions, and compatibility behavior.

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -18,5 +18,8 @@ These tutorials walk you through common development tasks when working with Gene
 14. [Run search reconciliation](search_reconciliation.md)
 15. [Upload files through GraphQL](graphql_file_uploads.md)
 16. [Use direct S3 uploads](graphql_file_uploads_s3.md)
+17. [Run the installed chat evaluation suite](run_chat_evals.md)
+18. [Keep ORM writes and history on one database](orm_atomic_writes.md)
+19. [Write validation rules with reliable fallback errors](write_validation_rules.md)
 
 Follow them in order when you start a new project, or jump to the topic relevant to your current task.

--- a/docs/howto/orm_atomic_writes.md
+++ b/docs/howto/orm_atomic_writes.md
@@ -1,0 +1,129 @@
+# Keep ORM writes and history on one database
+
+Writable `DatabaseInterface` and `ExistingModelInterface` managers apply an
+ordinary `create()` or `update()` as one transaction: the main row, history
+actor and reason, and every `<relation>_id_list` change either commit together
+or roll back together. The transaction uses the interface's configured database
+alias.
+
+## 1. Configure the database alias
+
+Declare the alias in Django settings, then select it on the interface:
+
+```python
+# settings.py
+DATABASES = {
+    "default": {...},
+    "archive": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "archive",
+        "USER": "archive_app",
+        "PASSWORD": "...",
+        "HOST": "db.example.com",
+    },
+}
+```
+
+```python
+# customers/managers.py
+from general_manager.interface import ExistingModelInterface
+from general_manager.manager import GeneralManager
+from customers.models import LegacyCustomer
+
+
+class Customer(GeneralManager):
+    class Interface(ExistingModelInterface):
+        model = LegacyCustomer
+        database = "archive"
+```
+
+The same `database = "archive"` declaration applies to a nested
+`DatabaseInterface` when GeneralManager owns the generated model.
+
+## 2. Prepare history tracking
+
+When the legacy model has no simple-history tracker, GeneralManager registers a
+database-aware tracker during manager creation and includes local many-to-many
+fields automatically.
+
+When the legacy model already declares `HistoricalRecords`, GeneralManager
+cannot replace its connected signal receivers. For a non-default alias, the
+existing tracker must be declared with the current database-aware records class
+before the manager is defined:
+
+```python
+# customers/models.py
+from django.db import models
+
+from general_manager.interface.utils.history import DatabaseAwareHistoricalRecords
+
+
+class LegacyCustomer(models.Model):
+    name = models.CharField(max_length=120)
+    owners = models.ManyToManyField("auth.User", blank=True)
+    history = DatabaseAwareHistoricalRecords(m2m_fields=["owners"])
+```
+
+!!! warning "Compatibility surface"
+
+    `DatabaseAwareHistoricalRecords` is the configuration helper required by
+    GeneralManager 0.63.1 for a pre-tracked model on a non-default alias, but it
+    is not registered in `general_manager.interface`'s stable public export
+    registry. Pin and test the GeneralManager version when using this current
+    implementation path. A normal `HistoricalRecords` tracker remains accepted
+    on the default alias.
+
+If a pre-tracked model lacks the database-aware marker, manager class creation
+raises `UnsafeHistoryConfigurationError` with the model, interface, and alias in
+the message. That exception also currently has no stable package-level import;
+let Django surface it as a startup configuration failure instead of importing
+it for application control flow.
+
+## 3. Write the row and relations together
+
+```python
+customer = Customer.create(
+    creator_id=request.user.id,
+    history_comment="created from onboarding",
+    name="Acme",
+    owners_id_list=[request.user.id],
+)
+
+customer.update(
+    creator_id=request.user.id,
+    history_comment="transferred ownership",
+    owners_id_list=[new_owner.id],
+)
+```
+
+Validation, saving, history-reason, or many-to-many failures propagate. For
+ordinary ORM writes, any such exception rolls back the row, history rows, and
+relation table on the configured alias. Upload-aware writes keep their separate
+atomic upload and post-commit finalization contract.
+
+## 4. Handle caller-owned rollbacks
+
+GeneralManager avoids putting an uncommitted ORM row into its run-scoped read
+cache while the configured connection is inside an application `atomic()`
+block. After a rollback, construct a fresh manager from its ID. A manager object
+updated in place may still hold values materialized inside the failed
+transaction.
+
+```python
+from django.db import transaction
+
+customer_id = customer.identification["id"]
+try:
+    with transaction.atomic(using="archive"):
+        customer.update(name="Temporary")
+        raise RuntimeError("cancel change")
+except RuntimeError:
+    customer = Customer(id=customer_id)
+
+assert customer.name == "Acme"
+```
+
+See the [ORM interface model](../concepts/interfaces/db_based_interface.md), the
+[existing-model history model](../concepts/interfaces/existing_model_interface.md),
+the [cookbook recipe](../examples/existing_model_interface.md#route-atomic-writes-and-history-to-another-database),
+and the [Core](../api/core.md) and [Interface](../api/interface.md) references.

--- a/docs/howto/run_chat_evals.md
+++ b/docs/howto/run_chat_evals.md
@@ -1,0 +1,92 @@
+# Run the installed chat evaluation suite
+
+Use the installed module CLI when you want to evaluate a provider against the
+datasets shipped in the GeneralManager wheel. The command runs inside a Django
+project, so it must load that project's settings before it imports providers or
+registers fixtures.
+
+## 1. Choose the Django settings module
+
+Pass the module explicitly:
+
+```bash
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --help
+```
+
+For repeated runs, set the standard Django environment variable instead:
+
+```bash
+export DJANGO_SETTINGS_MODULE=myproject.settings
+python -m general_manager.chat.evals --help
+```
+
+`--help` is the only normal invocation that does not require settings. A run
+without `--settings` or a nonempty `DJANGO_SETTINGS_MODULE` exits with status 2
+before `django.setup()` runs. GeneralManager 0.62.3 removed the old fallback to
+the repository's test settings, so installed commands cannot silently evaluate
+against a development-only configuration.
+
+## 2. Run a shipped dataset
+
+The wheel includes `basic_queries`, `demo_readiness`, `edge_cases`,
+`follow_ups`, `large_schema`, and `multi_hop`. The `basic_queries` dataset can
+use the built-in toy schema and data:
+
+```bash
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --provider general_manager.chat.providers.OllamaProvider \
+  --dataset basic_queries \
+  --fixture toy \
+  --tier 0 \
+  --verbose
+```
+
+Omit `--provider` to use the provider configured in
+`GENERAL_MANAGER["CHAT"]`. Omit `--dataset` to run every shipped dataset whose
+managers and expectations fit the configured project. Use `--fixture large`
+with `large_schema`; omit fixtures when the selected dataset is intended to run
+against your project's own managers and data.
+
+## 3. Narrow or compare a run
+
+Repeat `--tag` to require several tags, and use `--model` to override the model
+inside the selected provider configuration for this invocation:
+
+```bash
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --dataset demo_readiness \
+  --tier 1 \
+  --tag grounding \
+  --tag discovery \
+  --model llama3 \
+  --trace-jsonl /tmp/chat-eval.jsonl
+```
+
+Compare providers by passing their import paths as one comma-separated value:
+
+```bash
+python -m general_manager.chat.evals \
+  --settings myproject.settings \
+  --dataset basic_queries \
+  --fixture toy \
+  --compare general_manager.chat.providers.OllamaProvider,myproject.chat.TestProvider
+```
+
+The command exits with status 0 when every selected case passes and status 1
+when any case fails. Provider imports, provider construction, Django setup, and
+dataset-loading errors propagate and produce a nonzero process exit.
+
+## 4. Interpret the report
+
+Treat hard product-contract failures as regressions. Strategy diagnostics can
+identify a skipped discovery path even when the final answer still satisfies
+the product contract. Use `--verbose` for failure details and `--trace-jsonl`
+when you need the full per-case trace.
+
+See the [chat prompt and eval model](../concepts/chat_prompting.md), the
+[copy-ready command recipes](../examples/chat_eval_cli.md), and the complete
+[chat eval CLI reference](../api/chat.md).

--- a/docs/howto/write_validation_rules.md
+++ b/docs/howto/write_validation_rules.md
@@ -17,6 +17,7 @@ from general_manager.rule import Rule
 class Booking(GeneralManager):
     starts_at: object
     ends_at: object
+    code: str | None
 
     class Interface(DatabaseInterface):
         class Meta:
@@ -43,7 +44,7 @@ referenced value is `None`; skipped rules contribute no validation error. Use
 ```python
 required_code = Rule(
     lambda booking: booking.code is not None,
-    custom_error_message="A booking code is required.",
+    custom_error_message="A booking code is required; received {code}.",
     ignore_if_none=False,
 )
 ```
@@ -51,9 +52,13 @@ required_code = Rule(
 ## Test both the result and message
 
 ```python
+from types import SimpleNamespace
+
+booking = SimpleNamespace(code=None)
+
 assert required_code.evaluate(booking) is False
 assert required_code.get_error_message() == {
-    "code": "A booking code is required."
+    "code": "A booking code is required; received None."
 }
 ```
 

--- a/docs/howto/write_validation_rules.md
+++ b/docs/howto/write_validation_rules.md
@@ -1,0 +1,72 @@
+# Write validation rules with reliable fallback errors
+
+Use a `Rule` when validation depends on more than one manager attribute or when
+the same predicate should run for both `create()` and `update()`.
+
+## Define and attach a rule
+
+Keep the predicate in source code that Python can inspect. Attach it through the
+interface `Meta.rules` list:
+
+```python
+from general_manager.interface import DatabaseInterface
+from general_manager.manager import GeneralManager
+from general_manager.rule import Rule
+
+
+class Booking(GeneralManager):
+    starts_at: object
+    ends_at: object
+
+    class Interface(DatabaseInterface):
+        class Meta:
+            rules = [
+                Rule["Booking"](
+                    lambda booking: booking.starts_at < booking.ends_at,
+                    custom_error_message=(
+                        "Start {starts_at} must be before end {ends_at}."
+                    ),
+                )
+            ]
+```
+
+The placeholders in `custom_error_message` must match variables referenced by
+the predicate. Missing placeholders raise `MissingErrorTemplateVariableError`
+when the message is generated.
+
+## Choose how `None` behaves
+
+The default `ignore_if_none=True` makes `evaluate()` return `None` when a
+referenced value is `None`; skipped rules contribute no validation error. Use
+`ignore_if_none=False` when absence must fail:
+
+```python
+required_code = Rule(
+    lambda booking: booking.code is not None,
+    custom_error_message="A booking code is required.",
+    ignore_if_none=False,
+)
+```
+
+## Test both the result and message
+
+```python
+assert required_code.evaluate(booking) is False
+assert required_code.get_error_message() == {
+    "code": "A booking code is required."
+}
+```
+
+As of 0.62.2, every failed rule produces a non-empty mapping. If a predicate
+cannot be explained by a registered AST handler, referenced fields receive a
+generic combination error. A variable-free predicate uses Django's non-field
+error key, `"__all__"`. Custom messages are preserved in either fallback.
+
+Do not call `get_error_message()` as the first operation: evaluate the rule
+first. Passing and skipped evaluations return `None` from
+`get_error_message()`.
+
+For the model and fallback behavior, read [Rule Validation](../concepts/rules_validation.md).
+For copy-ready tests, use the [rule-validation cookbook](../examples/rule_validation.md).
+The [API reference](../api/core.md#general_manager.rule.rule.Rule) documents the
+constructor, return values, and exceptions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,9 @@ nav:
       - howto/add_permission_rule.md
       - howto/permission_walkthrough.md
       - howto/expose_via_graphql.md
+      - howto/write_validation_rules.md
+      - howto/run_chat_evals.md
+      - howto/orm_atomic_writes.md
       - howto/graphql_file_uploads.md
       - howto/graphql_file_uploads_s3.md
       - howto/search.md
@@ -150,6 +153,10 @@ nav:
       - examples/project_volume_curve.md
       - examples/derivatives_groups.md
       - examples/graphql_queries.md
+      - examples/graphql_error_handling.md
+      - examples/graphql_file_upload.md
+      - examples/rule_validation.md
+      - examples/chat_eval_cli.md
       - examples/permission_patterns.md
       - examples/permission_cookbook.md
       - examples/audit_logger_custom.md
@@ -160,6 +167,7 @@ nav:
       - examples/request_interface_end_to_end.md
   - API-Reference:
       - api/core.md
+      - api/chat.md
       - api/measurement.md
       - api/dataframes.md
       - api/interface.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,9 +131,9 @@ nav:
       - howto/add_permission_rule.md
       - howto/permission_walkthrough.md
       - howto/expose_via_graphql.md
-      - howto/write_validation_rules.md
       - howto/run_chat_evals.md
       - howto/orm_atomic_writes.md
+      - howto/write_validation_rules.md
       - howto/graphql_file_uploads.md
       - howto/graphql_file_uploads_s3.md
       - howto/search.md

--- a/src/general_manager/rule/rule.py
+++ b/src/general_manager/rule/rule.py
@@ -311,10 +311,15 @@ class Rule(Generic[GeneralManagerType]):
         Returns:
             dict[str, str] | None: Mapping keyed by referenced variables or
             Django's `NON_FIELD_ERRORS` fallback when no variables are available;
-            `None` if the predicate passed or was not evaluated.
+            `None` if the predicate passed, was skipped, or has not been evaluated.
 
         Raises:
-            ErrorMessageGenerationError: If called before any input has been evaluated.
+            MissingErrorTemplateVariableError: If a failed rule's custom message
+                omits a placeholder for a referenced variable.
+            ErrorMessageGenerationError: If internal evaluation state records a
+                failed result without retaining its evaluated input.
+            Exception: A matching rule handler's documented message-generation
+                exceptions propagate unchanged.
         """
         if self._last_result or self._last_result is None:
             return None


### PR DESCRIPTION
## Summary

- audit all 113 commits reachable from `origin/main` whose commit timestamps fall in the rolling window `2026-07-08T17:44:03.178849Z` through `2026-07-15T17:44:03.178849Z`
- complete the concept/how-to/cookbook/API-reference matrix for every affected public API
- correct stale ORM history and transaction reference text, add compatibility notes, and wire new pages into navigation and cross-links
- document only; application behavior is unchanged (the sole Python edit corrects the generated `Rule.get_error_message()` docstring)

## Affected public APIs

- **GraphQL file uploads (added in 0.62.0):** `FileUploadPolicy`, `FileInspection`, `FileContentInspector`, upload adapter protocols/factory/registration, boundary values and enums, `UploadToken`, `StoredFile`, `StoredImage`, and the stable `UploadError` hierarchy; generated file-field schema, begin/transfer/finalize/download/cleanup behavior, and same-release hardening are covered.
- **Rule validation (changed in 0.62.2):** failed `Rule.get_error_message()` calls now retain a non-empty field or Django non-field fallback, including custom messages.
- **Installed chat evaluation CLI (changed in 0.62.3):** `python -m general_manager.chat.evals` now requires project settings for runs, keeps help settings-free, and loads datasets shipped in distributions.
- **GraphQL mutation errors (added/changed in 0.63.0):** `PublicGraphQLError(message, *, code)` is the explicit client-safe contract; unexpected `ValueError` and other internal failures are sanitized.
- **ORM manager writes/history (changed in 0.63.1):** ordinary `GeneralManager.create()`/`update()` writes are alias-aware atomic units across row/history/M2M work, transaction-local reads bypass the run cache, and existing-model history follows the configured database alias.

The performance-budget series and distribution/release workflow series alter test or maintainer tooling only and do not change the registered public package surface.

## Documentation added

- `docs/api/chat.md`
- `docs/howto/run_chat_evals.md`
- `docs/howto/orm_atomic_writes.md`
- `docs/howto/write_validation_rules.md`
- `docs/examples/chat_eval_cli.md`
- `docs/examples/graphql_error_handling.md`
- `docs/examples/graphql_file_upload.md`
- `docs/examples/rule_validation.md`

## Documentation updated

- `mkdocs.yml`
- `docs/api/core.md`
- `docs/api/graphql.md`
- `docs/api/interface.md`
- `docs/concepts/graphql/custom_mutations.md`
- `docs/concepts/graphql/file_uploads.md`
- `docs/concepts/interfaces/db_based_interface.md`
- `docs/concepts/interfaces/existing_model_interface.md`
- `docs/concepts/rules_validation.md`
- `docs/howto/expose_via_graphql.md`
- `docs/howto/index.md`
- `docs/examples/existing_model_interface.md`
- `docs/examples/index.md`
- `src/general_manager/rule/rule.py` (API docstring only)

## Validation

- `mkdocs build --strict` — passed
- `python -m pytest tests/docs/test_public_api_docs_coverage.py tests/unit/test_chat_eval_cli.py tests/unit/test_rules.py tests/unit/test_graphql_helpers.py tests/unit/test_mutation.py tests/unit/test_graphql_upload_mutation.py tests/integration/test_graphql_file_uploads.py` — 165 passed
- `python -m pytest tests/unit/test_database_based_interface.py tests/unit/test_orm_capabilities_comprehensive.py -k 'atomic or rollback or configured_database or history'` — 28 passed, 153 deselected
- `ruff check src/general_manager/rule/rule.py` — passed
- `ruff format --check src/general_manager/rule/rule.py` — passed
- `mypy --follow-imports=skip src/general_manager/rule/rule.py` — passed
- `git diff --check` — passed
- file-scoped pre-commit hooks — Ruff, format, whitespace, line endings, merge-conflict, and debug checks passed

## Remaining limitations

- The repository-wide pre-commit mypy hook still reports 15 existing errors in seven untouched files. The commit skipped only that hook after reproducing and recording the failures; the changed Python docstring file passes the targeted check above.
- `DatabaseAwareHistoricalRecords` and `UnsafeHistoryConfigurationError` are required current 0.63.1 implementation paths for a pre-tracked model on a non-default alias, but they are not registered stable `general_manager.interface` exports. The docs call this out instead of promising those direct imports.
- The browser upload cookbook was schema-checked through the focused GraphQL upload suites but was not executed against a live browser/storage deployment.
- Open PRs #400 and #401 were inspected and are unrelated.

## Reviewed commits (chronological)

```text
f360e862 feat: add file upload configuration contracts
9e41de7c fix: harden file upload configuration contracts
89ba4285 fix: reject unsafe Unicode upload paths
33780f31 feat: generate typed GraphQL file fields
f99f43cc fix: keep file filters input-compatible
507aa4ae feat: persist file upload intents
8befda1a fix: preserve upload intents after user deletion
37222dd1 feat: add upload storage adapters
8bfa8507 fix: enforce adapter no-overwrite guarantees
def8eb63 fix: fail closed for opaque upload storage
8d416fe2 fix: harden upload adapter contracts
2e39e765 fix: enforce upload staging invariants
3c953ece fix: support S3 bucket owner enforcement
7e1c4b0a feat: create GraphQL upload intents
c5d432cf fix: make upload admission deterministic
a66431c0 fix: harden upload admission boundaries
633c7855 feat: stream proxy file uploads
7b9f9fd0 feat: preflight upload tokens before permissions
98690504 feat: finalize uploaded files after commit
84ffe9e5 feat: expose secure uploaded file downloads
be240d30 fix: prevent upload route shadowing
d4fcf194 feat: reconcile and clean file uploads
85c42f1b docs: document GraphQL file uploads
bb20eae4 fix: harden GraphQL file upload lifecycle
f2b9a6eb fix: align file upload CI dependencies
09e299a5 fix: install image upload test dependencies
59044255 fix: harden upload checks and coverage
79fc099f fix: tolerate in-flight upload markers
6ba584ad 0.62.0
ead5dec4 perf: specify issue 337 benchmark coverage
8bf5f104 perf: plan issue 337 benchmark coverage
8f4950ce perf: add deterministic performance budget support
ff2ac966 perf: harden performance measurement support
fc9dc4e1 perf: cover calculation bucket hot paths
08381d47 perf: harden calculation performance fixtures
c784aeb2 perf: cover group bucket hot paths
f5135c47 perf: gate group diagnostics by verbosity
704bbca9 perf: keep group workloads single-pass
9bf677eb perf: cover database bucket terminal hot paths
7a2ac649 perf: isolate database performance fixtures
0b8c2ec4 perf: harden database performance fixture lifecycle
4b427ae6 perf: cover mixed run-cache invalidation
db9a804f perf: verify mixed-cache value preservation
d24e1773 perf: cover relation and history hot paths
7c9ff1e4 perf: include historical plan construction in measurement
94989147 perf: validate complete performance budget manifest
17531451 perf: validate manifest after final teardown
dfd503b4 perf: harden manifest and fixture safeguards
1ebcd00f perf: document performance regression workflow
06fa69e8 perf: clarify performance calibration guidance
81051355 perf: isolate database fixture primary keys
450c3ca8 perf: harden performance workload isolation
8a07f99e perf: scope manifest node selection
5d970eed perf: remove ignored planning artifacts
6d4932cc 0.62.1
51d68fee docs: design rule validation fallback
0b641b6a test: cover failed rule message fallback
7e95a1fa fix: preserve failed rule validation
d7ade6cc test: cover custom non-field rule errors
e7349d93 0.62.2
5f29d85a fix: make chat eval CLI settings-safe
7c75f6fe fix: ship chat eval datasets
d7168a5e ci: smoke-test built chat eval distribution
3bccaf4e docs: explain installed chat eval CLI settings
713e4220 0.62.3
39680fd3 feat: add explicit public GraphQL error contract
29c31c26 fix: sanitize internal GraphQL errors
083a74e0 fix: sanitize unexpected mutation exceptions
b1d18484 fix: harden GraphQL exception rendering
b94ee984 docs: document safe GraphQL error handling
80b0a3ba docs: refine GraphQL error migration example
8608d39b test: cover GraphQL error type export list
09cf4514 docs: align GraphQL mutation error contracts
cfb04f93 docs: correct GraphQL mutation failure semantics
69305c8e docs: clarify GraphQL permission error shape
6cc9ece7 docs: correct GraphQL overview error shape
65585742 0.63.0
08039424 test: reproduce non-atomic ORM mutations
74969ba4 fix: make ORM mutations atomic
80ab92ad docs: document atomic ORM mutations
672f5ae7 fix: preserve ORM mutation override compatibility
57303358 test: reproduce configured database history leak
c08f5946 test: cover configured database m2m history
23f4ce11 fix: route ORM history to configured database
f98f97b7 docs: explain database-aware ORM history
bb7fba6e docs: align ORM history docstrings
eaceb04f test: address ORM history review feedback
d5097d1e 0.63.1
5e263d9a test: add distribution artifact validator
1be32094 fix: harden distribution archive validation
4ac5c2ba fix: enforce canonical distribution members
365d82b4 fix: validate src-layout source distributions
4968ef5a fix: include chat eval datasets in distributions
d275b459 test: smoke test installed distributions
f128cb99 fix: isolate installed distribution smoke checks
55d85de9 ci: consolidate reusable quality gates
3692f64a fix: preserve required quality check name
585110a4 fix: gate publishing on validated artifacts
fa498c67 test: verify published artifact hashes
2dd3a3ec fix: harden release recovery
f2e8ecc6 fix: recover partial release state
54f843d6 docs: explain gated release recovery
953e0ced fix: trust recovered release provenance
0884adc7 docs: clarify release retry window
a27e9acd ci: integrate distribution smoke gates
56d42676 fix: bind package smoke to required check
10d20383 fix: recover prestamped release tags
a7f93be4 docs: describe valid release provenance
5982cb96 fix: block conflicting releases before mutation
ade5e163 docs: clarify pre-release PyPI checks
3618944a fix: address release workflow review feedback
430bc5e5 fix: attach release preflight to branch
f47e992e 0.63.2
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added and expanded how-to guides for the installed chat evaluation CLI, including dataset selection, provider comparisons, tracing, and exit status behavior.
  - Clarified atomic ORM write/rollback semantics, multi-database history routing, and required database-aware history configuration (including unsafe setup errors).
  - Strengthened GraphQL documentation with formal public error contracts, a safe mutation error recipe, and a new browser-side GraphQL file upload example.
  - Updated validation rule documentation and API references for reliable fallback error mappings, plus refreshed site navigation with new examples and API pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->