### PR TITLE
docs: document safe GraphQL upload errors

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -313,8 +313,15 @@ an adapter with a backend-native atomic exact-delete operation.
 Every public upload exception listed above inherits
 `UploadError(message: str | None = None)`, returns no value when raised, and
 exposes its stable `code` plus a safe default message. Passing a message changes
-the local exception text, but GraphQL and HTTP boundaries sanitize arbitrary
-messages and non-framework subclasses.
+the local exception text only. At generated-mutation and `@graph_ql_mutation`
+GraphQL boundaries, framework-owned exception types are re-created with their
+documented safe default message and code. An application-defined `UploadError`
+subclass is mapped to `UploadStorageError`, producing
+`The file upload could not be completed.` with code `UPLOAD_STORAGE_ERROR`.
+GraphQL and HTTP boundaries sanitize arbitrary messages and exception chains;
+third-party GraphQL resolvers that bypass these mutation paths are outside this
+contract. This GraphQL normalization behavior is part of the public contract
+from GeneralManager 0.67.4.
 
 `MeasurementScalar` parses string inputs such as `"12.5 m/s"` into
 `Measurement` values and serializes stored measurements with the canonical

--- a/docs/concepts/graphql/file_uploads.md
+++ b/docs/concepts/graphql/file_uploads.md
@@ -129,6 +129,22 @@ Projects that need strong format recognition must supply an inspector. Its
 `FileInspection.content` is bounded by `MAX_INSPECTION_BYTES`, may be truncated,
 and deliberately contains no credentials or storage keys.
 
+## Safe GraphQL failures
+
+Upload failures crossing a generated mutation or `@graph_ql_mutation` boundary
+are converted into safe top-level GraphQL errors. Framework-owned `UploadError`
+subclasses use their documented default message and stable `extensions.code`,
+even when application code supplied a different exception message. For example,
+`InvalidImageError()` returns `INVALID_IMAGE` with
+`The file upload could not be completed.`
+
+An application-defined `UploadError` subclass is sanitized to the generic
+`UPLOAD_STORAGE_ERROR` code and the same safe message; its custom code, message,
+and exception details do not reach the client. Clients should branch on
+`extensions.code`, not exception text. This boundary covers GeneralManager's
+generated and decorator mutation paths; third-party resolvers that bypass those
+paths own their own error handling.
+
 ## Downloads
 
 Files are private by default. Local storage returns a short-lived signed

