### PR TITLE
docs: document GraphQL relation annotation compatibility

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -62,6 +62,38 @@ flushed; if flushing also raises, both failures are reported in a
 in 0.64.0 and later; the notification batching module is an implementation
 location rather than a separate package-level compatibility promise.
 
+## Relation annotation compatibility
+
+Generated GraphQL relation fields resolve annotations to one registered
+`GeneralManager` class before generating the schema. The supported annotation
+shapes are:
+
+- a manager class, a generated/existing Django model class with its manager
+  back-reference, or a named postponed reference such as `"User"`;
+- `Bucket[User]`, `list[User]`, `tuple[User, ...]`, `set[User]`, and their
+  `typing` spellings; and
+- `User | None`, `Optional[User]`, and equivalent postponed string forms such
+  as `"Bucket[User]"` or `"typing.List[User]"`.
+
+The resolved type is used for object fields, paginated relation-list fields,
+nested relation filters, mutation relation inputs, sort options, and
+subscription identifiers. If a postponed name is not registered, or a union
+contains more than one manager target, the annotation is not recognized as a
+manager relation and the generated schema does not provide manager-relation
+behavior for that field. The resolver returns the single manager target when
+recognized and otherwise no manager target; it does not raise a framework
+exception for an unresolved or ambiguous annotation.
+
+The helper that performs this resolution is an implementation detail, not a
+stable import. Applications should declare manager annotations and consume the
+generated schema rather than importing the helper directly.
+
+This compatibility behavior is covered by the 0.64.1 and 0.64.2 GraphQL
+relation fixes. The [concept guide](../concepts/graphql/schema_autogen.md#relation-annotation-compatibility)
+explains the model, the [task guide](../howto/expose_via_graphql.md#declare-manager-relations)
+shows declaration patterns, and the [cookbook recipe](../examples/graphql_queries.md#query-a-manager-relation)
+shows directly usable queries.
+
 ## File uploads
 
 Use the lazy stable imports from `general_manager.api`; modules under

--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -18,6 +18,33 @@ Single-valued manager relations are exposed as object fields. Relation fields
 whose Python-side name ends with `_list` are exposed as paginated list fields
 with filtering, grouping, sorting, and pagination arguments.
 
+### Relation annotation compatibility
+
+Before mapping a relation, schema generation resolves its annotation to one
+registered `GeneralManager` class. The resolver accepts:
+
+- a concrete manager class such as `User`;
+- a generated or existing Django model class that carries the manager
+  back-reference;
+- `Bucket[User]`, `list[User]`, `tuple[User, ...]`, or `set[User]`; and
+- optional and union forms such as `User | None`, `Optional[User]`, and their
+  postponed string equivalents, including `"Bucket[User]"` and
+  `"typing.List[User]"`.
+
+This lets annotations remain useful with `from __future__ import annotations`
+and with manager classes declared in a different order. A postponed annotation
+must name a manager that GeneralManager registers during startup. An ambiguous
+union containing more than one manager target is not treated as a manager
+relation, so use one manager target per generated relation field.
+
+The same resolution controls generated object fields, relation-list fields,
+relation filters, sort options, mutation inputs, and subscription identifiers.
+For a task-oriented declaration pattern, see [Expose managers via
+GraphQL](../../howto/expose_via_graphql.md#declare-manager-relations); the
+[GraphQL query cookbook](../../examples/graphql_queries.md#query-a-manager-relation)
+shows the resulting schema, and the [GraphQL API reference](../../api/graphql.md#relation-annotation-compatibility)
+records the compatibility note for 0.64.1 and 0.64.2.
+
 ## Mutations
 
 Create, update, and delete mutations are added automatically when the interface

--- a/docs/examples/graphql_queries.md
+++ b/docs/examples/graphql_queries.md
@@ -33,6 +33,43 @@ query ProjectWithDerivatives($id: Int!) {
 }
 ```
 
+## Query a manager relation
+
+For a manager declaration such as `owner: User | None` and
+`reviewer_list: Bucket[User]`, generated GraphQL exposes an object field and a
+paginated relation-list field. Query both fields directly:
+
+```graphql
+query ProjectRelations($projectId: ID!) {
+  project(id: $projectId) {
+    owner { id name }
+    reviewerList(page: 1, pageSize: 20) {
+      items { id name }
+      pageInfo { totalCount currentPage totalPages pageSize }
+    }
+  }
+}
+```
+
+Nested relation filters use the same resolved manager type. A direct relation
+uses a nested object, while a collection relation uses `any` or `none`:
+
+```graphql
+query ProjectsWithRelatedUsers {
+  projectList(filter: {
+    owner: { name: "Alice" }
+    reviewerList: { any: { name: "Alice" } }
+  }) {
+    items { id name owner { id name } }
+  }
+}
+```
+
+For the Python annotation forms and the generated mutation/subscription
+contracts, see the [GraphQL concept guide](../concepts/graphql/schema_autogen.md#relation-annotation-compatibility),
+the [task guide](../howto/expose_via_graphql.md#declare-manager-relations), and
+the [API reference](../api/graphql.md#relation-annotation-compatibility).
+
 ## Custom mutation with Measurement input
 
 ```graphql

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -12,26 +12,49 @@ annotations` is enabled:
 ```python
 from __future__ import annotations
 
+from django.db import models
+
 from general_manager import GeneralManager
 from general_manager.bucket import Bucket
+from general_manager.interface import DatabaseInterface
 
 
 class User(GeneralManager):
     name: str
 
+    class Interface(DatabaseInterface):
+        name = models.CharField(max_length=100)
+
 
 class Project(GeneralManager):
     owner: User | None
     reviewer_list: Bucket[User]
+
+    class Interface(DatabaseInterface):
+        owner = models.ForeignKey(
+            User.Interface._model,
+            on_delete=models.SET_NULL,
+            null=True,
+            blank=True,
+        )
+        reviewer = models.ManyToManyField(User.Interface._model, blank=True)
+
+
+attribute_types = Project.Interface.get_attribute_types()
+assert attribute_types["owner"]["type"] is User
+assert attribute_types["reviewer_list"]["type"] is User
 ```
 
-When the schema is built, `owner` becomes a single `User` object field and
-`reviewer_list` becomes a paginated relation-list field. The same manager target
-is used for nested relation filters, mutation relation inputs, and subscription
-identifiers. `list[User]`, `tuple[User, ...]`, `set[User]`, `Optional[User]`,
-`"User"`, and `"Bucket[User]"` are also supported. Keep one manager target in a
-relation annotation; a union such as `User | Team` is ambiguous and does not
-produce manager-relation behavior.
+`DatabaseInterface` registers both managers and derives relation metadata from
+the Django fields: `owner` maps directly to the foreign key, while the
+`reviewer` many-to-many field is exposed as `reviewer_list`. When the schema is
+built, `owner` becomes a single `User` object field and `reviewer_list` becomes
+a paginated relation-list field. The same manager target is used for nested
+relation filters, mutation relation inputs, and subscription identifiers.
+`list[User]`, `tuple[User, ...]`, `set[User]`, `Optional[User]`, `"User"`, and
+`"Bucket[User]"` are also supported. Keep one manager target in a relation
+annotation; a union such as `User | Team` is ambiguous and does not produce
+manager-relation behavior.
 
 For existing or generated Django models, GeneralManager uses the model's
 manager back-reference to recover the corresponding manager type. Register

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -2,6 +2,43 @@
 
 Managers with an `Interface` are registered during GeneralManager startup and receive generated query, mutation, and subscription fields based on their interface capabilities.
 
+## Declare manager relations
+
+Annotate related fields with the manager class that should appear in generated
+GraphQL. GeneralManager also recognizes collection wrappers, optional values,
+and postponed annotations, so this pattern works when `from __future__ import
+annotations` is enabled:
+
+```python
+from __future__ import annotations
+
+from general_manager import GeneralManager
+from general_manager.bucket import Bucket
+
+
+class User(GeneralManager):
+    name: str
+
+
+class Project(GeneralManager):
+    owner: User | None
+    reviewer_list: Bucket[User]
+```
+
+When the schema is built, `owner` becomes a single `User` object field and
+`reviewer_list` becomes a paginated relation-list field. The same manager target
+is used for nested relation filters, mutation relation inputs, and subscription
+identifiers. `list[User]`, `tuple[User, ...]`, `set[User]`, `Optional[User]`,
+`"User"`, and `"Bucket[User]"` are also supported. Keep one manager target in a
+relation annotation; a union such as `User | Team` is ambiguous and does not
+produce manager-relation behavior.
+
+For existing or generated Django models, GeneralManager uses the model's
+manager back-reference to recover the corresponding manager type. Register
+manager modules during startup as described in the [installation
+guide](../installation.md), and then use the generated field names in queries,
+mutations, and subscriptions.
+
 ## Filter by identifier
 
 Identifier equality filters (`id`, `id_Exact`, and `id_In`) use the GraphQL


### PR DESCRIPTION
## Summary

Document the public GraphQL relation-annotation behavior fixed in the reviewed 0.64.1 and 0.64.2 commits.

## Review window and commits

Review window: 2026-07-16T04:01:40Z through 2026-07-17T04:01:40Z. All commits below are reachable from `origin/main` after fetching origin:

- `3f7588867fc83c3f5ee47fe9cf061b06ebef56c2` — preserve GraphQL manager relation types
- `76ba33397a27a5f76c7cd434283950b974373d9e` — resolve named GraphQL relations consistently
- `bb3cb15cc7c0e5abec656051de2e45161fb1ada6` — release 0.64.1
- `feffdba65fdf6bdb232463aa7c2037c6a0399b9b` — cover seven-day public API changes
- `24b97141332256ae6c31baadc4c1eaf1fda1de2f` — address API audit review feedback
- `5035d56e3261d6c9bb4d026e659c739c15ee5796` — fix existing model write example
- `6e7f0521c16be8014bb6d145c9ea1edc7f4456d1` — resolve postponed GraphQL relation annotations
- `cabe0bceef8edcf099777a3ce4186ae177849107` — cover postponed GraphQL relation parsing
- `ea4bf100bac9e675a8d5ab05ffd9b7141357c1bf` — resolve generated GraphQL relation types
- `3adf9a20c08d6cae0e52ad39a53487efeb6b9298` — support typing collection relation wrappers
- `06c8b5019375d852540506fe2e42b0fc832b4b37` — release 0.64.2
- `69ea5873fc7e2a4ca87d97987a0b24004cfb418d` — rewrite README onboarding
- `2a4c3b599627175c033455c58eafe9fbcfb8a7c2` — refresh installation guidance
- `2545dc75dcc2a7e247e0704f05a74737aaa40a1f` — add pull request template
- `4ba1d2325b915e43bb34d3aa78067c252d79e02f` — clarify release channel wording
- `fb6e949e08fdee408c7b605572c145983cb47297` — use non-mutating Ruff format check
- `22d430dbcc96a7bf59bac555f7a515b38ed14b65` — document bulk notification API

## Affected public API

- Generated GraphQL manager relations now consistently resolve concrete managers, generated/existing model back-references, collection wrappers, optional/union forms, and postponed string annotations.
- The resolved manager type drives generated object fields, relation-list fields, nested filters, mutation inputs, sort options, and subscription identifiers.
- No new stable Python export was added; the relation resolver remains an internal implementation helper.
- The bulk notification API already had all four required documentation forms in the reviewed tip, so no duplicate changes were made for it.
- The release/doc-only commits did not introduce additional undocumented public API behavior; existing four-form coverage was verified for the Rule, upload, ORM, GraphQL error, and onboarding surfaces they touched.

## Documentation updated

- `docs/concepts/graphql/schema_autogen.md` — relation model and supported annotation forms.
- `docs/howto/expose_via_graphql.md` — declaration workflow and compatibility guidance.
- `docs/examples/graphql_queries.md` — directly usable relation fields and filters.
- `docs/api/graphql.md` — compatibility contract, behavior, and internal-helper boundary.

## Validation

- `python -m pytest tests/docs/test_public_api_docs_coverage.py tests/unit/test_public_api_init_modules.py -q` — 290 passed.
- `python -m pytest tests/unit/test_graphql_relations.py tests/integration/test_graphql_relation_filters.py -q` — 16 passed.
- `mkdocs build --strict` — completed successfully; only existing unnav-linked planning/ADR files were reported.
- `pre-commit run --files docs/api/graphql.md docs/concepts/graphql/schema_autogen.md docs/examples/graphql_queries.md docs/howto/expose_via_graphql.md` — passed; Python-only hooks skipped as expected.
- Both new GraphQL cookbook snippets parsed successfully with graphql-core.
- `git diff --check` — passed.

## Limitations

The docs describe the generated schema contract rather than exposing the internal relation-resolution helper as a stable import. Ambiguous unions with multiple manager targets remain unsupported by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on declaring manager relations for GraphQL schemas.
  * Documented supported relation annotations, including optional and collection forms.
  * Explained how relations appear in queries, mutations, subscriptions, filters, and sorting.
  * Added examples for querying object and paginated relation-list fields.
  * Clarified behavior for unresolved, postponed, and ambiguous annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->