### PR TITLE
docs: add search invalidation cookbook

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -18,5 +18,6 @@ The cookbook collects self-contained snippets that demonstrate how to solve doma
 - [Request interface end-to-end](request_interface_end_to_end.md)
 - [Remote manager interface end-to-end](remote_manager_interface_end_to_end.md)
 - [Startup hooks with custom ordering](startup_hooks.md)
+- [Related search invalidation](search_invalidation.md)
 
 Contributions are welcome—add your own recipes as your project evolves.

--- a/docs/examples/search_invalidation.md
+++ b/docs/examples/search_invalidation.md
@@ -1,0 +1,106 @@
+# Related search invalidation
+
+Use a `SearchInvalidationRule` when a search document includes data owned by a
+different manager. The rule belongs on the manager that owns the document. This
+recipe updates projects when their customer changes and when an investment
+number is added to or removed from the project's many-to-many relation.
+
+## Declare the rules
+
+Assume `Customer` and `InvestNumber` are existing ORM-backed managers:
+
+```python
+from general_manager import (
+    GeneralManager,
+    IndexConfig,
+    SearchChange,
+    SearchInvalidationRule,
+)
+from myapp.managers import Customer, InvestNumber
+
+
+def projects_for_customer(
+    change: SearchChange,
+    owner_class: type[GeneralManager],
+):
+    # The source still exists during the before phase of an update or delete.
+    return owner_class.filter(customer=change.instance)
+
+
+def projects_for_investment(
+    change: SearchChange,
+    owner_class: type[GeneralManager],
+):
+    return owner_class.filter(invest_numbers=change.instance)
+
+
+class Project(GeneralManager):
+    class SearchConfig:
+        indexes = (
+            IndexConfig(
+                name="global",
+                fields=("name", "customer__name", "invest_numbers__name"),
+                filters=("status",),
+                sorts=("name",),
+            ),
+        )
+        invalidation_rules = (
+            SearchInvalidationRule(
+                source=Customer,
+                resolve=projects_for_customer,
+                indexes=("global",),
+            ),
+            SearchInvalidationRule(
+                source=InvestNumber,
+                resolve=projects_for_investment,
+                relation="invest_numbers",
+                indexes=("global",),
+            ),
+        )
+```
+
+`SearchChange` is frozen and provides `action`, `phase`, `instance`, and
+`database_alias`. Create resolves after the source exists, update resolves
+before and after, and delete resolves before deletion. Each resolver must yield
+`Project` manager instances; yielding identifiers, ORM model instances, or a
+different manager type switches that rule to dirty-index reconciliation.
+
+Use a dotted string such as
+`"myapp.managers.Customer"` for `source` when it avoids an import cycle. Omit
+`indexes` to select every configured project index. Set `resolve=None` when
+individual targets cannot be discovered and the selected index pairs should
+always be repaired by reconciliation.
+
+The `relation` value is the owner-side many-to-many field. It enables exact
+invalidation for related-manager `add()`, `remove()`, `clear()`, and `set()` in
+both directions, including custom through models. The owner must use exactly
+the standard `{"id": pk}` identification, and both through foreign keys must
+target their endpoint primary keys. Direct through-model writes, raw SQL, bulk
+writes, and self-symmetrical relations are unsupported.
+
+## Bound and repair the work
+
+Configure bounds for resolver results and task payloads:
+
+```python
+GENERAL_MANAGER = {
+    **GENERAL_MANAGER,
+    "SEARCH_INVALIDATION_MAX_TARGETS": 1000,
+    "SEARCH_INVALIDATION_BATCH_SIZE": 100,
+}
+```
+
+Both settings must be positive, non-boolean integers. Resolver errors, invalid
+targets, and target overflow discard partial targeted work and leave the exact
+owner/index pairs dirty. Run reconciliation after unsupported writes or when a
+fallback needs repair:
+
+```bash
+python manage.py search_reconcile --once
+```
+
+Apply migration `0011_search_index_state_dirty_generation` before deploying
+lifecycle invalidation workers. Search dispatch is commit-bound, but a
+non-default source database still has a documented crash window between the
+source commit and the control-plane callback; periodic reconciliation remains
+the repair path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,7 @@ nav:
       - examples/startup_hooks.md
       - examples/remote_manager_interface_end_to_end.md
       - examples/request_interface_end_to_end.md
