### PR TITLE
docs: document hard-delete history reasons

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -24,9 +24,13 @@ created identification, and returns a new manager constructed from that
 identification. `manager.update(...)` checks that the manager is still valid,
 checks update permission unless skipped, delegates to the interface, reloads the
 backing interface in place, preserves request payload cache when available, and
-returns the same manager instance. `manager.delete(...)` checks delete
-permission unless skipped, delegates to the interface, invalidates the manager
-for later field reads, and returns `None`.
+returns the same manager instance. `manager.delete(creator_id=None,
+history_comment=None, ignore_permission=False)` checks delete permission unless
+skipped, delegates to the interface, invalidates the manager for later field
+reads, and returns `None`. ORM hard deletes record the supplied history comment
+with a ` (deleted)` suffix, or `Deleted` when omitted, even when no earlier
+history row exists; soft deletes append ` (deactivated)` to a supplied comment
+and otherwise use `Deactivated`.
 
 For writable ORM interfaces as of GeneralManager 0.63.1, ordinary
 `create()`/`update()` calls commit the row save, history actor/reason, and

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -28,8 +28,8 @@ returns the same manager instance. `manager.delete(creator_id=None,
 history_comment=None, ignore_permission=False)` checks delete permission unless
 skipped, delegates to the interface, invalidates the manager for later field
 reads, and returns `None`. ORM hard deletes record the supplied history comment
-with a ` (deleted)` suffix, or `Deleted` when omitted, even when no earlier
-history row exists; soft deletes append ` (deactivated)` to a supplied comment
+with a `(deleted)` suffix, or `Deleted` when omitted, even when no earlier
+history row exists; soft deletes append `(deactivated)` to a supplied comment
 and otherwise use `Deactivated`.
 
 For writable ORM interfaces as of GeneralManager 0.63.1, ordinary

--- a/docs/api/interface.md
+++ b/docs/api/interface.md
@@ -734,12 +734,16 @@ and returns the same manager instance from `manager.update(...)`.
 ignores positional arguments. It accepts only the reserved metadata keys
 `creator_id` and `history_comment`; other keyword arguments are currently
 ignored by this capability. With soft delete enabled it requires activation
-support, sets `is_active=False`, saves with a deactivation history comment,
+support, sets `is_active=False`, saves with `<comment> (deactivated)` (or
+`Deactivated` when omitted) as the history comment,
 clears the read cache, and returns `{"id": pk}`. Without soft delete it sets
-history actor metadata, applies a deletion change reason, hard-deletes in an
-atomic transaction using the configured database alias, clears the read cache,
-and returns `{"id": pk}`. The GeneralManager layer consumes that result and
-invalidates the public manager instance for later field reads. Missing
+history actor metadata, stores the supplied reason as `<comment> (deleted)` (or
+`Deleted` when omitted) before the model delete, and hard-deletes in an atomic
+transaction using the configured database alias. The reason is therefore
+present on the delete history row even when no earlier history row exists. The
+capability then clears the read cache and returns `{"id": pk}`. The
+GeneralManager layer consumes that result and invalidates the public manager
+instance for later field reads. Missing
 activation support raises `MissingActivationSupportError`; queryset `.get()`,
 validation, transaction, delete, many-to-many, history, cache invalidation, and
 observability errors propagate unchanged.

--- a/docs/concepts/interfaces/db_based_interface.md
+++ b/docs/concepts/interfaces/db_based_interface.md
@@ -82,8 +82,11 @@ model fields. The write path removes those metadata keys before field
 normalization, validates payload keys, converts manager-valued foreign keys to
 identifiers, and applies the atomic write contract described below. Deletes use
 soft delete when enabled by setting `is_active=False`; otherwise they hard-delete
-inside the configured database transaction. Both delete paths record history
-comments and clear the same read cache. Internally the mutation capability returns
+inside the configured database transaction. Soft deletes store the supplied
+comment with a ` (deactivated)` suffix. Hard deletes store it with a
+` (deleted)` suffix, or store `Deleted` when no comment is supplied; this reason
+is recorded even when the object has no earlier history row. Both delete paths
+clear the same read cache. Internally the mutation capability returns
 `{"id": pk}` to the manager layer. The public manager API turns that result into
 the manager behavior described here: `create()` returns a manager instance,
 `update()` refreshes and returns the same manager instance, and `delete()`
@@ -143,7 +146,7 @@ used as filter constraints.
 
 ### Soft deletes
 
-New database-backed managers perform hard deletes by default. Add `use_soft_delete = True` to the interface's `Meta` class to keep the historical `is_active` flag and route `delete()` calls through a soft delete. When enabled GeneralManager automatically injects filtered managers (`objects` returns active rows, `all_objects` includes inactive ones), honours explicit `filter(is_active=…)` lookups, and preserves the existing history comments (`"… (deactivated)"`). Pass `include_inactive=True` to `filter()`/`exclude()` when you need the full dataset without touching the model's managers directly.
+New database-backed managers perform hard deletes by default. Add `use_soft_delete = True` to the interface's `Meta` class to keep the historical `is_active` flag and route `delete()` calls through a soft delete. When enabled GeneralManager automatically injects filtered managers (`objects` returns active rows, `all_objects` includes inactive ones), honours explicit `filter(is_active=…)` lookups, and preserves the existing history comments (`"… (deactivated)"`). Hard-delete history uses the corresponding `"… (deleted)"` reason even when the deleted object has no prior history row. Pass `include_inactive=True` to `filter()`/`exclude()` when you need the full dataset without touching the model's managers directly.
 
 ## Many-to-many relationships
 

