### PR TITLE
fix: record hard-delete history reason

### DIFF
--- a/src/general_manager/interface/capabilities/orm/mutations.py
+++ b/src/general_manager/interface/capabilities/orm/mutations.py
@@ -666,7 +666,7 @@ class OrmDeleteCapability(BaseCapability):
             )
             if model_has_field(instance, "changed_by"):
                 object.__setattr__(instance, "changed_by_id", creator_id)
-            call_update_change_reason(instance, history_comment_local)
+            object.__setattr__(instance, "_change_reason", history_comment_local)
             atomic_context = _mutation_atomic(database_alias)
             with atomic_context:
                 if database_alias:

--- a/tests/integration/test_default_mutations.py
+++ b/tests/integration/test_default_mutations.py
@@ -589,6 +589,29 @@ class DefaultDeleteMutationTest(GeneralManagerTransactionTestCase):
         with self.assertRaises(ObjectDoesNotExist):
             self.TestProject(self.project.id)
 
+    def test_hard_delete_records_reason_without_existing_history_row(self):
+        """Hard delete records its reason without relying on prior history."""
+        model = self.TestProject.Interface._model
+        project_id = self.project.id
+        model.history.filter(id=project_id).delete()
+
+        self.project.delete(
+            history_comment="manual cleanup",
+            ignore_permission=True,
+        )
+
+        with self.assertRaises(ObjectDoesNotExist):
+            self.TestProject(project_id)
+        history_record = (
+            model.history.filter(id=project_id).order_by("-history_date").first()
+        )
+        self.assertIsNotNone(history_record)
+        self.assertEqual(history_record.history_type, "-")
+        self.assertEqual(
+            history_record.history_change_reason,
+            "manual cleanup (deleted)",
+        )
+
     def test_delete_project_sets_history_user_for_database_alias_branch(self):
         """
         Verifies that hard delete attributes the delete history row to the current actor when the database-alias path is used.

--- a/tests/unit/test_orm_capabilities_comprehensive.py
+++ b/tests/unit/test_orm_capabilities_comprehensive.py
@@ -3065,20 +3065,17 @@ class TestOrmMutationCapability:
                                 return_value=True,
                             ):
                                 with patch(
-                                    "general_manager.interface.capabilities.orm.mutations.call_update_change_reason"
-                                ) as update_reason:
+                                    "general_manager.interface.capabilities.orm.mutations.transaction.atomic",
+                                    return_value=nullcontext(),
+                                ):
                                     with patch(
-                                        "general_manager.interface.capabilities.orm.mutations.transaction.atomic",
-                                        return_value=nullcontext(),
-                                    ):
-                                        with patch(
-                                            "general_manager.interface.capabilities.orm.mutations.discard_orm_instance_cache"
-                                        ) as discard_cache:
-                                            result = capability.delete(
-                                                interface_instance,
-                                                creator_id=9,
-                                                history_comment="remove",
-                                            )
+                                        "general_manager.interface.capabilities.orm.mutations.discard_orm_instance_cache"
+                                    ) as discard_cache:
+                                        result = capability.delete(
+                                            interface_instance,
+                                            creator_id=9,
+                                            history_comment="remove",
+                                        )
 
         assert result == {"id": 5}
         assign_actor.assert_called_once_with(
@@ -3087,7 +3084,7 @@ class TestOrmMutationCapability:
             database_alias="archive",
         )
         assert model_instance.changed_by_id == 9
-        update_reason.assert_called_once_with(model_instance, "remove (deleted)")
+        assert model_instance._change_reason == "remove (deleted)"
         model_instance.delete.assert_called_once_with(using="archive")
         discard_cache.assert_called_once_with(interface_instance.__class__, 5)
 


### PR DESCRIPTION
## Summary

Fix hard deletion when no prior history row matches the current model state. The hard-delete path now attaches the normalized reason to the deletion event itself instead of attempting to mutate an older history row.

## Related issue

Closes #433.

## What changed

- Set django-simple-history's transient `_change_reason` before hard deletion.
- Add integration coverage for deletion after prior history rows have been removed.
- Update ORM capability coverage to assert the deletion reason passed to the history event.

## Validation

```text
python -m pytest tests/integration/test_default_mutations.py::DefaultDeleteMutationTest tests/unit/test_database_aware_history.py tests/unit/test_orm_capabilities_comprehensive.py -q — 99 passed
ruff check src/general_manager/interface/capabilities/orm/mutations.py tests/integration/test_default_mutations.py tests/unit/test_orm_capabilities_comprehensive.py — passed
ruff format --check src/general_manager/interface/capabilities/orm/mutations.py tests/integration/test_default_mutations.py tests/unit/test_orm_capabilities_comprehensive.py — passed
mypy src/general_manager/interface/capabilities/orm/mutations.py — passed
python -m pytest -q — 5618 passed, 3 skipped, 1 pre-existing warning
git diff --check — passed
pre-commit hooks during commit — passed
```

## Documentation

Not applicable. This restores the documented hard-delete history behavior without changing the public API.

## Reviewer notes

The key review point is the hard-delete branch in `OrmDeleteCapability`: django-simple-history reads `_change_reason` while creating the new `"-"` history row. Soft-delete and other mutation history paths are unchanged.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [ ] User-facing documentation is updated where behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hard deletions now reliably preserve the supplied change reason.
  * Deletion history entries are recorded correctly, including when previous history records have been removed.

* **Tests**
  * Expanded integration and unit test coverage for hard-delete history and reason handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->