### PR TITLE
fix: update vulnerable build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=83.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -43,7 +43,7 @@ dependencies = [
     "flexcache>=0.3",
     "flexparser>=0.4",
     "gitdb>=4.0.12",
-    "GitPython>=3.1.41",
+    "GitPython>=3.1.55",
     "graphene>=3.4.3",
     "graphene-django>=3.2.3",
     "graphql-core>=3.2.6",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ Faker==40.15.0
 flexcache==0.3
 flexparser==0.4
 gitdb==4.0.12
-GitPython==3.1.50
+GitPython==3.1.55
 graphene==3.4.3
 graphene-django==3.2.3
 graphql-core==3.2.8
@@ -18,7 +18,7 @@ platformdirs==4.9.6
 promise==2.3
 python-dateutil==2.9.0.post0
 PyYAML==6.0.3
-setuptools==80.0.0
+setuptools==83.0.0
 six==1.17.0
 smmap==5.0.3
 sqlparse==0.5.5

--- a/tests/unit/test_validate_distribution.py
+++ b/tests/unit/test_validate_distribution.py
@@ -41,6 +41,21 @@ def test_distribution_metadata_packages_datasets_and_uses_workflow_uploads() -> 
     assert "upload_to_release" not in semantic_release
 
 
+def test_dependency_metadata_keeps_security_patched_versions() -> None:
+    repository_root = Path(__file__).parents[2]
+    with (repository_root / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+
+    assert "setuptools>=83.0.0" in pyproject["build-system"]["requires"]
+    assert "GitPython>=3.1.55" in pyproject["project"]["dependencies"]
+
+    base_requirements = (repository_root / "requirements" / "base.txt").read_text(
+        encoding="utf-8"
+    )
+    assert "GitPython==3.1.55\n" in base_requirements
+    assert "setuptools==83.0.0\n" in base_requirements
+
+
 def _write_wheel(
     dist_dir: Path,
     version: str,


### PR DESCRIPTION
## Summary

Update the direct GitPython and setuptools dependency floors to versions containing the upstream security fixes reported by Dependabot. The locked base environment and published package/build metadata now agree on the patched minimums.

## Related issue

No public issue. This addresses the repository's open Dependabot security alerts for GitPython and setuptools.

## What changed

- Update GitPython from `3.1.50` to `3.1.55` in the locked base requirements and raise the package metadata floor to `>=3.1.55`.
- Update setuptools from `80.0.0` to `83.0.0` in the locked base requirements and raise the build-system floor to `>=83.0.0`.
- Add a regression test that prevents the security-patched dependency floors from drifting backward.

## Validation

```text
python -m pytest tests/unit/test_validate_distribution.py -q — 31 passed
PYTHONPATH=src python -m pytest -q — 5,606 passed, 3 skipped, 1 warning, 1,982 subtests passed
ruff check — passed
ruff format --check — 523 files already formatted
mypy --strict — passed
git diff --check — passed
```

## Documentation

Not applicable. This changes dependency security floors without changing the public API or user-facing behavior.

## Reviewer notes

GitHub currently reports 30 open Dependabot alerts on the default branch. They represent the same GitPython and setuptools advisories repeated across the base, development, and production manifests because the latter two include `requirements/base.txt`.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [ ] User-facing documentation is updated where behavior changed. (Not applicable; see Documentation.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency versions to include security-patched releases of `setuptools` and `GitPython`.
  * Improved dependency metadata validation to help prevent regressions in required package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->