--- a/docs/concepts/interfaces/db_based_interface.md
+++ b/docs/concepts/interfaces/db_based_interface.md
@@ -83,8 +83,9 @@ normalization, validates payload keys, converts manager-valued foreign keys to
 identifiers, and applies the atomic write contract described below. Deletes use
 soft delete when enabled by setting `is_active=False`; otherwise they hard-delete
 inside the configured database transaction. Soft deletes store the supplied
-comment with a ` (deactivated)` suffix. Hard deletes store it with a
-` (deleted)` suffix, or store `Deleted` when no comment is supplied; this reason
+comment with a `(deactivated)` suffix, or store `Deactivated` when no comment is
+supplied. Hard deletes store it with a `(deleted)` suffix, or store `Deleted`
+when no comment is supplied; this reason
 is recorded even when the object has no earlier history row. Both delete paths
 clear the same read cache. Internally the mutation capability returns
 `{"id": pk}` to the manager layer. The public manager API turns that result into

--- a/docs/concepts/interfaces/existing_model_interface.md
+++ b/docs/concepts/interfaces/existing_model_interface.md
@@ -119,7 +119,7 @@ compatibility promise.
 ## Auditing and validation
 
 - `create` and `update` assign `changed_by_id` when the model exposes that column and record `history_comment` values using `django-simple-history`.
-- `delete` toggles `is_active` (when the column exists) and appends `" (deactivated)"` to the provided history comment; if your legacy model lacks that field the interface performs a hard delete and records `"<comment> (deleted)"` (or `"Deleted"` when omitted), even when no earlier history row exists. Use `filter(include_inactive=True)` when you need to surface soft-deleted rows explicitly.
+- `delete` toggles `is_active` (when the column exists) and appends `" (deactivated)"` to the provided history comment (or uses `"Deactivated"` when omitted); if your legacy model lacks that field the interface performs a hard delete and records `"<comment> (deleted)"` (or `"Deleted"` when omitted), even when no earlier history row exists. Use `filter(include_inactive=True)` when you need to surface soft-deleted rows explicitly.
 - Define `Meta.rules` on the interface to add GeneralManager validation
   alongside any rules already declared on the model. The interface appends the
   interface rules after existing model rules and replaces `full_clean()` so the

--- a/docs/concepts/interfaces/existing_model_interface.md
+++ b/docs/concepts/interfaces/existing_model_interface.md
@@ -119,7 +119,7 @@ compatibility promise.
 ## Auditing and validation
 
 - `create` and `update` assign `changed_by_id` when the model exposes that column and record `history_comment` values using `django-simple-history`.
-- `delete` toggles `is_active` (when the column exists) and appends `" (deactivated)"` to the provided history comment; if your legacy model lacks that field the interface performs a hard delete instead. Use `filter(include_inactive=True)` when you need to surface soft-deleted rows explicitly.
+- `delete` toggles `is_active` (when the column exists) and appends `" (deactivated)"` to the provided history comment; if your legacy model lacks that field the interface performs a hard delete and records `"<comment> (deleted)"` (or `"Deleted"` when omitted), even when no earlier history row exists. Use `filter(include_inactive=True)` when you need to surface soft-deleted rows explicitly.
 - Define `Meta.rules` on the interface to add GeneralManager validation
   alongside any rules already declared on the model. The interface appends the
   interface rules after existing model rules and replaces `full_clean()` so the

--- a/docs/examples/existing_model_interface.md
+++ b/docs/examples/existing_model_interface.md
@@ -145,3 +145,26 @@ for a pre-tracked model on a non-default alias, but its implementation-module
 import is not part of the stable `general_manager.interface` export registry;
 pin and test the dependency when using it. See the
 [task guide](../howto/orm_atomic_writes.md) for rollback handling.
+
+To retain the reason for a hard delete, capture the identifier before deleting
+the manager. The history row remains queryable after the live row is gone:
+
+```python
+contract_id = contract.identification["id"]
+contract.delete(
+    history_comment="manual cleanup",
+    ignore_permission=True,
+)
+
+delete_history = (
+    LegacyContract.history.filter(id=contract_id)
+    .order_by("-history_date")
+    .first()
+)
+assert delete_history is not None
+assert delete_history.history_change_reason == "manual cleanup (deleted)"
+```
+
+This `LegacyContract` has no `is_active` field, so the example hard-deletes the
+row. If the wrapped model has `is_active`, deletion is soft by default and the
+stored reason ends in ` (deactivated)` instead.

