### PR TITLE
feat: support dotted custom error message placeholders

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -691,10 +691,12 @@ evaluation returns `None`.
 `custom_error_message` may be static or contain optional placeholders for any
 subset of predicate variables, such as `{project.name}`. Placeholders support
 only dot-separated Python identifiers; they read attributes and do not call
-methods. Syntax and predicate roots are validated at `Rule` construction, and
-dotted paths are validated against manager schemas during shared manager
-startup. Invalid syntax, unrelated roots, and unknown or non-traversable paths
-raise `InvalidErrorTemplateError`. Calls, indexes, conversions, format
+methods. Syntax and predicate roots are validated at `Rule` construction.
+Dotted paths are validated against manager schemas during shared manager
+startup for normal application managers. Late-created managers validate on
+their first eligible public use after app readiness, before CRUD or field
+evaluation. Invalid syntax, unrelated roots, and unknown or non-traversable
+paths raise `InvalidErrorTemplateError`. Calls, indexes, conversions, format
 specifications, filters, arbitrary expressions, and literal-brace escaping are
 unsupported. With `ignore_if_none=False`, an intermediate or final `None`
 renders as `"None"` when a failed rule is formatted. Templates do not change

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -686,9 +686,24 @@ non-empty `dict[str, str]`: handler-derived messages when available, a
 variable-keyed combination fallback otherwise, or Django's `"__all__"` key for
 a variable-free predicate. A custom message is retained by the fallback.
 Calling `get_error_message()` before evaluation or after a passing/skipped
-evaluation returns `None`. For a failed rule, missing custom-message
-placeholders raise `MissingErrorTemplateVariableError`, and documented custom or
-built-in handler exceptions propagate unchanged. The defensive
+evaluation returns `None`.
+
+`custom_error_message` may be static or contain optional placeholders for any
+subset of predicate variables, such as `{project.name}`. Placeholders support
+only dot-separated Python identifiers; they read attributes and do not call
+methods. Syntax and predicate roots are validated at `Rule` construction, and
+dotted paths are validated against manager schemas during shared manager
+startup. Invalid syntax, unrelated roots, and unknown or non-traversable paths
+raise `InvalidErrorTemplateError`. Calls, indexes, conversions, format
+specifications, filters, arbitrary expressions, and literal-brace escaping are
+unsupported. With `ignore_if_none=False`, an intermediate or final `None`
+renders as `"None"` when a failed rule is formatted. Templates do not change
+the existing variable or non-field keys to which error output is attached.
+
+The deprecated `MissingErrorTemplateVariableError` remains importable directly
+from `general_manager.rule.rule` for compatibility, but omitted placeholders no
+longer raise it. Documented custom or built-in handler exceptions propagate
+unchanged. The defensive
 `ErrorMessageGenerationError` applies only if internal state records failure
 without retaining the evaluated input. The non-empty failed-rule fallback is
 guaranteed from 0.62.2.
@@ -717,3 +732,5 @@ during `Rule` construction.
 ::: general_manager.rule.handler.NumericIterableError
 
 ::: general_manager.rule.rule.InvalidRuleHandlerConfigurationError
+
+::: general_manager.rule.rule.InvalidErrorTemplateError

--- a/docs/concepts/rules_validation.md
+++ b/docs/concepts/rules_validation.md
@@ -42,16 +42,46 @@ If a rule returns `False`, the interface raises `ValidationError`. Errors propag
 
 ## Custom messages and `None` handling
 
-Rules automatically generate helpful error messages by analysing the expression. Override the text with `custom_error_message` and use placeholders that match variable names:
+Rules automatically generate helpful error messages by analysing the
+expression. Override the text with either a static message or a template:
 
 ```python
 Rule(
     lambda order: order.quantity <= order.stock,
-    custom_error_message="Ordered quantity ({quantity}) exceeds stock ({stock}).",
+    custom_error_message="The order exceeds available stock.",
+)
+
+Rule(
+    lambda task: task.project is not None and task.project.name is not None,
+    custom_error_message="A named project is required; received {project.name}.",
+    ignore_if_none=False,
 )
 ```
 
-By default, rules ignore `None` values and return `None`. Set `ignore_if_none=False` when `None` should fail the validation.
+Placeholders are optional and may cover only a subset of the attributes
+referenced by the predicate. They consist only of dot-separated Python
+identifiers. A dotted placeholder such as `{project.name}` follows declared
+single-manager relations; it does not call a method. Template choice does not
+change where validation errors are attached: the formatted message remains
+keyed by the rule's existing referenced fields (or by Django's non-field error
+key for a variable-free predicate).
+
+Placeholder syntax and roots are checked when the `Rule` is constructed. Dotted
+paths are checked against manager schemas during shared manager startup.
+Malformed syntax, a root unrelated to the predicate, and unknown or
+non-traversable schema paths raise `InvalidErrorTemplateError`. Calls, indexes,
+conversion or format specifications, filters, arbitrary expressions, and
+literal-brace escaping are unsupported.
+
+By default, rules ignore `None` values and `evaluate()` returns `None`. Set
+`ignore_if_none=False` when `None` should fail validation. If a failed rule is
+formatted, an intermediate or final `None` in a dotted path renders as
+`"None"`, as in the `{project.name}` example when `project` is absent. Passing
+and skipped rules still return no message from `get_error_message()`.
+
+`MissingErrorTemplateVariableError` remains importable from
+`general_manager.rule.rule` for compatibility, but omitting placeholders no
+longer raises it.
 
 ## Manual evaluation
 

--- a/docs/concepts/rules_validation.md
+++ b/docs/concepts/rules_validation.md
@@ -67,11 +67,13 @@ keyed by the rule's existing referenced fields (or by Django's non-field error
 key for a variable-free predicate).
 
 Placeholder syntax and roots are checked when the `Rule` is constructed. Dotted
-paths are checked against manager schemas during shared manager startup.
-Malformed syntax, a root unrelated to the predicate, and unknown or
-non-traversable schema paths raise `InvalidErrorTemplateError`. Calls, indexes,
-conversion or format specifications, filters, arbitrary expressions, and
-literal-brace escaping are unsupported.
+paths are checked against manager schemas during shared manager startup for
+normal application managers. Late-created managers perform the same check on
+their first eligible public use after app readiness, before CRUD or descriptor
+evaluation. Malformed syntax, a root unrelated to the predicate, and unknown
+or non-traversable schema paths raise `InvalidErrorTemplateError`. Calls,
+indexes, conversion or format specifications, filters, arbitrary expressions,
+and literal-brace escaping are unsupported.
 
 By default, rules ignore `None` values and `evaluate()` returns `None`. Set
 `ignore_if_none=False` when `None` should fail validation. If a failed rule is

--- a/docs/examples/rule_validation.md
+++ b/docs/examples/rule_validation.md
@@ -79,12 +79,14 @@ intermediate or final `None` renders as `"None"` when the failed rule is
 formatted.
 
 Only dot-separated Python identifiers are supported in placeholders. Syntax and
-predicate roots are validated at rule construction, while paths are validated
-against declared manager schemas during shared manager startup. Invalid syntax,
-unrelated roots, and unknown or non-traversable paths raise
-`InvalidErrorTemplateError`. Calls, indexes, conversions, format
-specifications, filters, arbitrary expressions, and literal-brace escaping are
-unsupported. Passing and skipped rules return no message.
+predicate roots are validated at rule construction. Paths are validated against
+declared manager schemas during shared manager startup for normal application
+managers; a manager declared later validates on its first public use after app
+readiness, before CRUD or field evaluation. Invalid syntax, unrelated roots,
+and unknown or non-traversable paths raise `InvalidErrorTemplateError`. Calls,
+indexes, conversions, format specifications, filters, arbitrary expressions,
+and literal-brace escaping are unsupported. Passing and skipped rules return no
+message.
 
 `MissingErrorTemplateVariableError` remains available from
 `general_manager.rule.rule` for compatibility, but a template may omit

--- a/docs/examples/rule_validation.md
+++ b/docs/examples/rule_validation.md
@@ -12,9 +12,15 @@ from general_manager.rule import Rule
 
 
 @dataclass
+class Project:
+    name: str | None
+
+
+@dataclass
 class Booking:
     starts_at: int
     ends_at: int
+    project: Project | None = None
 
 
 def ordered(booking: Booking) -> bool:
@@ -23,13 +29,13 @@ def ordered(booking: Booking) -> bool:
 
 field_rule = Rule(
     ordered,
-    custom_error_message="Start {starts_at} must be before end {ends_at}.",
+    custom_error_message="Start {starts_at} must be before the end.",
 )
 
 assert field_rule.evaluate(Booking(starts_at=20, ends_at=10)) is False
 assert field_rule.get_error_message() == {
-    "starts_at": "Start 20 must be before end 10.",
-    "ends_at": "Start 20 must be before end 10.",
+    "starts_at": "Start 20 must be before the end.",
+    "ends_at": "Start 20 must be before the end.",
 }
 
 
@@ -47,7 +53,42 @@ assert non_field_rule.evaluate(Booking(starts_at=1, ends_at=2)) is False
 assert non_field_rule.get_error_message() == {
     NON_FIELD_ERRORS: "Bookings are temporarily disabled."
 }
+
+
+def project_selected(booking: Booking) -> bool:
+    return booking.project is not None
+
+
+dotted_rule = Rule(
+    project_selected,
+    custom_error_message="A project is required; received {project.name}.",
+    ignore_if_none=False,
+)
+
+assert dotted_rule.evaluate(Booking(starts_at=1, ends_at=2, project=None)) is False
+assert dotted_rule.get_error_message() == {
+    "project": "A project is required; received None."
+}
 ```
+
+The first custom template intentionally covers only `starts_at`; placeholders
+are optional and do not change the existing `starts_at` and `ends_at` error
+keys. The second message is static. The last rule demonstrates a dotted
+attribute path without calling a method. With `ignore_if_none=False`, an
+intermediate or final `None` renders as `"None"` when the failed rule is
+formatted.
+
+Only dot-separated Python identifiers are supported in placeholders. Syntax and
+predicate roots are validated at rule construction, while paths are validated
+against declared manager schemas during shared manager startup. Invalid syntax,
+unrelated roots, and unknown or non-traversable paths raise
+`InvalidErrorTemplateError`. Calls, indexes, conversions, format
+specifications, filters, arbitrary expressions, and literal-brace escaping are
+unsupported. Passing and skipped rules return no message.
+
+`MissingErrorTemplateVariableError` remains available from
+`general_manager.rule.rule` for compatibility, but a template may omit
+predicate variables without raising it.
 
 The guaranteed non-empty fallback was added in 0.62.2. Earlier versions could
 return `None` after a failed predicate when no AST handler produced a message.

--- a/docs/howto/write_validation_rules.md
+++ b/docs/howto/write_validation_rules.md
@@ -102,16 +102,19 @@ assert project_required.get_error_message() == {
 A placeholder may follow declared single-manager relations using only
 dot-separated Python identifiers. In the attached `project_required` rule
 above, `{project.name}` has the predicate root `project`, and
-`Booking.Interface.project` declares a single-manager relation. Shared manager
-startup therefore discovers the rule and validates `project.name` against the
-`Booking` and `Project` schemas. When the predicate fails because `project` is
-`None`, formatting stops at that intermediate value and renders `"None"`. A
-final `None`, such as a project whose `name` is `None`, renders the same way.
+`Booking.Interface.project` declares a single-manager relation. Normal
+application managers validate the path against the `Booking` and `Project`
+schemas during shared manager startup. Managers declared later validate on
+their first public use after Django's apps are ready, before a CRUD operation or
+field evaluation runs. When the predicate fails because `project` is `None`,
+formatting stops at that intermediate value and renders `"None"`. A final
+`None`, such as a project whose `name` is `None`, renders the same way.
 
 Placeholder syntax and roots are validated when the rule is constructed.
 Dotted paths such as `project.name` are validated against the declared manager
-schemas during shared manager startup. Invalid syntax, unrelated roots, unknown
-fields, scalar traversal, and collection traversal raise
+schemas during shared manager startup, or on the first eligible public use
+after app readiness for a late-created manager. Invalid syntax, unrelated
+roots, unknown fields, scalar traversal, and collection traversal raise
 `InvalidErrorTemplateError`.
 
 Templates do not evaluate Python. Calls, indexes, conversion and format

--- a/docs/howto/write_validation_rules.md
+++ b/docs/howto/write_validation_rules.md
@@ -9,31 +9,59 @@ Keep the predicate in source code that Python can inspect. Attach it through the
 interface `Meta.rules` list:
 
 ```python
+from django.db.models import CASCADE, CharField, ForeignKey, IntegerField
+
 from general_manager.interface import DatabaseInterface
 from general_manager.manager import GeneralManager
 from general_manager.rule import Rule
 
 
-class Booking(GeneralManager):
-    starts_at: object
-    ends_at: object
-    code: str | None
+class Project(GeneralManager):
+    name: str
 
     class Interface(DatabaseInterface):
+        name = CharField(max_length=200)
+
+
+project_required = Rule(
+    lambda booking: booking.project is not None,
+    custom_error_message="A project is required; received {project.name}.",
+    ignore_if_none=False,
+)
+
+
+class Booking(GeneralManager):
+    starts_at: int
+    ends_at: int
+    code: str | None
+    project: Project | None
+
+    class Interface(DatabaseInterface):
+        starts_at = IntegerField()
+        ends_at = IntegerField()
+        code = CharField(max_length=100, null=True)
+        project = ForeignKey(
+            Project.Interface._model,
+            on_delete=CASCADE,
+            null=True,
+        )
+
         class Meta:
             rules = [
                 Rule["Booking"](
                     lambda booking: booking.starts_at < booking.ends_at,
                     custom_error_message=(
-                        "Start {starts_at} must be before end {ends_at}."
+                        "Booking must end after {starts_at}."
                     ),
-                )
+                ),
+                project_required,
             ]
 ```
 
-The placeholders in `custom_error_message` must match variables referenced by
-the predicate. Missing placeholders raise `MissingErrorTemplateVariableError`
-when the message is generated.
+Placeholders are optional. A template may use only a subset of the attributes
+referenced by the predicate, as above, or may be entirely static. The formatted
+message is still attached to the predicate's existing error fields, so this
+example reports the same message for both `starts_at` and `ends_at`.
 
 ## Choose how `None` behaves
 
@@ -44,7 +72,7 @@ referenced value is `None`; skipped rules contribute no validation error. Use
 ```python
 required_code = Rule(
     lambda booking: booking.code is not None,
-    custom_error_message="A booking code is required; received {code}.",
+    custom_error_message="A booking code is required.",
     ignore_if_none=False,
 )
 ```
@@ -58,9 +86,42 @@ booking = SimpleNamespace(code=None)
 
 assert required_code.evaluate(booking) is False
 assert required_code.get_error_message() == {
-    "code": "A booking code is required; received None."
+    "code": "A booking code is required."
+}
+
+booking_without_project = SimpleNamespace(project=None)
+
+assert project_required.evaluate(booking_without_project) is False
+assert project_required.get_error_message() == {
+    "project": "A project is required; received None."
 }
 ```
+
+## Use dotted placeholders for manager relations
+
+A placeholder may follow declared single-manager relations using only
+dot-separated Python identifiers. In the attached `project_required` rule
+above, `{project.name}` has the predicate root `project`, and
+`Booking.Interface.project` declares a single-manager relation. Shared manager
+startup therefore discovers the rule and validates `project.name` against the
+`Booking` and `Project` schemas. When the predicate fails because `project` is
+`None`, formatting stops at that intermediate value and renders `"None"`. A
+final `None`, such as a project whose `name` is `None`, renders the same way.
+
+Placeholder syntax and roots are validated when the rule is constructed.
+Dotted paths such as `project.name` are validated against the declared manager
+schemas during shared manager startup. Invalid syntax, unrelated roots, unknown
+fields, scalar traversal, and collection traversal raise
+`InvalidErrorTemplateError`.
+
+Templates do not evaluate Python. Calls, indexes, conversion and format
+specifications, filters, arbitrary expressions, and literal-brace escaping are
+unsupported. In particular, `{project.name}` reads an attribute; it never calls
+a method.
+
+The deprecated `MissingErrorTemplateVariableError` remains importable from
+`general_manager.rule.rule` for compatibility. A template no longer has to
+mention every predicate variable, so omission does not raise that exception.
 
 As of 0.62.2, every failed rule produces a non-empty mapping. If a predicate
 cannot be explained by a registered AST handler, referenced fields receive a

