### PR TITLE
feat(cache): expose data-change transaction lifecycle

### DIFF
--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -706,11 +706,10 @@ for the whole envelope. A receiver can use `metadata` for coordination and can
 record every changed manager class through
 `register_data_change_class(class_name, database_alias)`. That helper returns
 `True` and adds the class name (deduplicated) when the requested alias has a
-matching live framework-owned envelope. It searches all live alias-scoped
-envelopes, so a nested cross-alias mutation can register against either matching
-framework-owned alias. It returns `False` only when the requested alias has no
-eligible live framework-owned envelope, including when that alias is absent or
-its live envelope is caller-owned.
+matching live framework-owned envelope. Registration checks only the requested
+`database_alias`; it never searches for or registers against another alias. It
+returns `False` when the requested alias is absent or its live envelope is
+caller-owned.
 
 Use the lifecycle signals with the ordinary post-change signal as follows:
 

--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -705,9 +705,12 @@ exit propagates to the mutation caller.
 for the whole envelope. A receiver can use `metadata` for coordination and can
 record every changed manager class through
 `register_data_change_class(class_name, database_alias)`. That helper returns
-`True` and adds the class name (deduplicated) only while the live envelope is
-framework-owned; it returns `False` for a caller-owned transaction, another
-alias, or no active envelope.
+`True` and adds the class name (deduplicated) when the requested alias has a
+matching live framework-owned envelope. It searches all live alias-scoped
+envelopes, so a nested cross-alias mutation can register against either matching
+framework-owned alias. It returns `False` only when the requested alias has no
+eligible live framework-owned envelope, including when that alias is absent or
+its live envelope is caller-owned.
 
 Use the lifecycle signals with the ordinary post-change signal as follows:
 

--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -611,6 +611,12 @@ manager, not a decorator or generator context manager; `__enter__()` yields a
 
 ::: general_manager.cache.signals.post_data_change
 
+::: general_manager.cache.signals.data_change_transaction_started
+
+::: general_manager.cache.signals.data_change_transaction_finishing
+
+::: general_manager.cache.signals.data_change_transaction_finished
+
 ::: general_manager.cache.signals.data_change
 
 `data_change(func)` wraps GeneralManager create, update, and delete methods with
@@ -648,6 +654,114 @@ closed, so nested `@data_change` calls enqueue one final rewarm batch. Failed
 mutations still drain pending rewarm keys after the outermost barrier closes,
 but enqueueing runs only for completed mutations. GraphQL warm-up enqueue errors
 are logged and suppressed.
+
+### ORM data-change transaction lifecycle
+
+ORM-backed `@data_change` mutations expose one transaction lifecycle envelope
+for the outermost active GeneralManager mutation on each database alias.
+Non-ORM-backed mutations do not emit these lifecycle signals. Nested mutations
+on the same alias share the envelope and do not emit additional lifecycle
+signals. The lifecycle action is `"create"`, `"update"`, or `"delete"` for
+those method names and `"other"` for every other decorated method.
+
+`data_change_transaction_started` and
+`data_change_transaction_finishing` receive exactly these keyword payload
+values in addition to Django's `sender`:
+
+- `transaction_context`: the live `DataChangeTransactionContext` for the
+  envelope;
+- `database_alias`: the ORM interface database alias;
+- `caller_in_atomic_block`: whether the caller was already inside Django
+  `atomic()` before GeneralManager opened its own block; and
+- `action`: the normalized lifecycle action.
+
+`data_change_transaction_finished` receives the same values plus `outcome`,
+which is either `"committed"` or `"rolled_back"`. Its `"committed"` value
+means that GeneralManager's own `atomic()` block or savepoint completed. It does
+not establish that a surrounding caller-owned transaction has durably committed.
+
+The signals run in this order for a successful outermost ORM mutation:
+
+1. `data_change_transaction_started`, after GeneralManager enters its
+   `atomic()` block or savepoint and before `pre_data_change`;
+2. `pre_data_change`, the decorated mutation body, and `post_data_change`;
+3. `data_change_transaction_finishing`, after the successful post-change
+   receivers and while GeneralManager's `atomic()` block or savepoint is still
+   active; and
+4. `data_change_transaction_finished`, after that block or savepoint exits.
+
+Failures skip the finishing signal, exit the GeneralManager block or savepoint,
+and still emit `data_change_transaction_finished` with
+`outcome="rolled_back"`. The finished signal runs before the dependency-cache
+barrier cleanup. Exceptions from lifecycle receivers follow the normal signal
+rules: started and finishing failures cause the GeneralManager block or
+savepoint to roll back, while a finished-receiver failure after a successful
+exit propagates to the mutation caller.
+
+`transaction_context` has immutable identity fields `database_alias` and
+`caller_in_atomic_block`, and three mutable transaction-local collections:
+`changed_classes` (`set[str]`), `metadata` (`dict[str, object]`), and
+`phase_seconds` (`dict[str, float]`). Receivers share the same context object
+for the whole envelope. A receiver can use `metadata` for coordination and can
+record every changed manager class through
+`register_data_change_class(class_name, database_alias)`. That helper returns
+`True` and adds the class name (deduplicated) only while the live envelope is
+framework-owned; it returns `False` for a caller-owned transaction, another
+alias, or no active envelope.
+
+Use the lifecycle signals with the ordinary post-change signal as follows:
+
+```python
+from django.db import transaction
+
+from general_manager.cache.data_change_context import register_data_change_class
+from general_manager.cache.signals import (
+    data_change_transaction_started,
+    post_data_change,
+)
+
+
+def transaction_started(sender, transaction_context, database_alias, **kwargs):
+    transaction_context.metadata["consumer"] = begin_coordination()
+    if transaction_context.caller_in_atomic_block:
+        transaction.on_commit(
+            lambda: finish_coordination(transaction_context.metadata["consumer"])
+        )
+
+
+def manager_changed(sender, database_alias, **kwargs):
+    register_data_change_class(sender.__name__, database_alias)
+
+
+data_change_transaction_started.connect(transaction_started, weak=False)
+post_data_change.connect(manager_changed, weak=False)
+```
+
+The `on_commit()` branch is required when the caller owns the outer Django
+transaction: lifecycle completion only proves completion of GeneralManager's
+inner savepoint, not the caller's durable commit. Django does not invoke an
+`on_commit()` callback when that caller-owned transaction rolls back. A
+consumer that acquires an external coordination lease at lifecycle start must
+therefore give the lease a bounded expiry and perform expiry-based cleanup; it
+cannot rely on a Django rollback callback to release the lease.
+
+For a non-default database alias, pass `using=database_alias` to
+`transaction.on_commit()` so the callback is registered on that alias's outer
+transaction.
+
+`phase_seconds` is an additive, non-negative timing map for synchronous work
+performed while the lifecycle context is live. It is not a wall-clock
+transaction duration: nested mutations and multiple receivers can contribute
+overlapping elapsed time. The only phase names recorded by GeneralManager are:
+
+- `database`: decorated ORM mutation-body execution;
+- `invalidation`: generic dependency-cache invalidation;
+- `subscription`: GraphQL and remote-invalidation subscription dispatch;
+- `search`: search invalidation receiver work; and
+- `workflow`: workflow signal-bridge publication.
+
+Absent keys mean that no configured receiver recorded that phase. Values for a
+phase accumulate across the envelope, including nested same-alias mutations.
 
 ::: general_manager.cache.dependency_index.record_dependencies
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -61,9 +61,11 @@ expiry-based cleanup for the rollback path.
 Use `register_data_change_class(sender.__name__, database_alias)` from a
 `post_data_change` receiver when a consumer needs the set of classes changed in
 one framework-owned envelope. The helper deduplicates names and returns `True`
