### PR TITLE
fix: repair README build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/GeneralManager.svg)](https://pypi.org/project/GeneralManager/)
 [![Python](https://img.shields.io/pypi/pyversions/GeneralManager.svg)](https://pypi.org/project/GeneralManager/)
-[![Build](https://github.com/TimKleindick/general_manager/actions/workflows/quality.yml/badge.svg?branch=main)](https://github.com/TimKleindick/general_manager/actions/workflows/quality.yml)
+[![Build](https://github.com/TimKleindick/general_manager/actions/workflows/publish.yml/badge.svg?branch=main)](https://github.com/TimKleindick/general_manager/actions/workflows/publish.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/TimKleindick/general_manager)](https://app.codecov.io/gh/TimKleindick/general_manager)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/TimKleindick/general_manager/blob/main/LICENSE)
 

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -95,6 +95,19 @@ def test_quality_workflow_has_reusable_least_privilege_triggers() -> None:
     }
 
 
+def test_readme_build_badge_tracks_the_main_push_workflow() -> None:
+    readme = (ROOT / "README.md").read_text()
+    badge_url = (
+        "https://github.com/TimKleindick/general_manager/actions/workflows/"
+        "publish.yml/badge.svg?branch=main"
+    )
+    workflow_url = (
+        "https://github.com/TimKleindick/general_manager/actions/workflows/publish.yml"
+    )
+
+    assert f"[![Build]({badge_url})]({workflow_url})" in readme
+
+
 def test_quality_test_job_preserves_supported_matrix_and_test_services() -> None:
     job = load_workflow("quality.yml")["jobs"]["test"]
 


### PR DESCRIPTION
## Summary

Fix the README build badge so it reports the status of the workflow that actually runs on `main` instead of always showing `no status`.

## Related issue

No linked issue; this is a focused documentation/CI-status correction.

## What changed

- Retargeted the README build badge and link from `quality.yml` to `publish.yml`.
- Added a regression test ensuring the badge tracks the workflow triggered by pushes to `main`.

## Validation

```text
python -m pytest tests/unit/test_release_workflows.py -q — 19 passed
python -m pytest — 5607 passed, 3 skipped
ruff check --config pyproject.toml src tests scripts — passed
ruff format --config pyproject.toml --check . — 523 files already formatted
mypy --strict — no issues found in 276 source files
git diff --check — passed
```

The live `publish.yml` badge endpoint returns a workflow state instead of `no status`.

## Documentation

Updated the build badge in the main README. No other documentation changes are needed.

## Reviewer notes

The quality workflow runs on `main` as a reusable job inside `publish.yml`, so GitHub records no standalone `quality.yml` runs for the branch. The badge therefore targets the owning main-branch workflow. Its displayed state covers the complete publish-and-release workflow, including its quality gate.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README build status badge to track the main publishing workflow.

* **Tests**
  * Added coverage to verify that the README badge points to the correct workflow and branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->