--- a/src/general_manager/_types/rule.py
+++ b/src/general_manager/_types/rule.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 __all__ = [
     "BaseRuleHandler",
+    "InvalidErrorTemplateError",
     "InvalidRuleHandlerConfigurationError",
     "Rule",
 ]
 
 from general_manager.rule.handler import BaseRuleHandler
+from general_manager.rule.rule import InvalidErrorTemplateError
 from general_manager.rule.rule import InvalidRuleHandlerConfigurationError
 from general_manager.rule.rule import Rule

--- a/src/general_manager/bootstrap.py
+++ b/src/general_manager/bootstrap.py
@@ -113,6 +113,7 @@ from general_manager.metrics import build_graphql_middleware
 
 if TYPE_CHECKING:
     from general_manager.manager.general_manager import GeneralManager
+    from general_manager.rule.rule import Rule
 
 logger = get_logger("apps")
 
@@ -134,6 +135,16 @@ class InvalidPermissionClassError(TypeError):
 
     def __init__(self, permission_name: str) -> None:
         super().__init__(f"{permission_name} must be a subclass of BasePermission.")
+
+
+class _InvalidManagerRuleCollectionError(TypeError):
+    """Raised when bootstrap receives a one-shot manager rule collection."""
+
+    def __init__(self, source_name: str) -> None:
+        super().__init__(
+            f"{source_name} must be a reusable iterable; "
+            "one-shot iterators are not supported."
+        )
 
 
 class InvalidGraphQLDirectiveError(TypeError):
@@ -332,6 +343,45 @@ def check_permission_class(general_manager_class: type[GeneralManager]) -> None:
         general_manager_class.Permission = AdditiveManagerPermission
 
 