+      - examples/search_invalidation.md
   - API-Reference:
       - api/core.md
       - api/chat.md


### PR DESCRIPTION
## Summary

Add the missing cookbook documentation form for the public search invalidation contract. The concept, how-to, and API-reference forms already existed on `origin/main`; this PR adds a directly usable recipe and wires it into both cookbook navigation locations.

## Review window and commits

Review window: 2026-07-18T04:01:51Z through 2026-07-19T04:01:51Z. All commits below were reviewed after fetching `origin` and are reachable from `origin/main`:

- `86108005ca0255854259d38cee62fd493ed866ec` — fence search reconciliation generations
- `964258d27613514ae1043b4af5426c7f677df484` — wrap ORM data changes in commit-safe signals
- `7400688d0298fc89581118f38aa5c936e49f9414` — defer search lifecycle dispatch until commit
- `f86dec224f2eeb6c0ab5b7b1c9d84de2c0169bc0` — add declarative search invalidation rules
- `13a75ff402244d10c5b34c3fb6b06d2035b64e89` — resolve related search invalidation targets
- `9b78857a632893a2574cacc7d97330c44deaa9de` — add exact-index search batch tasks
- `d92012d4049b307b9c7af0b192e58e01090a7dd6` — dispatch bounded search invalidation batches
- `b08483c008a6ac73752ef91df2c26c12cf3bc966` — preserve commit-safe ORM mutation behavior
- `243082831cecec24182be9d2722e1972e7926f96` — bridge many-to-many search invalidation
- `e16099fe2ef3b57853fe353307c751dd3cf31e27` — document related search invalidation
- `1cb0bfbd70271acc8e65c22b89fd30ec27a126f5` — recover search invalidation failures
- `dee3e2c82e61a3926885bd305d0125fc97ca7aae` — keep transaction ownership context-local
- `b95c83770a7570ded3487f2d3f09d4c3cf206bf0` — preserve update invalidation fallback
- `f8e0b84c1131d19fbf5333402b8b1537fc2c819e` — preserve search invalidation recovery
- `ad67ea4cab178271dd7d294f6b2f9903e8fbbe10` — linearize search migration ordering
- `a2125a1aa9df41ba43fb12cdfcbce8b7c003eaf5` — reuse canonical manager import path
- `54f452e8009a85f48a30c8391ff5a56d3741b271` — preserve configured secondary database aliases
- `ace6893b589d8103dc3d336eaa053cf003ad27b0` — scope SQLite upload transaction cases
- `78c7b1bb657de614083eb8be4c15a27968433b5a` — release 0.65.0

## Affected public APIs

- New stable exports `SearchChange` and `SearchInvalidationRule`, re-exported from `general_manager` and `general_manager.search`.
- `SearchConfigSpec.invalidation_rules` and the corresponding `SearchConfigProtocol` contract.
- Related search invalidation behavior, including resolver phases, bounded targeting, owner-side M2M relations, and reconciliation fallback.

## Documentation changed

- `docs/examples/search_invalidation.md` — new cookbook recipe covering resolver callbacks, M2M `relation`, settings bounds, and repair.
- `docs/examples/index.md` — cookbook index link.
- `mkdocs.yml` — explicit navigation entry.

## Validation

- `python -m pytest tests/docs/test_public_api_docs_coverage.py -q` — 4 passed.
- `python -m mkdocs build --strict --site-dir /tmp/general-manager-docs-review-20260719-final` — passed; only existing unnav-linked planning/ADR notices remained.
- Python AST parsing of both cookbook code blocks — parsed 2 blocks.
- `pre-commit run --files docs/examples/search_invalidation.md docs/examples/index.md mkdocs.yml` — passed; Python-only hooks skipped because only documentation/YAML files changed.
- `git diff --check` — passed.

Open PRs #409 and #411 were inspected before editing; neither overlaps this search-invalidation documentation scope.

## Limitations

The recipe assumes the application already has ORM-backed `Customer`, `Project`, and `InvestNumber` managers plus the `Project.Interface` relation metadata. It documents the public contract without changing application behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a cookbook guide for configuring search invalidation when indexed documents depend on related data.
  * Documented resolver behavior, relationship handling, operational limits, overflow scenarios, reconciliation, and deployment requirements.
  * Added the guide to the examples index and site navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->