### PR TITLE
fix: preserve GraphQL manager relation types

### DIFF
--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -101,6 +101,7 @@ from general_manager.api.graphql_resolvers import (
     create_list_resolver as _create_list_resolver_fn,
     create_resolver as _create_resolver_fn,
 )
+from general_manager.api.graphql_relations import resolve_general_manager_type
 from general_manager.api.graphql_search import (
     register_search_query as _register_search_query_fn,
     create_search_union as _create_search_union_fn,
@@ -546,8 +547,13 @@ class GraphQL:
         # Map Attribute Types to Graphene Fields
         for field_name, field_info in interface_cls.get_attribute_types().items():
             field_type = field_info["type"]
-            fields[field_name] = cls._map_field_to_graphene_read(
+            resolved_manager_type = resolve_general_manager_type(
                 field_type,
+                cls.manager_registry,
+            )
+            resolved_field_type = resolved_manager_type or field_type
+            fields[field_name] = cls._map_field_to_graphene_read(
+                resolved_field_type,
                 field_name,
                 field_info,
             )
@@ -576,7 +582,10 @@ class GraphQL:
 
                 fields[resolver_name] = resolve_stored_file
             else:
-                fields[resolver_name] = cls._create_resolver(field_name, field_type)
+                fields[resolver_name] = cls._create_resolver(
+                    field_name,
+                    resolved_field_type,
+                )
 
         # handle GraphQLProperty attributes
         for (
@@ -594,9 +603,13 @@ class GraphQL:
 
             if origin in (list, tuple, set):
                 element = type_args[0] if type_args else object
-                if isinstance(element, type) and issubclass(element, GeneralManager):
+                manager_type = resolve_general_manager_type(
+                    element,
+                    cls.manager_registry,
+                )
+                if manager_type is not None:
                     graphene_field = graphene.List(
-                        lambda elem=element: GraphQL.graphql_type_registry[
+                        lambda elem=manager_type: GraphQL.graphql_type_registry[
                             elem.__name__
                         ]
                     )
@@ -605,12 +618,21 @@ class GraphQL:
                         element if isinstance(element, type) else str
                     )
                     graphene_field = graphene.List(base_type)
-                resolved_type = element if isinstance(element, type) else str
+                resolved_type = manager_type or (
+                    element if isinstance(element, type) else str
+                )
             else:
                 resolved_type = (
                     cast(type[object], type_args[0])
                     if type_args
                     else cast(type[object], raw_hint)
+                )
+                resolved_type = (
+                    resolve_general_manager_type(
+                        resolved_type,
+                        cls.manager_registry,
+                    )
+                    or resolved_type
                 )
                 graphene_field = cls._map_field_to_graphene_read(
                     resolved_type, attr_name
@@ -821,7 +843,7 @@ class GraphQL:
             field_info,
         ) in generalManagerClass.Interface.get_attribute_types().items():
             field_type = field_info["type"]
-            if safe_issubclass(field_type, GeneralManager):
+            if resolve_general_manager_type(field_type, GraphQL.manager_registry):
                 continue
             else:
                 sort_options.append(field_name)
@@ -970,7 +992,7 @@ class GraphQL:
 
     @staticmethod
     def _map_field_to_graphene_read(
-        field_type: type,
+        field_type: object,
         field_name: str,
         field_info: Mapping[str, object] | None = None,
     ) -> object:
@@ -998,6 +1020,13 @@ class GraphQL:
         Returns:
             object: Graphene field or type configured for the attribute.
         """
+        manager_type = resolve_general_manager_type(
+            field_type,
+            GraphQL.manager_registry,
+        )
+        if manager_type is not None:
+            field_type = manager_type
+
         if safe_issubclass(field_type, Measurement):
             return graphene.Field(MeasurementType, target_unit=graphene.String())
         elif safe_issubclass(field_type, GeneralManager):
@@ -1032,8 +1061,9 @@ class GraphQL:
                 return graphene.Field(StoredFile)
             if orm_field_kind == "image":
                 return graphene.Field(StoredImage)
+            scalar_type = cast(type, field_type)
             return GraphQL._map_field_to_graphene_base_type(
-                field_type,
+                scalar_type,
                 field_info,
             )()
 
@@ -1191,7 +1221,10 @@ class GraphQL:
             input_field_name,
             input_field,
         ) in generalManagerClass.Interface.input_fields.items():
-            if safe_issubclass(input_field.type, GeneralManager):
+            if resolve_general_manager_type(
+                input_field.type,
+                cls.manager_registry,
+            ):
                 key = f"{input_field_name}_id"
                 identification_fields[key] = graphene.Argument(
                     graphene.ID, required=input_field.required

--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -21,11 +21,11 @@ from django.db import models
 from django.core.exceptions import FieldDoesNotExist
 
 from general_manager.interface.base_interface import AttributeTypedDict, InterfaceBase
+from general_manager.api.graphql_relations import resolve_general_manager_type
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.uploads.errors import UploadError, stable_upload_error
 from general_manager.uploads.graphql_types import UploadToken
 from general_manager.uploads.types import UploadOperation
-from general_manager.utils.type_checks import safe_issubclass
 from general_manager.utils.format_string import snake_to_camel
 from general_manager.api.graphql_errors import (
     MissingManagerIdentifierError,
@@ -172,7 +172,7 @@ def _normalize_mutation_kwargs_for_manager(
             base_key = key.removesuffix("_list")
             type_info = attribute_types.get(key)
             relation_type = type_info["type"] if type_info is not None else None
-            if safe_issubclass(relation_type, GeneralManager):
+            if resolve_general_manager_type(relation_type) is not None:
                 normalized.setdefault(f"{base_key}_id_list", normalized[key])
                 normalized.pop(key, None)
                 continue
@@ -180,7 +180,7 @@ def _normalize_mutation_kwargs_for_manager(
         if not key.endswith("_id"):
             type_info = attribute_types.get(key)
             relation_type = type_info["type"] if type_info is not None else None
-            if safe_issubclass(relation_type, GeneralManager):
+            if resolve_general_manager_type(relation_type) is not None:
                 normalized.setdefault(f"{key}_id", normalized[key])
                 normalized.pop(key, None)
 
@@ -200,16 +200,16 @@ def _graphql_mutation_field_name(
     if field_name.endswith("_id_list"):
         relation_name = f"{field_name.removesuffix('_id_list')}_list"
         relation_info = attribute_types.get(relation_name)
-        if relation_info is not None and safe_issubclass(
-            relation_info["type"], GeneralManager
+        if relation_info is not None and resolve_general_manager_type(
+            relation_info["type"]
         ):
             return snake_to_camel(relation_name)
 
     if field_name.endswith("_id"):
         relation_name = field_name.removesuffix("_id")
         relation_info = attribute_types.get(relation_name)
-        if relation_info is not None and safe_issubclass(
-            relation_info["type"], GeneralManager
+        if relation_info is not None and resolve_general_manager_type(
+            relation_info["type"]
         ):
             return snake_to_camel(relation_name)
 
@@ -231,7 +231,7 @@ def _is_direct_relation_raw_id_alias(
         relation_info = attribute_types.get(relation_name)
         if relation_info is None:
             return False
-        return safe_issubclass(relation_info["type"], GeneralManager)
+        return resolve_general_manager_type(relation_info["type"]) is not None
 
     if not name.endswith("_id"):
         return False
@@ -307,7 +307,7 @@ def create_write_fields(
         fld: object
         if info.get("orm_field_kind") in {"file", "image"}:
             fld = UploadToken(required=req, default_value=default)
-        elif safe_issubclass(typ, GeneralManager):
+        elif resolve_general_manager_type(typ) is not None:
             if name.endswith("_list"):
                 fld = graphene.List(graphene.ID, required=req, default_value=default)
             else:

--- a/src/general_manager/api/graphql_mutations.py
+++ b/src/general_manager/api/graphql_mutations.py
@@ -21,7 +21,10 @@ from django.db import models
 from django.core.exceptions import FieldDoesNotExist
 
 from general_manager.interface.base_interface import AttributeTypedDict, InterfaceBase
-from general_manager.api.graphql_relations import resolve_general_manager_type
+from general_manager.api.graphql_relations import (
+    get_graphql_manager_registry,
+    resolve_general_manager_type,
+)
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.uploads.errors import UploadError, stable_upload_error
 from general_manager.uploads.graphql_types import UploadToken
@@ -166,13 +169,20 @@ def _normalize_mutation_kwargs_for_manager(
 
     attribute_types = interface_cls.get_attribute_types()
     normalized = dict(kwargs)
+    manager_registry = get_graphql_manager_registry()
 
     for key in list(kwargs.keys()):
         if key.endswith("_list") and not key.endswith("_id_list"):
             base_key = key.removesuffix("_list")
             type_info = attribute_types.get(key)
             relation_type = type_info["type"] if type_info is not None else None
-            if resolve_general_manager_type(relation_type) is not None:
+            if (
+                resolve_general_manager_type(
+                    relation_type,
+                    manager_registry,
+                )
+                is not None
+            ):
                 normalized.setdefault(f"{base_key}_id_list", normalized[key])
                 normalized.pop(key, None)
                 continue
@@ -180,7 +190,13 @@ def _normalize_mutation_kwargs_for_manager(
         if not key.endswith("_id"):
             type_info = attribute_types.get(key)
             relation_type = type_info["type"] if type_info is not None else None
-            if resolve_general_manager_type(relation_type) is not None:
+            if (
+                resolve_general_manager_type(
+                    relation_type,
+                    manager_registry,
+                )
+                is not None
+            ):
                 normalized.setdefault(f"{key}_id", normalized[key])
                 normalized.pop(key, None)
 
@@ -196,12 +212,14 @@ def _graphql_mutation_field_name(
         return snake_to_camel(field_name)
 
     attribute_types = interface_cls.get_attribute_types()
+    manager_registry = get_graphql_manager_registry()
 
     if field_name.endswith("_id_list"):
         relation_name = f"{field_name.removesuffix('_id_list')}_list"
         relation_info = attribute_types.get(relation_name)
         if relation_info is not None and resolve_general_manager_type(
-            relation_info["type"]
+            relation_info["type"],
+            manager_registry,
         ):
             return snake_to_camel(relation_name)
 
@@ -209,7 +227,8 @@ def _graphql_mutation_field_name(
         relation_name = field_name.removesuffix("_id")
         relation_info = attribute_types.get(relation_name)
         if relation_info is not None and resolve_general_manager_type(
-            relation_info["type"]
+            relation_info["type"],
+            manager_registry,
         ):
             return snake_to_camel(relation_name)
 
@@ -224,6 +243,7 @@ def _graphql_mutation_field_name(
 def _is_direct_relation_raw_id_alias(
     name: str,
     attribute_types: dict[str, AttributeTypedDict],
+    manager_registry: dict[str, type[GeneralManager]],
 ) -> bool:
     """Return true when ``name`` is a raw relation id alias with a canonical field."""
     if name.endswith("_id_list"):
@@ -231,7 +251,13 @@ def _is_direct_relation_raw_id_alias(
         relation_info = attribute_types.get(relation_name)
         if relation_info is None:
             return False
-        return resolve_general_manager_type(relation_info["type"]) is not None
+        return (
+            resolve_general_manager_type(
+                relation_info["type"],
+                manager_registry,
+            )
+            is not None
+        )
 
     if not name.endswith("_id"):
         return False
@@ -292,12 +318,17 @@ def create_write_fields(
     """
     fields: GrapheneFieldMap = {}
     attribute_types = interface_cls.get_attribute_types()
+    manager_registry = get_graphql_manager_registry()
     for name, info in attribute_types.items():
         if name in ["changed_by", "created_at", "updated_at"]:
             continue
         if info["is_derived"]:
             continue
-        if _is_direct_relation_raw_id_alias(name, attribute_types):
+        if _is_direct_relation_raw_id_alias(
+            name,
+            attribute_types,
+            manager_registry,
+        ):
             continue
 
         typ = info["type"]
@@ -307,7 +338,13 @@ def create_write_fields(
         fld: object
         if info.get("orm_field_kind") in {"file", "image"}:
             fld = UploadToken(required=req, default_value=default)
-        elif resolve_general_manager_type(typ) is not None:
+        elif (
+            resolve_general_manager_type(
+                typ,
+                manager_registry,
+            )
+            is not None
+        ):
             if name.endswith("_list"):
                 fld = graphene.List(graphene.ID, required=req, default_value=default)
             else:

--- a/src/general_manager/api/graphql_relations.py
+++ b/src/general_manager/api/graphql_relations.py
@@ -11,6 +11,13 @@ from general_manager.manager.general_manager import GeneralManager
 from general_manager.utils.type_checks import safe_issubclass
 
 
+def get_graphql_manager_registry() -> dict[str, type[GeneralManager]]:
+    """Return the live GraphQL manager registry without an import-time cycle."""
+    from general_manager.api.graphql import GraphQL
+
+    return GraphQL.manager_registry
+
+
 def resolve_general_manager_type(
     declared_type: object,
     manager_registry: Mapping[str, type[GeneralManager]] | None = None,

--- a/src/general_manager/api/graphql_relations.py
+++ b/src/general_manager/api/graphql_relations.py
@@ -1,0 +1,65 @@
+"""Resolve manager targets from GraphQL relation annotations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import UnionType
+from typing import ForwardRef, Union, get_args, get_origin
+
+from general_manager.bucket.base_bucket import Bucket
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.utils.type_checks import safe_issubclass
+
+
+def resolve_general_manager_type(
+    declared_type: object,
+    manager_registry: Mapping[str, type[GeneralManager]] | None = None,
+) -> type[GeneralManager] | None:
+    """Return the single manager target represented by ``declared_type``.
+
+    Concrete manager classes, supported collection annotations, optional
+    unions, and exact names in ``manager_registry`` are recognized. Ambiguous
+    annotations containing multiple manager targets return ``None``.
+    """
+    registry = manager_registry or {}
+    resolved = _collect_general_manager_types(declared_type, registry, set())
+    if len(resolved) != 1:
+        return None
+    return next(iter(resolved))
+
+
+def _collect_general_manager_types(
+    declared_type: object,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    seen: set[int],
+) -> set[type[GeneralManager]]:
+    value_id = id(declared_type)
+    if value_id in seen:
+        return set()
+    seen.add(value_id)
+
+    if safe_issubclass(declared_type, GeneralManager):
+        return {declared_type}
+
+    if isinstance(declared_type, ForwardRef):
+        declared_type = declared_type.__forward_arg__
+    if isinstance(declared_type, str):
+        manager_type = manager_registry.get(declared_type)
+        return {manager_type} if manager_type is not None else set()
+
+    origin = get_origin(declared_type)
+    if origin is None:
+        return set()
+    if origin not in {list, tuple, set, Union, UnionType} and not safe_issubclass(
+        origin, Bucket
+    ):
+        return set()
+
+    manager_types: set[type[GeneralManager]] = set()
+    for argument in get_args(declared_type):
+        if argument is None or argument is type(None) or argument is Ellipsis:
+            continue
+        manager_types.update(
+            _collect_general_manager_types(argument, manager_registry, seen)
+        )
+    return manager_types

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -24,7 +24,10 @@ from general_manager.bucket.group_bucket import GroupBucket
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
 from general_manager.api.graphql_errors import get_read_permission_filter
-from general_manager.api.graphql_relations import resolve_general_manager_type
+from general_manager.api.graphql_relations import (
+    get_graphql_manager_registry,
+    resolve_general_manager_type,
+)
 from general_manager.api.graphql_prefetch import (
     collect_selected_graphql_property_names,
     plan_dependency_cache_prefetches,
@@ -846,7 +849,10 @@ def create_resolver(
     :class:`~general_manager.measurement.Measurement` fields, and
     :func:`create_normal_resolver` for everything else.
     """
-    manager_field_type = resolve_general_manager_type(field_type)
+    manager_field_type = resolve_general_manager_type(
+        field_type,
+        get_graphql_manager_registry(),
+    )
     if field_name.endswith("_list") and manager_field_type is not None:
         return create_list_resolver(
             lambda self, _include_inactive: cast(

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -24,6 +24,7 @@ from general_manager.bucket.group_bucket import GroupBucket
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.measurement.measurement import Measurement
 from general_manager.api.graphql_errors import get_read_permission_filter
+from general_manager.api.graphql_relations import resolve_general_manager_type
 from general_manager.api.graphql_prefetch import (
     collect_selected_graphql_property_names,
     plan_dependency_cache_prefetches,
@@ -834,7 +835,7 @@ def _selection_set_includes_path(
 
 def create_resolver(
     field_name: str,
-    field_type: type[object],
+    field_type: object,
     filter_normalizer: ManagerFilterNormalizer | None = None,
 ) -> Resolver:
     """
@@ -845,8 +846,8 @@ def create_resolver(
     :class:`~general_manager.measurement.Measurement` fields, and
     :func:`create_normal_resolver` for everything else.
     """
-    if field_name.endswith("_list") and safe_issubclass(field_type, GeneralManager):
-        manager_field_type = cast(type[GeneralManager], field_type)
+    manager_field_type = resolve_general_manager_type(field_type)
+    if field_name.endswith("_list") and manager_field_type is not None:
         return create_list_resolver(
             lambda self, _include_inactive: cast(
                 Bucket[GeneralManager],

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -41,6 +41,7 @@ from general_manager.api.graphql_errors import (
     map_field_to_graphene_base_type,
     get_read_permission_filter,
 )
+from general_manager.api.graphql_relations import resolve_general_manager_type
 from general_manager.api.graphql_resolvers import (
     can_read_instance,
     get_backend_shape,
@@ -538,9 +539,12 @@ def get_filter_options(
         "endswith",
     ]
 
-    normalized_type = attribute_type if isinstance(attribute_type, type) else str
+    manager_type = resolve_general_manager_type(attribute_type)
+    normalized_type = manager_type or (
+        attribute_type if isinstance(attribute_type, type) else str
+    )
 
-    if safe_issubclass(normalized_type, GeneralManager):
+    if manager_type is not None:
         yield attribute_name, None
     elif attribute_name == "id":
         yield attribute_name, graphene.ID()
@@ -591,7 +595,7 @@ def get_filter_options(
 
 
 def get_relation_filter_option(
-    attribute_type: type,
+    attribute_type: object,
     attribute_name: str,
     attr_info: Mapping[str, object],
     graphql_filter_type_registry: dict[str, type[graphene.InputObjectType]],
@@ -614,7 +618,8 @@ def get_relation_filter_option(
     """
     if remaining_depth <= 0:
         return None
-    if not safe_issubclass(attribute_type, GeneralManager):
+    manager_type = resolve_general_manager_type(attribute_type)
+    if manager_type is None:
         return None
 
     relation_kind = attr_info.get("relation_kind")
@@ -622,7 +627,7 @@ def get_relation_filter_option(
         return None
 
     nested_type = create_filter_options(
-        attribute_type,
+        manager_type,
         graphql_filter_type_registry,
         map_field_to_graphene_read,
         relation_depth=remaining_depth - 1,
@@ -633,7 +638,7 @@ def get_relation_filter_option(
 
     if relation_kind == "collection":
         relation_type_name = (
-            f"{attribute_type.__name__}{attribute_name.title().replace('_', '')}"
+            f"{manager_type.__name__}{attribute_name.title().replace('_', '')}"
             f"RelationFilterTypeDepth{remaining_depth - 1}"
         )
         if relation_type_name not in graphql_filter_type_registry:
@@ -700,9 +705,10 @@ def create_filter_options(
     filter_fields: dict[str, GrapheneFieldType] = {}
     for attr_name, attr_info in field_type.Interface.get_attribute_types().items():
         attr_type = attr_info["type"]
-        if safe_issubclass(attr_type, GeneralManager):
+        manager_type = resolve_general_manager_type(attr_type)
+        if manager_type is not None:
             relation_option = get_relation_filter_option(
-                attr_type,
+                manager_type,
                 attr_name,
                 attr_info,
                 graphql_filter_type_registry,
@@ -826,12 +832,13 @@ def normalize_filter_input(
         attr_type = attr_info.get("type")
         relation_kind = attr_info.get("relation_kind")
         lookup = attr_info.get("filter_lookup", key)
-        if not safe_issubclass(attr_type, GeneralManager) or relation_kind is None:
+        manager_type = resolve_general_manager_type(attr_type)
+        if manager_type is None or relation_kind is None:
             filters[key] = value
             continue
 
         if relation_kind == "direct":
-            nested = normalize_filter_input(attr_type, value)
+            nested = normalize_filter_input(manager_type, value)
             for nested_key, nested_value in nested["filter"].items():
                 filters[f"{lookup}__{nested_key}"] = nested_value
             for nested_key, nested_value in nested["exclude"].items():
@@ -842,13 +849,13 @@ def normalize_filter_input(
             any_value = value.get("any")
             none_value = value.get("none")
             if isinstance(any_value, dict):
-                nested = normalize_filter_input(attr_type, any_value)
+                nested = normalize_filter_input(manager_type, any_value)
                 for nested_key, nested_value in nested["filter"].items():
                     filters[f"{lookup}__{nested_key}"] = nested_value
                 for nested_key, nested_value in nested["exclude"].items():
                     excludes[f"{lookup}__{nested_key}"] = nested_value
             if isinstance(none_value, dict):
-                nested = normalize_filter_input(attr_type, none_value)
+                nested = normalize_filter_input(manager_type, none_value)
                 for nested_key, nested_value in nested["filter"].items():
                     excludes[f"{lookup}__{nested_key}"] = nested_value
                 for nested_key, nested_value in nested["exclude"].items():

--- a/src/general_manager/api/graphql_search.py
+++ b/src/general_manager/api/graphql_search.py
@@ -41,7 +41,10 @@ from general_manager.api.graphql_errors import (
     map_field_to_graphene_base_type,
     get_read_permission_filter,
 )
-from general_manager.api.graphql_relations import resolve_general_manager_type
+from general_manager.api.graphql_relations import (
+    get_graphql_manager_registry,
+    resolve_general_manager_type,
+)
 from general_manager.api.graphql_resolvers import (
     can_read_instance,
     get_backend_shape,
@@ -539,7 +542,10 @@ def get_filter_options(
         "endswith",
     ]
 
-    manager_type = resolve_general_manager_type(attribute_type)
+    manager_type = resolve_general_manager_type(
+        attribute_type,
+        get_graphql_manager_registry(),
+    )
     normalized_type = manager_type or (
         attribute_type if isinstance(attribute_type, type) else str
     )
@@ -618,7 +624,10 @@ def get_relation_filter_option(
     """
     if remaining_depth <= 0:
         return None
-    manager_type = resolve_general_manager_type(attribute_type)
+    manager_type = resolve_general_manager_type(
+        attribute_type,
+        get_graphql_manager_registry(),
+    )
     if manager_type is None:
         return None
 
@@ -705,7 +714,10 @@ def create_filter_options(
     filter_fields: dict[str, GrapheneFieldType] = {}
     for attr_name, attr_info in field_type.Interface.get_attribute_types().items():
         attr_type = attr_info["type"]
-        manager_type = resolve_general_manager_type(attr_type)
+        manager_type = resolve_general_manager_type(
+            attr_type,
+            get_graphql_manager_registry(),
+        )
         if manager_type is not None:
             relation_option = get_relation_filter_option(
                 manager_type,
@@ -832,7 +844,10 @@ def normalize_filter_input(
         attr_type = attr_info.get("type")
         relation_kind = attr_info.get("relation_kind")
         lookup = attr_info.get("filter_lookup", key)
-        manager_type = resolve_general_manager_type(attr_type)
+        manager_type = resolve_general_manager_type(
+            attr_type,
+            get_graphql_manager_registry(),
+        )
         if manager_type is None or relation_kind is None:
             filters[key] = value
             continue

--- a/src/general_manager/bootstrap.py
+++ b/src/general_manager/bootstrap.py
@@ -522,6 +522,13 @@ def handle_graph_ql(
         "creating graphql interfaces and mutations",
         context={"pending": len(pending_graphql_interfaces)},
     )
+    GraphQL.manager_registry.update(
+        {
+            general_manager_class.__name__: general_manager_class
+            for general_manager_class in pending_graphql_interfaces
+            if getattr(general_manager_class, "Interface", None) is not None
+        }
+    )
     for general_manager_class in pending_graphql_interfaces:
         GraphQL.create_graphql_interface(general_manager_class)
         GraphQL.create_graphql_mutation(general_manager_class)

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -1184,6 +1184,22 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertIn("Alice", human_names)
         self.assertIn("Bob", human_names)
 
+    def test_many_to_many_graphql_pages_use_related_manager_types(self):
+        from general_manager.api.graphql import GraphQL
+
+        expected_types = {
+            ("TestFamily", "humans_list"): "TestHuman",
+            ("TestHuman", "families_list"): "TestFamily",
+        }
+        for (manager_name, field_name), related_name in expected_types.items():
+            relation_field = GraphQL.graphql_type_registry[manager_name]._meta.fields[
+                field_name
+            ]
+            self.assertEqual(
+                relation_field.type._meta.fields["items"].type.of_type.of_type,
+                GraphQL.graphql_type_registry[related_name],
+            )
+
     def test_multiple_many_to_many_fields_to_same_manager_stay_independent(self):
         """
         Verify direct M2M buckets scope reads to their own relation field.

--- a/tests/integration/test_graphql_relation_filters.py
+++ b/tests/integration/test_graphql_relation_filters.py
@@ -202,6 +202,16 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
         self.assertEqual(fields.count("changeRequestFeasibilityList"), 1)
         self.assertNotIn("changerequestfeasibilityList", fields)
 
+    def test_reverse_relation_graphql_page_uses_related_manager_type(self):
+        relation_field = GraphQL.graphql_type_registry["ChangeRequest"]._meta.fields[
+            "change_request_feasibility_list"
+        ]
+
+        self.assertEqual(
+            relation_field.type._meta.fields["items"].type.of_type.of_type,
+            GraphQL.graphql_type_registry["ChangeRequestFeasibility"],
+        )
+
     def test_reverse_one_to_one_has_only_canonical_singular_graphql_field(self):
         query = """
         query {

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -19,6 +19,7 @@ from general_manager.api.graphql import (
     get_read_permission_filter,
 )
 from general_manager.api.graphql_mutations import (
+    _graphql_mutation_field_name,
     _normalize_mutation_kwargs_for_manager,
 )
 from general_manager.api.graphql_view import GeneralManagerGraphQLView
@@ -400,6 +401,27 @@ class GraphQLTests(TestCase):
         mock_instance.labels = ["a", "b"]
         resolver = GraphQL._create_resolver("labels", list[str])
         self.assertEqual(resolver(mock_instance, self.info), ["a", "b"])
+
+    def test_create_resolver_resolves_named_manager_relation(self):
+        class RelatedManager(GeneralManager):
+            pass
+
+        previous_registry = GraphQL.manager_registry
+        GraphQL.manager_registry = {"RelatedManager": RelatedManager}
+        self.addCleanup(setattr, GraphQL, "manager_registry", previous_registry)
+        sentinel = object()
+
+        with patch(
+            "general_manager.api.graphql_resolvers.create_list_resolver",
+            return_value=sentinel,
+        ) as create_list_resolver:
+            resolver = GraphQL._create_resolver(
+                "related_manager_list",
+                "RelatedManager",
+            )
+
+        self.assertIs(resolver, sentinel)
+        self.assertIs(create_list_resolver.call_args.args[1], RelatedManager)
 
     def test_create_resolver_handles_any_type(self):
         mock_instance = MagicMock()
@@ -1471,6 +1493,70 @@ class TestGrapQlMutation(TestCase):
                 {"manager": "1", "manager_list": ["2"]},
             ),
             {"manager_id": "1", "manager_id_list": ["2"]},
+        )
+
+    def test_mutation_helpers_resolve_named_manager_relations(self):
+        class RelatedManager(GeneralManager):
+            pass
+
+        def field_info(
+            field_type,
+            *,
+            relation_kind=None,
+        ):
+            return {
+                "type": field_type,
+                "is_required": False,
+                "is_derived": False,
+                "default": None,
+                "is_editable": True,
+                "relation_kind": relation_kind,
+            }
+
+        class DummyInterface:
+            @staticmethod
+            def get_attribute_types():
+                return {
+                    "manager": field_info(
+                        "RelatedManager",
+                        relation_kind="direct",
+                    ),
+                    "manager_id": field_info(int),
+                    "manager_list": field_info(
+                        "RelatedManager",
+                        relation_kind="collection",
+                    ),
+                    "manager_id_list": field_info(int),
+                }
+
+        class DummyManager:
+            Interface = DummyInterface
+
+        previous_registry = GraphQL.manager_registry
+        GraphQL.manager_registry = {"RelatedManager": RelatedManager}
+        self.addCleanup(setattr, GraphQL, "manager_registry", previous_registry)
+
+        fields = GraphQL.create_write_fields(DummyInterface)
+        normalized = _normalize_mutation_kwargs_for_manager(
+            DummyManager,
+            {"manager": "1", "manager_list": ["2"]},
+        )
+
+        self.assertIsInstance(fields["manager"], graphene.ID)
+        self.assertIsInstance(fields["manager_list"], graphene.List)
+        self.assertNotIn("manager_id", fields)
+        self.assertNotIn("manager_id_list", fields)
+        self.assertEqual(
+            normalized,
+            {"manager_id": "1", "manager_id_list": ["2"]},
+        )
+        self.assertEqual(
+            _graphql_mutation_field_name(DummyManager, "manager_id"),
+            "manager",
+        )
+        self.assertEqual(
+            _graphql_mutation_field_name(DummyManager, "manager_id_list"),
+            "managerList",
         )
 
     def test_generate_create_mutation_class(self):

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -22,6 +22,7 @@ from general_manager.api.graphql_mutations import (
     _normalize_mutation_kwargs_for_manager,
 )
 from general_manager.api.graphql_view import GeneralManagerGraphQLView
+from general_manager.bucket.base_bucket import Bucket
 from general_manager.measurement.measurement import Measurement
 from general_manager.manager.general_manager import GeneralManager, GeneralManagerMeta
 from general_manager.manager.input import Input
@@ -346,6 +347,44 @@ class GraphQLTests(TestCase):
         field = GraphQL._map_field_to_graphene_read(list[str], "labels")
         self.assertIsInstance(field, graphene.String)
 
+    def test_map_field_to_graphene_resolves_annotated_manager_relations(self):
+        class RelatedManager(GeneralManager):
+            pass
+
+        class RelatedManagerType(graphene.ObjectType):
+            name = graphene.String()
+
+        GraphQL.manager_registry["RelatedManager"] = RelatedManager
+        GraphQL.graphql_type_registry["RelatedManager"] = RelatedManagerType
+
+        with (
+            patch.object(GraphQL, "_create_filter_options", return_value=None),
+            patch.object(GraphQL, "_sort_by_options", return_value=None),
+        ):
+            for declared_type in (
+                list[RelatedManager],
+                Bucket[RelatedManager],
+                "RelatedManager",
+            ):
+                field = GraphQL._map_field_to_graphene_read(
+                    declared_type,
+                    "related_manager_list",
+                    {"relation_kind": "collection"},
+                )
+                self.assertIsInstance(field, graphene.Field)
+                self.assertEqual(
+                    field.type._meta.fields["items"].type.of_type.of_type,
+                    RelatedManagerType,
+                )
+
+        direct_field = GraphQL._map_field_to_graphene_read(
+            RelatedManager | None,
+            "related_manager",
+            {"relation_kind": "direct"},
+        )
+        self.assertIsInstance(direct_field, graphene.Field)
+        self.assertIs(direct_field.type, RelatedManagerType)
+
     def test_map_field_to_graphene_handles_any_type(self):
         field = GraphQL._map_field_to_graphene_read(Any, "metadata")
         self.assertIsInstance(field, graphene.String)
@@ -575,7 +614,7 @@ class GraphQLTests(TestCase):
             return isinstance(candidate, type) and issubclass(candidate, parent)
 
         with patch(
-            "general_manager.api.graphql_search.safe_issubclass",
+            "general_manager.api.graphql_relations.safe_issubclass",
             side_effect=relation_safe_issubclass,
         ):
             filter_type = GraphQL._create_filter_options(DummyManager)
@@ -608,7 +647,7 @@ class GraphQLTests(TestCase):
                     return {
                         "id": {"type": int},
                         "child_list": {
-                            "type": ChildManager,
+                            "type": Bucket[ChildManager],
                             "relation_kind": "collection",
                             "filter_lookup": "child",
                         },
@@ -622,7 +661,7 @@ class GraphQLTests(TestCase):
             return isinstance(candidate, type) and issubclass(candidate, parent)
 
         with patch(
-            "general_manager.api.graphql_search.safe_issubclass",
+            "general_manager.api.graphql_relations.safe_issubclass",
             side_effect=relation_safe_issubclass,
         ):
             filter_type = GraphQL._create_filter_options(ParentManager)
@@ -672,7 +711,7 @@ class GraphQLTests(TestCase):
             return isinstance(candidate, type) and issubclass(candidate, parent)
 
         with patch(
-            "general_manager.api.graphql_search.safe_issubclass",
+            "general_manager.api.graphql_relations.safe_issubclass",
             side_effect=relation_safe_issubclass,
         ):
             normalized = GraphQL._normalize_filter_input(
@@ -727,7 +766,7 @@ class GraphQLTests(TestCase):
             return isinstance(candidate, type) and issubclass(candidate, parent)
 
         with patch(
-            "general_manager.api.graphql_search.safe_issubclass",
+            "general_manager.api.graphql_relations.safe_issubclass",
             side_effect=relation_safe_issubclass,
         ):
             normalized = GraphQL._normalize_filter_input(
@@ -831,6 +870,39 @@ class GraphQLDirectiveRegistrationTests(TestCase):
         schema = GraphQL.get_schema()
         self.assertIsNotNone(schema)
         return schema  # type: ignore[return-value]
+
+    def test_bootstrap_registers_manager_names_before_building_interfaces(self):
+        class FirstManager(GeneralManager):
+            pass
+
+        class SecondManager(GeneralManager):
+            pass
+
+        FirstManager.Interface = object()
+        SecondManager.Interface = object()
+        GraphQL._query_fields = {"ping": graphene.String()}
+
+        def assert_all_managers_registered(_manager):
+            self.assertIs(GraphQL.manager_registry["FirstManager"], FirstManager)
+            self.assertIs(GraphQL.manager_registry["SecondManager"], SecondManager)
+
+        with (
+            patch.object(
+                gm_bootstrap.GraphQL,
+                "create_graphql_interface",
+                side_effect=assert_all_managers_registered,
+            ),
+            patch.object(gm_bootstrap.GraphQL, "create_graphql_mutation"),
+            patch.object(gm_bootstrap.GraphQL, "register_file_upload_mutation"),
+            patch.object(gm_bootstrap.GraphQL, "register_search_query"),
+            patch.object(
+                gm_bootstrap.GraphQL,
+                "register_current_user_capabilities",
+            ),
+            patch("general_manager.uploads.urls.add_file_upload_urls"),
+            patch("general_manager.bootstrap.add_graphql_url"),
+        ):
+            gm_bootstrap.handle_graph_ql([FirstManager, SecondManager])
 
     def test_build_schema_directives_uses_specified_directives_by_default(self) -> None:
         directives = gm_bootstrap._build_schema_directives()
@@ -1360,6 +1432,46 @@ class TestGrapQlMutation(TestCase):
         self.assertIn("manager_list", fields)
         self.assertIsInstance(fields["manager"], graphene.ID)
         self.assertIsInstance(fields["manager_list"], graphene.List)
+
+    def test_create_write_fields_resolves_annotated_manager_relations(self):
+        class RelatedManager(GeneralManager):
+            pass
+
+        class DummyInterface:
+            @staticmethod
+            def get_attribute_types():
+                return {
+                    "manager": {
+                        "type": RelatedManager | None,
+                        "is_required": False,
+                        "is_derived": False,
+                        "default": None,
+                        "is_editable": True,
+                    },
+                    "manager_list": {
+                        "type": Bucket[RelatedManager],
+                        "is_required": False,
+                        "is_derived": False,
+                        "default": None,
+                        "is_editable": True,
+                    },
+                }
+
+        fields = GraphQL.create_write_fields(DummyInterface)
+
+        self.assertIsInstance(fields["manager"], graphene.ID)
+        self.assertIsInstance(fields["manager_list"], graphene.List)
+
+        class DummyManager:
+            Interface = DummyInterface
+
+        self.assertEqual(
+            _normalize_mutation_kwargs_for_manager(
+                DummyManager,
+                {"manager": "1", "manager_list": ["2"]},
+            ),
+            {"manager_id": "1", "manager_id_list": ["2"]},
+        )
 
     def test_generate_create_mutation_class(self):
         """

--- a/tests/unit/test_graphql_relations.py
+++ b/tests/unit/test_graphql_relations.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from general_manager.api.graphql_relations import resolve_general_manager_type
+from general_manager.bucket.base_bucket import Bucket
+from general_manager.manager.general_manager import GeneralManager
+
+
+class PrimaryManager(GeneralManager):
+    pass
+
+
+class SecondaryManager(GeneralManager):
+    pass
+
+
+def test_resolve_general_manager_type_handles_concrete_and_wrapped_managers() -> None:
+    registry = {"PrimaryManager": PrimaryManager}
+
+    for declared_type in (
+        PrimaryManager,
+        list[PrimaryManager],
+        tuple[PrimaryManager, ...],
+        set[PrimaryManager],
+        Bucket[PrimaryManager],
+        PrimaryManager | None,
+        "PrimaryManager",
+    ):
+        assert resolve_general_manager_type(declared_type, registry) is PrimaryManager
+
+
+def test_resolve_general_manager_type_rejects_non_manager_and_unresolved_types() -> (
+    None
+):
+    registry = {"PrimaryManager": PrimaryManager}
+
+    for declared_type in (
+        str,
+        list[str],
+        dict[str, PrimaryManager],
+        "MissingManager",
+    ):
+        assert resolve_general_manager_type(declared_type, registry) is None
+
+
+def test_resolve_general_manager_type_rejects_ambiguous_manager_union() -> None:
+    assert resolve_general_manager_type(PrimaryManager | SecondaryManager, {}) is None

--- a/tests/unit/test_graphql_search.py
+++ b/tests/unit/test_graphql_search.py
@@ -1071,6 +1071,66 @@ class GraphQLSearchHelperCoverageTests(SimpleTestCase):
                 is None
             )
 
+    def test_string_manager_annotations_use_central_registry(self) -> None:
+        previous_registry = GraphQL.manager_registry
+        GraphQL.manager_registry = {"Project": Project}
+        self.addCleanup(setattr, GraphQL, "manager_registry", previous_registry)
+
+        class ParentInterface(BaseTestInterface):
+            @classmethod
+            def get_attribute_types(cls):
+                return {
+                    "project": {
+                        "type": "Project",
+                        "relation_kind": "direct",
+                        "filter_lookup": "project",
+                    }
+                }
+
+        class ParentManager:
+            __name__ = "NamedRelationParent"
+            Interface = ParentInterface
+
+        mapper = MagicMock(return_value=graphql_search_module.graphene.String())
+        scalar_options = list(
+            graphql_search_module.get_filter_options(
+                "Project",
+                "project",
+                mapper,
+            )
+        )
+        registry: dict[
+            str,
+            type[graphql_search_module.graphene.InputObjectType],
+        ] = {}
+        relation_option = graphql_search_module.get_relation_filter_option(
+            "Project",
+            "project",
+            {"relation_kind": "direct"},
+            registry,
+            mapper,
+            remaining_depth=1,
+        )
+        parent_filter_type = graphql_search_module.create_filter_options(
+            ParentManager,
+            registry,
+            mapper,
+            relation_depth=1,
+        )
+        normalized = graphql_search_module.normalize_filter_input(
+            ParentManager,
+            {"project": {"name": "Alpha"}},
+        )
+
+        assert scalar_options == [("project", None)]
+        assert relation_option is not None
+        assert parent_filter_type is not None
+        assert "project" in parent_filter_type._meta.fields
+        assert normalized == {
+            "filter": {"project__name": "Alpha"},
+            "exclude": {},
+        }
+
     def test_create_filter_options_skips_unfilterable_props_and_empty_types(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- resolve concrete, wrapped, optional, and forward-referenced GeneralManager relation annotations before GraphQL scalar mapping
- preserve related object/page types across read fields, resolvers, filters, sorting, identification arguments, and mutation inputs
- pre-register pending managers so named relations do not depend on declaration order
- add unit and integration regression coverage for generic managers, reverse many-to-one, and both sides of many-to-many relations

## Root cause

The GraphQL type-hardening change replaced direct subclass checks with a safe class-only guard. Generic aliases such as `Bucket[RelatedManager]` and forward references therefore stopped qualifying as manager relations and fell through to the compatibility scalar mapper, which represents unsupported types as `String`.

## Impact

GeneralManager relationships now expose the generated related GraphQL object type again. Collection relations retain their existing paginated `<Manager>Page` shape and relation filtering behavior. Non-manager generic scalar fallback behavior is unchanged.

## Validation

- `python -m pytest` — 5,089 passed, 2 skipped
- `ruff check .`
- `ruff format --check .`
- changed production modules checked with `mypy`
- pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL handling of direct, collection, reverse, and many-to-many relations.
  * Fixed relation fields, mutation inputs, resolvers, sorting, and search filters for annotated or forward-referenced manager types.
  * Ensured manager types are registered before GraphQL schema generation.

* **Tests**
  * Added coverage for relation pages, filters, mutation inputs, type resolution, and GraphQL manager registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->