### PR TITLE
fix: preserve generated GraphQL relation type hints

### DIFF
--- a/src/general_manager/api/property.py
+++ b/src/general_manager/api/property.py
@@ -214,9 +214,10 @@ class GraphQLProperty(property):
         return self._cached_fget
 
     def _try_resolve_type_hint(self) -> None:
-        """Resolve and cache the wrapped resolver's return type hint.
+        """Resolve and cache the original resolver's return type hint.
 
-        Resolution uses the resolver module globals and owner class namespace.
+        Resolution uses the original resolver rather than the property wrapper,
+        along with its module globals and the owner class namespace.
         It runs on first `graphql_type_hint` access, not during descriptor
         construction. `AttributeError`, `KeyError`, `NameError`, `TypeError`,
         and `ValueError` from `typing.get_type_hints` are swallowed and cached
@@ -227,7 +228,8 @@ class GraphQLProperty(property):
             return
 
         try:
-            mod = sys.modules.get(self.fget.__module__)
+            resolver = getattr(self._raw_fget, "__wrapped__", self._raw_fget)
+            mod = sys.modules.get(resolver.__module__)
             globalns = vars(mod) if mod else {}
 
             localns: dict[str, object] = {}
@@ -235,7 +237,7 @@ class GraphQLProperty(property):
                 localns = dict(self._owner.__dict__)
                 localns[self._owner.__name__] = self._owner
 
-            hints = get_type_hints(self.fget, globalns=globalns, localns=localns)
+            hints = get_type_hints(resolver, globalns=globalns, localns=localns)
             self._graphql_type_hint = hints.get("return", None)
         except (AttributeError, KeyError, NameError, TypeError, ValueError):
             self._graphql_type_hint = None

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -72,6 +72,18 @@ class GraphQLPropertyTests(TestCase):
         prop = GraphQLProperty(mock_getter)
         self.assertEqual(prop.graphql_type_hint, str)
 
+    def test_graphql_property_reads_dynamic_annotation_from_original_resolver(self):
+        """Generated relation annotations survive wrapper metadata changes."""
+
+        def generated_relation(_instance):
+            return None
+
+        generated_relation.__annotations__ = {"return": GeneralManager}
+        prop = GraphQLProperty(generated_relation)
+        prop.fget.__annotations__ = {}
+
+        self.assertIs(prop.graphql_type_hint, GeneralManager)
+
     def test_graphql_property_uses_cached_resolver_after_set_name(self):
         """Descriptor access should not redo cached resolver lookup after setup."""
         calls = []


### PR DESCRIPTION
## Summary

Preserve framework-generated reverse relation type hints on Python 3.14 so GraphQL maps them to their `GeneralManager` page type instead of `String`.

## Related issue

Follow-up to #406 and #407.

## What changed

- Resolve `GraphQLProperty` return annotations from the original resolver rather than its internal property wrapper.
- Add a regression test for dynamically assigned manager return annotations when wrapper annotation metadata is absent, matching Python 3.14 behavior.

## Validation

```text
python -m pytest tests/unit/test_graph_ql.py tests/unit/test_graphql_relations.py -q — 83 passed
python -m pytest -q — 5093 passed, 2 skipped, 1874 subtests passed
ruff check src/general_manager/api/property.py tests/unit/test_graph_ql.py — passed
ruff format --check src/general_manager/api/property.py tests/unit/test_graph_ql.py — passed
mypy src/general_manager — passed, 268 source files
KnowledgeHub origin/main devcontainer with GeneralManager 0.64.2 — reproduced String before the fix; DerivativeConstelliumPage after the fix
KnowledgeHub with the user-declared derivative_constellium_list annotation removed — generated relation still resolves to DerivativeConstelliumPage
```

## Documentation

Not applicable. This restores the documented manager relation behavior and does not change the public API.

## Reviewer notes

Python 3.14 changed `functools.WRAPPER_ASSIGNMENTS` to copy `__annotate__` instead of `__annotations__`. GeneralManager assigns the concrete related manager dynamically to the generated resolver's `__annotations__`; the internal `GraphQLProperty` wrapper therefore lost that metadata on Python 3.14 and cached a `None` type hint. Reading the original resolver is also consistent with constructor validation and avoids depending on wrapper metadata.

The change is rebased onto current `main` and contains no KnowledgeHub files or ignored files.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [ ] User-facing documentation is updated where behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL type-hint detection for properties whose return annotations are defined on the original resolver.
  * Preserved correct type resolution when property-level annotations are unavailable or modified.

* **Tests**
  * Added coverage verifying dynamic annotations are correctly resolved from the original resolver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->