-only for the active framework-owned alias; it returns `False` for caller-owned
-transactions, different aliases, or no live envelope. The API reference gives
-the exact signal payloads, consumer wiring, and phase-timing meanings:
+when the requested alias has a matching live framework-owned envelope. It can
+therefore register against either live alias during nested cross-alias mutations
+and returns `False` only when the requested alias has no eligible
+framework-owned envelope. The API reference gives the exact signal payloads,
+consumer wiring, and phase-timing meanings:
 [ORM data-change transaction lifecycle](../api/cache.md#orm-data-change-transaction-lifecycle).
 
 ## Bucket Dependency Semantics

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -36,6 +36,36 @@ warm-up cache keys collected by signal handlers are drained and enqueued only
 after that outermost barrier is closed, so warm-up work never starts while a
 data change is still active.
 
+## ORM transaction lifecycle consumers
+
+For ORM-backed mutations, GeneralManager also provides an outermost,
+database-alias-scoped lifecycle envelope around the existing data-change
+signals. `data_change_transaction_started` runs after GeneralManager enters its
+own `atomic()` block or savepoint and before `pre_data_change`.
+`data_change_transaction_finishing` runs after successful post-change receivers
+but before that block or savepoint exits. `data_change_transaction_finished`
+runs after the exit with `outcome="committed"` or `outcome="rolled_back"`.
+The three lifecycle signals share a mutable `transaction_context` that exposes
+the alias, whether the caller already owned an atomic block, a deduplicated set
+of changed class names, consumer metadata, and accumulated phase timings.
+
+The lifecycle is deliberately not an outer caller-transaction commit signal.
+If `transaction_context.caller_in_atomic_block` is true, a `"committed"`
+finished outcome means only the GeneralManager savepoint completed. Consumers
+that need work to run after the caller's durable commit must register it with
+`transaction.on_commit()` from the started receiver. If that outer transaction
+rolls back, Django does not call the callback. Any consumer that holds a lease
+or other external coordination resource must therefore use a bounded lease and
+expiry-based cleanup for the rollback path.
+
+Use `register_data_change_class(sender.__name__, database_alias)` from a
+`post_data_change` receiver when a consumer needs the set of classes changed in
+one framework-owned envelope. The helper deduplicates names and returns `True`
+only for the active framework-owned alias; it returns `False` for caller-owned
+transactions, different aliases, or no live envelope. The API reference gives
+the exact signal payloads, consumer wiring, and phase-timing meanings:
+[ORM data-change transaction lifecycle](../api/cache.md#orm-data-change-transaction-lifecycle).
+
 ## Bucket Dependency Semantics
 
 For ORM-backed buckets, dependency tracking happens when the bucket is actually evaluated, not when the bucket object is first constructed.

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -62,10 +62,10 @@ Use `register_data_change_class(sender.__name__, database_alias)` from a
 `post_data_change` receiver when a consumer needs the set of classes changed in
 one framework-owned envelope. The helper deduplicates names and returns `True`
 when the requested alias has a matching live framework-owned envelope. It can
-therefore register against either live alias during nested cross-alias mutations
-and returns `False` only when the requested alias has no eligible
-framework-owned envelope. The API reference gives the exact signal payloads,
-consumer wiring, and phase-timing meanings:
+register only against the requested `database_alias`; it never searches or
+registers against another alias. It returns `False` when the requested alias is
+absent or its live envelope is caller-owned. The API reference gives the exact
+signal payloads, consumer wiring, and phase-timing meanings:
 [ORM data-change transaction lifecycle](../api/cache.md#orm-data-change-transaction-lifecycle).
 
 ## Bucket Dependency Semantics

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -6,6 +6,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from copy import deepcopy
 import re
+from time import perf_counter
 from types import UnionType
 from typing import (
     AsyncIterator,
@@ -37,6 +38,7 @@ from general_manager.bucket.group_bucket import GroupBucket
 from general_manager.cache.dependency_index import (
     Dependency,
 )
+from general_manager.cache.data_change_context import record_data_change_phase
 from general_manager.cache.signals import post_data_change
 from general_manager.conf import get_setting
 from general_manager.interface.base_interface import InterfaceBase
@@ -1784,38 +1786,44 @@ class GraphQL:
             instance (GeneralManager | None): The GeneralManager instance that changed.
             action (str): A string describing the change action (e.g., "created", "updated", "deleted").
         """
-        event_instance = instance if instance is not None else previous_instance
-        if event_instance is None or not isinstance(event_instance, GeneralManager):
-            return
+        started = perf_counter()
+        try:
+            event_instance = instance if instance is not None else previous_instance
+            if event_instance is None or not isinstance(event_instance, GeneralManager):
+                return
 
-        if isinstance(sender, type) and issubclass(sender, GeneralManager):
-            manager_class: type[GeneralManager] = sender
-        else:
-            manager_class = event_instance.__class__
+            if isinstance(sender, type) and issubclass(sender, GeneralManager):
+                manager_class: type[GeneralManager] = sender
+            else:
+                manager_class = event_instance.__class__
 
-        if manager_class.__name__ not in cls.manager_registry:
-            logger.debug(
-                "skipping subscription event for unregistered manager",
-                context={
-                    "manager": manager_class.__name__,
-                    "action": action,
-                },
+            if manager_class.__name__ not in cls.manager_registry:
+                logger.debug(
+                    "skipping subscription event for unregistered manager",
+                    context={
+                        "manager": manager_class.__name__,
+                        "action": action,
+                    },
+                )
+                return
+
+            event_identification = deepcopy(
+                identification
+                if identification is not None
+                else event_instance.identification
             )
-            return
-
-        event_identification = deepcopy(
-            identification
-            if identification is not None
-            else event_instance.identification
-        )
-        transaction.on_commit(
-            lambda: cls._publish_data_change(
-                manager_class,
-                action,
-                event_identification,
-            ),
-            using=database_alias,
-        )
+            transaction.on_commit(
+                lambda: cls._publish_data_change(
+                    manager_class,
+                    action,
+                    event_identification,
+                ),
+                using=database_alias,
+            )
+        finally:
+            record_data_change_phase(
+                "subscription", perf_counter() - started, database_alias
+            )
 
     @classmethod
     def _publish_data_change(

--- a/src/general_manager/api/remote_invalidation.py
+++ b/src/general_manager/api/remote_invalidation.py
@@ -8,6 +8,7 @@ from datetime import date, datetime
 import json
 from importlib import import_module
 import re
+from time import perf_counter
 from uuid import UUID, uuid4
 from collections.abc import Callable, Coroutine, Mapping, MutableSequence, Sequence
 from types import ModuleType
@@ -25,6 +26,7 @@ from general_manager.api.remote_api import (
     get_remote_api_config,
 )
 from general_manager.api.notification_batching import _queue_notification
+from general_manager.cache.data_change_context import record_data_change_phase
 from general_manager.cache.signals import post_data_change
 from general_manager.logging import get_logger
 
@@ -200,24 +202,30 @@ def emit_remote_invalidation(
     originating database alias and delegates channel lookup, batching, payload
     creation, and delivery to `_publish_remote_invalidation` after commit.
     """
-    config = get_remote_api_config(sender)
-    if config is None or not config.websocket_invalidation:
-        return
+    started = perf_counter()
+    try:
+        config = get_remote_api_config(sender)
+        if config is None or not config.websocket_invalidation:
+            return
 
-    event_identification = identification
-    if event_identification is None and instance is not None:
-        event_identification = dict(instance.identification)
-    captured_identification = (
-        deepcopy(event_identification) if event_identification is not None else None
-    )
-    transaction.on_commit(
-        lambda: _publish_remote_invalidation(
-            config,
-            action,
-            captured_identification,
-        ),
-        using=database_alias,
-    )
+        event_identification = identification
+        if event_identification is None and instance is not None:
+            event_identification = dict(instance.identification)
+        captured_identification = (
+            deepcopy(event_identification) if event_identification is not None else None
+        )
+        transaction.on_commit(
+            lambda: _publish_remote_invalidation(
+                config,
+                action,
+                captured_identification,
+            ),
+            using=database_alias,
+        )
+    finally:
+        record_data_change_phase(
+            "subscription", perf_counter() - started, database_alias
+        )
 
 
 post_data_change.connect(emit_remote_invalidation, weak=False)

--- a/src/general_manager/cache/data_change_context.py
+++ b/src/general_manager/cache/data_change_context.py
@@ -5,16 +5,43 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass
+class DataChangeTransactionContext:
+    """Mutable state owned by one framework-managed data-change transaction."""
+
+    database_alias: str
+    caller_in_atomic_block: bool
+    changed_classes: set[str] = field(default_factory=set)
+    metadata: dict[str, object] = field(default_factory=dict)
+    phase_seconds: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DataChangeTransactionScope:
+    """Public view of a context-manager entry's transaction state."""
+
+    transaction: DataChangeTransactionContext
+    is_outermost: bool
 
 
 @dataclass
 class _DataChangeTransaction:
     """Live marker for one framework-owned transaction envelope."""
 
-    database_alias: str
-    caller_in_atomic_block: bool
+    context: DataChangeTransactionContext
     active: bool = True
+
+    @property
+    def database_alias(self) -> str:
+        return self.context.database_alias
+
+    @property
+    def caller_in_atomic_block(self) -> bool:
+        return self.context.caller_in_atomic_block
 
 
 _owned_transactions: ContextVar[tuple[_DataChangeTransaction, ...]] = ContextVar(
@@ -34,23 +61,64 @@ def _current_owner(database_alias: str) -> _DataChangeTransaction | None:
     return None
 
 
+def current_data_change_transaction(
+    database_alias: str,
+) -> DataChangeTransactionContext | None:
+    """Return the live framework-owned context for a database alias, if any."""
+    owner = _current_owner(database_alias)
+    return owner.context if owner is not None else None
+
+
 @contextmanager
 def own_data_change_transaction(
     database_alias: str,
     *,
     caller_in_atomic_block: bool,
-) -> Iterator[None]:
+) -> Iterator[DataChangeTransactionScope]:
     """Record a live framework envelope without inspecting Django internals."""
-    owner = _DataChangeTransaction(
+    existing_owner = _current_owner(database_alias)
+    if existing_owner is not None:
+        yield DataChangeTransactionScope(
+            transaction=existing_owner.context,
+            is_outermost=False,
+        )
+        return
+
+    context = DataChangeTransactionContext(
         database_alias=database_alias,
         caller_in_atomic_block=caller_in_atomic_block,
     )
+    owner = _DataChangeTransaction(
+        context=context,
+    )
     token = _owned_transactions.set((*_owned_transactions.get(), owner))
     try:
-        yield
+        yield DataChangeTransactionScope(transaction=context, is_outermost=True)
     finally:
         owner.active = False
         _owned_transactions.reset(token)
+
+
+def register_data_change_class(class_name: str, database_alias: str) -> bool:
+    """Record a changed class when the framework owns the live transaction."""
+    context = current_data_change_transaction(database_alias)
+    if context is None or context.caller_in_atomic_block:
+        return False
+    context.changed_classes.add(class_name)
+    return True
+
+
+def record_data_change_phase(
+    phase: Literal["database", "invalidation", "subscription", "search", "workflow"],
+    duration_seconds: float,
+    database_alias: str,
+) -> None:
+    """Accumulate a non-negative duration for a phase in the live context."""
+    context = current_data_change_transaction(database_alias)
+    if context is not None:
+        context.phase_seconds[phase] = context.phase_seconds.get(phase, 0.0) + max(
+            duration_seconds, 0.0
+        )
 
 
 @contextmanager

--- a/src/general_manager/cache/data_change_context.py
+++ b/src/general_manager/cache/data_change_context.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 
-@dataclass
+@dataclass(frozen=True)
 class DataChangeTransactionContext:
     """Mutable state owned by one framework-managed data-change transaction."""
 

--- a/src/general_manager/cache/data_change_context.py
+++ b/src/general_manager/cache/data_change_context.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from math import isfinite
 from typing import Literal
 
 
@@ -114,6 +115,8 @@ def record_data_change_phase(
     database_alias: str,
 ) -> None:
     """Accumulate a non-negative duration for a phase in the live context."""
+    if not isfinite(duration_seconds):
+        return
     context = current_data_change_transaction(database_alias)
     if context is not None:
         context.phase_seconds[phase] = context.phase_seconds.get(phase, 0.0) + max(

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -1399,6 +1399,7 @@ def generic_cache_invalidation(
         sender (type[GeneralManager]): Manager class that emitted the signal.
         instance (GeneralManager): The manager instance that was changed.
         old_relevant_values (dict[str, object]): Mapping of lookup paths (joined by "__") to their values as captured before the change; used to compare old vs. new values for invalidation decisions.
+        database_alias (str): Database alias used to attribute invalidation timing.
     """
     started = perf_counter()
     try:

--- a/src/general_manager/cache/dependency_index.py
+++ b/src/general_manager/cache/dependency_index.py
@@ -8,9 +8,11 @@ import time
 import uuid
 from contextvars import ContextVar
 from datetime import date, datetime
+from time import perf_counter
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Tuple, Type, cast
 
 from django.core.cache import cache
+from django.db import DEFAULT_DB_ALIAS
 from django.dispatch import receiver
 
 from general_manager.cache.dependency_matching import (
@@ -34,6 +36,7 @@ from general_manager.cache.dependency_shards import (
     reverse_memberships,
     tracked_lookup_names,
 )
+from general_manager.cache.data_change_context import record_data_change_phase
 from general_manager.cache.signals import post_data_change, pre_data_change
 from general_manager.logging import get_logger
 
@@ -1384,6 +1387,7 @@ def generic_cache_invalidation(
     sender: type[GeneralManager],
     instance: GeneralManager,
     old_relevant_values: dict[str, object],
+    database_alias: str = DEFAULT_DB_ALIAS,
     **kwargs: object,
 ) -> None:
     """
@@ -1396,26 +1400,32 @@ def generic_cache_invalidation(
         instance (GeneralManager): The manager instance that was changed.
         old_relevant_values (dict[str, object]): Mapping of lookup paths (joined by "__") to their values as captured before the change; used to compare old vs. new values for invalidation decisions.
     """
-    manager_name = sender.__name__
-    invalidated_cache_keys: set[str] = set()
-    lock_token = acquire_lock_with_retry("generic_cache_invalidation")
+    started = perf_counter()
     try:
-        if legacy_dependency_index_exists():
-            idx = get_full_index()
-            invalidated_cache_keys = _generic_cache_invalidation_locked(
-                idx,
-                manager_name,
-                instance,
-                old_relevant_values,
-            )
-            set_full_index(idx)
-        else:
-            invalidated_cache_keys = _generic_cache_invalidation_from_shards(
-                manager_name,
-                instance,
-                old_relevant_values,
-            )
+        manager_name = sender.__name__
+        invalidated_cache_keys: set[str] = set()
+        lock_token = acquire_lock_with_retry("generic_cache_invalidation")
+        try:
+            if legacy_dependency_index_exists():
+                idx = get_full_index()
+                invalidated_cache_keys = _generic_cache_invalidation_locked(
+                    idx,
+                    manager_name,
+                    instance,
+                    old_relevant_values,
+                )
+                set_full_index(idx)
+            else:
+                invalidated_cache_keys = _generic_cache_invalidation_from_shards(
+                    manager_name,
+                    instance,
+                    old_relevant_values,
+                )
+        finally:
+            release_lock(lock_token)
+        if invalidated_cache_keys:
+            record_invalidated_cache_keys_for_graphql_rewarm(invalidated_cache_keys)
     finally:
-        release_lock(lock_token)
-    if invalidated_cache_keys:
-        record_invalidated_cache_keys_for_graphql_rewarm(invalidated_cache_keys)
+        record_data_change_phase(
+            "invalidation", perf_counter() - started, database_alias
+        )

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -275,19 +275,10 @@ def data_change(
                 try:
                     if transaction_scope is not None and transaction_scope.is_outermost:
                         try:
+                            lifecycle_kwargs["outcome"] = transaction_outcome
                             data_change_transaction_finished.send(
                                 sender=sender,
-                                transaction_context=transaction_scope.transaction,
-                                database_alias=database_alias,
-                                caller_in_atomic_block=(
-                                    transaction_scope.transaction.caller_in_atomic_block
-                                ),
-                                action=(
-                                    action
-                                    if action in {"create", "update", "delete"}
-                                    else "other"
-                                ),
-                                outcome=transaction_outcome,
+                                **lifecycle_kwargs,
                             )
                         except Exception:
                             if primary_exc is not None:

--- a/src/general_manager/cache/signals.py
+++ b/src/general_manager/cache/signals.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import nullcontext
 from copy import deepcopy
 from functools import wraps
+from time import perf_counter
 from typing import Callable, ParamSpec, TypeVar, cast, overload
 
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
@@ -12,8 +13,10 @@ from django.dispatch import Signal
 from django.utils.connection import ConnectionDoesNotExist
 
 from general_manager.cache.data_change_context import (
+    DataChangeTransactionScope,
     authorize_data_change_operation,
     own_data_change_transaction,
+    record_data_change_phase,
 )
 from general_manager.as_of import reject_historical_mutation
 from general_manager.logging import get_logger
@@ -21,6 +24,12 @@ from general_manager.logging import get_logger
 post_data_change = Signal()
 
 pre_data_change = Signal()
+
+data_change_transaction_started = Signal()
+
+data_change_transaction_finishing = Signal()
+
+data_change_transaction_finished = Signal()
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -63,6 +72,12 @@ def data_change(
     during signal handling are drained only after the outermost active
     data-change barrier has closed; failed mutations drain pending keys but do
     not enqueue rewarm work.
+
+    ORM-backed outermost mutations also emit transaction lifecycle signals.
+    A ``committed`` finished outcome means this GeneralManager atomic block or
+    savepoint completed. When ``caller_in_atomic_block`` is true, consumers
+    requiring the caller's durable commit must register work with
+    ``transaction.on_commit()``.
 
     Parameters:
         func: Function that performs a data mutation. Methods named `create`
@@ -134,6 +149,8 @@ def data_change(
 
         primary_exc: BaseException | None = None
         completed = False
+        transaction_scope: DataChangeTransactionScope | None = None
+        transaction_outcome = "rolled_back"
         begin_dependency_data_change()
         context = current_calculation_run_context()
         if context is not None:
@@ -157,7 +174,30 @@ def data_change(
                 if is_orm_backed
                 else nullcontext()
             )
-            with transaction_context, ownership_context:
+            with transaction_context, ownership_context as entered_scope:
+                if is_orm_backed:
+                    assert isinstance(entered_scope, DataChangeTransactionScope)
+                    transaction_scope = entered_scope
+                lifecycle_action = (
+                    action if action in {"create", "update", "delete"} else "other"
+                )
+                lifecycle_kwargs = (
+                    {
+                        "transaction_context": transaction_scope.transaction,
+                        "database_alias": database_alias,
+                        "caller_in_atomic_block": (
+                            transaction_scope.transaction.caller_in_atomic_block
+                        ),
+                        "action": lifecycle_action,
+                    }
+                    if transaction_scope is not None
+                    else {}
+                )
+                if transaction_scope is not None and transaction_scope.is_outermost:
+                    data_change_transaction_started.send(
+                        sender=sender,
+                        **lifecycle_kwargs,
+                    )
                 pre_data_change.send(
                     sender=sender,
                     instance=instance_before,
@@ -174,11 +214,22 @@ def data_change(
                     else nullcontext()
                 )
                 with operation_context:
-                    if isinstance(func, classmethod):
-                        inner = cast(Callable[P, R], func.__func__)
-                        result = inner(*args, **kwargs)
-                    else:
-                        result = func(*args, **kwargs)
+                    mutation_started = (
+                        perf_counter() if transaction_scope is not None else None
+                    )
+                    try:
+                        if isinstance(func, classmethod):
+                            inner = cast(Callable[P, R], func.__func__)
+                            result = inner(*args, **kwargs)
+                        else:
+                            result = func(*args, **kwargs)
+                    finally:
+                        if mutation_started is not None:
+                            record_data_change_phase(
+                                "database",
+                                perf_counter() - mutation_started,
+                                database_alias,
+                            )
 
                 context = current_calculation_run_context()
                 if context is not None:
@@ -205,6 +256,13 @@ def data_change(
                         delattr(instance_before, "_old_values")
                     except AttributeError:
                         pass
+                if transaction_scope is not None and transaction_scope.is_outermost:
+                    data_change_transaction_finishing.send(
+                        sender=sender,
+                        **lifecycle_kwargs,
+                    )
+            if transaction_scope is not None and transaction_scope.is_outermost:
+                transaction_outcome = "committed"
             completed = True
         except BaseException as error:
             primary_exc = error
@@ -215,15 +273,40 @@ def data_change(
             cache_keys: tuple[str, ...] = ()
             try:
                 try:
+                    if transaction_scope is not None and transaction_scope.is_outermost:
+                        try:
+                            data_change_transaction_finished.send(
+                                sender=sender,
+                                transaction_context=transaction_scope.transaction,
+                                database_alias=database_alias,
+                                caller_in_atomic_block=(
+                                    transaction_scope.transaction.caller_in_atomic_block
+                                ),
+                                action=(
+                                    action
+                                    if action in {"create", "update", "delete"}
+                                    else "other"
+                                ),
+                                outcome=transaction_outcome,
+                            )
+                        except Exception:
+                            if primary_exc is not None:
+                                logger.exception(
+                                    "Data-change transaction finished receiver failed "
+                                    "while handling another exception."
+                                )
+                            else:
+                                raise
+                finally:
                     end_dependency_data_change()
-                except Exception:
-                    if primary_exc is not None:
-                        logger.exception(
-                            "Dependency data-change cleanup failed while handling "
-                            "another exception."
-                        )
-                    else:
-                        raise
+            except Exception:
+                if primary_exc is not None:
+                    logger.exception(
+                        "Dependency data-change cleanup failed while handling "
+                        "another exception."
+                    )
+                else:
+                    raise
             finally:
                 try:
                     if not is_dependency_data_change_active():

--- a/src/general_manager/search/invalidation.py
+++ b/src/general_manager/search/invalidation.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from inspect import getattr_static
 from itertools import islice
+from time import perf_counter
 from types import MappingProxyType
 from typing import Literal, cast
 
@@ -14,6 +15,7 @@ from django.db import DEFAULT_DB_ALIAS, transaction
 from django.utils.module_loading import import_string
 
 from general_manager.cache.signals import post_data_change, pre_data_change
+from general_manager.cache.data_change_context import record_data_change_phase
 from general_manager.conf import get_setting
 from general_manager.logging import get_logger
 from general_manager.manager.general_manager import GeneralManager
@@ -1168,53 +1170,57 @@ def _handle_search_post_change(
     **_: object,
 ) -> None:
     """Finalize direct and related work and register one commit-bound callback."""
-    if action not in {"create", "update", "delete"} or change_context is None:
-        return
-    direct_action = cast(_DirectAction, action)
-    manager_class = _manager_class(sender, instance)
-    if manager_class is None:
-        return
-    direct_plan, delete_targets = _direct_work(
-        manager_class,
-        instance,
-        direct_action,
-        change_context,
-        database_alias,
-    )
-    change_context.pop(_DIRECT_SEARCH_CHANGE_CONTEXT, None)
-    prior = change_context.pop(_RELATED_SEARCH_CHANGE_CONTEXT, None)
-    prior_capture = prior if isinstance(prior, SearchInvalidationCapture) else None
+    started = perf_counter()
     try:
-        if direct_action == "delete":
-            related_capture = prior_capture or SearchInvalidationCapture()
-        elif instance is None:
-            related_capture = SearchInvalidationCapture()
-        else:
-            related_capture = resolve_search_invalidation_phase(
-                SearchChange(
-                    action=direct_action,
-                    phase="after",
-                    instance=instance,
-                    database_alias=database_alias,
-                ),
-                previous=prior_capture if direct_action == "update" else None,
-            )
-        related_plan = finalize_search_invalidation_capture(related_capture)
-    except Exception as exc:  # noqa: BLE001 - registry/config hooks are open-ended
-        logger.warning(
-            "related search invalidation finalization failed",
-            context={"manager": manager_class.__name__, "phase": "after"},
-            exc_info=exc,
+        if action not in {"create", "update", "delete"} or change_context is None:
+            return
+        direct_action = cast(_DirectAction, action)
+        manager_class = _manager_class(sender, instance)
+        if manager_class is None:
+            return
+        direct_plan, delete_targets = _direct_work(
+            manager_class,
+            instance,
+            direct_action,
+            change_context,
+            database_alias,
         )
-        related_plan = SearchInvalidationPlan()
-    work = SearchScheduledWork(
-        upserts=_combine_plans(direct_plan, related_plan),
-        deletes=delete_targets,
-    )
-    schedule_search_invalidation_work(
-        work,
-        source_database_alias=database_alias,
-    )
+        change_context.pop(_DIRECT_SEARCH_CHANGE_CONTEXT, None)
+        prior = change_context.pop(_RELATED_SEARCH_CHANGE_CONTEXT, None)
+        prior_capture = prior if isinstance(prior, SearchInvalidationCapture) else None
+        try:
+            if direct_action == "delete":
+                related_capture = prior_capture or SearchInvalidationCapture()
+            elif instance is None:
+                related_capture = SearchInvalidationCapture()
+            else:
+                related_capture = resolve_search_invalidation_phase(
+                    SearchChange(
+                        action=direct_action,
+                        phase="after",
+                        instance=instance,
+                        database_alias=database_alias,
+                    ),
+                    previous=prior_capture if direct_action == "update" else None,
+                )
+            related_plan = finalize_search_invalidation_capture(related_capture)
+        except Exception as exc:  # noqa: BLE001 - registry/config hooks are open-ended
+            logger.warning(
+                "related search invalidation finalization failed",
+                context={"manager": manager_class.__name__, "phase": "after"},
+                exc_info=exc,
+            )
+            related_plan = SearchInvalidationPlan()
+        work = SearchScheduledWork(
+            upserts=_combine_plans(direct_plan, related_plan),
+            deletes=delete_targets,
+        )
+        schedule_search_invalidation_work(
+            work,
+            source_database_alias=database_alias,
+        )
+    finally:
+        record_data_change_phase("search", perf_counter() - started, database_alias)
 
 
 def configure_search_invalidation() -> None:

--- a/src/general_manager/workflow/signal_bridge.py
+++ b/src/general_manager/workflow/signal_bridge.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import datetime
+from time import perf_counter
 from typing import TypedDict, cast
 
+from django.db import DEFAULT_DB_ALIAS
+
+from general_manager.cache.data_change_context import record_data_change_phase
 from general_manager.cache.signals import post_data_change
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.workflow.event_registry import (
@@ -133,19 +137,24 @@ def _handle_post_data_change(
     uses `previous_instance` from the signal kwargs. Exceptions raised by
     `publish()` propagate to the signal caller.
     """
-    del sender
-    event_instance = (
-        instance if instance is not None else kwargs.get("previous_instance")
-    )
-    event = _manager_change_to_event(
-        instance=event_instance,
-        action=action,
-        old_relevant_values=old_relevant_values,
-        kwargs=kwargs,
-    )
-    if event is None:
-        return
-    get_event_registry().publish(event)
+    database_alias = cast(str, kwargs.get("database_alias", DEFAULT_DB_ALIAS))
+    started = perf_counter()
+    try:
+        del sender
+        event_instance = (
+            instance if instance is not None else kwargs.get("previous_instance")
+        )
+        event = _manager_change_to_event(
+            instance=event_instance,
+            action=action,
+            old_relevant_values=old_relevant_values,
+            kwargs=kwargs,
+        )
+        if event is None:
+            return
+        get_event_registry().publish(event)
+    finally:
+        record_data_change_phase("workflow", perf_counter() - started, database_alias)
 
 
 def connect_workflow_signal_bridge(*, registry: EventRegistry | None = None) -> None:

--- a/tests/unit/test_data_change_context.py
+++ b/tests/unit/test_data_change_context.py
@@ -27,6 +27,20 @@ def test_nested_same_alias_reuses_outer_transaction_context() -> None:
             assert inner.is_outermost is False
 
 
+def test_outer_scope_is_current_only_while_it_is_live() -> None:
+    """An outer scope exposes its live context and marks itself as outermost."""
+    assert data_change_context.current_data_change_transaction("default") is None
+
+    with _own("default", caller_in_atomic_block=False) as outer:
+        assert outer.is_outermost is True
+        assert (
+            data_change_context.current_data_change_transaction("default")
+            is outer.transaction
+        )
+
+    assert data_change_context.current_data_change_transaction("default") is None
+
+
 def test_changed_classes_are_deduplicated_and_alias_scoped() -> None:
     """Only a framework-owned transaction records its own alias's classes."""
     with _own("default", caller_in_atomic_block=False) as current:
@@ -45,6 +59,13 @@ def test_changed_classes_register_against_each_matching_live_alias() -> None:
             assert not data_change_context.register_data_change_class("Task", "missing")
             assert default.transaction.changed_classes == {"Project"}
             assert secondary.transaction.changed_classes == {"Part"}
+
+
+def test_caller_owned_transaction_rejects_class_registration() -> None:
+    """A caller-owned atomic transaction does not record changed classes."""
+    with _own("default", caller_in_atomic_block=True) as current:
+        assert not data_change_context.register_data_change_class("Project", "default")
+        assert current.transaction.changed_classes == set()
 
 
 def test_caller_owned_transaction_is_exposed() -> None:
@@ -70,6 +91,16 @@ def test_transaction_identity_is_immutable_while_state_is_mutable() -> None:
         assert transaction.changed_classes == {"Project"}
         assert transaction.metadata == {"source": "test"}
         assert transaction.phase_seconds == {"database": 0.1}
+
+
+def test_phase_durations_accumulate_and_clamp_negative_values() -> None:
+    """Repeated phase measurements add together without reducing elapsed time."""
+    with _own("default", caller_in_atomic_block=False) as current:
+        data_change_context.record_data_change_phase("database", 0.2, "default")
+        data_change_context.record_data_change_phase("database", 0.3, "default")
+        data_change_context.record_data_change_phase("database", -1.0, "default")
+
+        assert current.transaction.phase_seconds == {"database": 0.5}
 
 
 def test_context_ownership_does_not_inspect_django_atomic_internals() -> None:

--- a/tests/unit/test_data_change_context.py
+++ b/tests/unit/test_data_change_context.py
@@ -36,6 +36,17 @@ def test_changed_classes_are_deduplicated_and_alias_scoped() -> None:
         assert current.transaction.changed_classes == {"Project"}
 
 
+def test_changed_classes_register_against_each_matching_live_alias() -> None:
+    """Cross-alias nesting records classes in each matching live context."""
+    with _own("default", caller_in_atomic_block=False) as default:
+        with _own("secondary", caller_in_atomic_block=False) as secondary:
+            assert data_change_context.register_data_change_class("Project", "default")
+            assert data_change_context.register_data_change_class("Part", "secondary")
+            assert not data_change_context.register_data_change_class("Task", "missing")
+            assert default.transaction.changed_classes == {"Project"}
+            assert secondary.transaction.changed_classes == {"Part"}
+
+
 def test_caller_owned_transaction_is_exposed() -> None:
     """The public context distinguishes caller-owned atomic transactions."""
     with _own("default", caller_in_atomic_block=True) as current:

--- a/tests/unit/test_data_change_context.py
+++ b/tests/unit/test_data_change_context.py
@@ -1,12 +1,18 @@
 """Tests for context-local ORM data-change transaction ownership."""
 
+from contextlib import AbstractContextManager
 from contextvars import copy_context
+from dataclasses import FrozenInstanceError
 import inspect
+
+import pytest
 
 from general_manager.cache import data_change_context
 
 
-def _own(database_alias: str, *, caller_in_atomic_block: bool):
+def _own(
+    database_alias: str, *, caller_in_atomic_block: bool
+) -> AbstractContextManager[data_change_context.DataChangeTransactionScope]:
     return data_change_context.own_data_change_transaction(
         database_alias,
         caller_in_atomic_block=caller_in_atomic_block,
@@ -34,6 +40,25 @@ def test_caller_owned_transaction_is_exposed() -> None:
     """The public context distinguishes caller-owned atomic transactions."""
     with _own("default", caller_in_atomic_block=True) as current:
         assert current.transaction.caller_in_atomic_block is True
+
+
+def test_transaction_identity_is_immutable_while_state_is_mutable() -> None:
+    """Identity cannot change without preventing transaction-local state updates."""
+    with _own("default", caller_in_atomic_block=False) as current:
+        transaction = current.transaction
+
+        with pytest.raises(FrozenInstanceError):
+            transaction.database_alias = "secondary"  # type: ignore[misc]
+        with pytest.raises(FrozenInstanceError):
+            transaction.caller_in_atomic_block = True  # type: ignore[misc]
+
+        transaction.changed_classes.add("Project")
+        transaction.metadata["source"] = "test"
+        transaction.phase_seconds["database"] = 0.1
+
+        assert transaction.changed_classes == {"Project"}
+        assert transaction.metadata == {"source": "test"}
+        assert transaction.phase_seconds == {"database": 0.1}
 
 
 def test_context_ownership_does_not_inspect_django_atomic_internals() -> None:

--- a/tests/unit/test_data_change_context.py
+++ b/tests/unit/test_data_change_context.py
@@ -13,6 +13,29 @@ def _own(database_alias: str, *, caller_in_atomic_block: bool):
     )
 
 
+def test_nested_same_alias_reuses_outer_transaction_context() -> None:
+    """Nested scopes for an alias share their transaction-owned state."""
+    with _own("default", caller_in_atomic_block=False) as outer:
+        with _own("default", caller_in_atomic_block=False) as inner:
+            assert inner.transaction is outer.transaction
+            assert inner.is_outermost is False
+
+
+def test_changed_classes_are_deduplicated_and_alias_scoped() -> None:
+    """Only a framework-owned transaction records its own alias's classes."""
+    with _own("default", caller_in_atomic_block=False) as current:
+        assert data_change_context.register_data_change_class("Project", "default")
+        assert data_change_context.register_data_change_class("Project", "default")
+        assert not data_change_context.register_data_change_class("Part", "secondary")
+        assert current.transaction.changed_classes == {"Project"}
+
+
+def test_caller_owned_transaction_is_exposed() -> None:
+    """The public context distinguishes caller-owned atomic transactions."""
+    with _own("default", caller_in_atomic_block=True) as current:
+        assert current.transaction.caller_in_atomic_block is True
+
+
 def test_context_ownership_does_not_inspect_django_atomic_internals() -> None:
     """Core ownership must remain independent of Django's private stack."""
     source = inspect.getsource(data_change_context)

--- a/tests/unit/test_data_change_context.py
+++ b/tests/unit/test_data_change_context.py
@@ -103,6 +103,22 @@ def test_phase_durations_accumulate_and_clamp_negative_values() -> None:
         assert current.transaction.phase_seconds == {"database": 0.5}
 
 
+@pytest.mark.parametrize(
+    "duration_seconds", [float("nan"), float("inf"), -float("inf")]
+)
+def test_non_finite_phase_durations_leave_total_unchanged(
+    duration_seconds: float,
+) -> None:
+    """Non-finite measurements do not contaminate the accumulated phase total."""
+    with _own("default", caller_in_atomic_block=False) as current:
+        data_change_context.record_data_change_phase("database", 0.5, "default")
+        data_change_context.record_data_change_phase(
+            "database", duration_seconds, "default"
+        )
+
+        assert current.transaction.phase_seconds == {"database": 0.5}
+
+
 def test_context_ownership_does_not_inspect_django_atomic_internals() -> None:
     """Core ownership must remain independent of Django's private stack."""
     source = inspect.getsource(data_change_context)

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -1246,6 +1246,43 @@ class GenericCacheInvalidationTests(TestCase):
         self.assertIsNone(result)
         record_phase.assert_called_once_with("invalidation", 0.25, "analytics")
 
+    def test_generic_invalidation_records_latency_when_invalidation_fails(self) -> None:
+        inst = DummyManager2(status="active", count=1)
+        error = RuntimeError("invalidation failed")
+
+        with (
+            patch(
+                "general_manager.cache.dependency_index.perf_counter",
+                side_effect=(10.0, 10.25),
+            ),
+            patch(
+                "general_manager.cache.dependency_index.record_data_change_phase",
+            ) as record_phase,
+            patch(
+                "general_manager.cache.dependency_index.acquire_lock_with_retry",
+                return_value="owner-token",
+            ),
+            patch("general_manager.cache.dependency_index.release_lock"),
+            patch(
+                "general_manager.cache.dependency_index.legacy_dependency_index_exists",
+                return_value=False,
+            ),
+            patch(
+                "general_manager.cache.dependency_index._generic_cache_invalidation_from_shards",
+                side_effect=error,
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                generic_cache_invalidation(
+                    sender=DummyManager2,
+                    instance=inst,
+                    old_relevant_values={"status": "inactive"},
+                    database_alias="analytics",
+                )
+
+        self.assertIs(raised.exception, error)
+        record_phase.assert_called_once_with("invalidation", 0.25, "analytics")
+
     @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
     @patch(
         "general_manager.cache.dependency_index.invalidate_request_query_dependencies",

--- a/tests/unit/test_dependency_index.py
+++ b/tests/unit/test_dependency_index.py
@@ -1211,6 +1211,41 @@ class GenericCacheInvalidationTests(TestCase):
 
         assert_absent(idx)
 
+    def test_generic_invalidation_records_bounded_receiver_latency(self) -> None:
+        inst = DummyManager2(status="active", count=1)
+
+        with (
+            patch(
+                "general_manager.cache.dependency_index.perf_counter",
+                side_effect=(10.0, 10.25),
+            ),
+            patch(
+                "general_manager.cache.dependency_index.record_data_change_phase",
+            ) as record_phase,
+            patch(
+                "general_manager.cache.dependency_index.acquire_lock_with_retry",
+                return_value="owner-token",
+            ),
+            patch("general_manager.cache.dependency_index.release_lock"),
+            patch(
+                "general_manager.cache.dependency_index.legacy_dependency_index_exists",
+                return_value=False,
+            ),
+            patch(
+                "general_manager.cache.dependency_index._generic_cache_invalidation_from_shards",
+                return_value=set(),
+            ),
+        ):
+            result = generic_cache_invalidation(
+                sender=DummyManager2,
+                instance=inst,
+                old_relevant_values={"status": "inactive"},
+                database_alias="analytics",
+            )
+
+        self.assertIsNone(result)
+        record_phase.assert_called_once_with("invalidation", 0.25, "analytics")
+
     @patch("general_manager.cache.dependency_index.remove_cache_key_from_index")
     @patch(
         "general_manager.cache.dependency_index.invalidate_request_query_dependencies",

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -1518,6 +1518,26 @@ class GraphQLTests(TestCase):
         self.assertIn("bulk_data_change_notifications", type_api.__all__)
         self.assertNotIn("bulk_data_change_notifications", general_manager.__all__)
 
+    def test_data_change_receiver_records_bounded_subscription_latency(self):
+        with (
+            patch(
+                "general_manager.api.graphql.perf_counter",
+                side_effect=(30.0, 30.75),
+            ),
+            patch(
+                "general_manager.api.graphql.record_data_change_phase",
+            ) as record_phase,
+        ):
+            result = GraphQL._handle_data_change(
+                sender=GeneralManager,
+                instance=None,
+                action="update",
+                database_alias="analytics",
+            )
+
+        self.assertIsNone(result)
+        record_phase.assert_called_once_with("subscription", 0.75, "analytics")
+
     def setUp(self):
         self.general_manager_class = MagicMock(spec=GeneralManagerMeta)
         self.general_manager_class.__name__ = "TestManager"

--- a/tests/unit/test_remote_invalidation.py
+++ b/tests/unit/test_remote_invalidation.py
@@ -28,6 +28,7 @@ from general_manager.api.remote_invalidation import (
     ensure_remote_invalidation_route,
 )
 from general_manager.api.remote_api import get_remote_api_config
+from general_manager.cache import data_change_context
 from general_manager.manager.general_manager import GeneralManager
 
 from tests import testing_asgi
@@ -262,6 +263,70 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
             payload["identification"],
             {"id": "12345678-1234-5678-1234-567812345678"},
         )
+
+    def test_emit_records_supplied_alias_duration_on_early_return(self) -> None:
+        """Early exits attribute subscription timing to the supplied database alias."""
+
+        class Project(GeneralManager):
+            identification: ClassVar[dict[str, object]] = {"id": 1}
+            Interface = BaseTestInterface
+
+        with (
+            data_change_context.own_data_change_transaction(
+                "default", caller_in_atomic_block=False
+            ) as default,
+            data_change_context.own_data_change_transaction(
+                "replica", caller_in_atomic_block=False
+            ) as replica,
+            patch(
+                "general_manager.api.remote_invalidation.perf_counter",
+                side_effect=(10.0, 10.25),
+            ),
+        ):
+            emit_remote_invalidation(Project, action="update", database_alias="replica")
+
+        self.assertEqual(default.transaction.phase_seconds, {})
+        self.assertEqual(replica.transaction.phase_seconds, {"subscription": 0.25})
+
+    def test_emit_propagates_scheduling_exception_after_recording_duration(
+        self,
+    ) -> None:
+        """A scheduling error retains its identity while timing is still recorded."""
+
+        class Project(GeneralManager):
+            identification: ClassVar[dict[str, object]] = {"id": 1}
+            Interface = BaseTestInterface
+
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        error = RuntimeError("commit scheduling failed")
+        with (
+            data_change_context.own_data_change_transaction(
+                "analytics", caller_in_atomic_block=False
+            ) as current,
+            patch(
+                "general_manager.api.remote_invalidation.transaction.on_commit",
+                side_effect=error,
+            ),
+            patch(
+                "general_manager.api.remote_invalidation.perf_counter",
+                side_effect=(20.0, 20.5),
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                emit_remote_invalidation(
+                    Project,
+                    action="update",
+                    database_alias="analytics",
+                )
+
+        self.assertIs(raised.exception, error)
+        self.assertEqual(current.transaction.phase_seconds, {"subscription": 0.5})
 
     def test_emit_remote_invalidation_defers_publish_until_commit(self) -> None:
         class Project:

--- a/tests/unit/test_remote_invalidation.py
+++ b/tests/unit/test_remote_invalidation.py
@@ -267,9 +267,8 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
     def test_emit_records_supplied_alias_duration_on_early_return(self) -> None:
         """Early exits attribute subscription timing to the supplied database alias."""
 
-        class Project(GeneralManager):
-            identification: ClassVar[dict[str, object]] = {"id": 1}
-            Interface = BaseTestInterface
+        class Project:
+            pass
 
         with (
             data_change_context.own_data_change_transaction(
@@ -293,10 +292,7 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
     ) -> None:
         """A scheduling error retains its identity while timing is still recorded."""
 
-        class Project(GeneralManager):
-            identification: ClassVar[dict[str, object]] = {"id": 1}
-            Interface = BaseTestInterface
-
+        class Project:
             class RemoteAPI:
                 enabled = True
                 base_path = "/remote"

--- a/tests/unit/test_search_indexer.py
+++ b/tests/unit/test_search_indexer.py
@@ -652,6 +652,36 @@ class SearchIndexerSignalStateTests(TestCase):
         assert result is None
         record_phase.assert_called_once_with("search", 0.5, "analytics")
 
+    def test_post_change_records_search_latency_when_scheduling_fails(self) -> None:
+        """Record synchronous receiver time before propagating scheduling errors."""
+        from general_manager.search.invalidation import _handle_search_post_change
+
+        error = RuntimeError("search scheduling failed")
+        with (
+            patch(
+                "general_manager.search.invalidation.perf_counter",
+                side_effect=(20.0, 20.5),
+            ),
+            patch(
+                "general_manager.search.invalidation.record_data_change_phase",
+            ) as record_phase,
+            patch(
+                "general_manager.search.invalidation.schedule_search_invalidation_work",
+                side_effect=error,
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                _handle_search_post_change(
+                    sender=Project,
+                    instance=Project(id=1),
+                    action="update",
+                    change_context={},
+                    database_alias="analytics",
+                )
+
+        self.assertIs(raised.exception, error)
+        record_phase.assert_called_once_with("search", 0.5, "analytics")
+
     def test_pre_delete_marks_search_state_dirty(self) -> None:
         """Pre-delete only captures immutable targets; post-delete marks state."""
         from general_manager.search.invalidation import (

--- a/tests/unit/test_search_indexer.py
+++ b/tests/unit/test_search_indexer.py
@@ -625,6 +625,33 @@ class SearchIndexerSignalStateTests(TestCase):
         state = SearchIndexState.objects.get(index_name="global")
         assert state.dirty_reason == SEARCH_INDEX_DIRTY_REASON_INITIALIZATION
 
+    def test_post_change_records_bounded_search_latency(self) -> None:
+        """Attribute only synchronous receiver work to the search phase."""
+        from general_manager.search.invalidation import _handle_search_post_change
+
+        with (
+            patch(
+                "general_manager.search.invalidation.perf_counter",
+                side_effect=(20.0, 20.5),
+            ),
+            patch(
+                "general_manager.search.invalidation.record_data_change_phase",
+            ) as record_phase,
+            patch(
+                "general_manager.search.invalidation.schedule_search_invalidation_work"
+            ),
+        ):
+            result = _handle_search_post_change(
+                sender=Project,
+                instance=Project(id=1),
+                action="update",
+                change_context={},
+                database_alias="analytics",
+            )
+
+        assert result is None
+        record_phase.assert_called_once_with("search", 0.5, "analytics")
+
     def test_pre_delete_marks_search_state_dirty(self) -> None:
         """Pre-delete only captures immutable targets; post-delete marks state."""
         from general_manager.search.invalidation import (

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -13,7 +13,20 @@ from general_manager.cache.dependency_index import (
     is_dependency_data_change_active,
     record_invalidated_cache_keys_for_graphql_rewarm,
 )
-from general_manager.cache.signals import data_change, pre_data_change, post_data_change
+from general_manager.cache.signals import (
+    data_change,
+    data_change_transaction_finished,
+    data_change_transaction_finishing,
+    data_change_transaction_started,
+    post_data_change,
+    pre_data_change,
+)
+from general_manager.interface.orm_interface import OrmInterfaceBase
+
+_MUTATION_ERROR = "mutation failed"
+_STARTED_ERROR = "started failed"
+_FINISHING_ERROR = "finishing failed"
+_FINISHED_ERROR = "finished failed"
 
 
 @contextmanager
@@ -124,6 +137,45 @@ class EventRecordingDummy:
         return self
 
 
+class OrmEventRecordingDummy:
+    """ORM-backed helper that records decorated mutation bodies."""
+
+    class Interface(OrmInterfaceBase):
+        """Mark this helper as ORM-backed on Django's default alias."""
+
+        database = DEFAULT_DB_ALIAS
+
+    events: ClassVar[list[str]] = []
+
+    @data_change
+    def update(self):
+        """Record the immediate mutation body."""
+        self.events.append("mutation")
+        return self
+
+    @data_change
+    def outer(self):
+        """Invoke a nested ORM-backed mutation on the same alias."""
+        self.inner()
+        return self
+
+    @data_change
+    def inner(self):
+        """Return from a nested ORM-backed mutation."""
+        return self
+
+
+class RaisingOrmDummy:
+    """ORM-backed helper whose decorated mutation raises."""
+
+    Interface = OrmEventRecordingDummy.Interface
+
+    @data_change
+    def update(self):
+        """Raise the business mutation error."""
+        raise ValueError(_MUTATION_ERROR)
+
+
 class ClassMethodWrappedDummy:
     """Test helper for manually wrapping a classmethod object."""
 
@@ -141,18 +193,291 @@ class DataChangeSignalTests(TestCase):
         # Preserve existing receivers so they can be restored after the test run
         self._original_pre_receivers = list(pre_data_change.receivers)
         self._original_post_receivers = list(post_data_change.receivers)
+        self._original_started_receivers = list(
+            data_change_transaction_started.receivers
+        )
+        self._original_finishing_receivers = list(
+            data_change_transaction_finishing.receivers
+        )
+        self._original_finished_receivers = list(
+            data_change_transaction_finished.receivers
+        )
         # Clear any existing receivers before each test
         pre_data_change.receivers.clear()
         post_data_change.receivers.clear()
+        data_change_transaction_started.receivers.clear()
+        data_change_transaction_finishing.receivers.clear()
+        data_change_transaction_finished.receivers.clear()
 
     def tearDown(self):
         """Restore signal receivers after each test."""
         # Clean up receivers after each test
         pre_data_change.receivers.clear()
         post_data_change.receivers.clear()
+        data_change_transaction_started.receivers.clear()
+        data_change_transaction_finishing.receivers.clear()
+        data_change_transaction_finished.receivers.clear()
         # Restore the original receivers to avoid leaking state into other tests
         pre_data_change.receivers[:] = self._original_pre_receivers
         post_data_change.receivers[:] = self._original_post_receivers
+        data_change_transaction_started.receivers[:] = self._original_started_receivers
+        data_change_transaction_finishing.receivers[:] = (
+            self._original_finishing_receivers
+        )
+        data_change_transaction_finished.receivers[:] = (
+            self._original_finished_receivers
+        )
+
+    def test_orm_mutation_emits_lifecycle_around_existing_signals_and_atomic(self):
+        """The outer lifecycle brackets pre/body/post and the atomic exit."""
+        events: list[str] = []
+        atomic_events: list[str] = []
+        started_payload: dict[str, object] = {}
+        finishing_payload: dict[str, object] = {}
+        finished_payload: dict[str, object] = {}
+
+        @contextmanager
+        def recording_atomic(*, using):
+            self.assertEqual(using, DEFAULT_DB_ALIAS)
+            atomic_events.append("entered")
+            try:
+                yield
+            finally:
+                atomic_events.append("exited")
+
+        def record_started(sender, **kwargs):
+            self.assertIs(sender, OrmEventRecordingDummy)
+            self.assertEqual(atomic_events, ["entered"])
+            started_payload.update(kwargs)
+            events.append("started")
+
+        def record_pre(sender, **kwargs):
+            del sender, kwargs
+            events.append("pre")
+
+        def record_post(sender, **kwargs):
+            del sender, kwargs
+            events.append("post")
+
+        def record_finishing(sender, **kwargs):
+            self.assertIs(sender, OrmEventRecordingDummy)
+            self.assertEqual(atomic_events, ["entered"])
+            finishing_payload.update(kwargs)
+            events.append("finishing")
+
+        def record_finished(sender, **kwargs):
+            self.assertIs(sender, OrmEventRecordingDummy)
+            self.assertEqual(atomic_events, ["entered", "exited"])
+            finished_payload.update(kwargs)
+            events.append(f"finished:{kwargs['outcome']}")
+
+        OrmEventRecordingDummy.events = events
+        data_change_transaction_started.connect(record_started, weak=False)
+        pre_data_change.connect(record_pre, weak=False)
+        post_data_change.connect(record_post, weak=False)
+        data_change_transaction_finishing.connect(record_finishing, weak=False)
+        data_change_transaction_finished.connect(record_finished, weak=False)
+
+        with (
+            patch("django.db.transaction.atomic", side_effect=recording_atomic),
+            patch(
+                "general_manager.cache.signals._caller_in_atomic_block",
+                return_value=True,
+            ),
+            patch(
+                "general_manager.cache.signals.perf_counter",
+                side_effect=(10.0, 10.25),
+            ),
+        ):
+            OrmEventRecordingDummy().update()
+
+        self.assertEqual(
+            events,
+            [
+                "started",
+                "pre",
+                "mutation",
+                "post",
+                "finishing",
+                "finished:committed",
+            ],
+        )
+        self.assertEqual(finished_payload["database_alias"], DEFAULT_DB_ALIAS)
+        self.assertIs(finished_payload["caller_in_atomic_block"], True)
+        self.assertEqual(finished_payload["action"], "update")
+        transaction_context = finished_payload["transaction_context"]
+        for payload in (started_payload, finishing_payload):
+            self.assertIs(payload["transaction_context"], transaction_context)
+            self.assertEqual(payload["database_alias"], DEFAULT_DB_ALIAS)
+            self.assertIs(payload["caller_in_atomic_block"], True)
+            self.assertEqual(payload["action"], "update")
+        self.assertEqual(transaction_context.phase_seconds["database"], 0.25)
+
+    def test_nested_orm_mutations_emit_one_outer_lifecycle(self):
+        """Same-alias nesting reuses one lifecycle transaction envelope."""
+        nested_counts = {"started": 0, "finishing": 0, "finished": 0}
+
+        def increment(event):
+            def receiver(sender, **kwargs):
+                del sender, kwargs
+                nested_counts[event] += 1
+
+            return receiver
+
+        data_change_transaction_started.connect(increment("started"), weak=False)
+        data_change_transaction_finishing.connect(increment("finishing"), weak=False)
+        data_change_transaction_finished.connect(increment("finished"), weak=False)
+
+        OrmEventRecordingDummy().outer()
+
+        self.assertEqual(
+            nested_counts,
+            {"started": 1, "finishing": 1, "finished": 1},
+        )
+
+    def test_failed_orm_mutation_emits_rolled_back_outcome(self):
+        """A business exception closes the outer lifecycle as rolled back."""
+        rollback_events: list[str] = []
+
+        def record_finished(sender, outcome, **kwargs):
+            del sender, kwargs
+            rollback_events.append(f"finished:{outcome}")
+
+        data_change_transaction_finished.connect(record_finished, weak=False)
+
+        with self.assertRaisesRegex(ValueError, "mutation failed"):
+            RaisingOrmDummy().update()
+
+        self.assertEqual(rollback_events[-1], "finished:rolled_back")
+
+    def test_lifecycle_action_normalizes_unknown_manager_method(self):
+        """Lifecycle consumers receive the bounded action vocabulary."""
+        actions: list[str] = []
+
+        def record_started(sender, action, **kwargs):
+            del sender, kwargs
+            actions.append(action)
+
+        data_change_transaction_started.connect(record_started, weak=False)
+
+        OrmEventRecordingDummy().outer()
+
+        self.assertEqual(actions, ["other"])
+
+    def test_started_receiver_failure_rolls_back_owned_transaction(self):
+        """A start receiver error exits the ORM transaction by exception."""
+        atomic_events: list[str] = []
+        finished_outcomes: list[str] = []
+
+        @contextmanager
+        def recording_atomic(*, using):
+            del using
+            atomic_events.append("entered")
+            try:
+                yield
+            except BaseException:
+                atomic_events.append("rolled_back")
+                raise
+
+        def raise_started(sender, **kwargs):
+            del sender, kwargs
+            raise RuntimeError(_STARTED_ERROR)
+
+        def record_finished(sender, outcome, **kwargs):
+            del sender, kwargs
+            finished_outcomes.append(outcome)
+
+        data_change_transaction_started.connect(raise_started, weak=False)
+        data_change_transaction_finished.connect(record_finished, weak=False)
+
+        with (
+            patch("django.db.transaction.atomic", side_effect=recording_atomic),
+            self.assertRaisesRegex(RuntimeError, "started failed"),
+        ):
+            OrmEventRecordingDummy().update()
+
+        self.assertEqual(atomic_events, ["entered", "rolled_back"])
+        self.assertEqual(finished_outcomes, ["rolled_back"])
+
+    def test_finishing_receiver_failure_rolls_back_owned_transaction(self):
+        """A finishing receiver error exits the ORM transaction by exception."""
+        atomic_events: list[str] = []
+        finished_outcomes: list[str] = []
+
+        @contextmanager
+        def recording_atomic(*, using):
+            del using
+            atomic_events.append("entered")
+            try:
+                yield
+            except BaseException:
+                atomic_events.append("rolled_back")
+                raise
+
+        def raise_finishing(sender, **kwargs):
+            del sender, kwargs
+            raise RuntimeError(_FINISHING_ERROR)
+
+        def record_finished(sender, outcome, **kwargs):
+            del sender, kwargs
+            finished_outcomes.append(outcome)
+
+        data_change_transaction_finishing.connect(raise_finishing, weak=False)
+        data_change_transaction_finished.connect(record_finished, weak=False)
+
+        with (
+            patch("django.db.transaction.atomic", side_effect=recording_atomic),
+            self.assertRaisesRegex(RuntimeError, "finishing failed"),
+        ):
+            OrmEventRecordingDummy().update()
+
+        self.assertEqual(atomic_events, ["entered", "rolled_back"])
+        self.assertEqual(finished_outcomes, ["rolled_back"])
+
+    def test_finished_receiver_failure_propagates_after_successful_commit(self):
+        """A post-commit lifecycle receiver error is not silently hidden."""
+        atomic_events: list[str] = []
+
+        @contextmanager
+        def recording_atomic(*, using):
+            del using
+            atomic_events.append("entered")
+            yield
+            atomic_events.append("committed")
+
+        def raise_finished(sender, **kwargs):
+            del sender, kwargs
+            raise RuntimeError(_FINISHED_ERROR)
+
+        data_change_transaction_finished.connect(raise_finished, weak=False)
+
+        with (
+            patch("django.db.transaction.atomic", side_effect=recording_atomic),
+            self.assertRaisesRegex(RuntimeError, "finished failed"),
+        ):
+            OrmEventRecordingDummy().update()
+
+        self.assertEqual(atomic_events, ["entered", "committed"])
+
+    def test_finished_receiver_failure_does_not_mask_mutation_exception(self):
+        """The business exception wins over a finished cleanup failure."""
+
+        def raise_finished(sender, **kwargs):
+            del sender, kwargs
+            raise RuntimeError(_FINISHED_ERROR)
+
+        data_change_transaction_finished.connect(raise_finished, weak=False)
+
+        with (
+            patch("general_manager.cache.signals.logger.exception") as log,
+            self.assertRaisesRegex(ValueError, "mutation failed"),
+        ):
+            RaisingOrmDummy().update()
+
+        log.assert_called_once_with(
+            "Data-change transaction finished receiver failed while handling "
+            "another exception."
+        )
 
     def test_create_emits_pre_and_post(self):
         """Create operations emit pre-change and post-change signals."""

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -45,6 +45,13 @@ def capture_signal(signal: Signal):
         signal.disconnect(_receiver)
 
 
+def _reset_receivers(signal: Signal, receivers: list[tuple[object, ...]]) -> None:
+    """Replace signal receivers and invalidate Django's sender cache."""
+    with signal.lock:
+        signal.receivers = list(receivers)
+        signal.sender_receivers_cache.clear()
+
+
 class Dummy:
     """Test helper class decorated with @data_change for create and update."""
 
@@ -202,30 +209,26 @@ class DataChangeSignalTests(TestCase):
         self._original_finished_receivers = list(
             data_change_transaction_finished.receivers
         )
-        # Clear any existing receivers before each test
-        pre_data_change.receivers.clear()
-        post_data_change.receivers.clear()
-        data_change_transaction_started.receivers.clear()
-        data_change_transaction_finishing.receivers.clear()
-        data_change_transaction_finished.receivers.clear()
+        # Clear any existing receivers and cached sender lookups before each test.
+        _reset_receivers(pre_data_change, [])
+        _reset_receivers(post_data_change, [])
+        _reset_receivers(data_change_transaction_started, [])
+        _reset_receivers(data_change_transaction_finishing, [])
+        _reset_receivers(data_change_transaction_finished, [])
 
     def tearDown(self):
         """Restore signal receivers after each test."""
-        # Clean up receivers after each test
-        pre_data_change.receivers.clear()
-        post_data_change.receivers.clear()
-        data_change_transaction_started.receivers.clear()
-        data_change_transaction_finishing.receivers.clear()
-        data_change_transaction_finished.receivers.clear()
-        # Restore the original receivers to avoid leaking state into other tests
-        pre_data_change.receivers[:] = self._original_pre_receivers
-        post_data_change.receivers[:] = self._original_post_receivers
-        data_change_transaction_started.receivers[:] = self._original_started_receivers
-        data_change_transaction_finishing.receivers[:] = (
-            self._original_finishing_receivers
+        # Restore the original receivers and invalidate cached sender lookups.
+        _reset_receivers(pre_data_change, self._original_pre_receivers)
+        _reset_receivers(post_data_change, self._original_post_receivers)
+        _reset_receivers(
+            data_change_transaction_started, self._original_started_receivers
         )
-        data_change_transaction_finished.receivers[:] = (
-            self._original_finished_receivers
+        _reset_receivers(
+            data_change_transaction_finishing, self._original_finishing_receivers
+        )
+        _reset_receivers(
+            data_change_transaction_finished, self._original_finished_receivers
         )
 
     def test_orm_mutation_emits_lifecycle_around_existing_signals_and_atomic(self):

--- a/tests/unit/test_workflow_signal_bridge.py
+++ b/tests/unit/test_workflow_signal_bridge.py
@@ -3,13 +3,65 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from general_manager.workflow.event_registry import InMemoryEventRegistry
 from general_manager.workflow.signal_bridge import (
+    _handle_post_data_change,
     connect_workflow_signal_bridge,
     configure_workflow_signal_bridge_from_settings,
     disconnect_workflow_signal_bridge,
     workflow_signal_bridge_enabled,
 )
+
+
+def test_post_change_records_bounded_workflow_latency() -> None:
+    with (
+        patch(
+            "general_manager.workflow.signal_bridge.perf_counter",
+            side_effect=(40.0, 41.25),
+        ),
+        patch(
+            "general_manager.workflow.signal_bridge.record_data_change_phase",
+        ) as record_phase,
+    ):
+        result = _handle_post_data_change(
+            sender=object(),
+            instance=None,
+            action="update",
+            database_alias="analytics",
+        )
+
+    assert result is None
+    record_phase.assert_called_once_with("workflow", 1.25, "analytics")
+
+
+def test_post_change_records_workflow_latency_without_suppressing_exceptions() -> None:
+    failure = RuntimeError("event conversion failed")
+
+    with (
+        patch(
+            "general_manager.workflow.signal_bridge.perf_counter",
+            side_effect=(50.0, 50.5),
+        ),
+        patch(
+            "general_manager.workflow.signal_bridge.record_data_change_phase",
+        ) as record_phase,
+        patch(
+            "general_manager.workflow.signal_bridge._manager_change_to_event",
+            side_effect=failure,
+        ),
+        pytest.raises(RuntimeError) as raised,
+    ):
+        _handle_post_data_change(
+            sender=object(),
+            instance=object(),
+            action="update",
+            database_alias="analytics",
+        )
+
+    assert raised.value is failure
+    record_phase.assert_called_once_with("workflow", 0.5, "analytics")
 
 
 def test_workflow_signal_bridge_enabled_prefers_nested_setting() -> None:


### PR DESCRIPTION
## Summary

GeneralManager applications need a commit-safe, outermost transaction lifecycle so downstream cache coordinators can avoid per-mutation duplication and shared database lock contention. This PR adds an alias-scoped lifecycle context and signals while preserving the existing `pre_data_change` and `post_data_change` contract.

## Related issue

Closes #438.

## What changed

- Added immutable transaction identity with mutable changed-class, metadata, and bounded phase-duration registries.
- Added outermost `data_change_transaction_started`, `data_change_transaction_finishing`, and `data_change_transaction_finished` signals.
- Preserved same-alias nesting, cross-alias isolation, caller-owned savepoint semantics, and existing exception precedence.
- Attributed dependency invalidation, search, GraphQL/remote subscription, and workflow receiver latency.
- Documented lifecycle ordering, payloads, `transaction.on_commit()` coordination, rollback lease expiry, and phase meanings.
- Added focused regression coverage for lifecycle boundaries, transaction context safety, receiver timing, and exception paths.

## Validation

```text
python -m pytest -q — 5641 passed, 3 skipped, 1 pre-existing warning, 1982 subtests passed
ruff check src tests — passed
ruff format --check src tests — passed
mypy — passed (276 source files)
pre-commit run --all-files — passed
mkdocs build --strict — passed
independent task reviews and whole-branch review — no open critical or important findings
```

## Documentation

Updated `docs/api/cache.md` and `docs/concepts/caching.md` with the new lifecycle contract, integration example, caller-owned transaction caveat, and phase attribution.

## Reviewer notes

No schema or data migration is required. Suggested review order:

1. `cache/data_change_context.py`
2. `cache/signals.py`
3. receiver timing wrappers
4. focused tests
5. documentation

The `finished` outcome for a caller-owned outer transaction means the GeneralManager savepoint completed; consumers requiring durable outer commit must use `transaction.on_commit()`.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction lifecycle notifications for data changes, including started, finishing, and completed states.
  * Added shared transaction context with database, mutation, outcome, and timing details.
  * Added phase-level performance tracking for caching, search, subscriptions, invalidation, and workflows.
  * Added changed-class tracking across nested and caller-managed transactions.

* **Documentation**
  * Documented lifecycle events, transaction behavior, rollback handling, and performance metadata.

* **Tests**
  * Expanded coverage for nested transactions, rollback outcomes, timing measurements, and exception handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->