### PR TITLE
fix: bound dependency invalidation and preserve lock ownership

### DIFF
--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -433,10 +433,12 @@ first reads the reverse registry through `cache_set_members()`, then returns
 only cached values that are actual `ReverseDependencyMembership` instances.
 
 Ordinary data-change and cleanup paths do not enumerate the reverse-membership
-registry to choose a storage implementation. They read the legacy
-`dependency_index` key once: a present payload selects the legacy full index,
-and an absent payload selects manager- and lookup-specific shards. Consequently,
-hot invalidation work is independent of unrelated reverse-membership cardinality.
+registry to choose a storage implementation. Mode selection uses one
+constant-time probe read of the legacy `dependency_index` key. A present payload
+selects legacy mode, which then loads the legacy index for the operation; an
+absent payload selects manager- and lookup-specific shards. Consequently, hot
+sharded invalidation work is independent of unrelated reverse-membership
+cardinality.
 
 `reverse_memberships()` remains an explicitly global operation for callers that
 need to reconstruct the complete dependency index. It reads the registry once

--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -242,6 +242,12 @@ Python-cache metadata rather than strict JSON interchange values. If
 `__getstate__()` exists but returns a non-mapping, the value uses the same
 `repr(...)` fallback as other unsupported objects.
 
+Dependency lock acquisitions store a unique owner token. Release deletes the
+lock only when the cached value still matches that token, so an expired holder
+does not delete an already-visible successor token. Django's generic cache API
+does not expose portable atomic compare-and-delete, so this ownership check is
+not documented as a backend-independent atomic release primitive.
+
 `record_dependencies()` deduplicates dependency tuples and is a no-op for an
 empty dependency iterable; an empty call does not clear existing metadata for
 that cache key. Re-recording non-empty dependencies for an existing cache key
@@ -425,6 +431,17 @@ Helpers that read shard sets inherit this behavior, so malformed filter and
 exclude lookup registries are ignored independently. `reverse_memberships()`
 first reads the reverse registry through `cache_set_members()`, then returns
 only cached values that are actual `ReverseDependencyMembership` instances.
+
+Ordinary data-change and cleanup paths do not enumerate the reverse-membership
+registry to choose a storage implementation. They read the legacy
+`dependency_index` key once: a present payload selects the legacy full index,
+and an absent payload selects manager- and lookup-specific shards. Consequently,
+hot invalidation work is independent of unrelated reverse-membership cardinality.
+
+`reverse_memberships()` remains an explicitly global operation for callers that
+need to reconstruct the complete dependency index. It reads the registry once
+and fetches referenced payloads with one batched `get_many()` call. Its transfer,
+validation, and result construction remain O(N).
 
 Shard-key builders interpolate string inputs exactly as provided; they do not
 escape empty strings, colons, or other unusual characters. `reverse_membership_key()`

--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -442,8 +442,8 @@ cardinality.
 
 `reverse_memberships()` remains an explicitly global operation for callers that
 need to reconstruct the complete dependency index. It reads the registry once
-and fetches referenced payloads with one batched `get_many()` call. Its transfer,
-validation, and result construction remain O(N).
+and fetches referenced payloads with bounded `get_many()` calls of at most 1,000
+keys each. Its transfer, validation, and result construction remain O(N).
 
 Shard-key builders interpolate string inputs exactly as provided; they do not
 escape empty strings, colons, or other unusual characters. `reverse_membership_key()`

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -107,10 +107,11 @@ _BACKOFF_INITIAL = 0.02  # 20ms initial sleep
 _BACKOFF_MAX = 0.5  # 500ms maximum sleep between retries
 
 
-def acquire_lock(timeout: int = LOCK_TIMEOUT) -> DependencyLockToken | None:
+def acquire_lock(timeout: int | float = LOCK_TIMEOUT) -> DependencyLockToken | None:
     """Acquire the dependency lock and return its unique owner token."""
     token = uuid.uuid4().hex
-    if cache.add(LOCK_KEY, token, timeout):
+    cache_add = cast(Callable[[str, object, int | float], bool], cache.add)
+    if cache_add(LOCK_KEY, token, timeout):
         return token
     return None
 
@@ -225,6 +226,9 @@ def acquire_lock_with_retry(operation: str) -> DependencyLockToken:
 
     Raises:
         DependencyLockTimeoutError: If the lock cannot be acquired within LOCK_TIMEOUT.
+
+    Returns:
+        DependencyLockToken: Owner token that callers must pass to release_lock().
     """
     token = acquire_lock()
     if token is not None:

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -24,6 +24,7 @@ from general_manager.cache.dependency_shards import (
     ReverseDependencyMembership,
     all_records_cache_keys,
     candidate_cache_keys_for_lookup,
+    legacy_dependency_index_exists,
     record_cache_dependencies,
     record_many_cache_dependencies,
     remove_cache_key_from_shards,
@@ -574,7 +575,7 @@ def remove_cache_key_from_index(cache_key: str) -> None:
     """
     acquire_lock_with_retry("remove_cache_key_from_index")
     try:
-        if cache.get(INDEX_KEY, None) is not None and not reverse_memberships():
+        if legacy_dependency_index_exists():
             idx = get_full_index()
             _remove_cache_keys_from_index_locked(idx, (cache_key,))
             set_full_index(idx)
@@ -669,7 +670,7 @@ def invalidate_and_remove_cache_keys(cache_keys: Iterable[str]) -> None:
         return
     acquire_lock_with_retry("invalidate_and_remove_cache_keys")
     try:
-        if cache.get(INDEX_KEY, None) is not None and not reverse_memberships():
+        if legacy_dependency_index_exists():
             idx = get_full_index()
             for cache_key in keys:
                 cache.delete(cache_key)