--- a/docs/examples/graphql_file_upload.md
+++ b/docs/examples/graphql_file_upload.md
@@ -101,6 +101,13 @@ async function uploadAvatar(profileId, file) {
 }
 ```
 
+The `isPublicCode` allowlist treats the stable upload codes as a client
+contract, so this recipe can show actionable upload failures without trusting
+arbitrary server messages. Framework-owned `UploadError` types use their safe
+default message and code; custom subclasses are normalized to
+`UPLOAD_STORAGE_ERROR` with `The file upload could not be completed.` Branch on
+the code, and use the message only for those allowlisted codes.
+
 Do not retry the final mutation with the same token once the intent reaches
 `FINALIZING`. Poll the normal profile query while the returned status is
 `PROCESSING`; begin a new upload after a terminal token error. This workflow and

--- a/docs/examples/graphql_file_upload.md
+++ b/docs/examples/graphql_file_upload.md
@@ -15,6 +15,36 @@ import {
 // than the server's upload policy, or use a reviewed streaming hash library.
 const MAX_CLIENT_HASH_BYTES = 25_000_000;
 
+const PUBLIC_UPLOAD_CODES = new Set([
+  "UNAUTHENTICATED",
+  "PERMISSION_DENIED",
+  "UPLOAD_MANAGER_INVALID",
+  "UPLOAD_FIELD_INVALID",
+  "UPLOAD_OPERATION_INVALID",
+  "UPLOAD_TARGET_UNAVAILABLE",
+  "INVALID_UPLOAD_FILENAME",
+  "INVALID_UPLOAD_SIZE",
+  "INVALID_UPLOAD_CHECKSUM",
+  "UPLOAD_QUOTA_EXCEEDED",
+  "UPLOAD_RATE_LIMITED",
+  "UPLOAD_EXPIRED",
+  "UPLOAD_TOKEN_INVALID",
+  "UPLOAD_INCOMPLETE",
+  "UPLOAD_ALREADY_CONSUMED",
+  "UPLOAD_TRANSFER_CONFLICT",
+  "UPLOAD_SUPERSEDED",
+  "UPLOAD_BINDING_MISMATCH",
+  "UPLOAD_SIZE_MISMATCH",
+  "UPLOAD_CHECKSUM_MISMATCH",
+  "INVALID_FILE_TYPE",
+  "INVALID_IMAGE",
+  "UPLOAD_BACKEND_UNSUPPORTED",
+  "UPLOAD_STORAGE_CHANGED",
+  "UPLOAD_DATABASE_MISMATCH",
+  "UPLOAD_FINALIZATION_FAILED",
+  "UPLOAD_STORAGE_ERROR",
+]);
+
 async function sha256Hex(file) {
   if (file.size > MAX_CLIENT_HASH_BYTES) {
     throw new RangeError("The file is too large to hash in this browser flow.");
@@ -36,11 +66,7 @@ async function graphql(query, variables) {
   const payload = await response.json();
   const failures = mapGraphQLErrors(payload.errors ?? [], {
     isPublicCode: (code) => (
-      code === "UNAUTHENTICATED"
-      || code === "INVALID_FILE_TYPE"
-      || code === "INVALID_IMAGE"
-      || code.startsWith("UPLOAD_")
-      || code.startsWith("INVALID_UPLOAD_")
+      PUBLIC_UPLOAD_CODES.has(code)
     ),
   });
   if (failures.length) throw new GraphQLRequestError(failures);

--- a/docs/howto/graphql_file_uploads.md
+++ b/docs/howto/graphql_file_uploads.md
@@ -313,6 +313,15 @@ It uses 401 for missing/invalid credentials, 404 for non-enumerating absence,
 409 for transfer replay/conflict, 410 for expiry, 413/422 for size/checksum,
 415 for type, 429 for rate limiting, and 503 for storage/configuration failure.
 
+GraphQL mutation errors are safe to consume by code. Framework-owned
+`UploadError` subclasses return their documented stable code and default safe
+message; a message passed to the exception is never exposed. An
+application-defined `UploadError` subclass is normalized to
+`UPLOAD_STORAGE_ERROR` with `The file upload could not be completed.` Clients
+should branch on `extensions.code`, never on arbitrary exception text. This
+normalization applies to generated mutations and mutations registered with
+`@graph_ql_mutation`.
+
 ## Stable GraphQL error codes
 
 | Code | Meaning |


### PR DESCRIPTION
## Summary

Reviewed the rolling 24-hour history reachable from `origin/main` and documented the changed public GraphQL upload-error contract from `bc6240d`. Framework-owned `UploadError` types retain their safe default message and stable code at GeneralManager mutation boundaries; application-defined subclasses are sanitized to `UPLOAD_STORAGE_ERROR`.

## Reviewed commits

- `6286429b20ef872b988a6a53dd69917582d22e35` — README build-status badge and regression test.
- `75f1bc9e111690c7fbeca3b72ebab32467397906` — 0.67.3 release metadata.
- `bc6240d236380b30babb4aa0160ce58ea8036865` — GraphQL upload-error sanitization behavior and API-reference update.
- `c416492a6dd8050de607b63342b6a69dc4427346` — 0.67.4 release metadata.

Only `bc6240d` changed a public API response contract.

## Affected public API

- GraphQL error responses produced by generated mutations and mutations registered with `@graph_ql_mutation` when they handle framework-owned or custom `UploadError` exceptions.
- Stable upload error codes and safe default messages, including the fallback `UPLOAD_STORAGE_ERROR`.

## Documentation updated

- `docs/concepts/graphql/file_uploads.md`
- `docs/howto/graphql_file_uploads.md`
- `docs/examples/graphql_file_upload.md`
- `docs/api/graphql.md`

## Validation

- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py tests/unit/test_graphql_helpers.py::GraphQLHelperTests::test_handle_graphql_error_maps_framework_upload_error tests/unit/test_graphql_helpers.py::GraphQLHelperTests::test_handle_graphql_error_sanitizes_custom_upload_error -q` — 6 passed.
- `PYTHONPATH=src python -m pytest tests/integration/test_request_docs_examples.py -q` — 2 passed.
- `python -m mkdocs build --strict --site-dir /tmp/general-manager-docs-review-20260731` — passed; only existing unnav-linked planning/ADR notices were reported.
- Node syntax check for the JavaScript cookbook block — passed.
- File-scoped pre-commit hooks — passed.
- `git diff --check` — passed.

## Limitations

This is documentation-only; no application behavior or tests were changed. The full test suite was not rerun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on file upload error handling in GraphQL, including details on error sanitization, stable error codes, and client-side error handling strategies across mutation boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->