### PR TITLE
fix: make Devcontainer workspace path portable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install -r /workspaces/general_manager/requirements/development.txt && pre-commit install"
+	"postCreateCommand": "pip3 install -r ${containerWorkspaceFolder}/requirements/development.txt && pre-commit install"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install -r ${containerWorkspaceFolder}/requirements/development.txt && pre-commit install"
+	"postCreateCommand": "pip3 install -r \"${containerWorkspaceFolder}/requirements/development.txt\" && pre-commit install"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.


### PR DESCRIPTION
## Summary

Development container initialization now resolves the development requirements file from the active workspace and quotes the resolved path, so setup remains reliable when the workspace folder is renamed or contains spaces.

## Related issue

Closes #420

## What changed

- Replaced the fixed workspace path with the Dev Containers workspace variable.
- Quoted the complete resolved requirements path for shell-safe execution.

## Validation

```text
Focused JSONC postCreateCommand assertion — exit 0
Dev Containers CLI startup — exit 0
Renamed and whitespace-containing workspace dependency installation plus pre-commit installation — exit 0
pre-commit run --all-files — exit 0
git diff --check origin/main...HEAD — exit 0
python -m pytest -q — exit 1: 5603 passed, 4 skipped, and one unchanged nondeterministic upload-adapter failure; isolated reruns reproduced the known baseline behavior (1, 0, 0, 1, 0)
```

## Documentation

No documentation changes are required for this configuration-only fix.

## Reviewer notes

The change is limited to `.devcontainer/devcontainer.json`. It has no migration or security impact.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant validation was run; no test-file changes are needed for this configuration-only fix.
- [x] Ruff lint, Ruff format, and strict mypy pass through the pinned pre-commit hooks.
- [ ] User-facing documentation is updated where behavior changed; not applicable to this configuration-only fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development container setup by using the active workspace path when installing development requirements.
  * Preserved automatic pre-commit hook installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->