### PR TITLE
test: stabilize GraphQL listener synchronization

### DIFF
--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -2634,14 +2634,15 @@ class GraphQLSubscriptionChannelListenerTests(unittest.TestCase):
                 {"type": "gm.subscription.event"},  # No action
             ]
             message_iter = iter(messages)
+            messages_consumed = asyncio.Event()
 
             async def mock_receive(_channel: str) -> dict[str, Any]:
                 try:
-                    await asyncio.sleep(0.001)  # Simulate async delay
+                    await asyncio.sleep(0)
                     return next(message_iter)
                 except StopIteration as err:
-                    # Simulate cancellation after messages exhausted
-                    await asyncio.sleep(10)
+                    messages_consumed.set()
+                    await asyncio.Event().wait()
                     raise AssertionError("Cancelled") from err
 
             mock_layer.receive = mock_receive
@@ -2651,8 +2652,7 @@ class GraphQLSubscriptionChannelListenerTests(unittest.TestCase):
                 GraphQL._channel_listener(mock_layer, "test_channel", queue)
             )
 
-            # Allow listener to process messages
-            await asyncio.sleep(0.01)
+            await asyncio.wait_for(messages_consumed.wait(), timeout=1)
 
             # Cancel the listener
             listener_task.cancel()
@@ -2717,13 +2717,15 @@ class GraphQLSubscriptionChannelListenerTests(unittest.TestCase):
                 {"type": "gm.subscription.event"},
             ]
             message_iter = iter(messages)
+            messages_consumed = asyncio.Event()
 
             async def mock_receive(_channel: str) -> dict[str, Any]:
                 try:
-                    await asyncio.sleep(0.001)
+                    await asyncio.sleep(0)
                     return next(message_iter)
                 except StopIteration as err:
-                    await asyncio.sleep(10)
+                    messages_consumed.set()
+                    await asyncio.Event().wait()
                     raise AssertionError("Cancelled") from err
 
             mock_layer.receive = mock_receive
@@ -2732,7 +2734,7 @@ class GraphQLSubscriptionChannelListenerTests(unittest.TestCase):
             listener_task = asyncio.create_task(
                 GraphQL._channel_message_listener(mock_layer, "test_channel", queue)
             )
-            await asyncio.sleep(0.01)
+            await asyncio.wait_for(messages_consumed.wait(), timeout=1)
             listener_task.cancel()
             try:
                 await listener_task


### PR DESCRIPTION
## Summary

Remove an async scheduling race from the GraphQL channel-listener tests. The tests now wait for explicit message-consumption completion before cancelling the listener instead of assuming the listener will run within 10 milliseconds.

## Related issue

Follow-up to the failed [MariaDB 11.8 / Python 3.14 Actions job](https://github.com/TimKleindick/general_manager/actions/runs/30357508743/job/90269030025).

## What changed

- Add an `asyncio.Event` to each channel-listener test that is set after the mock message sequence is exhausted.
- Await that event with a bounded one-second timeout before cancelling the listener task.
- Replace millisecond timing delays with `asyncio.sleep(0)` cooperative yields.
- Keep production listener behavior unchanged.

## Validation

```text
GraphQLSubscriptionChannelListenerTests repeated 20 times — 60/60 test executions passed
python -m pytest tests/unit/test_graphql_subscriptions.py -q — 77 passed
PYTHONPATH=src python -m pytest -q — 5,606 passed, 3 skipped, 1 warning, 1,982 subtests passed
ruff check — passed
ruff format --check — 523 files already formatted
mypy --strict — passed
git diff --check — passed
independent code review — ready to merge; no critical, important, or minor issues
```

## Documentation

Not applicable. This stabilizes internal tests without changing public or production behavior.

## Reviewer notes

The failed matrix cell reported an empty listener queue while MariaDB passed on Python 3.12 and 3.13 and Python 3.14 passed against the other backends. The test was database-independent and cancelled its listener after an arbitrary 10 ms delay. The completion event now proves all supplied messages were processed before cancellation, while the timeout keeps failures bounded.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [ ] User-facing documentation is updated where behavior changed. (Not applicable; see Documentation.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved GraphQL subscription listener test reliability by replacing timing-based waits with deterministic synchronization.
  * Preserved existing checks for correctly enqueued actions and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->