### PR TITLE
fix: resolve generated GraphQL relation types

### DIFF
--- a/src/general_manager/api/graphql_relations.py
+++ b/src/general_manager/api/graphql_relations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from collections.abc import Mapping
 from types import UnionType
 from typing import ForwardRef, Union, get_args, get_origin
@@ -25,8 +26,8 @@ def resolve_general_manager_type(
     """Return the single manager target represented by ``declared_type``.
 
     Concrete manager classes, supported collection annotations, optional
-    unions, and exact names in ``manager_registry`` are recognized. Ambiguous
-    annotations containing multiple manager targets return ``None``.
+    unions, and postponed string forms of those annotations are recognized.
+    Ambiguous annotations containing multiple manager targets return ``None``.
     """
     registry = manager_registry or {}
     resolved = _collect_general_manager_types(declared_type, registry, set())
@@ -52,7 +53,13 @@ def _collect_general_manager_types(
         declared_type = declared_type.__forward_arg__
     if isinstance(declared_type, str):
         manager_type = manager_registry.get(declared_type)
-        return {manager_type} if manager_type is not None else set()
+        if manager_type is not None:
+            return {manager_type}
+        return _collect_string_general_manager_types(
+            declared_type,
+            manager_registry,
+            set(),
+        )
 
     origin = get_origin(declared_type)
     if origin is None:
@@ -70,3 +77,96 @@ def _collect_general_manager_types(
             _collect_general_manager_types(argument, manager_registry, seen)
         )
     return manager_types
+
+
+_SUPPORTED_STRING_WRAPPERS = {
+    "Bucket",
+    "Optional",
+    "Union",
+    "list",
+    "set",
+    "tuple",
+}
+
+
+def _collect_string_general_manager_types(
+    annotation: str,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    seen: set[str],
+) -> set[type[GeneralManager]]:
+    expression = annotation.strip()
+    if not expression or expression in seen:
+        return set()
+    seen.add(expression)
+
+    try:
+        node = ast.parse(expression, mode="eval").body
+    except (SyntaxError, ValueError):
+        return set()
+    return _collect_annotation_node_manager_types(node, manager_registry, seen)
+
+
+def _collect_annotation_node_manager_types(
+    node: ast.expr,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    seen: set[str],
+) -> set[type[GeneralManager]]:
+    if isinstance(node, ast.Name):
+        manager_type = manager_registry.get(node.id)
+        return {manager_type} if manager_type is not None else set()
+
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, str):
+            return _collect_string_general_manager_types(
+                node.value,
+                manager_registry,
+                seen,
+            )
+        return set()
+
+    if isinstance(node, ast.Subscript):
+        wrapper_name = _annotation_node_name(node.value)
+        if wrapper_name is None or wrapper_name.rsplit(".", 1)[-1] not in (
+            _SUPPORTED_STRING_WRAPPERS
+        ):
+            return set()
+        return _collect_annotation_node_manager_types(
+            node.slice,
+            manager_registry,
+            seen,
+        )
+
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _collect_annotation_node_manager_types(
+            node.left,
+            manager_registry,
+            seen,
+        ) | _collect_annotation_node_manager_types(
+            node.right,
+            manager_registry,
+            seen,
+        )
+
+    if isinstance(node, ast.Tuple):
+        manager_types: set[type[GeneralManager]] = set()
+        for element in node.elts:
+            manager_types.update(
+                _collect_annotation_node_manager_types(
+                    element,
+                    manager_registry,
+                    seen,
+                )
+            )
+        return manager_types
+
+    return set()
+
+
+def _annotation_node_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent_name = _annotation_node_name(node.value)
+        if parent_name is not None:
+            return f"{parent_name}.{node.attr}"
+    return None

--- a/src/general_manager/api/graphql_relations.py
+++ b/src/general_manager/api/graphql_relations.py
@@ -25,9 +25,10 @@ def resolve_general_manager_type(
 ) -> type[GeneralManager] | None:
     """Return the single manager target represented by ``declared_type``.
 
-    Concrete manager classes, supported collection annotations, optional
-    unions, and postponed string forms of those annotations are recognized.
-    Ambiguous annotations containing multiple manager targets return ``None``.
+    Concrete manager classes, interface model classes carrying a manager
+    back-reference, supported collection annotations, optional unions, and
+    postponed string forms of those annotations are recognized. Ambiguous
+    annotations containing multiple manager targets return ``None``.
     """
     registry = manager_registry or {}
     resolved = _collect_general_manager_types(declared_type, registry, set())
@@ -48,6 +49,10 @@ def _collect_general_manager_types(
 
     if safe_issubclass(declared_type, GeneralManager):
         return {declared_type}
+
+    related_manager_type = getattr(declared_type, "_general_manager_class", None)
+    if safe_issubclass(related_manager_type, GeneralManager):
+        return {related_manager_type}
 
     if isinstance(declared_type, ForwardRef):
         declared_type = declared_type.__forward_arg__

--- a/src/general_manager/api/graphql_relations.py
+++ b/src/general_manager/api/graphql_relations.py
@@ -86,7 +86,10 @@ def _collect_general_manager_types(
 
 _SUPPORTED_STRING_WRAPPERS = {
     "Bucket",
+    "List",
     "Optional",
+    "Set",
+    "Tuple",
     "Union",
     "list",
     "set",

--- a/tests/integration/test_graphql_relation_filters.py
+++ b/tests/integration/test_graphql_relation_filters.py
@@ -27,7 +27,6 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
         class ChangeRequest(GeneralManager):
             title: str
             change_request_approval: ChangeRequestApproval
-            change_request_feasibility_list: Bucket[ChangeRequestFeasibility]
 
             class Interface(DatabaseInterface):
                 title = models.CharField(max_length=100)
@@ -202,11 +201,15 @@ class GraphQLRelationFilterIntegrationTests(GeneralManagerTransactionTestCase):
         self.assertEqual(fields.count("changeRequestFeasibilityList"), 1)
         self.assertNotIn("changerequestfeasibilityList", fields)
 
-    def test_reverse_relation_graphql_page_uses_related_manager_type(self):
+    def test_automatic_reverse_relation_graphql_page_uses_related_manager_type(self):
+        relation_info = self.ChangeRequest.Interface.get_attribute_types()[
+            "change_request_feasibility_list"
+        ]
         relation_field = GraphQL.graphql_type_registry["ChangeRequest"]._meta.fields[
             "change_request_feasibility_list"
         ]
 
+        self.assertIs(relation_info["type"], self.ChangeRequestFeasibility)
         self.assertEqual(
             relation_field.type._meta.fields["items"].type.of_type.of_type,
             GraphQL.graphql_type_registry["ChangeRequestFeasibility"],

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -366,6 +366,7 @@ class GraphQLTests(TestCase):
                 list[RelatedManager],
                 Bucket[RelatedManager],
                 "RelatedManager",
+                "Bucket[RelatedManager]",
             ):
                 field = GraphQL._map_field_to_graphene_read(
                     declared_type,

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -348,12 +348,15 @@ class GraphQLTests(TestCase):
         field = GraphQL._map_field_to_graphene_read(list[str], "labels")
         self.assertIsInstance(field, graphene.String)
 
-    def test_map_field_to_graphene_resolves_annotated_manager_relations(self):
+    def test_map_field_to_graphene_resolves_manager_relations(self):
         class RelatedManager(GeneralManager):
             pass
 
         class RelatedManagerType(graphene.ObjectType):
             name = graphene.String()
+
+        class RelatedModel:
+            _general_manager_class = RelatedManager
 
         GraphQL.manager_registry["RelatedManager"] = RelatedManager
         GraphQL.graphql_type_registry["RelatedManager"] = RelatedManagerType
@@ -365,6 +368,7 @@ class GraphQLTests(TestCase):
             for declared_type in (
                 list[RelatedManager],
                 Bucket[RelatedManager],
+                RelatedModel,
                 "RelatedManager",
                 "Bucket[RelatedManager]",
             ):

--- a/tests/unit/test_graphql_relations.py
+++ b/tests/unit/test_graphql_relations.py
@@ -24,6 +24,7 @@ def test_resolve_general_manager_type_handles_concrete_and_wrapped_managers() ->
         Bucket[PrimaryManager],
         PrimaryManager | None,
         "PrimaryManager",
+        "Bucket[PrimaryManager]",
     ):
         assert resolve_general_manager_type(declared_type, registry) is PrimaryManager
 
@@ -37,6 +38,7 @@ def test_resolve_general_manager_type_rejects_non_manager_and_unresolved_types()
         str,
         list[str],
         dict[str, PrimaryManager],
+        "dict[str, PrimaryManager]",
         "MissingManager",
     ):
         assert resolve_general_manager_type(declared_type, registry) is None
@@ -44,3 +46,14 @@ def test_resolve_general_manager_type_rejects_non_manager_and_unresolved_types()
 
 def test_resolve_general_manager_type_rejects_ambiguous_manager_union() -> None:
     assert resolve_general_manager_type(PrimaryManager | SecondaryManager, {}) is None
+    registry = {
+        "PrimaryManager": PrimaryManager,
+        "SecondaryManager": SecondaryManager,
+    }
+    assert (
+        resolve_general_manager_type(
+            "PrimaryManager | SecondaryManager",
+            registry,
+        )
+        is None
+    )

--- a/tests/unit/test_graphql_relations.py
+++ b/tests/unit/test_graphql_relations.py
@@ -18,8 +18,12 @@ class SecondaryManager(GeneralManager):
 def test_resolve_general_manager_type_handles_concrete_and_wrapped_managers() -> None:
     registry = {"PrimaryManager": PrimaryManager}
 
+    class PrimaryModel:
+        _general_manager_class = PrimaryManager
+
     for declared_type in (
         PrimaryManager,
+        PrimaryModel,
         list[PrimaryManager],
         tuple[PrimaryManager, ...],
         set[PrimaryManager],

--- a/tests/unit/test_graphql_relations.py
+++ b/tests/unit/test_graphql_relations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import ForwardRef
+
 from general_manager.api.graphql_relations import resolve_general_manager_type
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.manager.general_manager import GeneralManager
@@ -25,6 +27,10 @@ def test_resolve_general_manager_type_handles_concrete_and_wrapped_managers() ->
         PrimaryManager | None,
         "PrimaryManager",
         "Bucket[PrimaryManager]",
+        "Bucket['PrimaryManager']",
+        "tuple[PrimaryManager, ...]",
+        "typing.Optional[PrimaryManager]",
+        ForwardRef("Bucket[PrimaryManager]"),
     ):
         assert resolve_general_manager_type(declared_type, registry) is PrimaryManager
 
@@ -38,8 +44,13 @@ def test_resolve_general_manager_type_rejects_non_manager_and_unresolved_types()
         str,
         list[str],
         dict[str, PrimaryManager],
+        "",
+        "Bucket[",
+        "Bucket[42]",
+        "Bucket[lambda: PrimaryManager]",
         "dict[str, PrimaryManager]",
         "MissingManager",
+        "typing().Bucket[PrimaryManager]",
     ):
         assert resolve_general_manager_type(declared_type, registry) is None
 

--- a/tests/unit/test_graphql_relations.py
+++ b/tests/unit/test_graphql_relations.py
@@ -33,7 +33,10 @@ def test_resolve_general_manager_type_handles_concrete_and_wrapped_managers() ->
         "Bucket[PrimaryManager]",
         "Bucket['PrimaryManager']",
         "tuple[PrimaryManager, ...]",
+        "typing.List[PrimaryManager]",
         "typing.Optional[PrimaryManager]",
+        "typing.Set[PrimaryManager]",
+        "typing.Tuple[PrimaryManager, ...]",
         ForwardRef("Bucket[PrimaryManager]"),
     ):
         assert resolve_general_manager_type(declared_type, registry) is PrimaryManager


### PR DESCRIPTION
## Summary

- resolve automatic relation types from `Interface.get_attribute_types()` even when metadata contains the related model class
- follow the model's framework-owned `_general_manager_class` back-reference before GraphQL scalar mapping
- support postponed composite annotations as a fallback, without requiring type hints for generated relations

## Root cause

GraphQL already reads relation metadata from `Interface.get_attribute_types()`. A generated or cached ORM descriptor can expose its related model class there. Although that model carries `_general_manager_class` and the runtime accessor returns a manager-backed bucket, the GraphQL relation normalizer did not follow the back-reference. The model class therefore fell through to Graphene's `String` mapper.

The resolver now recognizes both the manager class and interface model metadata. The reverse-relation integration fixture intentionally has no collection type hint and asserts both the interface metadata and generated GraphQL page type.

Postponed annotations remain supported as an independent fallback; annotation strings are parsed but never evaluated.

Closes #406

## Validation

- `python -m pytest -q` — 5,092 passed, 2 skipped
- `ruff format --check .`
- `ruff check .`
- `mypy src`
- `pre-commit run --all-files`