--- a/docs/examples/existing_model_interface.md
+++ b/docs/examples/existing_model_interface.md
@@ -167,4 +167,4 @@ assert delete_history.history_change_reason == "manual cleanup (deleted)"
 
 This `LegacyContract` has no `is_active` field, so the example hard-deletes the
 row. If the wrapped model has `is_active`, deletion is soft by default and the
-stored reason ends in ` (deactivated)` instead.
+stored reason ends in `(deactivated)` instead.

--- a/docs/howto/orm_atomic_writes.md
+++ b/docs/howto/orm_atomic_writes.md
@@ -101,7 +101,34 @@ ordinary ORM writes, any such exception rolls back the row, history rows, and
 relation table on the configured alias. Upload-aware writes keep their separate
 atomic upload and post-commit finalization contract.
 
-## 4. Handle caller-owned rollbacks
+## 4. Preserve the reason for a hard delete
+
+Hard deletes also create a history row inside the configured database
+transaction. Pass `history_comment` to retain the reason after the live row is
+gone; GeneralManager stores it with a ` (deleted)` suffix, including when the
+object had no earlier history row.
+
+```python
+customer_id = customer.identification["id"]
+customer.delete(
+    history_comment="manual cleanup",
+    ignore_permission=True,
+)
+
+history_record = (
+    LegacyCustomer.history.filter(id=customer_id)
+    .order_by("-history_date")
+    .first()
+)
+assert history_record is not None
+assert history_record.history_change_reason == "manual cleanup (deleted)"
+```
+
+When `is_active` is present and soft delete is enabled, the row remains
+available through `include_inactive=True` and the reason ends in
+` (deactivated)` instead.
+
+## 5. Handle caller-owned rollbacks
 
 GeneralManager avoids putting an uncommitted ORM row into its run-scoped read
 cache while the configured connection is inside an application `atomic()`

--- a/docs/howto/orm_atomic_writes.md
+++ b/docs/howto/orm_atomic_writes.md
@@ -105,8 +105,9 @@ atomic upload and post-commit finalization contract.
 
 Hard deletes also create a history row inside the configured database
 transaction. Pass `history_comment` to retain the reason after the live row is
-gone; GeneralManager stores it with a ` (deleted)` suffix, including when the
-object had no earlier history row.
+gone; GeneralManager stores it with a `(deleted)` suffix, including when the
+object had no earlier history row. When `history_comment` is omitted, it stores
+`Deleted` instead.
 
 ```python
 customer_id = customer.identification["id"]
@@ -126,7 +127,7 @@ assert history_record.history_change_reason == "manual cleanup (deleted)"
 
 When `is_active` is present and soft delete is enabled, the row remains
 available through `include_inactive=True` and the reason ends in
-` (deactivated)` instead.
+`(deactivated)` instead.
 
 ## 5. Handle caller-owned rollbacks
 


### PR DESCRIPTION
## Summary

Document the corrected hard-delete audit-reason behavior introduced by the reviewed 0.67.6 fix. ORM hard deletes now preserve the supplied `history_comment` on the delete history row as `<comment> (deleted)`, including when no earlier history row exists; omitted comments use `Deleted`.

## Reviewed commits

- `bcb62b0c0f787d7e5f687b014833ca0b73a47882` — `fix: record hard-delete history reason`
- `e7a763c36107bedbcffdab75f8d53ccff429a8dc` — `0.67.6` release metadata

## Affected public API

- `GeneralManager.delete(creator_id=None, history_comment=None, ignore_permission=False)` for ORM-backed managers.
- Soft-delete compatibility is documented alongside the hard-delete behavior: supplied reasons end in ` (deactivated)`, and omitted reasons use `Deactivated`.

## Documentation changed

- `docs/concepts/interfaces/db_based_interface.md`
- `docs/concepts/interfaces/existing_model_interface.md`
- `docs/howto/orm_atomic_writes.md`
- `docs/examples/existing_model_interface.md`
- `docs/api/core.md`
- `docs/api/interface.md`

The four required forms are covered by the interface concept pages, ORM task guide, existing-model cookbook recipe, and API-reference entries. Existing navigation already includes all six files.

## Validation

- `PYTHONPATH=src python -m pytest tests/integration/test_default_mutations.py -k hard_delete_records_reason_without_existing_history_row -q` — 1 passed
- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py -q` — 4 passed
- Strict MkDocs build — passed; only existing unnav-linked planning/ADR notices were emitted
- Python code blocks in the updated how-to and cookbook — parsed successfully with `ast`
- File-scoped pre-commit hooks — passed
- `git diff --check` — passed

## Limitations

- The full test suite was not rerun because this is a documentation-only change.
- The GitHub CLI token is invalid; the branch was pushed with Git after network escalation and this draft PR was opened through the authenticated GitHub connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified delete behavior and history-comment formatting for soft and hard deletes.
  * Documented default comments and suffixes for supplied reasons, including `(deactivated)` and `(deleted)`.
  * Explained that hard-delete history is preserved even without prior history records.
  * Added an example showing how to verify retained deletion reasons.
  * Updated atomic-write guidance for preserving hard-delete reasons and handling rollbacks.
  * Clarified behavior for legacy models without an active-status field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->