### PR TITLE
docs: document GraphQL calculation input filters

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -150,6 +150,36 @@ explains the model, the [task guide](../howto/expose_via_graphql.md#declare-mana
 shows declaration patterns, and the [cookbook recipe](../examples/graphql_queries.md#query-a-manager-relation)
 shows directly usable queries.
 
+## Manager-typed calculation input filters
+
+`GraphQL.create_graphql_interface(manager: type[GeneralManager])` generates a
+direct nested relation filter for a calculation input declared with
+`Input(RelatedManager)`, even though calculation `get_attribute_types()` rows
+do not include `relation_kind` or `filter_lookup`. A list query can therefore
+use:
+
+```graphql
+query ProjectCommercials($projectId: ID!) {
+  projectCommercialList(filter: {project: {id: $projectId}}) {
+    items { project { id } targetDate }
+  }
+}
+```
+
+The resolver returns the equivalent backend plan
+`{"filter": {"project__id": 42}, "exclude": {}}` when the variable is `42`.
+Nested fields and lookups are prefixed in the same way. The generated input is
+subject to `GRAPHQL_FILTER_RELATION_DEPTH`; when the depth is exhausted or the
+input type is not a registered manager, the nested relation field is omitted.
+Explicit `relation_kind` and `filter_lookup` metadata remains authoritative,
+including custom prefixes. Invalid nested values continue through the existing
+GraphQL input and bucket error paths; no new framework exception is introduced.
+
+The [calculation concept guide](../concepts/interfaces/computed_data_interfaces.md#iterating-combinations)
+explains the model, the [task guide](../howto/expose_via_graphql.md#filter-calculation-managers-by-manager-input)
+shows the declaration, and the [cookbook recipe](../examples/graphql_queries.md#filter-a-calculation-by-manager-input)
+provides a directly usable request.
+
 ## File uploads
 
 Use the lazy stable imports from `general_manager.api`; modules under

--- a/docs/concepts/interfaces/computed_data_interfaces.md
+++ b/docs/concepts/interfaces/computed_data_interfaces.md
@@ -118,6 +118,13 @@ query ProjectCommercials($projectId: ID!) {
 The resolver normalizes this filter to the Python lookup
 `project__id=<projectId>`.
 
+This inference applies when calculation metadata does not already describe the
+field as a relation; explicit relation metadata remains authoritative. For the
+declaration and query workflow, see [Filter calculation managers by manager
+input](../../howto/expose_via_graphql.md#filter-calculation-managers-by-manager-input),
+the [calculation filter recipe](../../examples/graphql_queries.md#filter-a-calculation-by-manager-input),
+and the [GraphQL API compatibility note](../../api/graphql.md#manager-typed-calculation-input-filters).
+
 Because calculation managers do not persist data, `create`, `update`, and `delete` are unavailable. They still participate in dependency tracking when a property opts into dependency-aware caching.
 
 ## Input helpers

--- a/docs/examples/graphql_queries.md
+++ b/docs/examples/graphql_queries.md
@@ -70,6 +70,33 @@ contracts, see the [GraphQL concept guide](../concepts/graphql/schema_autogen.md
 the [task guide](../howto/expose_via_graphql.md#declare-manager-relations), and
 the [API reference](../api/graphql.md#relation-annotation-compatibility).
 
+## Filter a calculation by manager input
+
+For a calculation manager with `project = Input(Project)`, use the same nested
+direct-relation shape as a persisted manager:
+
+```graphql
+query ProjectCommercials($projectId: ID!) {
+  projectCommercialList(filter: {project: {id: $projectId}}) {
+    items {
+      project { id name }
+      targetDate
+    }
+  }
+}
+```
+
+```json
+{"projectId": 42}
+```
+
+The generated filter is directly usable with a normal GraphQL request. The
+server translates `project: {id: ...}` to the calculation lookup
+`project__id=...`; replace `id` with a supported nested field or lookup when
+needed. See the [calculation how-to](../howto/expose_via_graphql.md#filter-calculation-managers-by-manager-input)
+and [API reference](../api/graphql.md#manager-typed-calculation-input-filters) for
+the declaration and compatibility rules.
+
 ## Custom mutation with Measurement input
 
 ```graphql

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -68,6 +68,46 @@ Identifier equality filters (`id`, `id_Exact`, and `id_In`) use the GraphQL
 `ID` scalar, matching detail-query arguments. Ordered comparisons such as
 `id_Gt` retain the identifier's underlying numeric scalar when available.
 
+## Filter calculation managers by manager input
+
+Calculation managers expose manager-typed `Input(...)` fields as direct nested
+GraphQL relation filters. For example, this calculation accepts a `Project`
+manager input:
+
+```python
+from datetime import date
+
+from general_manager.interface import CalculationInterface
+from general_manager.manager import GeneralManager, Input
+from myapp.managers import Project
+
+
+class ProjectCommercial(GeneralManager):
+    class Interface(CalculationInterface):
+        project = Input(Project)
+        target_date = Input(date)
+```
+
+Filter the generated list field with the nested manager's fields:
+
+```graphql
+query ProjectCommercials($projectId: ID!) {
+  projectCommercialList(filter: {project: {id: $projectId}}) {
+    items {
+      project { id name }
+      targetDate
+    }
+  }
+}
+```
+
+The GraphQL resolver flattens the nested input to the Python lookup
+`project__id=<projectId>` before calling the calculation bucket. Nested manager
+lookups such as `{project: {name__startswith: "North"}}` are flattened in the
+same way. This behavior applies when the calculation input metadata omits
+relation descriptors; explicitly declared relation metadata and custom lookup
+prefixes remain authoritative.
+
 ## Use measurements and large integers
 
 Interface fields typed as `Measurement` are exposed with `MeasurementScalar` for


### PR DESCRIPTION
## Summary

Documents the public GraphQL behavior added by `bd5d2ff5`: calculation managers with manager-typed `Input(...)` fields now expose nested direct-relation filters and normalize them to the corresponding Python lookup prefix.

## Reviewed commits

All commits reachable from `origin/main` with committer timestamps in the 2026-07-20T04:02:13Z–2026-07-21T04:02:13Z rolling window:

- `3dc87c1b4f321576cff4321dcb229a9a81241137`
- `a55b1c2ed4cae4e8eddea217195fe069487b4de7`
- `8b726eb0729f596945cbc1d7d92e9138f50470f5`
- `bd5d2ff5d6542566aba81252a1a862b1d3a7b4a`
- `391876c151deb4cf90e2e9326f5a173e56b7876f`
- `cd1b85526825fb424607fc34a16620fa26202e8e`
- `bafb331cebb727ba03acd434509133db32efdabf`
- `1df45ef971cab449233da277b799e84df782f613`
- `6358cbaf8a4297a904217824d346a95a7c7d5415`
- `ac5795f28d6e23652f79a0e385e83a10f8fba908`
- `927ee14ad828c4d449dac7ab4cb969f88f301a40`
- `05d7da094fdb487ec84d817b1c4db8f9ae91a231`
- `207ead323aab2a0e9d17aec61a7812fde1f27341`
- `66e105815bcdeef85cd315af774eab65a87fdcd3`

## Affected public API

- Generated GraphQL list filters for calculation managers with manager-typed inputs, such as `filter: {project: {id: $projectId}}`.
- Normalization to `project__id` (and equivalent nested lookup prefixes).
- Explicit relation metadata and custom `filter_lookup` values remain authoritative.
- Relation-depth and existing GraphQL/bucket error behavior remain unchanged.

## Documentation changes

- `docs/concepts/interfaces/computed_data_interfaces.md`
- `docs/howto/expose_via_graphql.md`
- `docs/examples/graphql_queries.md`
- `docs/api/graphql.md`

## Validation

- `python -m pytest tests/docs/test_public_api_docs_coverage.py -q` — 4 passed.
- `python -m pytest tests/unit/test_graph_ql.py tests/integration/test_graphql_calculation_input_options.py -q` — 97 passed.
- `python -m mkdocs build --strict --site-dir /tmp/general-manager-docs-review-20260721` — passed.
- 12 GraphQL fenced examples parsed successfully with the GraphQL parser.
- `ruff check src tests` — passed.
- `ruff format --check src tests` — passed.
- `mypy src` — passed.
- File-scoped pre-commit hooks and `git diff --check` — passed.

MkDocs emitted only the repository's existing notices for unnav-linked planning/ADR files. No application behavior was changed, and the full test suite was not rerun because this branch changes documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for filtering GraphQL calculation lists using manager-typed `Input(...)` fields with nested relation-style inputs.
  * Included worked Python and GraphQL examples, including variables payloads.
  * Explained how nested inputs are translated into backend lookup filters (e.g., `project__id`).
  * Clarified precedence rules for explicit relation/filter metadata and the effect of relation-depth limits.
  * Documented behavior for invalid nested values and added links to related guides and recipes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->