@@ -711,7 +712,7 @@ def invalidate_request_query_dependencies(manager_name: str) -> tuple[str, ...]:
     """
     acquire_lock_with_retry("invalidate_request_query_dependencies")
     try:
-        if cache.get(INDEX_KEY, None) is not None and not reverse_memberships():
+        if legacy_dependency_index_exists():
             idx = get_full_index()
             invalidated_keys = _invalidate_request_query_dependencies_locked(
                 idx,
@@ -745,7 +746,7 @@ def capture_old_values(
         return
     manager_name = sender.__name__
     lookups = tracked_lookup_names(manager_name)
-    if not lookups and not reverse_memberships():
+    if not lookups and legacy_dependency_index_exists():
         idx = get_full_index()
         for action in ACTIONS:
             model_section = idx[action].get(manager_name)
@@ -1394,24 +1395,15 @@ def generic_cache_invalidation(
     invalidated_cache_keys: set[str] = set()
     acquire_lock_with_retry("generic_cache_invalidation")
     try:
-        if not reverse_memberships():
+        if legacy_dependency_index_exists():
             idx = get_full_index()
-            sections: tuple[Literal["filter", "exclude", "all", "request_query"], ...]
-            sections = ("filter", "exclude", "all", "request_query")
-            if any(idx.get(section) for section in sections):
-                invalidated_cache_keys = _generic_cache_invalidation_locked(
-                    idx,
-                    manager_name,
-                    instance,
-                    old_relevant_values,
-                )
-                set_full_index(idx)
-            else:
-                invalidated_cache_keys = _generic_cache_invalidation_from_shards(
-                    manager_name,
-                    instance,
-                    old_relevant_values,
-                )
+            invalidated_cache_keys = _generic_cache_invalidation_locked(
+                idx,
+                manager_name,
+                instance,
+                old_relevant_values,
+            )
+            set_full_index(idx)
         else:
             invalidated_cache_keys = _generic_cache_invalidation_from_shards(
                 manager_name,

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import random
 import time
+import uuid
 from contextvars import ContextVar
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Tuple, Type, cast
@@ -59,6 +60,7 @@ type filter_type = Literal[
     "filter", "exclude", "identification", "request_query", "all"
 ]
 type Dependency = Tuple[general_manager_name, filter_type, str]
+type DependencyLockToken = str
 
 logger = get_logger("cache.dependency_index")
 _pending_graphql_rewarm_cache_keys: ContextVar[frozenset[str]] = ContextVar(
@@ -105,27 +107,22 @@ _BACKOFF_INITIAL = 0.02  # 20ms initial sleep
 _BACKOFF_MAX = 0.5  # 500ms maximum sleep between retries
 
 
-def acquire_lock(timeout: int = LOCK_TIMEOUT) -> bool:
+def acquire_lock(timeout: int = LOCK_TIMEOUT) -> DependencyLockToken | None:
+    """Acquire the dependency lock and return its unique owner token."""
+    token = uuid.uuid4().hex
+    if cache.add(LOCK_KEY, token, timeout):
+        return token
+    return None
+
+
+def release_lock(token: DependencyLockToken) -> None:
+    """Release the dependency lock only while ``token`` remains its owner.
+
+    Django's generic cache API has no portable atomic compare-and-delete, so
+    ownership is checked immediately before deletion without stronger claims.
     """
-    Attempt to acquire the cache-backed lock guarding dependency writes.
-
-    Parameters:
-        timeout (int): Expiration time for the lock entry in seconds.
-
-    Returns:
-        bool: True if the lock was acquired; otherwise, False.
-    """
-    return cache.add(LOCK_KEY, "1", timeout)
-
-
-def release_lock() -> None:
-    """
-    Release the cache-backed lock guarding dependency writes.
-
-    Returns:
-        None
-    """
-    cache.delete(LOCK_KEY)
+    if cache.get(LOCK_KEY) == token:
+        cache.delete(LOCK_KEY)
 
 
 def get_dependency_generation() -> int:
@@ -164,13 +161,13 @@ def begin_dependency_data_change() -> int:
     The generation bump happens before the underlying mutation, so computations
     that started before the mutation cannot publish dependency-scoped values.
     """
-    acquire_lock_with_retry("begin_dependency_data_change")
+    lock_token = acquire_lock_with_retry("begin_dependency_data_change")
     try:
         generation = _set_dependency_generation(get_dependency_generation() + 1)
         _set_dependency_data_change_count(_get_dependency_data_change_count() + 1)
         cache.set(DATA_CHANGE_LOCK_KEY, "1", None)
     finally:
-        release_lock()
+        release_lock(lock_token)
     try:
         _discard_active_context_dependency_cache_state()
     except Exception:
@@ -184,7 +181,7 @@ def begin_dependency_data_change() -> int:
 
 def end_dependency_data_change() -> None:
     """Release the publish barrier for a completed data change."""
-    acquire_lock_with_retry("end_dependency_data_change")
+    lock_token = acquire_lock_with_retry("end_dependency_data_change")
     try:
         count = _set_dependency_data_change_count(
             max(_get_dependency_data_change_count() - 1, 0)
@@ -194,7 +191,7 @@ def end_dependency_data_change() -> None:
         else:
             cache.set(DATA_CHANGE_LOCK_KEY, "1", None)
     finally:
-        release_lock()
+        release_lock(lock_token)
 
 
 def is_dependency_data_change_active() -> bool:
@@ -219,7 +216,7 @@ def drain_invalidated_cache_keys_for_graphql_rewarm() -> tuple[str, ...]:
     return cache_keys
 
 
-def acquire_lock_with_retry(operation: str) -> None:
+def acquire_lock_with_retry(operation: str) -> DependencyLockToken:
     """
     Acquire the dependency index lock, retrying with exponential backoff.
 
@@ -229,8 +226,9 @@ def acquire_lock_with_retry(operation: str) -> None:
     Raises:
         DependencyLockTimeoutError: If the lock cannot be acquired within LOCK_TIMEOUT.
     """
-    if acquire_lock():
-        return
+    token = acquire_lock()
+    if token is not None:
+        return token
     start = time.time()
     delay = _BACKOFF_INITIAL
     while True:
@@ -238,8 +236,9 @@ def acquire_lock_with_retry(operation: str) -> None:
         if remaining <= 0:
             raise DependencyLockTimeoutError(operation)
         time.sleep(random.uniform(0, min(delay, remaining)))  # noqa: S311 - jitter, not crypto
-        if acquire_lock():
-            return
+        token = acquire_lock()
+        if token is not None:
+            return token
         if time.time() - start > LOCK_TIMEOUT:
             raise DependencyLockTimeoutError(operation)
         delay = min(delay * 2, _BACKOFF_MAX)
@@ -527,11 +526,11 @@ def record_dependencies(
     Raises:
         DependencyLockTimeoutError: If a lock cannot be acquired within the configured timeout while updating the index.
     """
-    acquire_lock_with_retry("record_dependencies")
+    lock_token = acquire_lock_with_retry("record_dependencies")
     try:
         record_cache_dependencies(cache_key, dependencies)
     finally:
-        release_lock()
+        release_lock(lock_token)
 
 
 def record_many_dependencies(
@@ -548,11 +547,11 @@ def record_many_dependencies(
     if not normalized:
         return
 
-    acquire_lock_with_retry("record_many_dependencies")
+    lock_token = acquire_lock_with_retry("record_many_dependencies")
     try:
         record_many_cache_dependencies(normalized.items())
     finally:
-        release_lock()
+        release_lock(lock_token)
 
 
 # -----------------------------------------------------------------------------
@@ -573,7 +572,7 @@ def remove_cache_key_from_index(cache_key: str) -> None:
     Raises:
         DependencyLockTimeoutError: If the dependency lock cannot be acquired within LOCK_TIMEOUT.
     """
-    acquire_lock_with_retry("remove_cache_key_from_index")
+    lock_token = acquire_lock_with_retry("remove_cache_key_from_index")
     try:
         if legacy_dependency_index_exists():
             idx = get_full_index()
@@ -582,7 +581,7 @@ def remove_cache_key_from_index(cache_key: str) -> None:
             return
         remove_cache_key_from_shards(cache_key)
     finally:
-        release_lock()
+        release_lock(lock_token)
 
 
 # -----------------------------------------------------------------------------
@@ -668,7 +667,7 @@ def invalidate_and_remove_cache_keys(cache_keys: Iterable[str]) -> None:
     keys = tuple(dict.fromkeys(cache_keys))
     if not keys:
         return
-    acquire_lock_with_retry("invalidate_and_remove_cache_keys")
+    lock_token = acquire_lock_with_retry("invalidate_and_remove_cache_keys")
     try:
         if legacy_dependency_index_exists():
             idx = get_full_index()
@@ -681,7 +680,7 @@ def invalidate_and_remove_cache_keys(cache_keys: Iterable[str]) -> None:
             cache.delete(cache_key)
             remove_cache_key_from_shards(cache_key)
     finally:
-        release_lock()
+        release_lock(lock_token)
 
 
 def _invalidate_request_query_dependencies_locked(
@@ -710,7 +709,7 @@ def invalidate_request_query_dependencies(manager_name: str) -> tuple[str, ...]:
     Returns:
         tuple[str, ...]: The cache keys that were invalidated.
     """
-    acquire_lock_with_retry("invalidate_request_query_dependencies")
+    lock_token = acquire_lock_with_retry("invalidate_request_query_dependencies")
     try:
         if legacy_dependency_index_exists():
             idx = get_full_index()
@@ -727,7 +726,7 @@ def invalidate_request_query_dependencies(manager_name: str) -> tuple[str, ...]:
             remove_cache_key_from_shards(cache_key)
         return invalidated_keys
     finally:
-        release_lock()
+        release_lock(lock_token)
 
 
 @receiver(pre_data_change)
@@ -1393,7 +1392,7 @@ def generic_cache_invalidation(
     """
     manager_name = sender.__name__
     invalidated_cache_keys: set[str] = set()
-    acquire_lock_with_retry("generic_cache_invalidation")
+    lock_token = acquire_lock_with_retry("generic_cache_invalidation")
     try:
         if legacy_dependency_index_exists():
             idx = get_full_index()
@@ -1411,6 +1410,6 @@ def generic_cache_invalidation(
                 old_relevant_values,
             )
     finally:
-        release_lock()
+        release_lock(lock_token)
     if invalidated_cache_keys:
         record_invalidated_cache_keys_for_graphql_rewarm(invalidated_cache_keys)

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -744,8 +744,8 @@ def capture_old_values(
     if instance is None:
         return
     manager_name = sender.__name__
-    lookups = tracked_lookup_names(manager_name)
-    if not lookups and legacy_dependency_index_exists():
+    if legacy_dependency_index_exists():
+        lookups: set[str] = set()
         idx = get_full_index()
         for action in ACTIONS:
             model_section = idx[action].get(manager_name)
@@ -761,6 +761,8 @@ def capture_old_values(
                     lookups.add(lookup)
             elif isinstance(model_section, list):
                 lookups |= set(model_section)
+    else:
+        lookups = tracked_lookup_names(manager_name)
     if lookups and instance.identification:
         # save old values for later comparison
         vals: dict[str, object] = {}

--- a/src/general_manager/cache/dependency_publish.py
+++ b/src/general_manager/cache/dependency_publish.py
@@ -386,7 +386,7 @@ def publish_dependency_cache_entries(
     if not pending_entries:
         return
 
-    acquire_lock_with_retry("publish_dependency_cache_entries")
+    lock_token = acquire_lock_with_retry("publish_dependency_cache_entries")
     try:
         if is_dependency_data_change_active():
             raise CachePublishAborted()
@@ -430,7 +430,7 @@ def publish_dependency_cache_entries(
         _ensure_publish_current(current_generation)
         _set_dependency_cache_entries(publishable_entries)
     finally:
-        release_lock()
+        release_lock(lock_token)
 
 
 def publish_dependency_cache_entry(
@@ -473,7 +473,7 @@ def publish_dependency_cache_entry(
     )
     dependency_set = set(dependencies)
 
-    acquire_lock_with_retry("publish_dependency_cache_entry")
+    lock_token = acquire_lock_with_retry("publish_dependency_cache_entry")
     try:
         _ensure_publish_current(started_generation)
 
@@ -529,4 +529,4 @@ def publish_dependency_cache_entry(
             else:
                 cache_backend.set(prefetch_manifest_key, (cache_key,), timeout)
     finally:
-        release_lock()
+        release_lock(lock_token)

--- a/src/general_manager/cache/dependency_shards.py
+++ b/src/general_manager/cache/dependency_shards.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable, Mapping
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import lru_cache
+from itertools import batched
 from typing import Literal
 
 from django.core.cache import cache
@@ -29,6 +30,7 @@ DEPENDENCY_SHARD_PREFIX = "general_manager:dependency:v1"
 LEGACY_DEPENDENCY_INDEX_KEY = "dependency_index"
 ALL_RECORDS_VALUE = "__all__"
 REVERSE_MEMBERSHIP_REGISTRY_KEY = f"{DEPENDENCY_SHARD_PREFIX}:reverse_keys"
+REVERSE_MEMBERSHIP_READ_BATCH_SIZE = 1000
 VALUE_NOT_PROVIDED = object()
 
 DependencyAction = Literal[
@@ -793,15 +795,19 @@ def reverse_memberships() -> tuple[ReverseDependencyMembership, ...]:
         Valid reverse-membership payloads currently listed in the reverse
         membership registry. Missing or malformed registry members are skipped.
         A malformed registry payload contributes no reverse keys through
-        `cache_set_members()`. Payloads are fetched with one `get_many()` call.
-        Dependency tuple members inside a valid `ReverseDependencyMembership`
-        are returned unchanged.
+        `cache_set_members()`. Payloads are fetched with bounded `get_many()`
+        calls. Dependency tuple members inside a valid
+        `ReverseDependencyMembership` are returned unchanged.
     """
     reverse_keys = cache_set_members(REVERSE_MEMBERSHIP_REGISTRY_KEY)
-    reverse_payloads = _cache_get_many(reverse_keys)
     memberships = []
-    for reverse_key in reverse_keys:
-        reverse = reverse_payloads.get(reverse_key)
-        if isinstance(reverse, ReverseDependencyMembership):
-            memberships.append(reverse)
+    for reverse_key_batch in batched(
+        reverse_keys,
+        REVERSE_MEMBERSHIP_READ_BATCH_SIZE,
+    ):
+        reverse_payloads = _cache_get_many(reverse_key_batch)
+        for reverse_key in reverse_key_batch:
+            reverse = reverse_payloads.get(reverse_key)
+            if isinstance(reverse, ReverseDependencyMembership):
+                memberships.append(reverse)
     return tuple(memberships)

--- a/src/general_manager/cache/dependency_shards.py
+++ b/src/general_manager/cache/dependency_shards.py
@@ -361,6 +361,15 @@ def _legacy_dependency_cache_keys(legacy_index: object) -> set[str]:
     return cache_keys
 
 
+def legacy_dependency_index_exists() -> bool:
+    """Return whether the legacy full dependency index is present.
+
+    This is the constant-read storage-mode probe used by hot invalidation paths.
+    The legacy key is authoritative when both legacy and sharded metadata exist.
+    """
+    return cache.get(LEGACY_DEPENDENCY_INDEX_KEY, None) is not None
+
+
 def clear_legacy_dependency_index() -> set[str]:
     """Delete legacy full-index metadata and cache values referenced by it.
 
@@ -784,12 +793,15 @@ def reverse_memberships() -> tuple[ReverseDependencyMembership, ...]:
         Valid reverse-membership payloads currently listed in the reverse
         membership registry. Missing or malformed registry members are skipped.
         A malformed registry payload contributes no reverse keys through
-        `cache_set_members()`. Dependency tuple members inside a valid
-        `ReverseDependencyMembership` are returned unchanged.
+        `cache_set_members()`. Payloads are fetched with one `get_many()` call.
+        Dependency tuple members inside a valid `ReverseDependencyMembership`
+        are returned unchanged.
     """
+    reverse_keys = cache_set_members(REVERSE_MEMBERSHIP_REGISTRY_KEY)
+    reverse_payloads = _cache_get_many(reverse_keys)
     memberships = []
-    for reverse_key in cache_set_members(REVERSE_MEMBERSHIP_REGISTRY_KEY):
-        reverse = cache.get(reverse_key)
+    for reverse_key in reverse_keys:
+        reverse = reverse_payloads.get(reverse_key)
         if isinstance(reverse, ReverseDependencyMembership):
             memberships.append(reverse)
     return tuple(memberships)

--- a/tests/unit/test_cache_decorator.py
+++ b/tests/unit/test_cache_decorator.py
@@ -529,7 +529,7 @@ class TestCacheDecoratorBackend(SimpleTestCase):
 
         with mock.patch(
             "general_manager.cache.dependency_index.acquire_lock",
-            return_value=True,
+            return_value="owner-token",
         ) as acquire_lock:
             with CalculationRunContext():
                 self.assertEqual(fn(1), 2)

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -70,9 +70,9 @@ class TestAcquireReleaseLock(TestCase):
         assert cache.get(LOCK_KEY) is None
 
     def test_stale_owner_does_not_release_successor(self) -> None:
-        stale_token = acquire_lock(0.1)  # type: ignore[arg-type]
+        stale_token = acquire_lock(0.2)
         assert stale_token is not None
-        time.sleep(0.15)
+        time.sleep(0.4)
         successor_token = acquire_lock()
         assert successor_token is not None
 
@@ -1042,6 +1042,8 @@ class DummyManager:
 
 class CaptureOldValuesTests(TestCase):
     def setUp(self) -> None:
+        cache.clear()
+        # Seed the legacy key so patched full-index reads use the legacy path.
         cache.set("dependency_index", {}, None)
 
     @patch("general_manager.cache.dependency_index.get_full_index")
@@ -1187,6 +1189,8 @@ class MissingAttrManager:
 
 class GenericCacheInvalidationTests(TestCase):
     def setUp(self) -> None:
+        cache.clear()
+        # Seed the legacy key so patched full-index reads use the legacy path.
         cache.set("dependency_index", {}, None)
 
     def assert_cache_keys_removed_from_index(

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -3,7 +3,9 @@ from general_manager.cache.dependency_index import (
     DATA_CHANGE_COUNT_KEY,
     DATA_CHANGE_LOCK_KEY,
     DEPENDENCY_GENERATION_KEY,
+    LOCK_KEY,
     acquire_lock,
+    acquire_lock_with_retry,
     begin_dependency_data_change,
     end_dependency_data_change,
     get_full_index,
@@ -42,39 +44,46 @@ TEST_CACHES = {
 
 @override_settings(CACHES=TEST_CACHES)
 class TestAcquireReleaseLock(TestCase):
-    def setUp(self):
-        # Clear the cache before each test
+    def setUp(self) -> None:
         cache.clear()
 
-    def test_acquire_lock(self):
-        locked = acquire_lock()
-        self.assertTrue(locked)
+    def test_acquire_lock_stores_and_returns_unique_owner_token(self) -> None:
+        first_token = acquire_lock()
 
-    def test_lock_funcionality(self):
-        acquire_lock()
-        secound_locked = acquire_lock()
-        self.assertFalse(secound_locked)
-        release_lock()
-        locked = acquire_lock()
-        self.assertTrue(locked)
+        assert isinstance(first_token, str)
+        assert first_token
+        assert cache.get(LOCK_KEY) == first_token
+        assert acquire_lock() is None
 
-    def test_release_lock(self):
-        locked = acquire_lock()
-        self.assertTrue(locked)
-        release_lock()
-        locked = acquire_lock()
-        self.assertTrue(locked)
-        release_lock()
+        release_lock(first_token)
+        second_token = acquire_lock()
 
-    def test_release_lock_without_acquire(self):
-        release_lock()
+        assert isinstance(second_token, str)
+        assert second_token != first_token
 
-    def test_lock_ttl(self):
-        locked = acquire_lock(0.1)  # type: ignore
-        self.assertTrue(locked)
+    def test_release_lock_removes_current_owner(self) -> None:
+        token = acquire_lock()
+        assert token is not None
+
+        release_lock(token)
+
+        assert cache.get(LOCK_KEY) is None
+
+    def test_stale_owner_does_not_release_successor(self) -> None:
+        stale_token = acquire_lock(0.1)  # type: ignore[arg-type]
+        assert stale_token is not None
         time.sleep(0.15)
-        locked = acquire_lock()
-        self.assertTrue(locked)
+        successor_token = acquire_lock()
+        assert successor_token is not None
+
+        release_lock(stale_token)
+
+        assert cache.get(LOCK_KEY) == successor_token
+
+    def test_unknown_owner_release_is_noop(self) -> None:
+        release_lock("not-the-owner")
+
+        assert cache.get(LOCK_KEY) is None
 
 
 @override_settings(CACHES=TEST_CACHES)
@@ -567,7 +576,7 @@ class TestRecordDependencies(TestCase):
 
     @patch("general_manager.cache.dependency_index.acquire_lock")
     def test_waits_until_lock_is_acquired(self, mock_acquire):
-        mock_acquire.side_effect = [False, False, True]
+        mock_acquire.side_effect = [None, None, "owner-token"]
         record_dependencies(
             "abc123",
             [
@@ -595,9 +604,18 @@ class TestRecordDependencies(TestCase):
         )
 
     @patch("general_manager.cache.dependency_index.acquire_lock")
+    def test_acquire_lock_with_retry_returns_successful_token(self, mock_acquire):
+        mock_acquire.side_effect = [None, None, "owner-token"]
+
+        token = acquire_lock_with_retry("test-operation")
+
+        assert token == "owner-token"  # noqa: S105 - test-only lock token
+        assert mock_acquire.call_count == 3
+
+    @patch("general_manager.cache.dependency_index.acquire_lock")
     @patch("general_manager.cache.dependency_index.LOCK_TIMEOUT", 0.1)
     def test_raises_timeout_error(self, mock_acquire):
-        mock_acquire.return_value = False
+        mock_acquire.return_value = None
         with self.assertRaises(TimeoutError):
             record_dependencies(
                 "abc123",
@@ -615,7 +633,7 @@ class TestRecordManyDependencies(TestCase):
 
     @patch("general_manager.cache.dependency_index.acquire_lock")
     def test_records_many_dependency_sets_under_one_lock(self, mock_acquire):
-        mock_acquire.return_value = True
+        mock_acquire.return_value = "owner-token"
 
         record_many_dependencies(
             [
@@ -833,9 +851,9 @@ class TestRemoveCacheKeyFromIndex(TestCase):
 
         set_full_index(idx)
         mock_acquire.side_effect = [
-            False,
-            False,
-            True,
+            None,
+            None,
+            "owner-token",
         ]
         remove_cache_key_from_index("abc123")
         self.assertEqual(mock_acquire.call_count, 3)
@@ -868,7 +886,7 @@ class TestRemoveCacheKeyFromIndex(TestCase):
         }
 
         set_full_index(idx)
-        mock_acquire.return_value = False
+        mock_acquire.return_value = None
         with self.assertRaises(TimeoutError):
             remove_cache_key_from_index("abc123")
 
@@ -1258,6 +1276,7 @@ class GenericCacheInvalidationTests(TestCase):
             ) as mock_release,
             patch("general_manager.cache.dependency_index.set_full_index") as mock_set,
         ):
+            mock_acquire.return_value = "owner-token"
             generic_cache_invalidation(
                 sender=DummyManager2,
                 instance=inst,
@@ -1265,7 +1284,7 @@ class GenericCacheInvalidationTests(TestCase):
             )
 
         mock_acquire.assert_called_once_with("generic_cache_invalidation")
-        mock_release.assert_called_once()
+        mock_release.assert_called_once_with("owner-token")
         mock_set.assert_called_once()
         for cache_key in invalidated_keys:
             self.assertIsNone(cache.get(cache_key))

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -1023,6 +1023,9 @@ class DummyManager:
 
 
 class CaptureOldValuesTests(TestCase):
+    def setUp(self) -> None:
+        cache.set("dependency_index", {}, None)
+
     @patch("general_manager.cache.dependency_index.get_full_index")
     def test_capture_old_values_sets_old_values_correctly(self, mock_get_full_index):
         mock_get_full_index.return_value = {
@@ -1165,6 +1168,9 @@ class MissingAttrManager:
 
 
 class GenericCacheInvalidationTests(TestCase):
+    def setUp(self) -> None:
+        cache.set("dependency_index", {}, None)
+
     def assert_cache_keys_removed_from_index(
         self,
         idx: dict[object, object],

--- a/tests/unit/test_dependency_publish.py
+++ b/tests/unit/test_dependency_publish.py
@@ -664,6 +664,48 @@ class TestDependencyPublish(SimpleTestCase):
         self.assertEqual(cache_entry(cache_backend, "cache-a").value, "alpha")
         self.assertEqual(cache_entry(cache_backend, "cache-b").value, "bravo")
 
+    @mock.patch("general_manager.cache.dependency_publish.release_lock")
+    @mock.patch("general_manager.cache.dependency_publish.acquire_lock_with_retry")
+    def test_batch_publish_releases_acquired_owner_token(
+        self,
+        mock_acquire: mock.Mock,
+        mock_release: mock.Mock,
+    ) -> None:
+        mock_acquire.return_value = "batch-owner"
+        cache_backend = FakeDependencyCacheBackend()
+        entry = self.make_pending_publication(
+            cache_key="cache-a",
+            result="value",
+            dependencies=set(),
+            cache_backend=cache_backend,
+        )
+
+        publish_dependency_cache_entries([entry])
+
+        mock_release.assert_called_once_with("batch-owner")
+
+    @mock.patch("general_manager.cache.dependency_publish.release_lock")
+    @mock.patch("general_manager.cache.dependency_publish.acquire_lock_with_retry")
+    def test_single_publish_releases_owner_token_after_failure(
+        self,
+        mock_acquire: mock.Mock,
+        mock_release: mock.Mock,
+    ) -> None:
+        mock_acquire.return_value = "single-owner"
+        cache_backend = FakeDependencyCacheBackend()
+
+        with self.assertRaises(CachePublishAborted):
+            publish_dependency_cache_entry(
+                cache_key="cache-a",
+                result="value",
+                dependencies=frozenset(),
+                cache_backend=cache_backend,
+                timeout=None,
+                started_generation=get_dependency_generation() + 1,
+            )
+
+        mock_release.assert_called_once_with("single-owner")
+
     def test_batch_publish_retries_set_many_failures_individually(self) -> None:
         cache_backend = FakeDependencyCachePartialSetManyBackend({"cache-b"})
 

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -112,16 +112,17 @@ def seed_unrelated_reverse_memberships(
     *,
     count: int = 20_000,
 ) -> set[str]:
-    reverse_keys = {
-        reverse_membership_key(f"unrelated-cache-{index}") for index in range(count)
-    }
-    counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY] = reverse_keys
-    for index, reverse_key in enumerate(reverse_keys):
+    reverse_keys = set()
+    for index in range(count):
+        cache_key = f"unrelated-cache-{index}"
+        reverse_key = reverse_membership_key(cache_key)
+        reverse_keys.add(reverse_key)
         counting_cache.store[reverse_key] = ReverseDependencyMembership(
-            cache_key=f"unrelated-cache-{index}",
+            cache_key=cache_key,
             shard_keys=frozenset(),
             composite_dependencies=frozenset(),
         )
+    counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY] = reverse_keys
     return reverse_keys
 
 
@@ -368,7 +369,7 @@ class DependencyShardKeyTests(TestCase):
         assert clear_legacy_dependency_index() == set()
         assert cache.get("dependency_index") is None
 
-    def test_legacy_dependency_index_exists_uses_one_cache_read(self) -> None:
+    def test_legacy_dependency_index_exists_uses_one_cache_read_per_call(self) -> None:
         counting_cache = CountingShardCache()
 
         with mock.patch(
@@ -411,16 +412,24 @@ class DependencyShardKeyTests(TestCase):
         counting_cache.store[reverse_b] = membership_b
         counting_cache.store[malformed] = "not-reverse-metadata"
 
-        with mock.patch(
-            "general_manager.cache.dependency_shards.cache",
-            counting_cache,
+        with (
+            mock.patch(
+                "general_manager.cache.dependency_shards.cache",
+                counting_cache,
+            ),
+            mock.patch(
+                "general_manager.cache.dependency_shards."
+                "REVERSE_MEMBERSHIP_READ_BATCH_SIZE",
+                2,
+            ),
         ):
             memberships = reverse_memberships()
 
         assert set(memberships) == {membership_a, membership_b}
         assert counting_cache.get_calls == [REVERSE_MEMBERSHIP_REGISTRY_KEY]
-        assert len(counting_cache.get_many_calls) == 1
-        assert set(counting_cache.get_many_calls[0]) == {
+        assert len(counting_cache.get_many_calls) == 2
+        assert all(len(call) <= 2 for call in counting_cache.get_many_calls)
+        assert {key for call in counting_cache.get_many_calls for key in call} == {
             reverse_a,
             reverse_b,
             malformed,
@@ -815,8 +824,8 @@ class DependencyIndexShardFacadeTests(TestCase):
         assert counting_cache.get_many_calls == []
         assert counting_cache.get_calls == [
             "dependency_index",
-            "general_manager:dependency:v1:lookups:UntrackedProject:filter",
-            "general_manager:dependency:v1:lookups:UntrackedProject:exclude",
+            lookup_registry_key("UntrackedProject", "filter"),
+            lookup_registry_key("UntrackedProject", "exclude"),
         ]
         assert not hasattr(instance, "_old_values")
 
@@ -906,7 +915,7 @@ class DependencyIndexShardFacadeTests(TestCase):
         )
         assert unrelated_reverse_keys.isdisjoint(counting_cache.get_calls)
         assert unrelated_reverse_keys.isdisjoint(fetched_in_batches)
-        assert len(counting_cache.get_calls) == 47
+        assert len(counting_cache.get_calls) <= 50
         assert counting_cache.get_many_calls == [
             (candidate_shard,),
             (REVERSE_MEMBERSHIP_REGISTRY_KEY,),

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -24,11 +24,12 @@ from general_manager.cache.dependency_shards import (
     clear_legacy_dependency_index,
     composite_lookup_shard_key,
     exact_lookup_shard_key,
+    legacy_dependency_index_exists,
+    lookup_registry_key,
     record_cache_dependencies,
     record_many_cache_dependencies,
     remove_cache_key_from_shards,
     request_query_shard_key,
-    legacy_dependency_index_exists,
     reverse_membership_key,
     reverse_memberships,
     scan_lookup_shard_key,
@@ -758,6 +759,44 @@ class DependencyIndexShardFacadeTests(TestCase):
 
         assert instance._old_values == {"status": "open"}
 
+    def test_capture_old_values_prefers_legacy_lookups_over_stale_shards(
+        self,
+    ) -> None:
+        class Project:
+            pass
+
+        record_dependencies(
+            "stale-sharded-cache",
+            [("Project", "filter", json.dumps({"title": "stale"}))],
+        )
+        cache.set(
+            "dependency_index",
+            {
+                "filter": {"Project": {"status": {'"open"': {"legacy-cache"}}}},
+                "exclude": {},
+                "request_query": {},
+                "all": {},
+            },
+            None,
+        )
+        cache.set("legacy-cache", "legacy-value", None)
+        instance = SimpleNamespace(
+            status="open",
+            title="stale",
+            identification=1,
+        )
+
+        capture_old_values(sender=Project, instance=instance)
+        instance.status = "closed"
+        generic_cache_invalidation(
+            sender=Project,
+            instance=instance,
+            old_relevant_values=instance._old_values,
+        )
+
+        assert instance._old_values == {"status": "open"}
+        assert cache.get("legacy-cache") is None
+
     def test_capture_old_values_does_not_scan_unrelated_reverse_registry(self) -> None:
         class UntrackedProject:
             pass
@@ -775,9 +814,9 @@ class DependencyIndexShardFacadeTests(TestCase):
         assert reverse_keys.isdisjoint(counting_cache.get_calls)
         assert counting_cache.get_many_calls == []
         assert counting_cache.get_calls == [
+            "dependency_index",
             "general_manager:dependency:v1:lookups:UntrackedProject:filter",
             "general_manager:dependency:v1:lookups:UntrackedProject:exclude",
-            "dependency_index",
         ]
         assert not hasattr(instance, "_old_values")
 
@@ -806,30 +845,71 @@ class DependencyIndexShardFacadeTests(TestCase):
     def test_generic_invalidation_does_not_scan_unrelated_reverse_registry(
         self,
     ) -> None:
-        class UntrackedProject:
+        class Project:
             pass
 
         counting_cache = CountingShardCache()
-        reverse_keys = seed_unrelated_reverse_memberships(counting_cache)
+        unrelated_reverse_keys = set(seed_unrelated_reverse_memberships(counting_cache))
+        cache_key = "relevant-cache"
+        lookup_registry = lookup_registry_key("Project", "filter")
+        candidate_shard = composite_lookup_shard_key(
+            "Project",
+            "filter",
+            "status",
+        )
+        relevant_reverse_key = reverse_membership_key(cache_key)
+        reverse_registry = counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY]
+        assert isinstance(reverse_registry, set)
+        reverse_registry.add(relevant_reverse_key)
+        counting_cache.store[lookup_registry] = {"status"}
+        counting_cache.store[candidate_shard] = {cache_key}
+        counting_cache.store[relevant_reverse_key] = ReverseDependencyMembership(
+            cache_key=cache_key,
+            shard_keys=frozenset({candidate_shard}),
+            composite_dependencies=frozenset(),
+            simple_dependencies=frozenset(
+                {("Project", "filter", json.dumps({"status": "open"}))}
+            ),
+        )
+        counting_cache.store[cache_key] = "cached-value"
 
-        with mock.patch(
-            "general_manager.cache.dependency_shards.cache",
-            counting_cache,
+        with (
+            mock.patch(
+                "general_manager.cache.dependency_shards.cache",
+                counting_cache,
+            ),
+            mock.patch(
+                "general_manager.cache.dependency_index.cache",
+                counting_cache,
+            ),
+            mock.patch(
+                "general_manager.cache.dependency_index.acquire_lock_with_retry",
+                return_value="owner-token",
+            ),
+            mock.patch("general_manager.cache.dependency_index.release_lock"),
         ):
             generic_cache_invalidation(
-                sender=UntrackedProject,
-                instance=SimpleNamespace(identification=None),
-                old_relevant_values={},
+                sender=Project,
+                instance=SimpleNamespace(status="closed", identification=None),
+                old_relevant_values={"status": "open"},
             )
 
-        assert reverse_keys.isdisjoint(counting_cache.get_calls)
-        assert counting_cache.get_many_calls == []
-        assert counting_cache.get_calls == [
-            "dependency_index",
-            "general_manager:dependency:v1:request_query:UntrackedProject",
-            "general_manager:dependency:v1:all:UntrackedProject",
-            "general_manager:dependency:v1:lookups:UntrackedProject:filter",
-            "general_manager:dependency:v1:lookups:UntrackedProject:exclude",
+        fetched_in_batches = {
+            key
+            for get_many_call in counting_cache.get_many_calls
+            for key in get_many_call
+        }
+        assert cache_key not in counting_cache.store
+        assert relevant_reverse_key not in counting_cache.store
+        assert counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY] == (
+            unrelated_reverse_keys
+        )
+        assert unrelated_reverse_keys.isdisjoint(counting_cache.get_calls)
+        assert unrelated_reverse_keys.isdisjoint(fetched_in_batches)
+        assert len(counting_cache.get_calls) == 47
+        assert counting_cache.get_many_calls == [
+            (candidate_shard,),
+            (REVERSE_MEMBERSHIP_REGISTRY_KEY,),
         ]
 
     def test_generic_cache_invalidation_keeps_nonmatching_exact_lookup_candidate(

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -28,7 +28,9 @@ from general_manager.cache.dependency_shards import (
     record_many_cache_dependencies,
     remove_cache_key_from_shards,
     request_query_shard_key,
+    legacy_dependency_index_exists,
     reverse_membership_key,
+    reverse_memberships,
     scan_lookup_shard_key,
     _cache_set_add_many,
     _shard_keys_for_dependency,
@@ -102,6 +104,24 @@ class CountingShardCache:
         self.delete_many_calls.append(key_tuple)
         for key in key_tuple:
             self.store.pop(key, None)
+
+
+def seed_unrelated_reverse_memberships(
+    counting_cache: CountingShardCache,
+    *,
+    count: int = 20_000,
+) -> set[str]:
+    reverse_keys = {
+        reverse_membership_key(f"unrelated-cache-{index}") for index in range(count)
+    }
+    counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY] = reverse_keys
+    for index, reverse_key in enumerate(reverse_keys):
+        counting_cache.store[reverse_key] = ReverseDependencyMembership(
+            cache_key=f"unrelated-cache-{index}",
+            shard_keys=frozenset(),
+            composite_dependencies=frozenset(),
+        )
+    return reverse_keys
 
 
 @override_settings(CACHES=TEST_CACHES)
@@ -346,6 +366,64 @@ class DependencyShardKeyTests(TestCase):
 
         assert clear_legacy_dependency_index() == set()
         assert cache.get("dependency_index") is None
+
+    def test_legacy_dependency_index_exists_uses_one_cache_read(self) -> None:
+        counting_cache = CountingShardCache()
+
+        with mock.patch(
+            "general_manager.cache.dependency_shards.cache",
+            counting_cache,
+        ):
+            assert legacy_dependency_index_exists() is False
+            counting_cache.store["dependency_index"] = {
+                "filter": {},
+                "exclude": {},
+                "request_query": {},
+                "all": {},
+            }
+            assert legacy_dependency_index_exists() is True
+
+        assert counting_cache.get_calls == ["dependency_index", "dependency_index"]
+        assert counting_cache.get_many_calls == []
+
+    def test_reverse_memberships_batches_payload_reads(self) -> None:
+        counting_cache = CountingShardCache()
+        reverse_a = reverse_membership_key("cache-a")
+        reverse_b = reverse_membership_key("cache-b")
+        malformed = reverse_membership_key("malformed")
+        membership_a = ReverseDependencyMembership(
+            cache_key="cache-a",
+            shard_keys=frozenset(),
+            composite_dependencies=frozenset(),
+        )
+        membership_b = ReverseDependencyMembership(
+            cache_key="cache-b",
+            shard_keys=frozenset(),
+            composite_dependencies=frozenset(),
+        )
+        counting_cache.store[REVERSE_MEMBERSHIP_REGISTRY_KEY] = {
+            reverse_a,
+            reverse_b,
+            malformed,
+        }
+        counting_cache.store[reverse_a] = membership_a
+        counting_cache.store[reverse_b] = membership_b
+        counting_cache.store[malformed] = "not-reverse-metadata"
+
+        with mock.patch(
+            "general_manager.cache.dependency_shards.cache",
+            counting_cache,
+        ):
+            memberships = reverse_memberships()
+
+        assert set(memberships) == {membership_a, membership_b}
+        assert counting_cache.get_calls == [REVERSE_MEMBERSHIP_REGISTRY_KEY]
+        assert len(counting_cache.get_many_calls) == 1
+        assert set(counting_cache.get_many_calls[0]) == {
+            reverse_a,
+            reverse_b,
+            malformed,
+        }
 
     def test_invalid_dependencies_write_empty_reverse_membership(self) -> None:
         record_cache_dependencies(
@@ -660,6 +738,49 @@ class DependencyIndexShardFacadeTests(TestCase):
 
         assert instance._old_values == {"status": "open"}
 
+    def test_capture_old_values_uses_legacy_index_when_present(self) -> None:
+        class Project:
+            pass
+
+        cache.set(
+            "dependency_index",
+            {
+                "filter": {"Project": {"status": {'"open"': {"cache-a"}}}},
+                "exclude": {},
+                "request_query": {},
+                "all": {},
+            },
+            None,
+        )
+        instance = SimpleNamespace(status="open", identification=1)
+
+        capture_old_values(sender=Project, instance=instance)
+
+        assert instance._old_values == {"status": "open"}
+
+    def test_capture_old_values_does_not_scan_unrelated_reverse_registry(self) -> None:
+        class UntrackedProject:
+            pass
+
+        counting_cache = CountingShardCache()
+        reverse_keys = seed_unrelated_reverse_memberships(counting_cache)
+        instance = SimpleNamespace(identification=1)
+
+        with mock.patch(
+            "general_manager.cache.dependency_shards.cache",
+            counting_cache,
+        ):
+            capture_old_values(sender=UntrackedProject, instance=instance)
+
+        assert reverse_keys.isdisjoint(counting_cache.get_calls)
+        assert counting_cache.get_many_calls == []
+        assert counting_cache.get_calls == [
+            "general_manager:dependency:v1:lookups:UntrackedProject:filter",
+            "general_manager:dependency:v1:lookups:UntrackedProject:exclude",
+            "dependency_index",
+        ]
+        assert not hasattr(instance, "_old_values")
+
     def test_generic_cache_invalidation_uses_sharded_candidates(self) -> None:
         class Project:
             pass
@@ -681,6 +802,35 @@ class DependencyIndexShardFacadeTests(TestCase):
             cache_set_members(composite_lookup_shard_key("Project", "filter", "status"))
             == set()
         )
+
+    def test_generic_invalidation_does_not_scan_unrelated_reverse_registry(
+        self,
+    ) -> None:
+        class UntrackedProject:
+            pass
+
+        counting_cache = CountingShardCache()
+        reverse_keys = seed_unrelated_reverse_memberships(counting_cache)
+
+        with mock.patch(
+            "general_manager.cache.dependency_shards.cache",
+            counting_cache,
+        ):
+            generic_cache_invalidation(
+                sender=UntrackedProject,
+                instance=SimpleNamespace(identification=None),
+                old_relevant_values={},
+            )
+
+        assert reverse_keys.isdisjoint(counting_cache.get_calls)
+        assert counting_cache.get_many_calls == []
+        assert counting_cache.get_calls == [
+            "dependency_index",
+            "general_manager:dependency:v1:request_query:UntrackedProject",
+            "general_manager:dependency:v1:all:UntrackedProject",
+            "general_manager:dependency:v1:lookups:UntrackedProject:filter",
+            "general_manager:dependency:v1:lookups:UntrackedProject:exclude",
+        ]
 
     def test_generic_cache_invalidation_keeps_nonmatching_exact_lookup_candidate(
         self,

--- a/tests/unit/test_dependency_shards.py
+++ b/tests/unit/test_dependency_shards.py
@@ -776,7 +776,7 @@ class DependencyIndexShardFacadeTests(TestCase):
 
         record_dependencies(
             "stale-sharded-cache",
-            [("Project", "filter", json.dumps({"title": "stale"}))],
+            [("Project", "filter", json.dumps({"status": "open"}))],
         )
         cache.set(
             "dependency_index",
@@ -789,9 +789,9 @@ class DependencyIndexShardFacadeTests(TestCase):
             None,
         )
         cache.set("legacy-cache", "legacy-value", None)
+        cache.set("stale-sharded-cache", "stale-value", None)
         instance = SimpleNamespace(
             status="open",
-            title="stale",
             identification=1,
         )
 
@@ -805,6 +805,7 @@ class DependencyIndexShardFacadeTests(TestCase):
 
         assert instance._old_values == {"status": "open"}
         assert cache.get("legacy-cache") is None
+        assert cache.get("stale-sharded-cache") == "stale-value"
 
     def test_capture_old_values_does_not_scan_unrelated_reverse_registry(self) -> None:
         class UntrackedProject:


### PR DESCRIPTION
## Summary

Fixes production-blocking dependency invalidation latency by removing global reverse-membership enumeration from ordinary data-change paths. The legacy `dependency_index` key now provides a constant-time mode probe, while explicitly global reconstruction batches reverse metadata reads.

The change also makes dependency-lock release ownership-aware so an expired holder does not unconditionally delete an already-visible successor token.

## Related issue

Closes #431.

## What changed

- Select legacy versus sharded invalidation without scanning every reverse membership.
- Batch complete reverse-membership payload retrieval through `get_many()`.
- Keep legacy lookup discovery authoritative when legacy and sharded metadata coexist.
- Store unique dependency-lock owner tokens and thread them through all ten critical sections.
- Add 20,000-entry bounded-I/O regressions, relevant-candidate invalidation coverage, and stale-owner lock tests.
- Document bounded invalidation and the portable lock-release guarantees.

## Validation

```text
python -m pytest — 5617 passed, 3 skipped, 1 known pre-existing warning
mypy --strict — success, no issues in 276 source files
ruff check <7 changed Python files> — all checks passed
ruff format --check <7 changed Python files> — 7 files already formatted
```

## Documentation

Updated `docs/api/cache.md` with the constant-time mode-probe contract, batched global enumeration behavior, and ownership-aware lock-release limitation.

## Reviewer notes

- A present legacy index is authoritative for both pre-change capture and post-change invalidation.
- Existing cache namespaces and serialized reverse-membership schemas are unchanged.
- Django's generic cache API does not expose portable atomic compare-and-delete. Release checks the owner token before deletion without claiming stronger backend-independent atomicity.
- Stale-registry garbage collection and per-key logging aggregation remain outside this focused fix.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache lock safety to prevent stale processes from releasing locks they no longer own.
  * Strengthened dependency-cache updates and cleanup during retries, failures, and concurrent changes.

* **Performance**
  * Improved sharded cache invalidation and reverse-membership lookups by reducing unnecessary reads and scans.

* **Documentation**
  * Added guidance on lock ownership behavior, cache API limitations, and sharded versus legacy invalidation modes.

* **Tests**
  * Expanded coverage for lock handling, invalidation behavior, batching, and large cache datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->