+def _iter_manager_validation_rules(
+    manager_class: type[GeneralManager],
+) -> Iterator[Rule[GeneralManager]]:
+    """Yield each attached Rule once across interface and model sources."""
+    from general_manager.rule.rule import Rule
+
+    interface = getattr(manager_class, "Interface", None)
+    model = getattr(interface, "_model", None)
+    model_meta = getattr(model, "_meta", None)
+    rule_sources = (
+        ("Interface.rules", getattr(interface, "rules", ())),
+        (
+            "Interface._model._meta.rules",
+            getattr(model_meta, "rules", ()),
+        ),
+    )
+    reusable_rule_sources: list[Iterator[object]] = []
+    for source_name, rule_source in rule_sources:
+        if isinstance(rule_source, (str, bytes)) or not isinstance(
+            rule_source, Iterable
+        ):
+            continue
+        rule_iterator = iter(rule_source)
+        if rule_iterator is rule_source:
+            raise _InvalidManagerRuleCollectionError(source_name)
+        reusable_rule_sources.append(rule_iterator)
+
+    seen_rule_ids: set[int] = set()
+    for rule_iterator in reusable_rule_sources:
+        for candidate in rule_iterator:
+            if not isinstance(candidate, Rule):
+                continue
+            candidate_id = id(candidate)
+            if candidate_id in seen_rule_ids:
+                continue
+            seen_rule_ids.add(candidate_id)
+            yield cast("Rule[GeneralManager]", candidate)
+
+
 def initialize_general_manager_classes(
     pending_attribute_initialization: list[type[GeneralManager]],
     all_classes: list[type[GeneralManager]],
@@ -454,6 +504,9 @@ def initialize_general_manager_classes(
                 f"{_to_snake_case(general_manager_class.__name__)}_list",
                 relation_property,
             )
+    for general_manager_class in dict.fromkeys(all_classes):
+        for rule in _iter_manager_validation_rules(general_manager_class):
+            rule.validate_custom_error_message(general_manager_class)
     for general_manager_class in all_classes:
         check_permission_class(general_manager_class)
 

--- a/src/general_manager/bootstrap.py
+++ b/src/general_manager/bootstrap.py
@@ -113,7 +113,6 @@ from general_manager.metrics import build_graphql_middleware
 
 if TYPE_CHECKING:
     from general_manager.manager.general_manager import GeneralManager
-    from general_manager.rule.rule import Rule
 
 logger = get_logger("apps")
 
@@ -135,16 +134,6 @@ class InvalidPermissionClassError(TypeError):
 
     def __init__(self, permission_name: str) -> None:
         super().__init__(f"{permission_name} must be a subclass of BasePermission.")
-
-
-class _InvalidManagerRuleCollectionError(TypeError):
-    """Raised when bootstrap receives a one-shot manager rule collection."""
-
-    def __init__(self, source_name: str) -> None:
-        super().__init__(
-            f"{source_name} must be a reusable iterable; "
-            "one-shot iterators are not supported."
-        )
 
 
 class InvalidGraphQLDirectiveError(TypeError):
@@ -343,45 +332,6 @@ def check_permission_class(general_manager_class: type[GeneralManager]) -> None:
         general_manager_class.Permission = AdditiveManagerPermission
 
 
-def _iter_manager_validation_rules(
-    manager_class: type[GeneralManager],
-) -> Iterator[Rule[GeneralManager]]:
-    """Yield each attached Rule once across interface and model sources."""
-    from general_manager.rule.rule import Rule
-
-    interface = getattr(manager_class, "Interface", None)
-    model = getattr(interface, "_model", None)
-    model_meta = getattr(model, "_meta", None)
-    rule_sources = (
-        ("Interface.rules", getattr(interface, "rules", ())),
-        (
-            "Interface._model._meta.rules",
-            getattr(model_meta, "rules", ()),
-        ),
-    )
-    reusable_rule_sources: list[Iterator[object]] = []
-    for source_name, rule_source in rule_sources:
-        if isinstance(rule_source, (str, bytes)) or not isinstance(
-            rule_source, Iterable
-        ):
-            continue
-        rule_iterator = iter(rule_source)
-        if rule_iterator is rule_source:
-            raise _InvalidManagerRuleCollectionError(source_name)
-        reusable_rule_sources.append(rule_iterator)
-
-    seen_rule_ids: set[int] = set()
-    for rule_iterator in reusable_rule_sources:
-        for candidate in rule_iterator:
-            if not isinstance(candidate, Rule):
-                continue
-            candidate_id = id(candidate)
-            if candidate_id in seen_rule_ids:
-                continue
-            seen_rule_ids.add(candidate_id)
-            yield cast("Rule[GeneralManager]", candidate)
-
-
 def initialize_general_manager_classes(
     pending_attribute_initialization: list[type[GeneralManager]],
     all_classes: list[type[GeneralManager]],
@@ -505,8 +455,7 @@ def initialize_general_manager_classes(
                 relation_property,
             )
     for general_manager_class in dict.fromkeys(all_classes):
-        for rule in _iter_manager_validation_rules(general_manager_class):
-            rule.validate_custom_error_message(general_manager_class)
+        GeneralManagerMeta.ensure_rule_templates_validated(general_manager_class)
     for general_manager_class in all_classes:
         check_permission_class(general_manager_class)
 

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -20,7 +20,11 @@ from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.cache.dependency_index import serialize_dependency_identifier
 from general_manager.cache.signals import data_change
 from general_manager.logging import get_logger
-from general_manager.manager.meta import GeneralManagerMeta, InvalidManagerStateError
+from general_manager.manager.meta import (
+    GeneralManagerMeta,
+    InvalidManagerStateError,
+    _validate_rule_templates_before_public_use,
+)
 
 
 class UnsupportedUnionOperandError(TypeError):
@@ -556,6 +560,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
                 yield name, getattr(self, name)
 
     @classmethod
+    @_validate_rule_templates_before_public_use
     @data_change
     def create(
         cls,
@@ -597,6 +602,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         )
         return cls(**identification)
 
+    @_validate_rule_templates_before_public_use
     @data_change
     def update(
         self,
@@ -647,6 +653,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         )
         return self
 
+    @_validate_rule_templates_before_public_use
     @data_change
     def delete(
         self,

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 import threading
-from _thread import LockType
+from _thread import RLock as RLockType
 from typing import TYPE_CHECKING, ClassVar, Iterable, TypeVar, cast
 from weakref import WeakKeyDictionary
 
@@ -193,7 +193,7 @@ class GeneralManagerMeta(type):
     read_only_classes: ClassVar[list[type[GeneralManager]]] = []
     pending_graphql_interfaces: ClassVar[list[type[GeneralManager]]] = []
     pending_attribute_initialization: ClassVar[list[type[GeneralManager]]] = []
-    _attribute_initialization_lock: ClassVar[LockType] = threading.Lock()
+    _attribute_initialization_lock: ClassVar[RLockType] = threading.RLock()
     Interface: type[InterfaceBase]
 
     def __getattribute__(cls, attribute_name: str) -> object:
@@ -371,9 +371,26 @@ class GeneralManagerMeta(type):
         """Validate attached rules while the attribute initialization lock is held."""
         if vars(manager_class).get("_gm_rule_templates_validated", False):
             return
-        for rule in _iter_manager_validation_rules(manager_class):
-            rule.validate_custom_error_message(manager_class)
-        type.__setattr__(manager_class, "_gm_rule_templates_validated", True)
+        if vars(manager_class).get(
+            "_gm_rule_templates_validation_in_progress",
+            False,
+        ):
+            return
+        type.__setattr__(
+            manager_class,
+            "_gm_rule_templates_validation_in_progress",
+            True,
+        )
+        try:
+            for rule in _iter_manager_validation_rules(manager_class):
+                rule.validate_custom_error_message(manager_class)
+            type.__setattr__(manager_class, "_gm_rule_templates_validated", True)
+        finally:
+            if "_gm_rule_templates_validation_in_progress" in vars(manager_class):
+                type.__delattr__(
+                    manager_class,
+                    "_gm_rule_templates_validation_in_progress",
+                )
 
     @staticmethod
     def ensure_rule_templates_validated(

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+from functools import wraps
 import threading
 from _thread import RLock as RLockType
-from typing import TYPE_CHECKING, ClassVar, Iterable, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    ClassVar,
+    Iterable,
+    TypeVar,
+    cast,
+)
 from weakref import WeakKeyDictionary
 
 from django.apps import apps
@@ -22,6 +29,7 @@ if TYPE_CHECKING:
 
 
 GeneralManagerType = TypeVar("GeneralManagerType", bound="GeneralManager")
+PublicUseCallable = TypeVar("PublicUseCallable", bound=Callable[..., object])
 type MetaPreCreationHook = Callable[
     [str, dict[str, object], type[InterfaceBase]],
     tuple[dict[str, object], type[InterfaceBase], type["Model"] | None],
@@ -178,6 +186,30 @@ def _iter_manager_validation_rules(
             yield cast("Rule[GeneralManager]", candidate)
 
 
+def _validate_rule_templates_before_public_use(
+    method: PublicUseCallable,
+) -> PublicUseCallable:
+    """Validate templates before an explicit public manager operation runs."""
+
+    @wraps(method)
+    def wrapper(
+        manager_or_class: object,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        manager_class = (
+            manager_or_class
+            if isinstance(manager_or_class, GeneralManagerMeta)
+            else type(manager_or_class)
+        )
+        GeneralManagerMeta.ensure_rule_templates_validated_after_readiness(
+            cast(type["GeneralManager"], manager_class)
+        )
+        return method(manager_or_class, *args, **kwargs)
+
+    return cast(PublicUseCallable, wrapper)
+
+
 class GeneralManagerMeta(type):
     """
     Metaclass responsible for wiring GeneralManager interfaces and registries.
@@ -245,6 +277,10 @@ class GeneralManagerMeta(type):
                 and isinstance(attributes, dict)
                 and attribute_name not in attributes
             ):
+                manager_class = cast(type["GeneralManager"], cls)
+                GeneralManagerMeta.ensure_rule_templates_validated_after_readiness(
+                    manager_class
+                )
                 return type.__getattribute__(cls, attribute_name)
             manager_class = cast(type["GeneralManager"], cls)
             GeneralManagerMeta.ensure_attributes_initialized(
@@ -275,6 +311,8 @@ class GeneralManagerMeta(type):
             Exception: Exceptions from ``Interface.get_attributes()`` other than
                 ``NotImplementedError`` propagate unchanged.
         """
+        if attribute_name.startswith("_") or attribute_name == "Interface":
+            raise AttributeError(attribute_name)
         manager_class = cast(type["GeneralManager"], cls)
         if GeneralManagerMeta.ensure_attributes_initialized(
             manager_class, attribute_name
@@ -329,12 +367,12 @@ class GeneralManagerMeta(type):
         with GeneralManagerMeta._attribute_initialization_lock:
             if "_attributes" in vars(manager_class):
                 attributes = manager_class._attributes
-                if attribute_name is not None and attribute_name not in attributes:
-                    return False
                 if apps.ready:
                     GeneralManagerMeta._ensure_rule_templates_validated_locked(
                         manager_class
                     )
+                if attribute_name is not None and attribute_name not in attributes:
+                    return False
                 if attribute_name is None or attribute_name not in vars(manager_class):
                     GeneralManagerMeta.create_at_properties_for_attributes(
                         attributes.keys(), manager_class
@@ -346,12 +384,12 @@ class GeneralManagerMeta(type):
                 attributes = interface.get_attributes()
             except NotImplementedError:
                 return False
-            if attribute_name is not None and attribute_name not in attributes:
-                return False
             if apps.ready:
                 GeneralManagerMeta._ensure_rule_templates_validated_locked(
                     manager_class
                 )
+            if attribute_name is not None and attribute_name not in attributes:
+                return False
             manager_class._attributes = attributes
             GeneralManagerMeta.create_at_properties_for_attributes(
                 attributes.keys(), manager_class
@@ -475,6 +513,14 @@ class GeneralManagerMeta(type):
         """Validate attached rules once using the shared initialization lock."""
         with GeneralManagerMeta._attribute_initialization_lock:
             GeneralManagerMeta._ensure_rule_templates_validated_locked(manager_class)
+
+    @staticmethod
+    def ensure_rule_templates_validated_after_readiness(
+        manager_class: type["GeneralManager"],
+    ) -> None:
+        """Validate templates for an eligible public use after app loading."""
+        if apps.ready:
+            GeneralManagerMeta.ensure_rule_templates_validated(manager_class)
 
     @staticmethod
     def ensure_manager_is_valid(
@@ -731,6 +777,9 @@ class GeneralManagerMeta(type):
                     """
                     if instance is None:
                         return self._class.Interface.get_field_type(self._attr_name)
+                    GeneralManagerMeta.ensure_rule_templates_validated_after_readiness(
+                        self._class
+                    )
                     try:
                         ensure_as_of_compatible = object.__getattribute__(
                             instance, "_ensure_as_of_compatible"

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -380,14 +380,25 @@ class GeneralManagerMeta(type):
                 type.__setattr__(manager_class, "_gm_attributes_initialized", True)
                 return True
 
+            interface_field_descriptors_before = vars(interface).get(
+                "_field_descriptors",
+                _MANAGER_CLASS_STATE_MISSING,
+            )
             try:
                 attributes = interface.get_attributes()
             except NotImplementedError:
                 return False
             if apps.ready:
-                GeneralManagerMeta._ensure_rule_templates_validated_locked(
-                    manager_class
-                )
+                try:
+                    GeneralManagerMeta._ensure_rule_templates_validated_locked(
+                        manager_class
+                    )
+                except Exception:
+                    GeneralManagerMeta._restore_interface_field_descriptors_locked(
+                        interface,
+                        interface_field_descriptors_before,
+                    )
+                    raise
             if attribute_name is not None and attribute_name not in attributes:
                 return False
             manager_class._attributes = attributes
@@ -416,6 +427,11 @@ class GeneralManagerMeta(type):
         ):
             return
         class_state_before = dict(vars(manager_class))
+        interface = type.__getattribute__(manager_class, "Interface")
+        interface_field_descriptors_before = vars(interface).get(
+            "_field_descriptors",
+            _MANAGER_CLASS_STATE_MISSING,
+        )
         pending_positions = tuple(
             index
             for index, pending_manager in enumerate(
@@ -436,6 +452,8 @@ class GeneralManagerMeta(type):
             GeneralManagerMeta._restore_rule_validation_initialization_state_locked(
                 manager_class,
                 class_state_before,
+                interface,
+                interface_field_descriptors_before,
                 pending_positions,
             )
             raise
@@ -450,9 +468,11 @@ class GeneralManagerMeta(type):
     def _restore_rule_validation_initialization_state_locked(
         manager_class: type["GeneralManager"],
         class_state_before: dict[str, object],
+        interface: type[InterfaceBase],
+        interface_field_descriptors_before: object,
         pending_positions: tuple[int, ...],
     ) -> None:
-        """Roll back same-manager initialization committed by reentrant validation."""
+        """Roll back only initialization-owned manager, interface, and queue state."""
         current_state = vars(manager_class)
         previous_attributes = class_state_before.get(
             "_attributes",
@@ -497,6 +517,11 @@ class GeneralManagerMeta(type):
             else:
                 type.__setattr__(manager_class, state_name, previous_value)
 
+        GeneralManagerMeta._restore_interface_field_descriptors_locked(
+            interface,
+            interface_field_descriptors_before,
+        )
+
         pending = GeneralManagerMeta.pending_attribute_initialization
         pending[:] = [
             pending_manager
@@ -507,10 +532,28 @@ class GeneralManagerMeta(type):
             pending.insert(min(position, len(pending)), manager_class)
 
     @staticmethod
+    def _restore_interface_field_descriptors_locked(
+        interface: type[InterfaceBase],
+        field_descriptors_before: object,
+    ) -> None:
+        """Restore the direct ORM field cache changed during initialization."""
+        if field_descriptors_before is _MANAGER_CLASS_STATE_MISSING:
+            if "_field_descriptors" in vars(interface):
+                type.__delattr__(interface, "_field_descriptors")
+            return
+        type.__setattr__(
+            interface,
+            "_field_descriptors",
+            field_descriptors_before,
+        )
+
+    @staticmethod
     def ensure_rule_templates_validated(
         manager_class: type["GeneralManager"],
     ) -> None:
         """Validate attached rules once using the shared initialization lock."""
+        if vars(manager_class).get("_gm_rule_templates_validated", False):
+            return
         with GeneralManagerMeta._attribute_initialization_lock:
             GeneralManagerMeta._ensure_rule_templates_validated_locked(manager_class)
 

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -205,12 +205,14 @@ class GeneralManagerMeta(type):
         fields override inherited names the same way bootstrap initialization
         does. Once a manager class has completed descriptor initialization,
         attributes already present on that class use normal type lookup without
-        rechecking initialization. Missing names and inherited public names
-        still pass through initialization so late-discovered fields keep the
-        existing override behavior. "Non-private" means the requested name does
-        not start with ``"_"`` and is not exactly ``"Interface"``. Probing an
-        unknown public name may call ``Interface.get_attributes()``, but it
-        installs descriptors only when the probed name is declared by the
+        reinstalling descriptors. If those descriptors were installed before
+        Django finished app loading, their first access after readiness validates
+        attached rule templates before returning. Missing names and inherited
+        public names still pass through initialization so late-discovered fields
+        keep the existing override behavior. "Non-private" means the requested
+        name does not start with ``"_"`` and is not exactly ``"Interface"``.
+        Probing an unknown public name may call ``Interface.get_attributes()``,
+        but it installs descriptors only when the probed name is declared by the
         interface.
 
         Parameters:
@@ -229,6 +231,12 @@ class GeneralManagerMeta(type):
             class_dict = type.__getattribute__(cls, "__dict__")
             initialized = class_dict.get("_gm_attributes_initialized", False)
             if initialized and attribute_name in class_dict:
+                if apps.ready and not class_dict.get(
+                    "_gm_rule_templates_validated",
+                    False,
+                ):
+                    manager_class = cast(type["GeneralManager"], cls)
+                    GeneralManagerMeta.ensure_rule_templates_validated(manager_class)
                 return type.__getattribute__(cls, attribute_name)
             attributes = class_dict.get("_attributes")
             if (

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 import threading
 from _thread import LockType
 from typing import TYPE_CHECKING, ClassVar, Iterable, TypeVar, cast
 from weakref import WeakKeyDictionary
+
+from django.apps import apps
 
 from general_manager.cache.cache_tracker import DependencyTracker
 from general_manager.interface.base_interface import InterfaceBase
@@ -15,6 +17,7 @@ from general_manager.logging import get_logger
 if TYPE_CHECKING:
     from general_manager.manager.general_manager import GeneralManager
     from general_manager.interface.manifests import ManifestCapabilityBuilder
+    from general_manager.rule.rule import Rule
     from django.db.models import Model
 
 
@@ -121,8 +124,57 @@ class InvalidManagerStateError(AttributeError):
         super().__init__(detail)
 
 
+class _InvalidManagerRuleCollectionError(TypeError):
+    """Raised when manager rules are configured as a one-shot iterator."""
+
+    def __init__(self, source_name: str) -> None:
+        super().__init__(
+            f"{source_name} must be a reusable iterable; "
+            "one-shot iterators are not supported."
+        )
+
+
 class _nonExistent:
     pass
+
+
+def _iter_manager_validation_rules(
+    manager_class: type["GeneralManager"],
+) -> Iterator["Rule[GeneralManager]"]:
+    """Yield attached rules once after preflighting both reusable sources."""
+    from general_manager.rule.rule import Rule
+
+    interface = type.__getattribute__(manager_class, "Interface")
+    model = getattr(interface, "_model", None)
+    model_meta = getattr(model, "_meta", None)
+    rule_sources = (
+        ("Interface.rules", getattr(interface, "rules", ())),
+        (
+            "Interface._model._meta.rules",
+            getattr(model_meta, "rules", ()),
+        ),
+    )
+    reusable_rule_sources: list[Iterator[object]] = []
+    for source_name, rule_source in rule_sources:
+        if isinstance(rule_source, (str, bytes)) or not isinstance(
+            rule_source, Iterable
+        ):
+            continue
+        rule_iterator = iter(rule_source)
+        if rule_iterator is rule_source:
+            raise _InvalidManagerRuleCollectionError(source_name)
+        reusable_rule_sources.append(rule_iterator)
+
+    seen_rule_ids: set[int] = set()
+    for rule_iterator in reusable_rule_sources:
+        for candidate in rule_iterator:
+            if not isinstance(candidate, Rule):
+                continue
+            candidate_id = id(candidate)
+            if candidate_id in seen_rule_ids:
+                continue
+            seen_rule_ids.add(candidate_id)
+            yield cast("Rule[GeneralManager]", candidate)
 
 
 class GeneralManagerMeta(type):
@@ -270,6 +322,10 @@ class GeneralManagerMeta(type):
                 attributes = manager_class._attributes
                 if attribute_name is not None and attribute_name not in attributes:
                     return False
+                if apps.ready:
+                    GeneralManagerMeta._ensure_rule_templates_validated_locked(
+                        manager_class
+                    )
                 if attribute_name is None or attribute_name not in vars(manager_class):
                     GeneralManagerMeta.create_at_properties_for_attributes(
                         attributes.keys(), manager_class
@@ -283,6 +339,10 @@ class GeneralManagerMeta(type):
                 return False
             if attribute_name is not None and attribute_name not in attributes:
                 return False
+            if apps.ready:
+                GeneralManagerMeta._ensure_rule_templates_validated_locked(
+                    manager_class
+                )
             manager_class._attributes = attributes
             GeneralManagerMeta.create_at_properties_for_attributes(
                 attributes.keys(), manager_class
@@ -295,6 +355,25 @@ class GeneralManagerMeta(type):
             except ValueError:
                 pass
             return True
+
+    @staticmethod
+    def _ensure_rule_templates_validated_locked(
+        manager_class: type["GeneralManager"],
+    ) -> None:
+        """Validate attached rules while the attribute initialization lock is held."""
+        if vars(manager_class).get("_gm_rule_templates_validated", False):
+            return
+        for rule in _iter_manager_validation_rules(manager_class):
+            rule.validate_custom_error_message(manager_class)
+        type.__setattr__(manager_class, "_gm_rule_templates_validated", True)
+
+    @staticmethod
+    def ensure_rule_templates_validated(
+        manager_class: type["GeneralManager"],
+    ) -> None:
+        """Validate attached rules once using the shared initialization lock."""
+        with GeneralManagerMeta._attribute_initialization_lock:
+            GeneralManagerMeta._ensure_rule_templates_validated_locked(manager_class)
 
     @staticmethod
     def ensure_manager_is_valid(

--- a/src/general_manager/manager/meta.py
+++ b/src/general_manager/manager/meta.py
@@ -33,6 +33,7 @@ _MANAGER_DEPENDENCY_TRACKING_CLASS_CACHE: WeakKeyDictionary[
     type["GeneralManager"] | None,
 ] = WeakKeyDictionary()
 _DESCRIPTOR_DEPENDENCY_TRACKING_CLASS_UNKNOWN = object()
+_MANAGER_CLASS_STATE_MISSING = object()
 
 
 def _manager_dependency_tracking_class(
@@ -376,6 +377,14 @@ class GeneralManagerMeta(type):
             False,
         ):
             return
+        class_state_before = dict(vars(manager_class))
+        pending_positions = tuple(
+            index
+            for index, pending_manager in enumerate(
+                GeneralManagerMeta.pending_attribute_initialization
+            )
+            if pending_manager is manager_class
+        )
         type.__setattr__(
             manager_class,
             "_gm_rule_templates_validation_in_progress",
@@ -385,12 +394,79 @@ class GeneralManagerMeta(type):
             for rule in _iter_manager_validation_rules(manager_class):
                 rule.validate_custom_error_message(manager_class)
             type.__setattr__(manager_class, "_gm_rule_templates_validated", True)
+        except Exception:
+            GeneralManagerMeta._restore_rule_validation_initialization_state_locked(
+                manager_class,
+                class_state_before,
+                pending_positions,
+            )
+            raise
         finally:
             if "_gm_rule_templates_validation_in_progress" in vars(manager_class):
                 type.__delattr__(
                     manager_class,
                     "_gm_rule_templates_validation_in_progress",
                 )
+
+    @staticmethod
+    def _restore_rule_validation_initialization_state_locked(
+        manager_class: type["GeneralManager"],
+        class_state_before: dict[str, object],
+        pending_positions: tuple[int, ...],
+    ) -> None:
+        """Roll back same-manager initialization committed by reentrant validation."""
+        current_state = vars(manager_class)
+        previous_attributes = class_state_before.get(
+            "_attributes",
+            _MANAGER_CLASS_STATE_MISSING,
+        )
+        current_attributes = current_state.get(
+            "_attributes",
+            _MANAGER_CLASS_STATE_MISSING,
+        )
+        field_names: set[str] = set()
+        for attributes in (previous_attributes, current_attributes):
+            if isinstance(attributes, dict):
+                field_names.update(
+                    field_name
+                    for field_name in attributes
+                    if isinstance(field_name, str)
+                )
+
+        for field_name in field_names:
+            previous_field = class_state_before.get(
+                field_name,
+                _MANAGER_CLASS_STATE_MISSING,
+            )
+            if previous_field is _MANAGER_CLASS_STATE_MISSING:
+                if field_name in vars(manager_class):
+                    type.__delattr__(manager_class, field_name)
+            else:
+                type.__setattr__(manager_class, field_name, previous_field)
+
+        for state_name in (
+            "_attributes",
+            "_gm_attributes_initialized",
+            "_gm_rule_templates_validated",
+        ):
+            previous_value = class_state_before.get(
+                state_name,
+                _MANAGER_CLASS_STATE_MISSING,
+            )
+            if previous_value is _MANAGER_CLASS_STATE_MISSING:
+                if state_name in vars(manager_class):
+                    type.__delattr__(manager_class, state_name)
+            else:
+                type.__setattr__(manager_class, state_name, previous_value)
+
+        pending = GeneralManagerMeta.pending_attribute_initialization
+        pending[:] = [
+            pending_manager
+            for pending_manager in pending
+            if pending_manager is not manager_class
+        ]
+        for position in pending_positions:
+            pending.insert(min(position, len(pending)), manager_class)
 
     @staticmethod
     def ensure_rule_templates_validated(

--- a/src/general_manager/public_api_registry.py
+++ b/src/general_manager/public_api_registry.py
@@ -689,6 +689,10 @@ MANAGER_EXPORTS: LazyExportMap = {
 
 RULE_EXPORTS: LazyExportMap = {
     "Rule": ("general_manager.rule.rule", "Rule"),
+    "InvalidErrorTemplateError": (
+        "general_manager.rule.rule",
+        "InvalidErrorTemplateError",
+    ),
     "InvalidRuleHandlerConfigurationError": (
         "general_manager.rule.rule",
         "InvalidRuleHandlerConfigurationError",

--- a/src/general_manager/rule/rule.py
+++ b/src/general_manager/rule/rule.py
@@ -394,6 +394,27 @@ class Rule(Generic[GeneralManagerType]):
                 )
             current_manager = related_manager
 
+    def _resolve_custom_error_path(self, parts: tuple[str, ...]) -> object | None:
+        """Resolve a parsed custom-message path against the last input."""
+        current: object | None = self._last_input
+        for part in parts:
+            if current is None:
+                return None
+            current = getattr(current, part)
+        return current
+
+    def _format_custom_error_message(self) -> str:
+        """Render parsed custom-message placeholders from the last input."""
+        assert self._custom_error_message is not None
+        values = {
+            placeholder: str(self._resolve_custom_error_path(parts))
+            for placeholder, parts in self._custom_error_paths.items()
+        }
+        return _ERROR_TEMPLATE_PLACEHOLDER.sub(
+            lambda match: values[match.group(1)],
+            self._custom_error_message,
+        )
+
     def _generate_fallback_error_messages(
         self,
         message: str | None = None,
@@ -440,10 +461,7 @@ class Rule(Generic[GeneralManagerType]):
         )
 
         if self._custom_error_message:
-            formatted = _ERROR_TEMPLATE_PLACEHOLDER.sub(
-                lambda m: str(vals.get(m.group(1), m.group(0))),
-                self._custom_error_message,
-            )
+            formatted = self._format_custom_error_message()
             logger.info(
                 "rule produced custom error message",
                 context={

--- a/src/general_manager/rule/rule.py
+++ b/src/general_manager/rule/rule.py
@@ -330,8 +330,9 @@ class Rule(Generic[GeneralManagerType]):
         """Validate custom message placeholders against rule variables and schemas.
 
         Construction-time validation checks that each placeholder root is
-        referenced by the rule. When ``manager_class`` is supplied, every path
-        segment is also validated against its manager schema.
+        referenced by the rule. When ``manager_class`` is supplied, dotted
+        relation traversal is also validated against manager schemas. A
+        single-segment root may remain runtime-only.
 
         Raises:
             InvalidErrorTemplateError: If a root is unrelated to the rule or a
@@ -353,7 +354,7 @@ class Rule(Generic[GeneralManagerType]):
         placeholder: str,
         parts: tuple[str, ...],
     ) -> None:
-        """Validate a placeholder path against manager schema metadata."""
+        """Validate relation traversal against manager schema metadata."""
         current_manager = manager_class
         for index, part in enumerate(parts):
             try:
@@ -366,6 +367,8 @@ class Rule(Generic[GeneralManagerType]):
                 ) from exc
 
             if part not in attribute_types:
+                if index == 0 and len(parts) == 1:
+                    return
                 raise InvalidErrorTemplateError(
                     placeholder,
                     f"unknown segment {part!r} on {current_manager.__name__}",

--- a/src/general_manager/rule/rule.py
+++ b/src/general_manager/rule/rule.py
@@ -327,8 +327,16 @@ class Rule(Generic[GeneralManagerType]):
         self,
         manager_class: type[GeneralManager] | None = None,
     ) -> None:
-        """Validate that placeholder roots are referenced by the rule."""
-        del manager_class
+        """Validate custom message placeholders against rule variables and schemas.
+
+        Construction-time validation checks that each placeholder root is
+        referenced by the rule. When ``manager_class`` is supplied, every path
+        segment is also validated against its manager schema.
+
+        Raises:
+            InvalidErrorTemplateError: If a root is unrelated to the rule or a
+                placeholder path is invalid for the supplied manager schema.
+        """
         variable_roots = {variable.split(".", 1)[0] for variable in self._variables}
         for placeholder, path in self._custom_error_paths.items():
             if path[0] not in variable_roots:
@@ -336,6 +344,55 @@ class Rule(Generic[GeneralManagerType]):
                     placeholder,
                     f"root {path[0]!r} is not referenced by the rule",
                 )
+            if manager_class is not None:
+                self._validate_custom_error_path(manager_class, placeholder, path)
+
+    def _validate_custom_error_path(
+        self,
+        manager_class: type[GeneralManager],
+        placeholder: str,
+        parts: tuple[str, ...],
+    ) -> None:
+        """Validate a placeholder path against manager schema metadata."""
+        current_manager = manager_class
+        for index, part in enumerate(parts):
+            try:
+                attribute_types = current_manager.Interface.get_attribute_types()
+            except NotImplementedError as exc:
+                detail = str(exc) or "get_attribute_types is not implemented"
+                raise InvalidErrorTemplateError(
+                    placeholder,
+                    f"schema unavailable for {current_manager.__name__}: {detail}",
+                ) from exc
+
+            if part not in attribute_types:
+                raise InvalidErrorTemplateError(
+                    placeholder,
+                    f"unknown segment {part!r} on {current_manager.__name__}",
+                )
+
+            if index == len(parts) - 1:
+                return
+
+            metadata = attribute_types[part]
+            if metadata.get("relation_kind") == "collection":
+                raise InvalidErrorTemplateError(
+                    placeholder,
+                    f"segment {part!r} on {current_manager.__name__} is a "
+                    "collection relation and cannot be traversed",
+                )
+
+            related_manager = metadata.get("type")
+            if not isinstance(related_manager, type) or not issubclass(
+                related_manager,
+                GeneralManager,
+            ):
+                raise InvalidErrorTemplateError(
+                    placeholder,
+                    f"segment {part!r} on {current_manager.__name__} is not a "
+                    "manager relation",
+                )
+            current_manager = related_manager
 
     def _generate_fallback_error_messages(
         self,

--- a/src/general_manager/rule/rule.py
+++ b/src/general_manager/rule/rule.py
@@ -46,6 +46,7 @@ _REVERSED_COMPARISON_OPS: dict[type[ast.cmpop], type[ast.cmpop]] = {
     ast.Is: ast.Is,
     ast.IsNot: ast.IsNot,
 }
+_ERROR_TEMPLATE_PLACEHOLDER = re.compile(r"{([^{}]*)}")
 
 
 class NonexistentAttributeError(AttributeError):
@@ -61,8 +62,19 @@ class NonexistentAttributeError(AttributeError):
         super().__init__(f"The attribute '{attribute}' does not exist.")
 
 
-class MissingErrorTemplateVariableError(ValueError):
-    """Raised when a custom error template omits required variables."""
+class InvalidErrorTemplateError(ValueError):
+    """Raised when a custom error template contains an invalid placeholder."""
+
+    def __init__(self, placeholder: str, reason: str) -> None:
+        self.placeholder = placeholder
+        self.reason = reason
+        super().__init__(
+            f"Invalid custom error message placeholder {placeholder!r}: {reason}."
+        )
+
+
+class MissingErrorTemplateVariableError(InvalidErrorTemplateError):
+    """Deprecated error for custom templates that omitted required variables."""
 
     def __init__(self, missing: List[str]) -> None:
         """
@@ -71,8 +83,12 @@ class MissingErrorTemplateVariableError(ValueError):
         Parameters:
             missing (List[str]): Names of the variables that are required by the template but were not found; these names will be included in the exception message.
         """
-        super().__init__(
-            f"The custom error message does not contain all used variables: {missing}."
+        self.missing = missing
+        self.placeholder = ", ".join(missing)
+        self.reason = "required variables are missing"
+        ValueError.__init__(
+            self,
+            f"The custom error message does not contain all used variables: {missing}.",
         )
 
 
@@ -115,6 +131,7 @@ class Rule(Generic[GeneralManagerType]):
     _primary_param: Optional[str]
     _tree: ast.AST
     _variables: List[str]
+    _custom_error_paths: dict[str, tuple[str, ...]]
     _handlers: Dict[str, BaseRuleHandler]
 
     def __init__(
@@ -128,7 +145,7 @@ class Rule(Generic[GeneralManagerType]):
 
         Parameters:
             func (Callable[[GeneralManagerType], bool]): Predicate that evaluates a GeneralManager instance.
-            custom_error_message (Optional[str]): Optional template used to format generated error messages; placeholders must match variables referenced by the predicate.
+            custom_error_message (Optional[str]): Optional template used to format generated error messages; placeholder roots must match variables referenced by the predicate.
             ignore_if_none (bool): If True, evaluation will be skipped (result recorded as None) when any referenced variable resolves to None.
         """
         self._func = func
@@ -153,6 +170,8 @@ class Rule(Generic[GeneralManagerType]):
 
         # 3) Extract referenced variables
         self._variables = self._extract_variables()
+        self._custom_error_paths = self._parse_custom_error_paths()
+        self.validate_custom_error_message()
 
         # 4) Register handlers
         self._handlers = {}  # type: Dict[str, BaseRuleHandler]
@@ -275,20 +294,48 @@ class Rule(Generic[GeneralManagerType]):
             )
         return self._last_result
 
-    def validate_custom_error_message(self) -> None:
-        """
-        Validate that a provided custom error message template includes placeholders for every variable referenced by the rule.
+    def _parse_custom_error_paths(self) -> dict[str, tuple[str, ...]]:
+        """Parse and validate placeholder syntax in the custom error message."""
+        if self._custom_error_message is None:
+            return {}
 
-        Raises:
-            MissingErrorTemplateVariableError: If one or more extracted variables are not present as `{name}` placeholders in the custom template.
-        """
-        if not self._custom_error_message:
-            return
+        paths: dict[str, tuple[str, ...]] = {}
+        cursor = 0
+        for match in _ERROR_TEMPLATE_PLACEHOLDER.finditer(self._custom_error_message):
+            unmatched_text = self._custom_error_message[cursor : match.start()]
+            if "{" in unmatched_text or "}" in unmatched_text:
+                brace = "{" if "{" in unmatched_text else "}"
+                raise InvalidErrorTemplateError(brace, "unmatched brace")
 
-        vars_in_msg = set(re.findall(r"{([^}]+)}", self._custom_error_message))
-        missing = [v for v in self._variables if v not in vars_in_msg]
-        if missing:
-            raise MissingErrorTemplateVariableError(missing)
+            placeholder = match.group(1)
+            parts = tuple(placeholder.split("."))
+            if not placeholder or not all(part.isidentifier() for part in parts):
+                raise InvalidErrorTemplateError(
+                    placeholder,
+                    "expected one or more dot-separated Python identifiers",
+                )
+            paths[placeholder] = parts
+            cursor = match.end()
+
+        unmatched_text = self._custom_error_message[cursor:]
+        if "{" in unmatched_text or "}" in unmatched_text:
+            brace = "{" if "{" in unmatched_text else "}"
+            raise InvalidErrorTemplateError(brace, "unmatched brace")
+        return paths
+
+    def validate_custom_error_message(
+        self,
+        manager_class: type[GeneralManager] | None = None,
+    ) -> None:
+        """Validate that placeholder roots are referenced by the rule."""
+        del manager_class
+        variable_roots = {variable.split(".", 1)[0] for variable in self._variables}
+        for placeholder, path in self._custom_error_paths.items():
+            if path[0] not in variable_roots:
+                raise InvalidErrorTemplateError(
+                    placeholder,
+                    f"root {path[0]!r} is not referenced by the rule",
+                )
 
     def _generate_fallback_error_messages(
         self,
@@ -314,8 +361,6 @@ class Rule(Generic[GeneralManagerType]):
             `None` if the predicate passed, was skipped, or has not been evaluated.
 
         Raises:
-            MissingErrorTemplateVariableError: If a failed rule's custom message
-                omits a placeholder for a referenced variable.
             ErrorMessageGenerationError: If internal evaluation state records a
                 failed result without retaining its evaluated input.
             Exception: A matching rule handler's documented message-generation
@@ -326,8 +371,7 @@ class Rule(Generic[GeneralManagerType]):
         if self._last_input is None:
             raise ErrorMessageGenerationError()
 
-        # Validate and substitute template placeholders
-        self.validate_custom_error_message()
+        # Substitute template placeholders
         vals = self._extract_variable_values(self._last_input)
         manager_class = type(self._last_input).__name__
         logger.debug(
@@ -339,8 +383,7 @@ class Rule(Generic[GeneralManagerType]):
         )
 
         if self._custom_error_message:
-            formatted = re.sub(
-                r"{([^}]+)}",
+            formatted = _ERROR_TEMPLATE_PLACEHOLDER.sub(
                 lambda m: str(vals.get(m.group(1), m.group(0))),
                 self._custom_error_message,
             )

--- a/tests/snapshots/public_api_exports.json
+++ b/tests/snapshots/public_api_exports.json
@@ -892,6 +892,10 @@
       "general_manager.rule.handler",
       "BaseRuleHandler"
     ],
+    "InvalidErrorTemplateError": [
+      "general_manager.rule.rule",
+      "InvalidErrorTemplateError"
+    ],
     "InvalidRuleHandlerConfigurationError": [
       "general_manager.rule.rule",
       "InvalidRuleHandlerConfigurationError"

--- a/tests/unit/test_database_based_interface.py
+++ b/tests/unit/test_database_based_interface.py
@@ -1746,8 +1746,17 @@ class OrmWritableInterfaceTestCase(
             positive_value,
             custom_error_message="Age: {age.amount}",
         )
-        previous_rules = getattr(PersonModel._meta, "rules", None)
+        missing = object()
+        previous_rules = vars(PersonModel._meta).get("rules", missing)
         previous_parent = PersonInterface._parent_class
+        registry_snapshots = tuple(
+            (registry, list(registry))
+            for registry in (
+                GeneralManagerMeta.all_classes,
+                GeneralManagerMeta.pending_attribute_initialization,
+                GeneralManagerMeta.pending_graphql_interfaces,
+            )
+        )
         object.__setattr__(
             PersonModel._meta,
             "rules",
@@ -1790,11 +1799,12 @@ class OrmWritableInterfaceTestCase(
             )
         finally:
             PersonInterface._parent_class = previous_parent
-            if previous_rules is None:
-                try:
+            for registry, snapshot in registry_snapshots:
+                registry.clear()
+                registry.extend(snapshot)
+            if previous_rules is missing:
+                if "rules" in vars(PersonModel._meta):
                     delattr(PersonModel._meta, "rules")
-                except AttributeError:
-                    pass
             else:
                 object.__setattr__(
                     PersonModel._meta,

--- a/tests/unit/test_database_based_interface.py
+++ b/tests/unit/test_database_based_interface.py
@@ -15,6 +15,7 @@ from django.core.exceptions import ValidationError, FieldDoesNotExist
 from django.apps import apps
 
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.interface import OrmInterfaceBase
 from general_manager.interface.bundles.database import (
     ORM_PERSISTENCE_CAPABILITIES,
@@ -32,6 +33,7 @@ from general_manager.interface.utils.errors import (
 )
 from general_manager.manager.input import Input
 from general_manager.rule import Rule
+from general_manager.rule.rule import InvalidErrorTemplateError
 from general_manager.bucket.database_bucket import DatabaseBucket
 from general_manager.interface.capabilities.orm_utils.payload_normalizer import (
     PayloadNormalizer,
@@ -1731,6 +1733,74 @@ class OrmWritableInterfaceTestCase(
         self.assertEqual(instance.value, 42)
         self.assertEqual(instance.owner, self.user1)
         self.assertEqual(instance.changed_by, self.user1)
+
+    def test_late_orm_manager_validates_templates_before_first_create(self):
+        """A late manager must fail template validation before ORM mutation."""
+        rule_evaluations: list[object] = []
+
+        def positive_value(item: GeneralManager) -> bool:
+            rule_evaluations.append(item)
+            return item.age > 0  # type: ignore[attr-defined]
+
+        invalid_rule = Rule(
+            positive_value,
+            custom_error_message="Age: {age.amount}",
+        )
+        previous_rules = getattr(PersonModel._meta, "rules", None)
+        previous_parent = PersonInterface._parent_class
+        object.__setattr__(
+            PersonModel._meta,
+            "rules",
+            [invalid_rule],
+        )
+
+        try:
+
+            class LateWritableManager(GeneralManager):
+                Interface = PersonInterface
+
+            with patch.object(LateWritableManager.Interface, "create") as create:
+                with self.assertRaises(InvalidErrorTemplateError):
+                    LateWritableManager.create(
+                        creator_id=self.user1.pk,
+                        ignore_permission=True,
+                        name="Must Not Persist",
+                        age=1,
+                        owner=self.user1,
+                    )
+
+                create.assert_not_called()
+            self.assertEqual(rule_evaluations, [])
+            self.assertFalse(
+                vars(LateWritableManager).get(
+                    "_gm_rule_templates_validated",
+                    False,
+                )
+            )
+
+            object.__setattr__(PersonModel._meta, "rules", [])
+            GeneralManagerMeta.ensure_rule_templates_validated_after_readiness(
+                LateWritableManager
+            )
+            self.assertTrue(
+                vars(LateWritableManager).get(
+                    "_gm_rule_templates_validated",
+                    False,
+                )
+            )
+        finally:
+            PersonInterface._parent_class = previous_parent
+            if previous_rules is None:
+                try:
+                    delattr(PersonModel._meta, "rules")
+                except AttributeError:
+                    pass
+            else:
+                object.__setattr__(
+                    PersonModel._meta,
+                    "rules",
+                    previous_rules,
+                )
 
     def test_create_with_history_comment(self):
         """

--- a/tests/unit/test_existing_model_interface.py
+++ b/tests/unit/test_existing_model_interface.py
@@ -301,6 +301,20 @@ class ExistingModelInterfaceTestCase(TransactionTestCase):
                 else:
                     type.__setattr__(self.model, attribute_name, previous_value)
 
+            if previous_rules is missing:
+                self.assertFalse(hasattr(self.model._meta, "rules"))
+            else:
+                self.assertIs(self.model._meta.rules, previous_rules)  # type: ignore[attr-defined]
+            for attribute_name, previous_value in (
+                ("full_clean", previous_full_clean),
+                ("_general_manager_class", previous_manager_class),
+                ("all_objects", previous_all_objects),
+            ):
+                if previous_value is missing:
+                    self.assertNotIn(attribute_name, vars(self.model))
+                else:
+                    self.assertIs(vars(self.model)[attribute_name], previous_value)
+
         self.addCleanup(restore_model_state)
 
         def has_name(customer: models.Model) -> bool:
@@ -350,6 +364,16 @@ class ExistingModelInterfaceTestCase(TransactionTestCase):
             else:
                 InterfaceUnderTest._automatic_capability_builder = (
                     previous_automatic_builder
+                )
+            if previous_automatic_builder is missing:
+                self.assertNotIn(
+                    "_automatic_capability_builder",
+                    vars(InterfaceUnderTest),
+                )
+            else:
+                self.assertIs(
+                    vars(InterfaceUnderTest)["_automatic_capability_builder"],
+                    previous_automatic_builder,
                 )
             self.assertEqual(
                 capability_registry._bindings,

--- a/tests/unit/test_existing_model_interface.py
+++ b/tests/unit/test_existing_model_interface.py
@@ -11,11 +11,13 @@ from django.db import connection, models
 from django.test import TransactionTestCase
 from simple_history.models import HistoricalRecords
 
+from general_manager.bootstrap import initialize_general_manager_classes
 from general_manager.interface import ExistingModelInterface
 from general_manager.interface.interfaces import existing_model as existing_model_module
 from general_manager.interface.capabilities.existing_model import (
     ExistingModelResolutionCapability,
 )
+from general_manager.interface.manifests import ManifestCapabilityBuilder
 from general_manager.interface.utils.errors import (
     InvalidModelReferenceError,
     MissingModelConfigurationError,
@@ -23,6 +25,8 @@ from general_manager.interface.utils.errors import (
 from general_manager.interface.utils import errors as interface_errors
 from general_manager.interface.utils.history import DatabaseAwareHistoricalRecords
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.rule import Rule
+from general_manager.rule.rule import InvalidErrorTemplateError
 
 
 class AlwaysFailRule:
@@ -268,6 +272,118 @@ class ExistingModelInterfaceTestCase(TransactionTestCase):
         self.assertIsInstance(TemporaryManager.Interface, type)  # type: ignore[attr-defined]
         self.assertIs(TemporaryManager.Interface._parent_class, TemporaryManager)  # type: ignore[attr-defined]
         self.assertIs(TemporaryManager.Interface._model, model)  # type: ignore[attr-defined]
+
+    def test_bootstrap_validates_rule_copied_to_existing_model_metadata(self) -> None:
+        missing = object()
+        previous_rules = getattr(self.model._meta, "rules", missing)
+        previous_full_clean = vars(self.model).get("full_clean", missing)
+        previous_manager_class = vars(self.model).get(
+            "_general_manager_class",
+            missing,
+        )
+        previous_all_objects = vars(self.model).get("all_objects", missing)
+
+        def restore_model_state() -> None:
+            if previous_rules is missing:
+                if hasattr(self.model._meta, "rules"):
+                    delattr(self.model._meta, "rules")
+            else:
+                object.__setattr__(self.model._meta, "rules", previous_rules)
+
+            for attribute_name, previous_value in (
+                ("full_clean", previous_full_clean),
+                ("_general_manager_class", previous_manager_class),
+                ("all_objects", previous_all_objects),
+            ):
+                if previous_value is missing:
+                    if attribute_name in vars(self.model):
+                        type.__delattr__(self.model, attribute_name)
+                else:
+                    type.__setattr__(self.model, attribute_name, previous_value)
+
+        self.addCleanup(restore_model_state)
+
+        def has_name(customer: models.Model) -> bool:
+            return bool(customer.name)  # type: ignore[attr-defined]
+
+        rule = Rule(
+            has_name,
+            custom_error_message="Name: {name.value}",
+        )
+
+        class InterfaceUnderTest(ExistingModelInterface):
+            model = self.model
+
+            class Meta:
+                rules: ClassVar[list[Rule]] = [rule]
+
+        previous_automatic_builder = vars(InterfaceUnderTest).get(
+            "_automatic_capability_builder",
+            missing,
+        )
+        capability_builder = InterfaceUnderTest._automatic_capability_builder
+        if capability_builder is None:
+            capability_builder = ManifestCapabilityBuilder()
+            InterfaceUnderTest._automatic_capability_builder = capability_builder
+        capability_registry = capability_builder.registry
+        capability_bindings_snapshot = {
+            interface: set(capabilities)
+            for interface, capabilities in capability_registry._bindings.items()
+        }
+        capability_instances_snapshot = dict(capability_registry._instances)
+
+        def restore_capability_registry() -> None:
+            for interface in tuple(capability_registry._bindings):
+                if interface not in capability_bindings_snapshot:
+                    del capability_registry._bindings[interface]
+            for interface, capabilities in capability_bindings_snapshot.items():
+                capability_registry._bindings[interface] = set(capabilities)
+
+            for interface in tuple(capability_registry._instances):
+                if interface not in capability_instances_snapshot:
+                    del capability_registry._instances[interface]
+            capability_registry._instances.update(capability_instances_snapshot)
+
+            if previous_automatic_builder is missing:
+                if "_automatic_capability_builder" in vars(InterfaceUnderTest):
+                    del InterfaceUnderTest._automatic_capability_builder
+            else:
+                InterfaceUnderTest._automatic_capability_builder = (
+                    previous_automatic_builder
+                )
+            self.assertEqual(
+                capability_registry._bindings,
+                capability_bindings_snapshot,
+            )
+            self.assertEqual(
+                capability_registry._instances,
+                capability_instances_snapshot,
+            )
+
+        self.addCleanup(restore_capability_registry)
+
+        new_attrs, interface_cls, model, post = self._invoke_handle(
+            InterfaceUnderTest,
+            name="ExistingRuleBootstrapManager",
+        )
+        TemporaryManager = type.__new__(
+            type(GeneralManager),
+            "ExistingRuleBootstrapManager",
+            (GeneralManager,),
+            new_attrs,
+        )
+        post(TemporaryManager, interface_cls, model)
+
+        self.assertIn(rule, model._meta.rules)  # type: ignore[attr-defined]
+        self.assertIs(TemporaryManager.Interface._model, model)  # type: ignore[attr-defined]
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            initialize_general_manager_classes(
+                [TemporaryManager],
+                [TemporaryManager],
+            )
+
+        self.assertEqual(ctx.exception.placeholder, "name.value")
 
     def test_ensure_history_when_already_registered(self) -> None:
         """

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -1,3 +1,8 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
 from types import SimpleNamespace
 from typing import ClassVar
 
@@ -1590,6 +1595,10 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
                 False,
             )
         )
+        self.assertNotIn(
+            "_gm_rule_templates_validation_in_progress",
+            vars(LateRetryManager),
+        )
         self.assertIn(
             LateRetryManager,
             GeneralManagerMeta.pending_attribute_initialization,
@@ -1704,3 +1713,112 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
                 False,
             )
         )
+
+    def test_rule_validation_can_reenter_lazy_field_access_without_deadlock(
+        self,
+    ) -> None:
+        project_root = Path(__file__).resolve().parents[2]
+        environment = os.environ.copy()
+        existing_pythonpath = environment.get("PYTHONPATH")
+        pythonpath_entries = [str(project_root / "src")]
+        if existing_pythonpath:
+            pythonpath_entries.append(existing_pythonpath)
+        environment["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+        environment["DJANGO_SETTINGS_MODULE"] = "tests.test_settings"
+        probe = textwrap.dedent(
+            """
+            import django
+
+            django.setup()
+
+            from general_manager.interface.interfaces.calculation import (
+                CalculationInterface,
+            )
+            from general_manager.manager.general_manager import GeneralManager
+            from general_manager.manager.input import Input
+            from general_manager.rule import Rule
+
+
+            class ReentrantRule(Rule):
+                def __init__(self):
+                    self.validation_calls = 0
+
+                def validate_custom_error_message(self, manager_class=None):
+                    self.validation_calls += 1
+                    assert manager_class.price is int
+
+
+            rule = ReentrantRule()
+
+
+            class ReentrantManager(GeneralManager):
+                price: int
+
+                class Interface(CalculationInterface):
+                    price = Input(int)
+                    rules = [rule]
+
+
+            assert ReentrantManager.price is int
+            assert rule.validation_calls == 1
+            assert vars(ReentrantManager)["_gm_rule_templates_validated"] is True
+            assert "_gm_rule_templates_validation_in_progress" not in vars(
+                ReentrantManager
+            )
+            print("reentrant-validation-complete")
+            """
+        )
+
+        result = subprocess.run(  # noqa: S603 - trusted interpreter and fixed probe
+            [sys.executable, "-c", probe],
+            cwd=project_root,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "reentrant-validation-complete")
+
+    def test_subclass_does_not_inherit_base_rule_validation_marker(self) -> None:
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        base_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price}",
+        )
+
+        class ValidatedBaseManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [base_rule]
+
+        self.assertIs(ValidatedBaseManager.price, int)
+        self.assertTrue(
+            vars(ValidatedBaseManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+        invalid_subclass_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class UnvalidatedSubclassManager(ValidatedBaseManager):
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [invalid_subclass_rule]
+
+        self.assertNotIn(
+            "_gm_rule_templates_validated",
+            vars(UnvalidatedSubclassManager),
+        )
+        with self.assertRaises(InvalidErrorTemplateError):
+            _ = UnvalidatedSubclassManager.price

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from typing import ClassVar
 
+from django.apps import apps
 from django.test import SimpleTestCase, override_settings
 
 from general_manager.interface import RequestInterface
@@ -1316,3 +1317,328 @@ class BootstrapRuleTemplateValidationTests(SimpleTestCase):
         )
 
         self.assertEqual(validation_manager_classes, [BootstrapRequestItem])
+
+
+class LateManagerRuleTemplateValidationTests(SimpleTestCase):
+    """Validate rules before exposing fields on managers imported after startup."""
+
+    def setUp(self) -> None:
+        self._apps_ready = apps.ready
+        apps.ready = True
+        self._registry_snapshots = {
+            "all_classes": list(GeneralManagerMeta.all_classes),
+            "read_only_classes": list(GeneralManagerMeta.read_only_classes),
+            "pending_graphql_interfaces": list(
+                GeneralManagerMeta.pending_graphql_interfaces
+            ),
+            "pending_attribute_initialization": list(
+                GeneralManagerMeta.pending_attribute_initialization
+            ),
+        }
+        self._capability_registry = manager_meta_module._capability_builder().registry
+        self._capability_bindings_snapshot = {
+            interface: set(capabilities)
+            for interface, capabilities in self._capability_registry._bindings.items()
+        }
+        self._capability_instances_snapshot = dict(self._capability_registry._instances)
+        GeneralManagerMeta.all_classes.clear()
+        GeneralManagerMeta.read_only_classes.clear()
+        GeneralManagerMeta.pending_graphql_interfaces.clear()
+        GeneralManagerMeta.pending_attribute_initialization.clear()
+
+    def tearDown(self) -> None:
+        apps.ready = self._apps_ready
+        for name, snapshot in self._registry_snapshots.items():
+            registry = getattr(GeneralManagerMeta, name)
+            registry.clear()
+            registry.extend(snapshot)
+        for interface in tuple(self._capability_registry._bindings):
+            if interface not in self._capability_bindings_snapshot:
+                del self._capability_registry._bindings[interface]
+        for interface, capabilities in self._capability_bindings_snapshot.items():
+            self._capability_registry._bindings[interface] = set(capabilities)
+        for interface in tuple(self._capability_registry._instances):
+            if interface not in self._capability_instances_snapshot:
+                del self._capability_registry._instances[interface]
+        self._capability_registry._instances.update(self._capability_instances_snapshot)
+        self.assertEqual(
+            self._capability_registry._bindings,
+            self._capability_bindings_snapshot,
+        )
+        self.assertEqual(
+            self._capability_registry._instances,
+            self._capability_instances_snapshot,
+        )
+        self.assertEqual(apps.ready, self._apps_ready)
+
+    def test_late_manager_rejects_scalar_template_traversal_before_exposure(
+        self,
+    ) -> None:
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class LatePriceManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [rule]
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            _ = LatePriceManager.price
+
+        self.assertNotIn("price", vars(LatePriceManager))
+        self.assertFalse(
+            vars(LatePriceManager).get("_gm_attributes_initialized", False)
+        )
+        self.assertFalse(
+            vars(LatePriceManager).get("_gm_rule_templates_validated", False)
+        )
+        self.assertIn(
+            LatePriceManager,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
+    def test_late_manager_accepts_related_template_path_on_lazy_access(self) -> None:
+        class LateProjectManager(GeneralManager):
+            name: str
+
+            class Interface(CalculationInterface):
+                name = GMInput(str)
+
+        def project_exists(item: GeneralManager) -> bool:
+            return item.project is not None  # type: ignore[attr-defined]
+
+        rule = Rule(
+            project_exists,
+            custom_error_message="Project: {project.name}",
+        )
+
+        class LateWorkItemManager(GeneralManager):
+            project: LateProjectManager
+
+            class Interface(CalculationInterface):
+                project = GMInput(LateProjectManager)
+                rules: ClassVar[list[object]] = [rule]
+
+        self.assertIs(LateWorkItemManager.project, LateProjectManager)
+        self.assertTrue(
+            vars(LateWorkItemManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+    def test_late_manager_rule_validation_runs_once_across_lazy_and_bootstrap(
+        self,
+    ) -> None:
+        validation_manager_classes: list[type[GeneralManager] | None] = []
+
+        class CountingRule(Rule[GeneralManager]):
+            def validate_custom_error_message(
+                self,
+                manager_class: type[GeneralManager] | None = None,
+            ) -> None:
+                if hasattr(self, "_handlers"):
+                    validation_manager_classes.append(manager_class)
+                super().validate_custom_error_message(manager_class)
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = CountingRule(
+            positive_price,
+            custom_error_message="Price: {price}",
+        )
+
+        class LateCountingManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [rule]
+
+        self.assertIs(LateCountingManager.price, int)
+        self.assertIs(LateCountingManager.price, int)
+        initialize_general_manager_classes(
+            GeneralManagerMeta.pending_attribute_initialization,
+            GeneralManagerMeta.all_classes,
+        )
+
+        self.assertEqual(validation_manager_classes, [LateCountingManager])
+
+    def test_late_manager_validates_cached_model_metadata_rules(self) -> None:
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class LateModelRuleManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+
+        LateModelRuleManager.Interface._model = SimpleNamespace(  # type: ignore[attr-defined]
+            _meta=SimpleNamespace(rules=[rule])
+        )
+        LateModelRuleManager._attributes = (
+            LateModelRuleManager.Interface.get_attributes()
+        )
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            _ = LateModelRuleManager.price
+
+        self.assertIn("_attributes", vars(LateModelRuleManager))
+        self.assertNotIn("price", vars(LateModelRuleManager))
+        self.assertFalse(
+            vars(LateModelRuleManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+    def test_late_manager_rejects_one_shot_source_before_partial_validation(
+        self,
+    ) -> None:
+        validation_manager_classes: list[type[GeneralManager] | None] = []
+
+        class CountingRule(Rule[GeneralManager]):
+            def validate_custom_error_message(
+                self,
+                manager_class: type[GeneralManager] | None = None,
+            ) -> None:
+                if hasattr(self, "_handlers"):
+                    validation_manager_classes.append(manager_class)
+                super().validate_custom_error_message(manager_class)
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = CountingRule(
+            positive_price,
+            custom_error_message="Price: {price}",
+        )
+        iterator_entry = object()
+        rule_iterator = iter([iterator_entry])
+
+        class LateIteratorManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [rule]
+
+        LateIteratorManager.Interface._model = SimpleNamespace(  # type: ignore[attr-defined]
+            _meta=SimpleNamespace(rules=rule_iterator)
+        )
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "rules must be a reusable iterable",
+        ):
+            _ = LateIteratorManager.price
+
+        self.assertEqual(validation_manager_classes, [])
+        self.assertIs(next(rule_iterator), iterator_entry)
+        self.assertNotIn("price", vars(LateIteratorManager))
+        self.assertFalse(
+            vars(LateIteratorManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+    def test_late_manager_rule_validation_failure_remains_retryable(self) -> None:
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        invalid_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class LateRetryManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [invalid_rule]
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            _ = LateRetryManager.price
+
+        self.assertNotIn("price", vars(LateRetryManager))
+        self.assertNotIn("_attributes", vars(LateRetryManager))
+        self.assertFalse(
+            vars(LateRetryManager).get(
+                "_gm_attributes_initialized",
+                False,
+            )
+        )
+        self.assertFalse(
+            vars(LateRetryManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+        self.assertIn(
+            LateRetryManager,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
+        LateRetryManager.Interface.rules = []
+
+        self.assertIs(LateRetryManager.price, int)
+        self.assertTrue(
+            vars(LateRetryManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+        self.assertNotIn(
+            LateRetryManager,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
+    def test_lazy_access_defers_rule_validation_until_bootstrap_while_apps_load(
+        self,
+    ) -> None:
+        apps.ready = False
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class LoadingPriceManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [rule]
+
+        self.assertIs(LoadingPriceManager.price, int)
+        self.assertFalse(
+            vars(LoadingPriceManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            initialize_general_manager_classes(
+                GeneralManagerMeta.pending_attribute_initialization,
+                GeneralManagerMeta.all_classes,
+            )

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -1642,3 +1642,65 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
                 GeneralManagerMeta.pending_attribute_initialization,
                 GeneralManagerMeta.all_classes,
             )
+
+    def test_cached_descriptor_validates_after_apps_become_ready(self) -> None:
+        apps.ready = False
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class ReadinessTransitionManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [rule]
+
+        self.assertIs(ReadinessTransitionManager.price, int)
+        self.assertIn("price", vars(ReadinessTransitionManager))
+        self.assertTrue(
+            vars(ReadinessTransitionManager).get(
+                "_gm_attributes_initialized",
+                False,
+            )
+        )
+        self.assertFalse(
+            vars(ReadinessTransitionManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+        apps.ready = True
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            _ = ReadinessTransitionManager.price
+
+        self.assertIn("price", vars(ReadinessTransitionManager))
+        self.assertTrue(
+            vars(ReadinessTransitionManager).get(
+                "_gm_attributes_initialized",
+                False,
+            )
+        )
+        self.assertFalse(
+            vars(ReadinessTransitionManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+        ReadinessTransitionManager.Interface.rules = []
+
+        self.assertIs(ReadinessTransitionManager.price, int)
+        self.assertTrue(
+            vars(ReadinessTransitionManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -15,7 +15,11 @@ from general_manager.interface.base_interface import InterfaceBase
 from general_manager.interface.interfaces.calculation import (
     CalculationInterface,
 )
-from general_manager.interface.requests import RequestField, RequestQueryOperation
+from general_manager.interface.requests import (
+    RequestField,
+    RequestMutationOperation,
+    RequestQueryOperation,
+)
 from general_manager.bootstrap import initialize_general_manager_classes
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.input import Input as GMInput
@@ -1409,6 +1413,35 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
             GeneralManagerMeta.pending_attribute_initialization,
         )
 
+    def test_missing_dunder_probe_does_not_validate_or_initialize_manager(
+        self,
+    ) -> None:
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        invalid_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class InternallyProbedManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [invalid_rule]
+
+        self.assertFalse(hasattr(InternallyProbedManager, "__origin__"))
+        self.assertNotIn("_attributes", vars(InternallyProbedManager))
+        self.assertNotIn(
+            "_gm_rule_templates_validated",
+            vars(InternallyProbedManager),
+        )
+        self.assertIn(
+            InternallyProbedManager,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
     def test_late_manager_accepts_related_template_path_on_lazy_access(self) -> None:
         class LateProjectManager(GeneralManager):
             name: str
@@ -1719,6 +1752,225 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
         self.assertIs(ReadinessTransitionManager.price, int)
         self.assertTrue(
             vars(ReadinessTransitionManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+    def test_late_request_manager_validates_before_first_create_rule_runtime(
+        self,
+    ) -> None:
+        rule_evaluations: list[object] = []
+
+        def positive_price(item: GeneralManager) -> bool:
+            rule_evaluations.append(item)
+            return item.price > 0  # type: ignore[attr-defined]
+
+        invalid_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class LateRequestManager(GeneralManager):
+            class Interface(RequestInterface):
+                id = GMInput(int)
+                price = RequestField(int)
+
+                class Meta:
+                    query_operations: ClassVar[dict[str, RequestQueryOperation]] = {
+                        "detail": RequestQueryOperation(
+                            name="detail",
+                            method="GET",
+                            path="/items/{id}",
+                        )
+                    }
+                    create_operation = RequestMutationOperation(
+                        name="create",
+                        method="POST",
+                        path="/items",
+                    )
+
+        LateRequestManager.Interface.rules = [invalid_rule]
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            LateRequestManager.create(ignore_permission=True, price=1)
+
+        self.assertEqual(rule_evaluations, [])
+        self.assertFalse(
+            vars(LateRequestManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+        self.assertIn(
+            LateRequestManager,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
+        LateRequestManager.Interface.rules = []
+        GeneralManagerMeta.ensure_rule_templates_validated_after_readiness(
+            LateRequestManager
+        )
+        self.assertTrue(
+            vars(LateRequestManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+    def test_cached_manager_validates_before_first_create_after_readiness(
+        self,
+    ) -> None:
+        apps.ready = False
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        invalid_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class CachedCreateManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [invalid_rule]
+
+        self.assertIs(CachedCreateManager.price, int)
+        apps.ready = True
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            CachedCreateManager.create(ignore_permission=True, price=1)
+
+        self.assertFalse(
+            vars(CachedCreateManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+    def test_cached_manager_validates_before_first_update_after_readiness(
+        self,
+    ) -> None:
+        apps.ready = False
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        invalid_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class CachedUpdateManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [invalid_rule]
+
+        self.assertIs(CachedUpdateManager.price, int)
+        manager = CachedUpdateManager(price=1)
+        interface_before_update = manager._interface
+        apps.ready = True
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            manager.update(ignore_permission=True, price=2)
+
+        self.assertIs(manager._interface, interface_before_update)
+        self.assertFalse(
+            vars(CachedUpdateManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+    def test_cached_manager_validates_before_first_delete_after_readiness(
+        self,
+    ) -> None:
+        apps.ready = False
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        invalid_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class CachedDeleteManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [invalid_rule]
+
+        self.assertIs(CachedDeleteManager.price, int)
+        manager = CachedDeleteManager(price=1)
+        apps.ready = True
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            manager.delete(ignore_permission=True)
+
+        self.assertTrue(manager._manager_state_valid)
+        self.assertFalse(
+            vars(CachedDeleteManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+    def test_cached_instance_descriptor_validates_before_first_evaluation(
+        self,
+    ) -> None:
+        apps.ready = False
+        attribute_evaluations: list[object] = []
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        invalid_rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class CachedDescriptorManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [invalid_rule]
+
+        self.assertIs(CachedDescriptorManager.price, int)
+        manager = CachedDescriptorManager(price=1)
+        manager._attributes["price"] = (
+            lambda interface: attribute_evaluations.append(interface) or 1
+        )
+        descriptor_before_validation = vars(CachedDescriptorManager)["price"]
+        apps.ready = True
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            _ = manager.price
+
+        self.assertEqual(attribute_evaluations, [])
+        self.assertIs(
+            vars(CachedDescriptorManager)["price"],
+            descriptor_before_validation,
+        )
+        self.assertFalse(
+            vars(CachedDescriptorManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+
+        CachedDescriptorManager.Interface.rules = []
+        self.assertEqual(manager.price, 1)
+        self.assertEqual(len(attribute_evaluations), 1)
+        self.assertTrue(
+            vars(CachedDescriptorManager).get(
                 "_gm_rule_templates_validated",
                 False,
             )

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -1,15 +1,21 @@
+from types import SimpleNamespace
 from typing import ClassVar
 
 from django.test import SimpleTestCase, override_settings
 
+from general_manager.interface import RequestInterface
 from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.interface.base_interface import InterfaceBase
 from general_manager.interface.interfaces.calculation import (
     CalculationInterface,
 )
+from general_manager.interface.requests import RequestField, RequestQueryOperation
 from general_manager.bootstrap import initialize_general_manager_classes
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.input import Input as GMInput
+from general_manager.manager import meta as manager_meta_module
+from general_manager.rule import Rule
+from general_manager.rule.rule import InvalidErrorTemplateError
 
 
 class dummyInterface:
@@ -971,3 +977,342 @@ class GeneralManagerMetaTests(SimpleTestCase):
             hasattr(ManagerB, "b_post") and ManagerB.b_post is True,  # type: ignore
             msg="ManagerB should have the attribute 'b_post'.",
         )
+
+
+class BootstrapRuleTemplateValidationTests(SimpleTestCase):
+    """Validate attached rule templates once manager schemas are bootstrapped."""
+
+    def setUp(self) -> None:
+        self._registry_snapshots = {
+            "all_classes": list(GeneralManagerMeta.all_classes),
+            "read_only_classes": list(GeneralManagerMeta.read_only_classes),
+            "pending_graphql_interfaces": list(
+                GeneralManagerMeta.pending_graphql_interfaces
+            ),
+            "pending_attribute_initialization": list(
+                GeneralManagerMeta.pending_attribute_initialization
+            ),
+        }
+        self._capability_registry = manager_meta_module._capability_builder().registry
+        self._capability_bindings_snapshot = {
+            interface: set(capabilities)
+            for interface, capabilities in self._capability_registry._bindings.items()
+        }
+        self._capability_instances_snapshot = dict(self._capability_registry._instances)
+        GeneralManagerMeta.all_classes.clear()
+        GeneralManagerMeta.read_only_classes.clear()
+        GeneralManagerMeta.pending_graphql_interfaces.clear()
+        GeneralManagerMeta.pending_attribute_initialization.clear()
+
+    def tearDown(self) -> None:
+        for name, snapshot in self._registry_snapshots.items():
+            registry = getattr(GeneralManagerMeta, name)
+            registry.clear()
+            registry.extend(snapshot)
+        self._restore_capability_registry()
+        self.assertEqual(
+            self._capability_registry._bindings,
+            self._capability_bindings_snapshot,
+        )
+        self.assertEqual(
+            self._capability_registry._instances,
+            self._capability_instances_snapshot,
+        )
+
+    def _restore_capability_registry(self) -> None:
+        for interface in tuple(self._capability_registry._bindings):
+            if interface not in self._capability_bindings_snapshot:
+                del self._capability_registry._bindings[interface]
+        for interface, capabilities in self._capability_bindings_snapshot.items():
+            self._capability_registry._bindings[interface] = set(capabilities)
+
+        for interface in tuple(self._capability_registry._instances):
+            if interface not in self._capability_instances_snapshot:
+                del self._capability_registry._instances[interface]
+        self._capability_registry._instances.update(self._capability_instances_snapshot)
+
+    def test_cleanup_restores_shared_capability_registry_state(self) -> None:
+        class BootstrapRegistryItem(GeneralManager):
+            value: int
+
+            class Interface(CalculationInterface):
+                value = GMInput(int)
+
+        self.assertIn(
+            BootstrapRegistryItem.Interface,
+            self._capability_registry._bindings,
+        )
+        self.assertIn(
+            BootstrapRegistryItem.Interface,
+            self._capability_registry._instances,
+        )
+
+        self._restore_capability_registry()
+
+        self.assertEqual(
+            self._capability_registry._bindings,
+            self._capability_bindings_snapshot,
+        )
+        self.assertEqual(
+            self._capability_registry._instances,
+            self._capability_instances_snapshot,
+        )
+
+    def test_bootstrap_accepts_valid_related_manager_template_path(self) -> None:
+        class BootstrapProject(GeneralManager):
+            name: str
+
+            class Interface(CalculationInterface):
+                name = GMInput(str)
+
+        def project_exists(item: GeneralManager) -> bool:
+            return item.project is not None  # type: ignore[attr-defined]
+
+        rule = Rule(
+            project_exists,
+            custom_error_message="Project: {project.name}",
+        )
+
+        class BootstrapWorkItem(GeneralManager):
+            project: BootstrapProject
+
+            class Interface(CalculationInterface):
+                project = GMInput(BootstrapProject)
+
+        BootstrapWorkItem.Interface.rules = [rule]  # type: ignore[attr-defined]
+
+        initialize_general_manager_classes(
+            GeneralManagerMeta.pending_attribute_initialization,
+            GeneralManagerMeta.all_classes,
+        )
+
+    def test_bootstrap_rejects_unknown_related_manager_template_path(self) -> None:
+        class BootstrapProject(GeneralManager):
+            name: str
+
+            class Interface(CalculationInterface):
+                name = GMInput(str)
+
+        def project_exists(item: GeneralManager) -> bool:
+            return item.project is not None  # type: ignore[attr-defined]
+
+        rule = Rule(
+            project_exists,
+            custom_error_message="Project: {project.nmae}",
+        )
+
+        class BootstrapWorkItem(GeneralManager):
+            project: BootstrapProject
+
+            class Interface(CalculationInterface):
+                project = GMInput(BootstrapProject)
+
+        BootstrapWorkItem.Interface.rules = [rule]  # type: ignore[attr-defined]
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            initialize_general_manager_classes(
+                GeneralManagerMeta.pending_attribute_initialization,
+                GeneralManagerMeta.all_classes,
+            )
+
+        self.assertEqual(ctx.exception.placeholder, "project.nmae")
+
+    def test_declarative_rule_schema_validation_is_deferred_until_bootstrap(
+        self,
+    ) -> None:
+        validation_manager_classes: list[type[GeneralManager] | None] = []
+
+        class CountingRule(Rule[GeneralManager]):
+            def validate_custom_error_message(
+                self,
+                manager_class: type[GeneralManager] | None = None,
+            ) -> None:
+                if hasattr(self, "_handlers"):
+                    validation_manager_classes.append(manager_class)
+                super().validate_custom_error_message(manager_class)
+
+        class BootstrapProject(GeneralManager):
+            name: str
+
+            class Interface(CalculationInterface):
+                name = GMInput(str)
+
+        def project_exists(item: GeneralManager) -> bool:
+            return item.project is not None  # type: ignore[attr-defined]
+
+        rule = CountingRule(
+            project_exists,
+            custom_error_message="Project: {project.nmae}",
+        )
+
+        class BootstrapWorkItem(GeneralManager):
+            project: BootstrapProject
+
+            class Interface(CalculationInterface):
+                project = GMInput(BootstrapProject)
+                rules: ClassVar[list[object]] = [rule]
+
+        self.assertEqual(validation_manager_classes, [])
+
+        with self.assertRaises(InvalidErrorTemplateError):
+            initialize_general_manager_classes(
+                GeneralManagerMeta.pending_attribute_initialization,
+                GeneralManagerMeta.all_classes,
+            )
+
+        self.assertEqual(validation_manager_classes, [BootstrapWorkItem])
+
+    def test_request_interface_rules_are_validated_at_bootstrap(self) -> None:
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class BootstrapRequestItem(GeneralManager):
+            class Interface(RequestInterface):
+                id = GMInput(int)
+                price = RequestField(int)
+
+                class Meta:
+                    query_operations: ClassVar[dict[str, RequestQueryOperation]] = {
+                        "detail": RequestQueryOperation(
+                            name="detail",
+                            method="GET",
+                            path="/items/{id}",
+                        )
+                    }
+
+        BootstrapRequestItem.Interface.rules = [rule]
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            initialize_general_manager_classes(
+                GeneralManagerMeta.pending_attribute_initialization,
+                GeneralManagerMeta.all_classes,
+            )
+
+        self.assertEqual(ctx.exception.placeholder, "price.amount")
+
+    def test_model_metadata_rules_are_validated_at_bootstrap(self) -> None:
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = Rule(
+            positive_price,
+            custom_error_message="Price: {price.amount}",
+        )
+
+        class BootstrapOrmItem(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+
+        BootstrapOrmItem.Interface._model = SimpleNamespace(  # type: ignore[attr-defined]
+            _meta=SimpleNamespace(rules=[rule])
+        )
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            initialize_general_manager_classes(
+                GeneralManagerMeta.pending_attribute_initialization,
+                GeneralManagerMeta.all_classes,
+            )
+
+        self.assertEqual(ctx.exception.placeholder, "price.amount")
+
+    def test_bootstrap_rejects_one_shot_rule_iterators_without_consuming_them(
+        self,
+    ) -> None:
+        validation_manager_classes: list[type[GeneralManager] | None] = []
+
+        class CountingRule(Rule[GeneralManager]):
+            def validate_custom_error_message(
+                self,
+                manager_class: type[GeneralManager] | None = None,
+            ) -> None:
+                if hasattr(self, "_handlers"):
+                    validation_manager_classes.append(manager_class)
+                super().validate_custom_error_message(manager_class)
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = CountingRule(
+            positive_price,
+            custom_error_message="Price: {price}",
+        )
+        iterator_entry = object()
+        rule_iterator = iter([iterator_entry])
+
+        class BootstrapIteratorItem(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [rule]
+
+        BootstrapIteratorItem.Interface._model = SimpleNamespace(  # type: ignore[attr-defined]
+            _meta=SimpleNamespace(rules=rule_iterator)
+        )
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "rules must be a reusable iterable",
+        ):
+            initialize_general_manager_classes(
+                GeneralManagerMeta.pending_attribute_initialization,
+                GeneralManagerMeta.all_classes,
+            )
+
+        self.assertEqual(validation_manager_classes, [])
+        self.assertIs(next(rule_iterator), iterator_entry)
+        with self.assertRaises(StopIteration):
+            next(rule_iterator)
+
+    def test_duplicate_rules_and_manager_classes_are_validated_once(self) -> None:
+        validation_manager_classes: list[type[GeneralManager] | None] = []
+
+        class CountingRule(Rule[GeneralManager]):
+            def validate_custom_error_message(
+                self,
+                manager_class: type[GeneralManager] | None = None,
+            ) -> None:
+                if hasattr(self, "_handlers"):
+                    validation_manager_classes.append(manager_class)
+                super().validate_custom_error_message(manager_class)
+
+        def positive_price(item: GeneralManager) -> bool:
+            return item.price > 0  # type: ignore[attr-defined]
+
+        rule = CountingRule(
+            positive_price,
+            custom_error_message="Price: {price}",
+        )
+
+        class BootstrapRequestItem(GeneralManager):
+            class Interface(RequestInterface):
+                id = GMInput(int)
+                price = RequestField(int)
+
+                class Meta:
+                    query_operations: ClassVar[dict[str, RequestQueryOperation]] = {
+                        "detail": RequestQueryOperation(
+                            name="detail",
+                            method="GET",
+                            path="/items/{id}",
+                        )
+                    }
+
+        BootstrapRequestItem.Interface.rules = [object(), rule]
+        BootstrapRequestItem.Interface._model = SimpleNamespace(  # type: ignore[attr-defined]
+            _meta=SimpleNamespace(rules=[object(), rule])
+        )
+
+        initialize_general_manager_classes(
+            GeneralManagerMeta.pending_attribute_initialization,
+            [BootstrapRequestItem, BootstrapRequestItem],
+        )
+
+        self.assertEqual(validation_manager_classes, [BootstrapRequestItem])

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -1672,6 +1672,8 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
 
         self.assertIs(ReadinessTransitionManager.price, int)
         self.assertIn("price", vars(ReadinessTransitionManager))
+        price_descriptor_before_validation = vars(ReadinessTransitionManager)["price"]
+        attributes_before_validation = vars(ReadinessTransitionManager)["_attributes"]
         self.assertTrue(
             vars(ReadinessTransitionManager).get(
                 "_gm_attributes_initialized",
@@ -1691,6 +1693,14 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
             _ = ReadinessTransitionManager.price
 
         self.assertIn("price", vars(ReadinessTransitionManager))
+        self.assertIs(
+            vars(ReadinessTransitionManager)["price"],
+            price_descriptor_before_validation,
+        )
+        self.assertIs(
+            vars(ReadinessTransitionManager)["_attributes"],
+            attributes_before_validation,
+        )
         self.assertTrue(
             vars(ReadinessTransitionManager).get(
                 "_gm_attributes_initialized",
@@ -1822,3 +1832,90 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
         )
         with self.assertRaises(InvalidErrorTemplateError):
             _ = UnvalidatedSubclassManager.price
+
+    def test_reentrant_validation_failure_rolls_back_nested_initialization(
+        self,
+    ) -> None:
+        class ReentrantValidationError(RuntimeError):
+            pass
+
+        class ReentrantFailingRule(Rule[GeneralManager]):
+            def __init__(self) -> None:
+                self.validation_calls = 0
+
+            def validate_custom_error_message(
+                self,
+                manager_class: type[GeneralManager] | None = None,
+            ) -> None:
+                self.validation_calls += 1
+                assert manager_class is not None
+                assert manager_class.price is int  # type: ignore[attr-defined]
+                raise ReentrantValidationError
+
+        rule = ReentrantFailingRule()
+
+        class UnrelatedPendingManager(GeneralManager):
+            value: int
+
+            class Interface(CalculationInterface):
+                value = GMInput(int)
+
+        class ReentrantFailureManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [rule]
+
+        pending_before_validation = list(
+            GeneralManagerMeta.pending_attribute_initialization
+        )
+
+        with self.assertRaises(ReentrantValidationError):
+            _ = ReentrantFailureManager.price
+
+        self.assertEqual(rule.validation_calls, 1)
+        self.assertNotIn("price", vars(ReentrantFailureManager))
+        self.assertNotIn("_attributes", vars(ReentrantFailureManager))
+        self.assertFalse(
+            vars(ReentrantFailureManager).get(
+                "_gm_attributes_initialized",
+                False,
+            )
+        )
+        self.assertFalse(
+            vars(ReentrantFailureManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+        self.assertNotIn(
+            "_gm_rule_templates_validation_in_progress",
+            vars(ReentrantFailureManager),
+        )
+        self.assertIn(
+            ReentrantFailureManager,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+        self.assertEqual(
+            GeneralManagerMeta.pending_attribute_initialization,
+            pending_before_validation,
+        )
+        self.assertIn(
+            UnrelatedPendingManager,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )
+
+        ReentrantFailureManager.Interface.rules = []
+
+        self.assertIs(ReentrantFailureManager.price, int)
+        self.assertTrue(
+            vars(ReentrantFailureManager).get(
+                "_gm_rule_templates_validated",
+                False,
+            )
+        )
+        self.assertNotIn(
+            ReentrantFailureManager,
+            GeneralManagerMeta.pending_attribute_initialization,
+        )

--- a/tests/unit/test_general_manager_meta.py
+++ b/tests/unit/test_general_manager_meta.py
@@ -2037,7 +2037,7 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
             env=environment,
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=60,
             check=False,
         )
 
@@ -2084,6 +2084,38 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
         )
         with self.assertRaises(InvalidErrorTemplateError):
             _ = UnvalidatedSubclassManager.price
+
+    def test_validated_manager_skips_rule_validation_lock(self) -> None:
+        class ValidatedManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+
+        GeneralManagerMeta.ensure_rule_templates_validated(ValidatedManager)
+
+        class ExplodingLock:
+            def __enter__(self) -> None:
+                raise AssertionError
+
+            def __exit__(
+                self,
+                exc_type: object,
+                exc_value: object,
+                traceback: object,
+            ) -> None:
+                return None
+
+        original_lock = GeneralManagerMeta._attribute_initialization_lock
+        GeneralManagerMeta._attribute_initialization_lock = ExplodingLock()  # type: ignore[assignment]
+        self.addCleanup(
+            setattr,
+            GeneralManagerMeta,
+            "_attribute_initialization_lock",
+            original_lock,
+        )
+
+        GeneralManagerMeta.ensure_rule_templates_validated(ValidatedManager)
 
     def test_reentrant_validation_failure_rolls_back_nested_initialization(
         self,
@@ -2170,4 +2202,51 @@ class LateManagerRuleTemplateValidationTests(SimpleTestCase):
         self.assertNotIn(
             ReentrantFailureManager,
             GeneralManagerMeta.pending_attribute_initialization,
+        )
+
+    def test_reentrant_validation_failure_restores_interface_field_cache(
+        self,
+    ) -> None:
+        class ReentrantValidationError(RuntimeError):
+            pass
+
+        class ReentrantFailingRule(Rule[GeneralManager]):
+            def __init__(self) -> None:
+                pass
+
+            def validate_custom_error_message(
+                self,
+                manager_class: type[GeneralManager] | None = None,
+            ) -> None:
+                assert manager_class is not None
+                assert manager_class.price is int  # type: ignore[attr-defined]
+                raise ReentrantValidationError
+
+        rule = ReentrantFailingRule()
+        original_field_descriptors = {"existing": object()}
+
+        class CachedInterfaceManager(GeneralManager):
+            price: int
+
+            class Interface(CalculationInterface):
+                price = GMInput(int)
+                rules: ClassVar[list[object]] = [rule]
+                _field_descriptors = original_field_descriptors
+
+                @classmethod
+                def get_attributes(cls) -> dict[str, object]:
+                    cls._field_descriptors = {"transient": object()}
+                    return super().get_attributes()
+
+        type.__setattr__(
+            CachedInterfaceManager.Interface,
+            "_field_descriptors",
+            original_field_descriptors,
+        )
+        with self.assertRaises(ReentrantValidationError):
+            _ = CachedInterfaceManager.price
+
+        self.assertIs(
+            vars(CachedInterfaceManager.Interface)["_field_descriptors"],
+            original_field_descriptors,
         )

--- a/tests/unit/test_public_api_init_modules.py
+++ b/tests/unit/test_public_api_init_modules.py
@@ -112,3 +112,14 @@ def test_search_invalidation_contract_is_exported(module_path: str) -> None:
 
     assert module.SearchChange.__module__ == "general_manager.search.config"
     assert module.SearchInvalidationRule.__module__ == "general_manager.search.config"
+
+
+def test_invalid_error_template_error_is_exported_from_rule() -> None:
+    public_module = import_module("general_manager.rule")
+    implementation_module = import_module("general_manager.rule.rule")
+
+    assert (
+        public_module.InvalidErrorTemplateError
+        is implementation_module.InvalidErrorTemplateError
+    )
+    assert "InvalidErrorTemplateError" in public_module.__all__

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -3,7 +3,9 @@ from django.test import TestCase, override_settings
 from datetime import datetime
 import ast
 from general_manager.rule.rule import (
+    InvalidErrorTemplateError,
     InvalidRuleHandlerConfigurationError,
+    MissingErrorTemplateVariableError,
     Rule,
 )
 from typing import cast
@@ -516,10 +518,8 @@ class RuleTests(TestCase):
         }
         self.assertEqual(error_message, expected_error)
 
-    def test_rule_with_missing_custom_error_variables(self):
-        """
-        Checks that validate_custom_error_message raises a ValueError when a custom error message lacks required template variables.
-        """
+    def test_rule_with_static_custom_error_message(self):
+        """A static custom message is attached to the referenced field."""
 
         def func(item: DummyObject) -> bool:
             """
@@ -533,10 +533,108 @@ class RuleTests(TestCase):
             """
             return item.height >= 150
 
-        custom_message = "Height must be at least 150 cm."
-        rule = Rule(func, custom_error_message=custom_message)
-        with self.assertRaises(ValueError):
-            rule.validate_custom_error_message()
+        rule = Rule(
+            func,
+            custom_error_message="Height must be at least 150 cm.",
+        )
+
+        self.assertFalse(rule.evaluate(DummyObject(height=140)))
+        self.assertEqual(
+            rule.get_error_message(),
+            {"height": "Height must be at least 150 cm."},
+        )
+
+    def test_custom_error_message_rejects_unmatched_braces_at_construction(self):
+        """Opening and closing braces must form complete placeholders."""
+
+        def func(item: DummyObject) -> bool:
+            return item.height >= 150
+
+        for message, brace in (
+            ("Height must exceed {height", "{"),
+            ("Height must exceed height}", "}"),
+        ):
+            with self.subTest(message=message):
+                with self.assertRaises(InvalidErrorTemplateError) as ctx:
+                    Rule(func, custom_error_message=message)
+
+                self.assertEqual(ctx.exception.placeholder, brace)
+                self.assertEqual(ctx.exception.reason, "unmatched brace")
+
+    def test_custom_error_message_rejects_empty_placeholder_at_construction(self):
+        """An empty pair of braces is not a valid placeholder."""
+
+        def func(item: DummyObject) -> bool:
+            return item.height >= 150
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            Rule(func, custom_error_message="Height must exceed {}")
+
+        self.assertEqual(ctx.exception.placeholder, "")
+        self.assertIn("dot-separated Python identifiers", ctx.exception.reason)
+
+    def test_custom_error_message_rejects_invalid_placeholder_grammar(self):
+        """Calls, indexes, format syntax, and malformed paths are rejected."""
+
+        def func(item: DummyObject) -> bool:
+            return item.height >= 150
+
+        for placeholder in (
+            "height()",
+            "height[0]",
+            "height!r",
+            "height..value",
+        ):
+            with self.subTest(placeholder=placeholder):
+                with self.assertRaises(InvalidErrorTemplateError) as ctx:
+                    Rule(func, custom_error_message=f"Invalid {{{placeholder}}}")
+
+                self.assertEqual(ctx.exception.placeholder, placeholder)
+                self.assertIn(
+                    "dot-separated Python identifiers",
+                    ctx.exception.reason,
+                )
+
+    def test_custom_error_message_rejects_unrelated_root_at_construction(self):
+        """Every placeholder root must be referenced by the predicate."""
+
+        def func(item: DummyObject) -> bool:
+            return item.height >= 150
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            Rule(func, custom_error_message="Weight is {weight}")
+
+        self.assertEqual(ctx.exception.placeholder, "weight")
+        self.assertEqual(
+            ctx.exception.reason,
+            "root 'weight' is not referenced by the rule",
+        )
+
+    def test_custom_error_message_accepts_valid_dotted_path_at_construction(self):
+        """Dotted placeholder schema and rendering are deferred to later tasks."""
+
+        def func(item: DummyObject) -> bool:
+            return item.height >= 150
+
+        Rule(func, custom_error_message="Height detail: {height.value}")
+
+    def test_missing_error_template_variable_error_remains_compatible(self):
+        """The deprecated exception retains its type and historical message."""
+
+        self.assertTrue(
+            issubclass(
+                MissingErrorTemplateVariableError,
+                InvalidErrorTemplateError,
+            )
+        )
+
+        error = MissingErrorTemplateVariableError(["quantity"])
+
+        self.assertEqual(
+            str(error),
+            "The custom error message does not contain all used variables: "
+            "['quantity'].",
+        )
 
     def test_rule_with_complex_condition(self):
         """
@@ -716,9 +814,8 @@ class RuleTests(TestCase):
         self.assertTrue(result)
         self.assertIsNone(rule.get_error_message())
 
-    def test_missing_error_template_variable_error(self):
-        """Test that MissingErrorTemplateVariableError is raised when custom error template is incomplete."""
-        from general_manager.rule.rule import MissingErrorTemplateVariableError
+    def test_custom_error_message_may_use_subset_of_rule_variables(self):
+        """A partial template is formatted and attached to every error field."""
 
         def func(item: DummyObject) -> bool:
             return item.price < 100.0 and item.quantity > 5
@@ -726,14 +823,14 @@ class RuleTests(TestCase):
         x = DummyObject(price=150.75, quantity=3)
         rule = Rule(func, custom_error_message="Price is too high: {price}")
 
-        result = rule.evaluate(x)
-        self.assertFalse(result)
-
-        # Should raise error because 'quantity' is missing from custom template
-        with self.assertRaises(MissingErrorTemplateVariableError) as ctx:
-            rule.get_error_message()
-        self.assertIn("quantity", str(ctx.exception))
-        self.assertIn("does not contain all used variables", str(ctx.exception))
+        self.assertFalse(rule.evaluate(x))
+        self.assertEqual(
+            rule.get_error_message(),
+            {
+                "price": "Price is too high: 150.75",
+                "quantity": "Price is too high: 150.75",
+            },
+        )
 
     def test_error_message_generation_error(self):
         """Test that ErrorMessageGenerationError is raised when getting error before evaluation."""

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -35,7 +35,7 @@ class SchemaInterface(InterfaceBase):
         return cls.schema
 
 
-class ProjectTemplateInterface(SchemaInterface):
+class CompanyTemplateInterface(SchemaInterface):
     schema: ClassVar[dict[str, AttributeTypedDict]] = {
         "name": {
             "type": str,
@@ -44,6 +44,33 @@ class ProjectTemplateInterface(SchemaInterface):
             "is_editable": True,
             "is_derived": False,
         }
+    }
+
+
+class CompanyTemplateManager(GeneralManager):
+    pass
+
+
+CompanyTemplateManager.Interface = CompanyTemplateInterface
+
+
+class ProjectTemplateInterface(SchemaInterface):
+    schema: ClassVar[dict[str, AttributeTypedDict]] = {
+        "company": {
+            "type": CompanyTemplateManager,
+            "relation_kind": "direct",
+            "default": None,
+            "is_required": False,
+            "is_editable": True,
+            "is_derived": False,
+        },
+        "name": {
+            "type": str,
+            "default": "",
+            "is_required": True,
+            "is_editable": True,
+            "is_derived": False,
+        },
     }
 
 
@@ -127,6 +154,10 @@ BareUnavailableTemplateManager.Interface = BareUnavailableTemplateInterface
 
 class UnexpectedSchemaError(RuntimeError):
     """Unexpected schema lookup failure used to verify propagation."""
+
+
+class ProjectNameUnavailableError(RuntimeError):
+    """Descriptor failure used to verify runtime placeholder propagation."""
 
 
 class FailingTemplateInterface(SchemaInterface):
@@ -747,6 +778,103 @@ class RuleTests(TestCase):
         rule = Rule(func, custom_error_message="Project: {project.name}")
 
         rule.validate_custom_error_message(ItemTemplateManager)
+
+    def test_custom_error_message_renders_related_attribute_on_root_error_key(self):
+        """A dotted placeholder renders while retaining predicate error keys."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is None
+
+        rule = Rule(func, custom_error_message="Project: {project.name}")
+        rule.validate_custom_error_message(ItemTemplateManager)
+
+        self.assertFalse(rule.evaluate(DummyObject(project=DummyObject(name="Apollo"))))
+        self.assertEqual(
+            rule.get_error_message(),
+            {"project": "Project: Apollo"},
+        )
+
+    def test_custom_error_message_renders_validated_multi_level_path(self):
+        """A schema-validated path may traverse multiple direct relations."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is None
+
+        rule = Rule(
+            func,
+            custom_error_message="Company: {project.company.name}",
+        )
+        rule.validate_custom_error_message(ItemTemplateManager)
+        item = DummyObject(
+            project=DummyObject(company=DummyObject(name="Acme")),
+        )
+
+        self.assertFalse(rule.evaluate(item))
+        self.assertEqual(
+            rule.get_error_message(),
+            {"project": "Company: Acme"},
+        )
+
+    def test_custom_error_message_renders_none_for_intermediate_value(self):
+        """A None relation renders as None without traversing later segments."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is None
+
+        rule = Rule(
+            func,
+            custom_error_message="Company: {project.company.name}",
+            ignore_if_none=False,
+        )
+        rule.validate_custom_error_message(ItemTemplateManager)
+        item = DummyObject(project=DummyObject(company=None))
+
+        self.assertFalse(rule.evaluate(item))
+        self.assertEqual(
+            rule.get_error_message(),
+            {"project": "Company: None"},
+        )
+
+    def test_custom_error_message_renders_none_for_final_value(self):
+        """A final None value is converted to its string representation."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is None
+
+        rule = Rule(
+            func,
+            custom_error_message="Project: {project.name}",
+            ignore_if_none=False,
+        )
+        rule.validate_custom_error_message(ItemTemplateManager)
+        item = DummyObject(project=DummyObject(name=None))
+
+        self.assertFalse(rule.evaluate(item))
+        self.assertEqual(
+            rule.get_error_message(),
+            {"project": "Project: None"},
+        )
+
+    def test_custom_error_message_propagates_descriptor_access_failure(self):
+        """Runtime failures from ordinary attribute access remain visible."""
+
+        expected_error = ProjectNameUnavailableError()
+
+        class FailingProject:
+            @property
+            def name(self) -> str:
+                raise expected_error
+
+        def func(item: DummyObject) -> bool:
+            return item.project is None
+
+        rule = Rule(func, custom_error_message="Project: {project.name}")
+        rule.validate_custom_error_message(ItemTemplateManager)
+
+        self.assertFalse(rule.evaluate(DummyObject(project=FailingProject())))
+        with self.assertRaises(ProjectNameUnavailableError) as ctx:
+            rule.get_error_message()
+        self.assertIs(ctx.exception, expected_error)
 
     def test_custom_error_message_rejects_unknown_related_manager_field(self):
         """A misspelled final segment is rejected against the related schema."""

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -876,6 +876,56 @@ class RuleTests(TestCase):
             rule.get_error_message()
         self.assertIs(ctx.exception, expected_error)
 
+    def test_custom_error_message_propagates_missing_later_attribute_error(self):
+        """A present root does not hide an AttributeError from a later segment."""
+
+        expected_error = AttributeError("project name is unavailable")
+
+        class ProjectWithoutName:
+            @property
+            def name(self) -> str:
+                raise expected_error
+
+        def func(item: DummyObject) -> bool:
+            return item.project is None
+
+        rule = Rule(func, custom_error_message="Project: {project.name}")
+        rule.validate_custom_error_message(ItemTemplateManager)
+
+        self.assertFalse(rule.evaluate(DummyObject(project=ProjectWithoutName())))
+        with self.assertRaises(AttributeError) as ctx:
+            rule.get_error_message()
+        self.assertIs(ctx.exception, expected_error)
+
+    def test_custom_error_message_resolves_repeated_placeholder_once(self):
+        """Repeated occurrences share one resolution of their unique path."""
+
+        class AccessCountingProject:
+            def __init__(self) -> None:
+                self.name_accesses = 0
+
+            @property
+            def name(self) -> str:
+                self.name_accesses += 1
+                return "Apollo"
+
+        def func(item: DummyObject) -> bool:
+            return item.project is None
+
+        project = AccessCountingProject()
+        rule = Rule(
+            func,
+            custom_error_message="{project.name} / {project.name}",
+        )
+        rule.validate_custom_error_message(ItemTemplateManager)
+
+        self.assertFalse(rule.evaluate(DummyObject(project=project)))
+        self.assertEqual(
+            rule.get_error_message(),
+            {"project": "Apollo / Apollo"},
+        )
+        self.assertEqual(project.name_accesses, 1)
+
     def test_custom_error_message_rejects_unknown_related_manager_field(self):
         """A misspelled final segment is rejected against the related schema."""
 

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -2,13 +2,16 @@ from django.core.exceptions import NON_FIELD_ERRORS
 from django.test import TestCase, override_settings
 from datetime import datetime
 import ast
+from typing import ClassVar, cast
+
+from general_manager.interface.base_interface import AttributeTypedDict, InterfaceBase
+from general_manager.manager.general_manager import GeneralManager
 from general_manager.rule.rule import (
     InvalidErrorTemplateError,
     InvalidRuleHandlerConfigurationError,
     MissingErrorTemplateVariableError,
     Rule,
 )
-from typing import cast
 from general_manager.rule.handler import BaseRuleHandler
 
 NONE_VALUE = None
@@ -20,6 +23,123 @@ class DummyObject:
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+
+class SchemaInterface(InterfaceBase):
+    """Lightweight interface exposing only schema metadata for rule tests."""
+
+    schema: ClassVar[dict[str, AttributeTypedDict]]
+
+    @classmethod
+    def get_attribute_types(cls) -> dict[str, AttributeTypedDict]:
+        return cls.schema
+
+
+class ProjectTemplateInterface(SchemaInterface):
+    schema: ClassVar[dict[str, AttributeTypedDict]] = {
+        "name": {
+            "type": str,
+            "default": "",
+            "is_required": True,
+            "is_editable": True,
+            "is_derived": False,
+        }
+    }
+
+
+class ProjectTemplateManager(GeneralManager):
+    pass
+
+
+ProjectTemplateManager.Interface = ProjectTemplateInterface
+
+
+class ItemTemplateInterface(SchemaInterface):
+    schema: ClassVar[dict[str, AttributeTypedDict]] = {
+        "project": {
+            "type": ProjectTemplateManager,
+            "relation_kind": "direct",
+            "default": None,
+            "is_required": False,
+            "is_editable": True,
+            "is_derived": False,
+        },
+        "projects": {
+            "type": ProjectTemplateManager,
+            "relation_kind": "collection",
+            "default": None,
+            "is_required": False,
+            "is_editable": True,
+            "is_derived": False,
+        },
+        "price": {
+            "type": float,
+            "default": 0.0,
+            "is_required": True,
+            "is_editable": True,
+            "is_derived": False,
+        },
+        "untyped_project": cast(
+            AttributeTypedDict,
+            {
+                "relation_kind": "direct",
+                "default": None,
+                "is_required": False,
+                "is_editable": True,
+                "is_derived": False,
+            },
+        ),
+    }
+
+
+class ItemTemplateManager(GeneralManager):
+    pass
+
+
+ItemTemplateManager.Interface = ItemTemplateInterface
+
+
+class UnavailableTemplateInterface(SchemaInterface):
+    @classmethod
+    def get_attribute_types(cls) -> dict[str, AttributeTypedDict]:
+        raise NotImplementedError("read capability is not configured")
+
+
+class UnavailableTemplateManager(GeneralManager):
+    pass
+
+
+UnavailableTemplateManager.Interface = UnavailableTemplateInterface
+
+
+class BareUnavailableTemplateInterface(SchemaInterface):
+    @classmethod
+    def get_attribute_types(cls) -> dict[str, AttributeTypedDict]:
+        raise NotImplementedError
+
+
+class BareUnavailableTemplateManager(GeneralManager):
+    pass
+
+
+BareUnavailableTemplateManager.Interface = BareUnavailableTemplateInterface
+
+
+class UnexpectedSchemaError(RuntimeError):
+    """Unexpected schema lookup failure used to verify propagation."""
+
+
+class FailingTemplateInterface(SchemaInterface):
+    @classmethod
+    def get_attribute_types(cls) -> dict[str, AttributeTypedDict]:
+        raise UnexpectedSchemaError
+
+
+class FailingTemplateManager(GeneralManager):
+    pass
+
+
+FailingTemplateManager.Interface = FailingTemplateInterface
 
 
 class CustomLenHandler(BaseRuleHandler):
@@ -617,6 +737,136 @@ class RuleTests(TestCase):
             return item.height >= 150
 
         Rule(func, custom_error_message="Height detail: {height.value}")
+
+    def test_custom_error_message_accepts_related_manager_path(self):
+        """A dotted placeholder may traverse a direct manager relation."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is not None
+
+        rule = Rule(func, custom_error_message="Project: {project.name}")
+
+        rule.validate_custom_error_message(ItemTemplateManager)
+
+    def test_custom_error_message_rejects_unknown_related_manager_field(self):
+        """A misspelled final segment is rejected against the related schema."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is not None
+
+        rule = Rule(func, custom_error_message="Project: {project.nmae}")
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            rule.validate_custom_error_message(ItemTemplateManager)
+
+        self.assertEqual(ctx.exception.placeholder, "project.nmae")
+        self.assertEqual(
+            ctx.exception.reason,
+            "unknown segment 'nmae' on ProjectTemplateManager",
+        )
+
+    def test_custom_error_message_rejects_scalar_path_traversal(self):
+        """A scalar field cannot be traversed as if it were a manager relation."""
+
+        def func(item: DummyObject) -> bool:
+            return item.price > 0
+
+        rule = Rule(func, custom_error_message="Price: {price.amount}")
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            rule.validate_custom_error_message(ItemTemplateManager)
+
+        self.assertEqual(ctx.exception.placeholder, "price.amount")
+        self.assertEqual(
+            ctx.exception.reason,
+            "segment 'price' on ItemTemplateManager is not a manager relation",
+        )
+
+    def test_custom_error_message_rejects_relation_without_manager_type(self):
+        """Missing relation type metadata is not a traversable manager relation."""
+
+        def func(item: DummyObject) -> bool:
+            return item.untyped_project is not None
+
+        rule = Rule(
+            func,
+            custom_error_message="Project: {untyped_project.name}",
+        )
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            rule.validate_custom_error_message(ItemTemplateManager)
+
+        self.assertEqual(ctx.exception.placeholder, "untyped_project.name")
+        self.assertEqual(
+            ctx.exception.reason,
+            "segment 'untyped_project' on ItemTemplateManager is not a "
+            "manager relation",
+        )
+
+    def test_custom_error_message_rejects_collection_path_traversal(self):
+        """A collection relation cannot be traversed by a dotted placeholder."""
+
+        def func(item: DummyObject) -> bool:
+            return bool(item.projects)
+
+        rule = Rule(func, custom_error_message="Project: {projects.name}")
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            rule.validate_custom_error_message(ItemTemplateManager)
+
+        self.assertEqual(ctx.exception.placeholder, "projects.name")
+        self.assertEqual(
+            ctx.exception.reason,
+            "segment 'projects' on ItemTemplateManager is a collection relation "
+            "and cannot be traversed",
+        )
+
+    def test_custom_error_message_rejects_unavailable_manager_schema(self):
+        """A manager without attribute metadata produces a template error."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is not None
+
+        rule = Rule(func, custom_error_message="Project: {project.name}")
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            rule.validate_custom_error_message(UnavailableTemplateManager)
+
+        self.assertEqual(ctx.exception.placeholder, "project.name")
+        self.assertEqual(
+            ctx.exception.reason,
+            "schema unavailable for UnavailableTemplateManager: "
+            "read capability is not configured",
+        )
+
+    def test_custom_error_message_explains_bare_unavailable_manager_schema(self):
+        """A bare schema availability error receives a useful fallback detail."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is not None
+
+        rule = Rule(func, custom_error_message="Project: {project.name}")
+
+        with self.assertRaises(InvalidErrorTemplateError) as ctx:
+            rule.validate_custom_error_message(BareUnavailableTemplateManager)
+
+        self.assertEqual(ctx.exception.placeholder, "project.name")
+        self.assertEqual(
+            ctx.exception.reason,
+            "schema unavailable for BareUnavailableTemplateManager: "
+            "get_attribute_types is not implemented",
+        )
+
+    def test_custom_error_message_propagates_unexpected_schema_error(self):
+        """Unexpected schema lookup errors are not translated."""
+
+        def func(item: DummyObject) -> bool:
+            return item.project is not None
+
+        rule = Rule(func, custom_error_message="Project: {project.name}")
+
+        with self.assertRaises(UnexpectedSchemaError):
+            rule.validate_custom_error_message(FailingTemplateManager)
 
     def test_missing_error_template_variable_error_remains_compatible(self):
         """The deprecated exception retains its type and historical message."""

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -6,6 +6,7 @@ from typing import ClassVar, cast
 
 from general_manager.interface.base_interface import AttributeTypedDict, InterfaceBase
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.rule.rule import (
     InvalidErrorTemplateError,
     InvalidRuleHandlerConfigurationError,
@@ -172,6 +173,18 @@ class FailingTemplateManager(GeneralManager):
 
 FailingTemplateManager.Interface = FailingTemplateInterface
 
+_TEMPLATE_MANAGER_STUBS = (
+    CompanyTemplateManager,
+    ProjectTemplateManager,
+    ItemTemplateManager,
+    UnavailableTemplateManager,
+    BareUnavailableTemplateManager,
+    FailingTemplateManager,
+)
+for _template_manager_stub in _TEMPLATE_MANAGER_STUBS:
+    while _template_manager_stub in GeneralManagerMeta.pending_graphql_interfaces:
+        GeneralManagerMeta.pending_graphql_interfaces.remove(_template_manager_stub)
+
 
 class CustomLenHandler(BaseRuleHandler):
     """Test handler that replaces the built-in len handler."""
@@ -297,6 +310,19 @@ class NotARuleHandler:
 
 
 class RuleTests(TestCase):
+    def test_template_manager_stubs_do_not_pollute_metaclass_registries(self):
+        """Module-level schema stubs must not participate in app initialization."""
+        for manager_class in _TEMPLATE_MANAGER_STUBS:
+            self.assertNotIn(manager_class, GeneralManagerMeta.all_classes)
+            self.assertNotIn(
+                manager_class,
+                GeneralManagerMeta.pending_attribute_initialization,
+            )
+            self.assertNotIn(
+                manager_class,
+                GeneralManagerMeta.pending_graphql_interfaces,
+            )
+
     @override_settings(
         GENERAL_MANAGER={
             "RULE_HANDLERS": ["tests.unit.test_rules.CustomLenHandler"],
@@ -762,12 +788,30 @@ class RuleTests(TestCase):
         )
 
     def test_custom_error_message_accepts_valid_dotted_path_at_construction(self):
-        """Dotted placeholder schema and rendering are deferred to later tasks."""
+        """A dotted path passes construction before manager-schema validation."""
 
         def func(item: DummyObject) -> bool:
             return item.height >= 150
 
         Rule(func, custom_error_message="Height detail: {height.value}")
+
+    def test_custom_error_message_allows_runtime_only_root_outside_schema(self):
+        """A one-part root may resolve at runtime without schema metadata."""
+
+        def func(item: DummyObject) -> bool:
+            return item.runtime_only == "expected"
+
+        rule = Rule(
+            func,
+            custom_error_message="Runtime value: {runtime_only}",
+        )
+
+        rule.validate_custom_error_message(ItemTemplateManager)
+        self.assertFalse(rule.evaluate(DummyObject(runtime_only="actual")))
+        self.assertEqual(
+            rule.get_error_message(),
+            {"runtime_only": "Runtime value: actual"},
+        )
 
     def test_custom_error_message_accepts_related_manager_path(self):
         """A dotted placeholder may traverse a direct manager relation."""


### PR DESCRIPTION
## Summary

Custom rule error messages can now be static, use only a subset of available placeholders, and traverse safe dotted attribute paths such as `{project.name}`. Templates are validated against manager schemas when rules load, while runtime rendering remains deliberately limited to attribute traversal.

## Related issue

No related issue was provided for this change.

## What changed

- Relaxed custom error message validation so static messages and subset placeholders are accepted.
- Added dotted identifier parsing, schema validation, and runtime rendering without calls, indexing, filters, or arbitrary expressions.
- Added the public `InvalidErrorTemplateError` while retaining direct-import compatibility for `MissingErrorTemplateVariableError`.
- Validated attached interface and model rules during normal application bootstrap and on the first eligible use of late-loaded managers.
- Hardened late-manager validation for cached descriptors, readiness transitions, concurrent/reentrant access, retryability, and rollback after failed validation.
- Added focused unit, lifecycle, Request, ORM, export-snapshot, and edge-case coverage.
- Updated API, concept, how-to, and example documentation.

## Validation

```text
PYTHONPATH=src python -m pytest -q — 5601 passed, 3 skipped, 1 warning, 1982 subtests passed
ruff check . — passed
ruff format --check . — 523 files already formatted
mypy src — no issues found in 276 source files
pre-commit run --all-files — passed
mkdocs build --strict — passed
git diff --check — passed
```

The single pytest warning is the existing Django duplicate registration warning for `general_manager.changerequest`.

## Documentation

Updated the public Rule API, validation-rule concept and how-to pages, and examples to describe static/subset templates, dotted paths, invalid syntax/path behavior, `None` rendering, startup validation, and first-use validation for late-loaded managers.

## Reviewer notes

Recommended review order:

1. Rule parsing/schema validation and exception exports.
2. Runtime dotted-path rendering.
3. Shared bootstrap and late-manager validation lifecycle.
4. Reentrancy, rollback, readiness-transition, and public-operation regression tests.

The internal design and implementation plan remain intentionally ignored and are not part of this PR.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom validation messages now support safe dotted placeholders for related attributes.
  * Templates may reference a subset of rule variables, with intermediate `None` values rendered as `"None"`.
  * Added `InvalidErrorTemplateError` to the public API for invalid syntax, unknown paths, or unsupported expressions.
  * Rule templates are validated before startup and before first use of late-created managers.

* **Bug Fixes**
  * Omitted template variables no longer cause errors; the legacy exception remains available for compatibility.

* **Documentation**
  * Expanded examples and guidance for template syntax, validation, restrictions, and `None` handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->