### PR TITLE
fix: expose safe GraphQL upload errors

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -468,11 +468,14 @@ validation field keys with `snake_to_camel`.
 
 `PermissionError` returns the fixed message `Permission denied.` with code
 `PERMISSION_DENIED`, unless application code deliberately raises an explicit
-public error. Every other ordinary exception crossing these boundaries,
-including `ValueError`, returns exactly `An internal server error occurred.`
-with code `INTERNAL_SERVER_ERROR` and an opaque `errorId`. Server logs retain the
-original exception details and traceback with the matching `error_id`; failures
-while rendering the original exception are also kept out of the client response.
+public error. Framework-owned `UploadError` types retain their documented safe
+message and stable upload code; application-defined subclasses are sanitized to
+`UPLOAD_STORAGE_ERROR`. Every other ordinary exception crossing these
+boundaries, including `ValueError`, returns exactly
+`An internal server error occurred.` with code `INTERNAL_SERVER_ERROR` and an
+opaque `errorId`. Server logs retain the original exception details and
+traceback with the matching `error_id`; failures while rendering the original
+exception are also kept out of the client response.
 
 Migrate client-facing `ValueError` uses to `PublicGraphQLError`, or to Django
 `ValidationError` for validation (use structured validation errors for field

--- a/src/general_manager/api/graphql_errors.py
+++ b/src/general_manager/api/graphql_errors.py
@@ -22,6 +22,7 @@ from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 
 from general_manager.logging import get_logger
 from general_manager.measurement.measurement import Measurement
+from general_manager.uploads.errors import UploadError, stable_upload_error
 from general_manager.as_of import (
     HistoricalContextConflictError,
     HistoricalMutationError,
@@ -554,10 +555,13 @@ def handle_graph_ql_error(
     ``nonFieldErrors``. When ``field_name_mapper`` is provided, it maps
     ``message_dict`` field keys before they are emitted in ``fieldErrors``;
     non-field errors are not mapped. ``PermissionError`` instances use a fixed
-    public message. Historical-context failures retain their stable public
-    historical code. All other exceptions use a generic internal-error message
-    and an opaque correlation ID. Logging level/category is diagnostic behavior
-    of the internal ``api.graphql`` logger and is not a public API contract.
+    public message. Framework-owned ``UploadError`` instances retain their safe
+    default message and stable code; custom subclasses are sanitized to
+    ``UPLOAD_STORAGE_ERROR``. Historical-context failures retain their stable
+    public historical code. All other exceptions use a generic internal-error
+    message and an opaque correlation ID. Logging level/category is diagnostic
+    behavior of the internal ``api.graphql`` logger and is not a public API
+    contract.
     """
     message = _safe_exception_message(error)
     error_name = type(error).__name__
@@ -597,6 +601,20 @@ def handle_graph_ql_error(
         return GraphQLError(
             _PERMISSION_DENIED_MESSAGE,
             extensions={"code": "PERMISSION_DENIED"},
+        )
+    if isinstance(error, UploadError):
+        public_error = stable_upload_error(error)
+        logger.warning(
+            "graphql upload error",
+            context={
+                "error": error_name,
+                "message": public_error.default_message,
+                "code": public_error.code,
+            },
+        )
+        return GraphQLError(
+            public_error.default_message,
+            extensions={"code": public_error.code},
         )
 
     error_id = uuid4().hex

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -38,6 +38,7 @@ from general_manager.permission.base_permission import (
     BasePermission,
     ReadPermissionPlan,
 )
+from general_manager.uploads.errors import InvalidImageError, UploadError
 from general_manager.utils.format_string import snake_to_camel
 from general_manager.api.graphql_resolvers import (
     apply_grouping,
@@ -518,6 +519,23 @@ class GraphQLHelperTests(SimpleTestCase):
         assert GraphQL._handle_graph_ql_error(error) is error
         assert error.message == "The project cannot be archived."
         assert error.extensions == {"code": "PROJECT_NOT_ARCHIVABLE"}
+
+    def test_handle_graphql_error_maps_framework_upload_error(self) -> None:
+        error = GraphQL._handle_graph_ql_error(InvalidImageError())
+
+        assert error.message == "The file upload could not be completed."
+        assert error.extensions == {"code": "INVALID_IMAGE"}
+
+    def test_handle_graphql_error_sanitizes_custom_upload_error(self) -> None:
+        class HostileUploadError(UploadError):
+            code = "SECRET_ERROR_CODE"
+            default_message = "graphql-upload-secret-must-not-escape"
+
+        error = GraphQL._handle_graph_ql_error(HostileUploadError())
+
+        assert error.message == "The file upload could not be completed."
+        assert error.extensions == {"code": "UPLOAD_STORAGE_ERROR"}
+        assert "graphql-upload-secret-must-not-escape" not in str(error.formatted)
 
     def test_handle_graphql_error_structures_validation_message_dict(self) -> None:
         error = GraphQL._handle_graph_ql_error(


### PR DESCRIPTION
## Summary

Map expected upload failures at the shared GraphQL error boundary so upload finalization errors retain their documented client-safe message and stable code.

The root cause was that `handle_graph_ql_error()` did not recognize `UploadError`, causing finalization failures such as `InvalidImageError` to fall through to `INTERNAL_SERVER_ERROR`.

## Related issue

Closes #428.

## What changed

- handle framework-owned `UploadError` instances in the shared GraphQL mapper
- sanitize application-defined upload-error subclasses through `stable_upload_error()`
- add regression coverage for `INVALID_IMAGE` and hostile custom subclasses
- document the shared GraphQL upload-error behavior

## Validation

```text
env PYTHONPATH=src:. python -m pytest -q — 5608 passed, 3 skipped, 1982 subtests passed
ruff check . — passed
ruff format --check . — 523 files already formatted
mypy src — no issues in 276 source files
pre-commit commit hooks, including mypy strict type checking — passed
```

## Documentation

Updated `docs/api/graphql.md` to describe stable framework upload codes and sanitization of application-defined subclasses.

## Reviewer notes

`stable_upload_error()` remains the exact-type allowlist: framework-owned upload errors retain their documented code, while unknown subclasses map to `UPLOAD_STORAGE_ERROR`. Generic unexpected exceptions continue to return `INTERNAL_SERVER_ERROR` with a correlation ID.

Suggested review order: mapper branch, regression tests, documentation.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL upload error responses with stable, safe messages and consistent error codes.
  * Prevented sensitive or unsafe upload error details from appearing in client-facing responses.
  * Preserved clear handling for permission failures and unexpected application errors, while keeping detailed diagnostics in server logs.

* **Documentation**
  * Clarified GraphQL error sanitization rules, including exceptions for explicitly public application errors and framework-managed upload failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->