### PR TITLE
fix: publish websocket notifications after commit

### DIFF
--- a/docs/concepts/graphql/subscriptions.md
+++ b/docs/concepts/graphql/subscriptions.md
@@ -159,7 +159,8 @@ task errors still propagate from the await.
 ### Signals and channels
 
 - Subscriptions require Django Channels. If `get_channel_layer()` returns `None`, the resolver raises a descriptive GraphQL error explaining that `CHANNEL_LAYERS` must be configured.
-- Managers are automatically decorated with `@data_change` and emit `pre_data_change` and `post_data_change` signals. GraphQL listens to `post_data_change` and forwards the event to the relevant instance channel group (`gm_subscriptions.<Manager>.<digest>`) and class channel group (`gm_subscriptions.<Manager>.__class__`).
+- Managers are automatically decorated with `@data_change` and emit `pre_data_change` and `post_data_change` signals. GraphQL receives `post_data_change` immediately, but deep-copies the event identification and schedules websocket publication with `transaction.on_commit()` using the changed manager's database alias. For ordinary events created inside a transaction, both the instance channel group (`gm_subscriptions.<Manager>.<digest>`) and class channel group (`gm_subscriptions.<Manager>.__class__`) receive the event only after the outermost commit. Events registered in a rolled-back transaction or savepoint disappear without publication.
+- Class-wide subscriptions hydrate the changed manager and call `can_read_instance()` after that commit before yielding the event. In particular, a newly created object is visible to hydration only after it is committed, eliminating the pre-commit create race while preserving object-level permission checks.
 
 ### Bulk notification refreshes
 
@@ -186,13 +187,25 @@ with bulk_data_change_notifications():
 ```
 
 Keep `bulk_data_change_notifications()` outside the true outermost database
-transaction. When the shown `transaction.atomic()` is outermost, it commits
-before the notification context flushes. With `ATOMIC_REQUESTS` or another
-enclosing atomic block, that block may only release a savepoint and the actual
-commit can occur after the refresh; place the notification context outside that
-enclosing boundary instead. The context is not transaction-aware, and it also
-flushes queued refreshes when its body exits exceptionally before re-raising the
-exception.
+transaction. When the shown `transaction.atomic()` is outermost, its commit
+runs the queued publication callbacks while the notification context is still
+open, then the context flushes one aggregate refresh per target. Rollbacks,
+including savepoint rollbacks, discard the callbacks before they can enter the
+batch. With `ATOMIC_REQUESTS` or another enclosing atomic block, place the
+notification context outside that enclosing boundary so it remains open until
+the actual commit.
+
+Reversing the contexts remains commit-safe, but does not guarantee aggregation:
+
+```python
+with transaction.atomic():
+    with bulk_data_change_notifications():
+        ...
+```
+
+In that order, the notification context closes before the outer transaction's
+commit callbacks run, so those callbacks publish ordinary events rather than
+adding their refreshes to the now-closed batch.
 
 During an explicit batch, row-level events are replaced by one `refresh` event
 for each affected manager class. A detail subscription receives refreshes for

--- a/docs/concepts/graphql/subscriptions.md
+++ b/docs/concepts/graphql/subscriptions.md
@@ -160,7 +160,7 @@ task errors still propagate from the await.
 
 - Subscriptions require Django Channels. If `get_channel_layer()` returns `None`, the resolver raises a descriptive GraphQL error explaining that `CHANNEL_LAYERS` must be configured.
 - Managers are automatically decorated with `@data_change` and emit `pre_data_change` and `post_data_change` signals. GraphQL receives `post_data_change` immediately, but deep-copies the event identification and schedules websocket publication with `transaction.on_commit()` using the changed manager's database alias. For ordinary events created inside a transaction, both the instance channel group (`gm_subscriptions.<Manager>.<digest>`) and class channel group (`gm_subscriptions.<Manager>.__class__`) receive the event only after the outermost commit. Events registered in a rolled-back transaction or savepoint disappear without publication.
-- Class-wide subscriptions hydrate the changed manager and call `can_read_instance()` after that commit before yielding the event. In particular, a newly created object is visible to hydration only after it is committed, eliminating the pre-commit create race while preserving object-level permission checks.
+- For ordinary identified row-level class events, subscriptions hydrate the changed manager and call `can_read_instance()` after that commit before yielding the event. In particular, a newly created object is visible to hydration only after it is committed, eliminating the pre-commit create race while preserving object-level permission checks. Aggregate batch `refresh` events have no identification, yield `item = null`, and are exempt from object-level permission hydration and checking.
 
 ### Bulk notification refreshes
 

--- a/docs/examples/remote_manager_interface_end_to_end.md
+++ b/docs/examples/remote_manager_interface_end_to_end.md
@@ -372,21 +372,25 @@ does not directly cancel a `listen_once()` call that is already waiting; that
 one-off receive finishes according to the connection's receive/close behavior.
 
 Server-side event emission is handled by `emit_remote_invalidation()` after data
-changes. It sends no message when the manager has no RemoteAPI config, websocket
-invalidation is disabled, or no Channels layer is configured. Explicit delete
-identification metadata wins over instance identification; UUID, date, and
-datetime values are serialized as strings, and other non-JSON values fall back
-to `str(value)`. The action string is forwarded as supplied. Messages are sent
-with fields `protocol_version`, `base_path`, `resource_name`, `action`,
-`identification`, and `event_id`; missing identification is sent as `null`.
-Serialization is shallow, so nested lists or mappings also fall back to
-`str(value)`. The channel-layer event type is `gm.remote.invalidation` and
-`event_id` is a UUID4 string. The ASGI consumer closes unknown or disabled
-resources with `4404`, protocol-version mismatches with `4406`, and missing
-channel-layer connections with `1011`. Missing `version` is accepted, multiple
-`version` query values use the first parsed value, non-disconnect inbound
-websocket messages are ignored, and client disconnect cleans up the
-channel-layer group subscription.
+changes. RemoteAPI receives `post_data_change` immediately but schedules each
+row invalidation with `transaction.on_commit()` using the changed manager's
+database alias. Invalidation is therefore commit-bound and rollback-safe:
+events registered in a rolled-back transaction or savepoint are never sent.
+Delivery after commit is best-effort; a missing configuration or channel layer
+produces no message, and channel-layer delivery failures are logged rather than
+raised. Explicit delete identification metadata wins over instance
+identification; UUID, date, and datetime values are serialized as strings, and
+other non-JSON values fall back to `str(value)`. The action string is forwarded
+as supplied. Messages are sent with fields `protocol_version`, `base_path`,
+`resource_name`, `action`, `identification`, and `event_id`; missing
+identification is sent as `null`. Serialization is shallow, so nested lists or
+mappings also fall back to `str(value)`. The channel-layer event type is
+`gm.remote.invalidation` and `event_id` is a UUID4 string. The ASGI consumer
+closes unknown or disabled resources with `4404`, protocol-version mismatches
+with `4406`, and missing channel-layer connections with `1011`. Missing
+`version` is accepted, multiple `version` query values use the first parsed
+value, non-disconnect inbound websocket messages are ignored, and client
+disconnect cleans up the channel-layer group subscription.
 
 For bulk writes, use the public notification context outside the true outermost
 database transaction:
@@ -406,12 +410,15 @@ with bulk_data_change_notifications():
 The context emits one invalidation per affected RemoteAPI resource with
 `action = "refresh"`, `identification = null`, and a UUID4 `event_id`. Clients
 should treat it as resource-wide invalidation and requery the resource over
-REST. The context is not transaction-aware by itself and flushes even when its
-body exits exceptionally. When the shown `transaction.atomic()` is outermost,
-its commit or rollback completes before the flush. With `ATOMIC_REQUESTS` or
-another enclosing atomic block, the actual commit may happen after refresh
-delivery; place the notification context outside that enclosing boundary.
-Outside the context, immediate row-level events remain unchanged.
+REST. When the shown `transaction.atomic()` is outermost, its commit runs the
+queued invalidation callbacks while the context remains open, and the context
+then flushes the aggregate invalidations. A rollback, including a savepoint
+rollback, discards the callbacks, so no refresh is queued. With `ATOMIC_REQUESTS`
+or another enclosing atomic block, place the notification context outside that
+enclosing boundary so it remains open until the actual commit. Reversing the
+contexts stays commit-safe, but the batch closes before commit callbacks run, so
+aggregation is not guaranteed. Outside the context, row-level invalidations are
+still scheduled for commit.
 
 ## Usage
 

--- a/docs/howto/bulk_data_change_notifications.md
+++ b/docs/howto/bulk_data_change_notifications.md
@@ -60,12 +60,14 @@ Inside the context, GraphQL and RemoteAPI delivery is deduplicated by target:
 
 Each aggregate event includes a UUID4 `event_id`. The context does not reveal
 which rows changed, how many changed, or the original row-level actions. Cache
-invalidation and unrelated signal receivers still run for each write. GraphQL
-class-wide subscriptions hydrate the changed object and call
-`can_read_instance()` only after commit, so a create cannot race pre-commit
-hydration. RemoteAPI delivery after commit is best-effort: unavailable channel
-layers produce no message, and channel-layer failures are logged rather than
-raised.
+invalidation and unrelated signal receivers still run for each write. For
+ordinary identified row-level GraphQL class events, subscriptions hydrate the
+changed object and call `can_read_instance()` only after commit, so a create
+cannot race pre-commit hydration. Aggregate batch `refresh` events have no
+identification, yield `item = null`, and are exempt from object-level permission
+hydration and checking. RemoteAPI delivery after commit is best-effort:
+unavailable channel layers produce no message, and channel-layer failures are
+logged rather than raised.
 
 ## Failure and nesting behavior
 

--- a/docs/howto/bulk_data_change_notifications.md
+++ b/docs/howto/bulk_data_change_notifications.md
@@ -69,7 +69,7 @@ hydration and checking. RemoteAPI delivery after commit is best-effort:
 unavailable channel layers produce no message, and channel-layer failures are
 logged rather than raised.
 
-## Failure and nesting behavior
+## Nesting behavior
 
 Nested notification contexts join the already-active outer batch instead of
 flushing independently. Outside the context, existing row-level notification

--- a/docs/howto/bulk_data_change_notifications.md
+++ b/docs/howto/bulk_data_change_notifications.md
@@ -22,10 +22,30 @@ with bulk_data_change_notifications():
             project.update(status="archived")
 ```
 
-The context is not transaction-aware. If another layer already encloses this
-code in `transaction.atomic()`—including Django's `ATOMIC_REQUESTS`—place the
-notification context outside that enclosing block so the flush follows the
-actual commit or rollback rather than an intermediate savepoint.
+GraphQL and RemoteAPI receive `post_data_change` immediately, but their
+websocket publishers schedule delivery with `transaction.on_commit()` on the
+changed manager's database alias. With the order above, the outermost commit
+runs those callbacks while the notification context remains open; its exit then
+flushes one aggregate refresh per target. A rollback, including a savepoint
+rollback, discards the callbacks, so no refresh enters the batch.
+
+If another layer already encloses this code in `transaction.atomic()`—including
+Django's `ATOMIC_REQUESTS`—place the notification context outside that
+enclosing block so it remains open through the actual commit rather than an
+intermediate savepoint.
+
+The reverse order is still commit-safe but does not guarantee aggregation:
+
+```python
+with transaction.atomic():
+    with bulk_data_change_notifications():
+        for project in Project.filter(status="active"):
+            project.update(status="archived")
+```
+
+Here the batch closes before the outer transaction runs its commit callbacks,
+so those callbacks publish ordinary row-level notifications instead of queuing
+aggregate refreshes.
 
 ## What clients receive
 
@@ -40,15 +60,18 @@ Inside the context, GraphQL and RemoteAPI delivery is deduplicated by target:
 
 Each aggregate event includes a UUID4 `event_id`. The context does not reveal
 which rows changed, how many changed, or the original row-level actions. Cache
-invalidation and unrelated signal receivers still run for each write.
+invalidation and unrelated signal receivers still run for each write. GraphQL
+class-wide subscriptions hydrate the changed object and call
+`can_read_instance()` only after commit, so a create cannot race pre-commit
+hydration. RemoteAPI delivery after commit is best-effort: unavailable channel
+layers produce no message, and channel-layer failures are logged rather than
+raised.
 
 ## Failure and nesting behavior
 
-The body is always allowed to finish its normal exception behavior: an
-exception raised by the body is re-raised after the queued flush is attempted.
 Nested notification contexts join the already-active outer batch instead of
 flushing independently. Outside the context, existing row-level notification
-delivery remains unchanged.
+delivery remains commit-bound and rollback-safe.
 
 For the full callable signature and exception contract, see the
 [GraphQL API reference](../api/graphql.md#bulk-notification-context). The

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -29,7 +29,7 @@ import graphene
 from asgiref.sync import async_to_sync
 from channels.layers import BaseChannelLayer
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import models
+from django.db import DEFAULT_DB_ALIAS, models, transaction
 from django.utils.module_loading import import_string
 
 from general_manager.bucket.base_bucket import Bucket
@@ -1743,21 +1743,18 @@ class GraphQL:
         action: str,
         previous_instance: GeneralManager | None = None,
         identification: GraphQLIdentification | None = None,
+        database_alias: str = DEFAULT_DB_ALIAS,
         **_: object,
     ) -> None:
         """
-        Send a "gm.subscription.event" message to the channel group corresponding to a changed GeneralManager instance.
+        Schedule publication of a subscription event after the data change commits.
 
-        If the provided instance is a registered GeneralManager and a channel
-        layer is configured, queue one manager-wide refresh while notification
-        batching is active. Outside a batch, publish the row-level message to
-        the instance and class-wide groups through one async bridge.
-        Identification comes from the provided `identification` mapping when
-        supplied, otherwise from the changed instance, and is deep-copied
-        before dispatch. If the instance is `None`, the manager type is not
-        registered, or no channel layer is available, the function returns
-        without dispatching. Ordinary group dispatch failures are logged and
-        do not stop attempts for remaining groups.
+        If the provided instance is a registered GeneralManager, schedule the
+        row-level publication after the transaction for the originating database
+        alias commits. Identification comes from the provided `identification`
+        mapping when supplied, otherwise from the changed instance, and is
+        deep-copied before scheduling. If the instance is `None` or the manager
+        type is not registered, the function returns without scheduling.
 
         Parameters:
             sender (type[GeneralManager] | GeneralManager): The signal sender; either a GeneralManager subclass or an instance.
@@ -1783,6 +1780,28 @@ class GraphQL:
             )
             return
 
+        event_identification = deepcopy(
+            identification
+            if identification is not None
+            else event_instance.identification
+        )
+        transaction.on_commit(
+            lambda: cls._publish_data_change(
+                manager_class,
+                action,
+                event_identification,
+            ),
+            using=database_alias,
+        )
+
+    @classmethod
+    def _publish_data_change(
+        cls,
+        manager_class: type[GeneralManager],
+        action: str,
+        identification: GraphQLIdentification,
+    ) -> None:
+        """Publish a committed subscription event to its row and class groups."""
         channel_layer = cls._get_channel_layer()
         if channel_layer is None:
             logger.warning(
@@ -1794,30 +1813,24 @@ class GraphQL:
             )
             return
 
-        event_identification = (
-            deepcopy(identification)
-            if identification is not None
-            else deepcopy(event_instance.identification)
-        )
-        group_name = cls._group_name(manager_class, event_identification)
+        group_name = cls._group_name(manager_class, identification)
         class_group_name = cls._class_group_name(manager_class)
         message: dict[str, object] = {
             "type": "gm.subscription.event",
             "action": action,
             "manager": manager_class.__name__,
-            "identification": event_identification,
+            "identification": identification,
         }
         refresh_group_name = cls._refresh_group_name(manager_class)
-        refresh_message: dict[str, object] = {
-            "type": "gm.subscription.event",
-            "action": "refresh",
-            "manager": manager_class.__name__,
-        }
         if _queue_notification(
             key=("graphql", refresh_group_name),
             group_send=channel_layer.group_send,
             group=refresh_group_name,
-            message=refresh_message,
+            message={
+                "type": "gm.subscription.event",
+                "action": "refresh",
+                "manager": manager_class.__name__,
+            },
         ):
             return
 

--- a/src/general_manager/api/remote_invalidation.py
+++ b/src/general_manager/api/remote_invalidation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 from datetime import date, datetime
 import json
 from importlib import import_module
@@ -15,6 +16,7 @@ from urllib.parse import parse_qs
 
 from asgiref.sync import async_to_sync
 from django.conf import settings
+from django.db import DEFAULT_DB_ALIAS, transaction
 from django.urls import re_path
 
 from general_manager.api.remote_api import (
@@ -130,38 +132,12 @@ def _get_channel_layer_safe() -> "BaseChannelLayer | None":
     return cast("BaseChannelLayer | None", get_channel_layer())
 
 
-def emit_remote_invalidation(
-    sender: type["GeneralManager"],
-    *,
-    instance: "GeneralManager | None" = None,
-    identification: IdentificationPayload | None = None,
+def _publish_remote_invalidation(
+    config: RemoteAPIConfig,
     action: str,
-    **_: object,
+    identification: IdentificationPayload | None,
 ) -> None:
-    """
-    Emit or queue a websocket invalidation for a RemoteAPI-enabled manager.
-
-    Returns without sending when the manager has no RemoteAPI config, websocket
-    invalidation is disabled, or Channels has no configured channel layer.
-    Identification is taken from the explicit mapping first, then from
-    `instance.identification` when an instance is provided; missing
-    identification is sent as `None`. The `action` string is forwarded without
-    validation. UUID, date, and datetime identification values are serialized to
-    strings, and other non-JSON values fall back to `str(value)`.
-
-    During a bulk notification batch, the receiver queues one resource-wide
-    `refresh` payload and returns without resolving row identification or
-    creating an immediate async bridge. Outside a batch, it sends one row-level
-    payload through `async_to_sync(channel_layer.group_send)`. Payload fields
-    are `type` (`"gm.remote.invalidation"`), `protocol_version`, `base_path`,
-    `resource_name`, `action`, `identification`, and `event_id` as a UUID4
-    string. Identification serialization is shallow; nested lists or mappings
-    fall back to `str(value)`. Missing `instance.identification`, pathological
-    `str(value)` errors, and channel-layer send errors propagate.
-    """
-    config = get_remote_api_config(sender)
-    if config is None or not config.websocket_invalidation:
-        return
+    """Publish or batch a committed RemoteAPI websocket invalidation."""
     channel_layer = _get_channel_layer_safe()
     if channel_layer is None:
         return
@@ -181,18 +157,68 @@ def emit_remote_invalidation(
     ):
         return
 
-    event_identification = identification
-    if event_identification is None and instance is not None:
-        event_identification = dict(instance.identification)
     payload = _build_remote_invalidation_payload(
         config,
         action=action,
-        identification=event_identification,
+        identification=identification,
         event_id=event_id,
     )
-    async_to_sync(channel_layer.group_send)(
-        group_name,
-        payload,
+    try:
+        async_to_sync(channel_layer.group_send)(group_name, payload)
+    except MemoryError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "failed to dispatch remote invalidation",
+            context={
+                "base_path": config.base_path,
+                "resource_name": config.resource_name,
+                "action": action,
+                "group": group_name,
+            },
+            exc_info=exc,
+        )
+
+
+def emit_remote_invalidation(
+    sender: type["GeneralManager"],
+    *,
+    instance: "GeneralManager | None" = None,
+    identification: IdentificationPayload | None = None,
+    action: str,
+    database_alias: str = DEFAULT_DB_ALIAS,
+    **_: object,
+) -> None:
+    """
+    Schedule a RemoteAPI websocket invalidation after the data change commits.
+
+    Returns without scheduling when the manager has no enabled websocket
+    RemoteAPI configuration. Identification is taken from the explicit mapping
+    first, then from `instance.identification` when an instance is provided,
+    and deep-copied so transaction callbacks observe the value at signal time.
+    The `action` string is forwarded without validation. The callback uses the
+    originating database alias and delegates channel lookup, batching, payload
+    creation, and delivery to `_publish_remote_invalidation` after commit.
+    """
+    config = get_remote_api_config(sender)
+    if config is None or not config.websocket_invalidation:
+        return
+
+    event_identification = identification
+    if event_identification is None and instance is not None:
+        event_identification = dict(instance.identification)
+    captured_identification = (
+        deepcopy(dict(event_identification))
+        if event_identification is not None
+        else None
+    )
+    transaction.on_commit(
+        lambda: _publish_remote_invalidation(
+            config,
+            action,
+            captured_identification,
+        ),
+        using=database_alias,
     )
 
 

--- a/src/general_manager/api/remote_invalidation.py
+++ b/src/general_manager/api/remote_invalidation.py
@@ -208,9 +208,7 @@ def emit_remote_invalidation(
     if event_identification is None and instance is not None:
         event_identification = dict(instance.identification)
     captured_identification = (
-        deepcopy(dict(event_identification))
-        if event_identification is not None
-        else None
+        deepcopy(event_identification) if event_identification is not None else None
     )
     transaction.on_commit(
         lambda: _publish_remote_invalidation(

--- a/tests/integration/test_websocket_notification_commit_safety.py
+++ b/tests/integration/test_websocket_notification_commit_safety.py
@@ -116,7 +116,7 @@ class WebsocketNotificationCommitSafetyTests(GeneralManagerTransactionTestCase):
                 with transaction.atomic():
                     self._emit_both()
                     raise ExpectedRollback
-        self.assertEqual(self.sent, [])
+            self.assertEqual(self.sent, [])
 
     def test_savepoint_rollback_discards_both_notifications(self) -> None:
         """Rolling back an inner savepoint discards both pending publishers."""

--- a/tests/integration/test_websocket_notification_commit_safety.py
+++ b/tests/integration/test_websocket_notification_commit_safety.py
@@ -1,0 +1,144 @@
+"""Integration coverage for commit-safe websocket data-change notifications."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import ClassVar
+from unittest.mock import patch
+
+from django.db import transaction
+
+from general_manager.api import bulk_data_change_notifications
+from general_manager.api.graphql import GraphQL
+from general_manager.api.remote_invalidation import emit_remote_invalidation
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.utils.testing import GeneralManagerTransactionTestCase
+from tests.utils.simple_manager_interface import BaseTestInterface
+
+
+class ExpectedRollback(RuntimeError):
+    """Expected exception used to exercise transaction rollbacks."""
+
+
+def _force_rollback() -> None:
+    """Raise the test-only exception that marks an intentional rollback."""
+    raise ExpectedRollback
+
+
+class WebsocketNotificationCommitSafetyTests(GeneralManagerTransactionTestCase):
+    """Verify both websocket publishers share Django commit semantics."""
+
+    Project: ClassVar[type[GeneralManager]]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Register a lightweight manager with both websocket publishers enabled."""
+
+        class Project(GeneralManager):
+            identification: ClassVar[dict[str, object]] = {"id": 1}
+            Interface = BaseTestInterface
+
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        cls.Project = Project
+        cls.general_manager_classes = [Project]
+        super().setUpClass()
+
+    def setUp(self) -> None:
+        """Prepare a shared record of messages sent to external transports."""
+        super().setUp()
+        self.sent: list[tuple[str, str, dict[str, object]]] = []
+
+    @contextmanager
+    def _patched_publishers(self) -> Iterator[None]:
+        """Record real publisher delivery while preserving Django commit hooks."""
+
+        async def graphql_group_send(group: str, message: dict[str, object]) -> None:
+            self.sent.append(("graphql", group, message))
+
+        async def remote_group_send(group: str, message: dict[str, object]) -> None:
+            self.sent.append(("remote", group, message))
+
+        graphql_layer = SimpleNamespace(group_send=graphql_group_send)
+        remote_layer = SimpleNamespace(group_send=remote_group_send)
+        with (
+            patch.object(
+                GraphQL,
+                "manager_registry",
+                {self.Project.__name__: self.Project},
+            ),
+            patch.object(GraphQL, "_get_channel_layer", return_value=graphql_layer),
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe",
+                return_value=remote_layer,
+            ),
+        ):
+            yield
+
+    def _emit_both(self, *, action: str = "create") -> None:
+        """Schedule matching GraphQL and RemoteAPI messages on the real transaction."""
+        project = self.Project()
+        GraphQL._handle_data_change(
+            sender=self.Project,
+            instance=project,
+            action=action,
+            database_alias="default",
+        )
+        emit_remote_invalidation(
+            self.Project,
+            instance=project,
+            action=action,
+            database_alias="default",
+        )
+
+    def test_both_publish_only_after_outer_commit(self) -> None:
+        """Both publishers defer transport delivery until the outer commit."""
+        with self._patched_publishers():
+            with transaction.atomic():
+                self._emit_both()
+                self.assertEqual(self.sent, [])
+            self.assertEqual(
+                [(kind, message["action"]) for kind, _, message in self.sent],
+                [("graphql", "create"), ("graphql", "create"), ("remote", "create")],
+            )
+
+    def test_outer_rollback_discards_both_notifications(self) -> None:
+        """Rolling back the outer transaction discards both pending publishers."""
+        with self._patched_publishers():
+            with self.assertRaises(ExpectedRollback):
+                with transaction.atomic():
+                    self._emit_both()
+                    raise ExpectedRollback
+        self.assertEqual(self.sent, [])
+
+    def test_savepoint_rollback_discards_both_notifications(self) -> None:
+        """Rolling back an inner savepoint discards both pending publishers."""
+        with self._patched_publishers(), transaction.atomic():
+            try:
+                with transaction.atomic():
+                    self._emit_both()
+                    _force_rollback()
+            except ExpectedRollback:
+                pass
+            self.assertEqual(self.sent, [])
+        self.assertEqual(self.sent, [])
+
+    def test_bulk_flushes_one_refresh_per_system_after_commit(self) -> None:
+        """Bulk delivery waits for commit and reduces each system to one refresh."""
+        with self._patched_publishers(), bulk_data_change_notifications():
+            with transaction.atomic():
+                self._emit_both(action="update")
+                self._emit_both(action="update")
+                self.assertEqual(self.sent, [])
+            self.assertEqual(self.sent, [])
+        self.assertEqual(
+            [(kind, message["action"]) for kind, _, message in self.sent],
+            [("graphql", "refresh"), ("remote", "refresh")],
+        )

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -4,12 +4,14 @@
 import asyncio
 import contextlib
 import os
+import threading
 from types import SimpleNamespace
-from typing import Any, ClassVar
+from typing import Any, Callable, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import graphene
 from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.db.models import CharField
 from django.utils.crypto import get_random_string
 from graphql import parse
@@ -616,6 +618,60 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         payload = event.data["onEmployeeClassChange"]
         self.assertEqual(payload["action"], "create")
         self.assertEqual(payload["item"]["name"], "Class Alice")
+
+    def test_class_subscription_emits_visible_create_only_after_outer_commit(
+        self,
+    ) -> None:
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item {
+                        id
+                        name
+                    }
+                }
+            }
+        """
+        transaction_open = threading.Event()
+        allow_commit = threading.Event()
+
+        def create_inside_outer_transaction() -> None:
+            with transaction.atomic():
+                self.Employee.create(name="Committed Alice", creator_id=self.user.id)
+                transaction_open.set()
+                self.assertTrue(
+                    allow_commit.wait(timeout=2),
+                    "test did not release outer transaction",
+                )
+
+        async def run_subscription() -> object:
+            generator = await schema.subscribe(subscription, context_value=context)
+            if hasattr(generator, "errors"):
+                raise AssertionError(generator.errors)
+            try:
+                next_event = asyncio.create_task(generator.__anext__())
+                worker = asyncio.create_task(
+                    asyncio.to_thread(create_inside_outer_transaction)
+                )
+                await asyncio.to_thread(transaction_open.wait, 2)
+                self.assertTrue(transaction_open.is_set())
+                self.assertFalse(next_event.done())
+                allow_commit.set()
+                await worker
+                return await next_event
+            finally:
+                allow_commit.set()
+                await generator.aclose()
+
+        event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        payload = event.data["onEmployeeClassChange"]
+        self.assertEqual(payload["action"], "create")
+        self.assertEqual(payload["item"]["name"], "Committed Alice")
 
     def test_class_subscription_batches_creates_into_one_refresh(self) -> None:
         schema = self._build_schema()
@@ -2220,25 +2276,20 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
             )
             mock_get_layer.assert_not_called()
 
-    def test_handle_data_change_ignores_when_no_channel_layer(self) -> None:
-        """Verify _handle_data_change does nothing when no channel layer is configured."""
+    def test_publish_data_change_ignores_when_no_channel_layer(self) -> None:
+        """Verify _publish_data_change does nothing when no layer is configured."""
 
         class RegisteredManager(GeneralManager):
             identification: ClassVar[dict[str, int]] = {"id": 1}
             Interface = BaseTestInterface
 
         GraphQL.manager_registry = {"RegisteredManager": RegisteredManager}
-        instance = RegisteredManager()
-
         with patch(
             "general_manager.api.graphql.GraphQL._get_channel_layer", return_value=None
         ):
-            # Should not raise
-            GraphQL._handle_data_change(
-                sender=RegisteredManager, instance=instance, action="test"
-            )
+            GraphQL._publish_data_change(RegisteredManager, "test", {"id": 1})
 
-    def test_handle_data_change_uses_one_bridge_for_both_groups(self) -> None:
+    def test_publish_data_change_uses_one_bridge_for_both_groups(self) -> None:
         """Verify one bridge sends the unchanged row payload to both groups."""
 
         class RegisteredManager(GeneralManager):
@@ -2246,8 +2297,6 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
             Interface = BaseTestInterface
 
         GraphQL.manager_registry = {"RegisteredManager": RegisteredManager}
-        instance = RegisteredManager()
-
         sent: list[tuple[str, dict[str, object]]] = []
 
         async def group_send(group: str, message: dict[str, object]) -> None:
@@ -2261,14 +2310,12 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
                 side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
             ) as bridge,
         ):
-            GraphQL._handle_data_change(
-                sender=RegisteredManager, instance=instance, action="update"
-            )
+            GraphQL._publish_data_change(RegisteredManager, "update", {"id": 1})
 
         bridge.assert_called_once_with(
             graphql_subscriptions.dispatch_subscription_event
         )
-        instance_group = GraphQL._group_name(RegisteredManager, instance.identification)
+        instance_group = GraphQL._group_name(RegisteredManager, {"id": 1})
         class_group = GraphQL._class_group_name(RegisteredManager)
         self.assertEqual(
             [group for group, _message in sent],
@@ -2292,46 +2339,59 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
             ],
         )
 
-    def test_handle_data_change_deep_copies_nested_identification(self) -> None:
-        """Verify dispatched row identification is detached from the source."""
-        source_identification: dict[str, object] = {
-            "id": 1,
-            "nested": {"labels": ["alpha", "beta"]},
-        }
+    def test_handle_data_change_defers_publish_until_commit(self) -> None:
+        source = {"id": 1, "nested": {"labels": ["original"]}}
 
         class RegisteredManager(GeneralManager):
-            identification: ClassVar = source_identification
+            identification: ClassVar = source
             Interface = BaseTestInterface
 
         GraphQL.manager_registry = {"RegisteredManager": RegisteredManager}
-        sent: list[dict[str, object]] = []
+        callbacks: list[Callable[[], None]] = []
 
-        async def group_send(_group: str, message: dict[str, object]) -> None:
-            sent.append(message)
+        def save_callback(callback: Callable[[], None], *, using: str) -> None:
+            self.assertEqual(using, "secondary")
+            callbacks.append(callback)
 
-        layer = SimpleNamespace(group_send=group_send)
         with (
-            patch.object(GraphQL, "_get_channel_layer", return_value=layer),
-            patch(
-                "general_manager.api.graphql.async_to_sync",
-                side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
-            ),
+            patch("general_manager.api.graphql.transaction.on_commit") as on_commit,
+            patch.object(GraphQL, "_publish_data_change") as publish,
         ):
+            on_commit.side_effect = save_callback
             GraphQL._handle_data_change(
                 sender=RegisteredManager,
                 instance=RegisteredManager(),
-                action="update",
+                action="create",
+                database_alias="secondary",
             )
+            source["nested"]["labels"].append("mutated")
 
-        dispatched_identification = sent[0]["identification"]
-        self.assertEqual(dispatched_identification, source_identification)
-        self.assertIsNot(dispatched_identification, source_identification)
-        self.assertIsNot(
-            dispatched_identification["nested"],  # type: ignore[index]
-            source_identification["nested"],
+            publish.assert_not_called()
+            self.assertEqual(on_commit.call_args.kwargs, {"using": "secondary"})
+            callbacks[0]()
+
+        publish.assert_called_once_with(
+            RegisteredManager,
+            "create",
+            {"id": 1, "nested": {"labels": ["original"]}},
         )
 
-    def test_bulk_changes_queue_one_manager_refresh(self) -> None:
+    def test_handle_data_change_defaults_commit_alias(self) -> None:
+        class RegisteredManager(GeneralManager):
+            identification: ClassVar[dict[str, int]] = {"id": 1}
+            Interface = BaseTestInterface
+
+        GraphQL.manager_registry = {"RegisteredManager": RegisteredManager}
+        with patch("general_manager.api.graphql.transaction.on_commit") as on_commit:
+            GraphQL._handle_data_change(
+                sender=RegisteredManager,
+                instance=RegisteredManager(),
+                action="create",
+            )
+
+        self.assertEqual(on_commit.call_args.kwargs, {"using": "default"})
+
+    def test_publish_data_change_bulk_changes_queue_one_manager_refresh(self) -> None:
         """Many changes for one manager flush one aggregate refresh event."""
 
         class RegisteredManager(GeneralManager):
@@ -2351,11 +2411,7 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
         ):
             with bulk_data_change_notifications():
                 for _ in range(5):
-                    GraphQL._handle_data_change(
-                        sender=RegisteredManager,
-                        instance=RegisteredManager(),
-                        action="update",
-                    )
+                    GraphQL._publish_data_change(RegisteredManager, "update", {"id": 1})
                 self.assertEqual(sent, [])
                 immediate_bridge.assert_not_called()
 
@@ -2373,7 +2429,9 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
             ],
         )
 
-    def test_bulk_changes_queue_distinct_manager_refreshes(self) -> None:
+    def test_publish_data_change_bulk_changes_queue_distinct_manager_refreshes(
+        self,
+    ) -> None:
         """A batch flushes one refresh target for each changed manager."""
 
         class AlphaManager(GeneralManager):
@@ -2399,21 +2457,9 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
             patch("general_manager.api.graphql.async_to_sync") as immediate_bridge,
         ):
             with bulk_data_change_notifications():
-                GraphQL._handle_data_change(
-                    sender=BetaManager,
-                    instance=BetaManager(),
-                    action="delete",
-                )
-                GraphQL._handle_data_change(
-                    sender=AlphaManager,
-                    instance=AlphaManager(),
-                    action="create",
-                )
-                GraphQL._handle_data_change(
-                    sender=BetaManager,
-                    instance=BetaManager(),
-                    action="update",
-                )
+                GraphQL._publish_data_change(BetaManager, "delete", {"id": 2})
+                GraphQL._publish_data_change(AlphaManager, "create", {"id": 1})
+                GraphQL._publish_data_change(BetaManager, "update", {"id": 2})
                 immediate_bridge.assert_not_called()
 
         self.assertEqual(

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -2242,23 +2242,19 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
 
     def test_handle_data_change_ignores_none_instance(self) -> None:
         """Verify _handle_data_change does nothing when instance is None."""
-        with patch(
-            "general_manager.api.graphql.GraphQL._get_channel_layer"
-        ) as mock_get_layer:
+        with patch("general_manager.api.graphql.transaction.on_commit") as on_commit:
             GraphQL._handle_data_change(
                 sender=GeneralManager, instance=None, action="test"
             )
-            mock_get_layer.assert_not_called()
+            on_commit.assert_not_called()
 
     def test_handle_data_change_ignores_non_manager_instance(self) -> None:
         """Verify _handle_data_change does nothing for non-GeneralManager instances."""
-        with patch(
-            "general_manager.api.graphql.GraphQL._get_channel_layer"
-        ) as mock_get_layer:
+        with patch("general_manager.api.graphql.transaction.on_commit") as on_commit:
             GraphQL._handle_data_change(
                 sender=GeneralManager, instance=object(), action="test"
             )  # type: ignore[arg-type]
-            mock_get_layer.assert_not_called()
+            on_commit.assert_not_called()
 
     def test_handle_data_change_ignores_unregistered_manager(self) -> None:
         """Verify _handle_data_change does nothing for managers not in registry."""
@@ -2268,13 +2264,11 @@ class GraphQLHandleDataChangeTests(unittest.TestCase):
             Interface = BaseTestInterface
 
         instance = UnregisteredManager()
-        with patch(
-            "general_manager.api.graphql.GraphQL._get_channel_layer"
-        ) as mock_get_layer:
+        with patch("general_manager.api.graphql.transaction.on_commit") as on_commit:
             GraphQL._handle_data_change(
                 sender=UnregisteredManager, instance=instance, action="test"
             )
-            mock_get_layer.assert_not_called()
+            on_commit.assert_not_called()
 
     def test_publish_data_change_ignores_when_no_channel_layer(self) -> None:
         """Verify _publish_data_change does nothing when no layer is configured."""

--- a/tests/unit/test_grapql_subscription_helper.py
+++ b/tests/unit/test_grapql_subscription_helper.py
@@ -637,8 +637,8 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
         """Restore original registry."""
         GraphQL.manager_registry = self._original_registry
 
-    def test_handle_data_change_with_instance_as_sender(self) -> None:
-        """Verify _handle_data_change extracts manager class from instance sender."""
+    def test_publish_data_change_sends_to_instance_and_class_groups(self) -> None:
+        """Verify _publish_data_change sends the row payload to both groups."""
 
         class TestManager(GeneralManager):
             identification: ClassVar = {"id": 1}
@@ -660,9 +660,7 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
                 side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
             ) as bridge,
         ):
-            GraphQL._handle_data_change(
-                sender=instance, instance=instance, action="test"
-            )
+            GraphQL._publish_data_change(TestManager, "test", {"id": 1})
 
         bridge.assert_called_once_with(
             graphql_subscriptions.dispatch_subscription_event
@@ -675,8 +673,8 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             ],
         )
 
-    def test_handle_data_change_with_subclass(self) -> None:
-        """Verify _handle_data_change works with GeneralManager subclasses."""
+    def test_publish_data_change_uses_subclass_groups(self) -> None:
+        """Verify _publish_data_change uses the registered subclass groups."""
 
         class BaseManager(GeneralManager):
             identification: ClassVar = {"id": 1}
@@ -701,9 +699,7 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
                 side_effect=lambda async_fn: lambda *args: asyncio.run(async_fn(*args)),
             ) as bridge,
         ):
-            GraphQL._handle_data_change(
-                sender=DerivedManager, instance=instance, action="test"
-            )
+            GraphQL._publish_data_change(DerivedManager, "test", {"id": 1})
 
         bridge.assert_called_once_with(
             graphql_subscriptions.dispatch_subscription_event
@@ -716,7 +712,7 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             ],
         )
 
-    def test_handle_data_change_continues_when_instance_group_send_fails(
+    def test_publish_data_change_continues_when_instance_group_send_fails(
         self,
     ) -> None:
         """Verify class-level dispatch still runs when instance dispatch fails."""
@@ -748,11 +744,7 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             patch.object(graphql_subscriptions, "logger") as dispatch_logger,
             patch("general_manager.api.graphql.logger") as handler_logger,
         ):
-            GraphQL._handle_data_change(
-                sender=TestManager,
-                instance=instance,
-                action="test",
-            )
+            GraphQL._publish_data_change(TestManager, "test", {"id": 1})
 
         self.assertEqual(
             sent,
@@ -772,7 +764,7 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             },
         )
 
-    def test_handle_data_change_does_not_log_success_when_all_sends_fail(
+    def test_publish_data_change_does_not_log_success_when_all_sends_fail(
         self,
     ) -> None:
         """Verify the handler does not claim success when no group accepted it."""
@@ -800,11 +792,7 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             patch.object(graphql_subscriptions, "logger") as dispatch_logger,
             patch("general_manager.api.graphql.logger") as handler_logger,
         ):
-            GraphQL._handle_data_change(
-                sender=TestManager,
-                instance=instance,
-                action="test",
-            )
+            GraphQL._publish_data_change(TestManager, "test", {"id": 1})
 
         self.assertEqual(
             sent,
@@ -816,7 +804,7 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
         self.assertEqual(dispatch_logger.warning.call_count, 2)
         handler_logger.debug.assert_not_called()
 
-    def test_handle_data_change_logs_bridge_construction_failure(self) -> None:
+    def test_publish_data_change_logs_bridge_construction_failure(self) -> None:
         """Verify ordinary bridge-construction errors are suppressed and logged."""
 
         class TestManager(GeneralManager):
@@ -824,7 +812,6 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             Interface = BaseTestInterface
 
         GraphQL.manager_registry = {"TestManager": TestManager}
-        instance = TestManager()
         layer = SimpleNamespace(group_send=MagicMock())
         failure_message = "bridge construction failed"
         bridge_error = RuntimeError(failure_message)
@@ -837,16 +824,12 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             ),
             patch("general_manager.api.graphql.logger") as handler_logger,
         ):
-            GraphQL._handle_data_change(
-                sender=TestManager,
-                instance=instance,
-                action="test",
-            )
+            GraphQL._publish_data_change(TestManager, "test", {"id": 1})
 
         handler_logger.warning.assert_called_once()
         handler_logger.debug.assert_not_called()
 
-    def test_handle_data_change_logs_bridge_invocation_failure(self) -> None:
+    def test_publish_data_change_logs_bridge_invocation_failure(self) -> None:
         """Verify ordinary bridge-invocation errors are suppressed and logged."""
 
         class TestManager(GeneralManager):
@@ -854,7 +837,6 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             Interface = BaseTestInterface
 
         GraphQL.manager_registry = {"TestManager": TestManager}
-        instance = TestManager()
         layer = SimpleNamespace(group_send=MagicMock())
         failure_message = "bridge invocation failed"
 
@@ -869,16 +851,12 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             ),
             patch("general_manager.api.graphql.logger") as handler_logger,
         ):
-            GraphQL._handle_data_change(
-                sender=TestManager,
-                instance=instance,
-                action="test",
-            )
+            GraphQL._publish_data_change(TestManager, "test", {"id": 1})
 
         handler_logger.warning.assert_called_once()
         handler_logger.debug.assert_not_called()
 
-    def test_handle_data_change_propagates_bridge_memory_error(self) -> None:
+    def test_publish_data_change_propagates_bridge_memory_error(self) -> None:
         """Verify bridge memory exhaustion propagates to the signal caller."""
 
         class TestManager(GeneralManager):
@@ -886,7 +864,6 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             Interface = BaseTestInterface
 
         GraphQL.manager_registry = {"TestManager": TestManager}
-        instance = TestManager()
         layer = SimpleNamespace(group_send=MagicMock())
 
         def exhausted_bridge(*_args: object) -> int:
@@ -901,11 +878,7 @@ class GraphQLHandleDataChangeEdgeCasesTests(unittest.TestCase):
             patch("general_manager.api.graphql.logger") as handler_logger,
             self.assertRaises(MemoryError),
         ):
-            GraphQL._handle_data_change(
-                sender=TestManager,
-                instance=instance,
-                action="test",
-            )
+            GraphQL._publish_data_change(TestManager, "test", {"id": 1})
 
         handler_logger.warning.assert_not_called()
         handler_logger.debug.assert_not_called()

--- a/tests/unit/test_remote_invalidation.py
+++ b/tests/unit/test_remote_invalidation.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from datetime import date, datetime
+import gc
 from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
 from uuid import UUID
+import weakref
 
 from asgiref.sync import async_to_sync
 from channels.auth import AuthMiddlewareStack  # type: ignore[import-untyped]
@@ -325,6 +327,48 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
             callbacks[0]()
 
         publish.assert_called_once()
+
+    def test_emit_remote_invalidation_captures_instance_identification_without_retaining_instance(
+        self,
+    ) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        class Instance:
+            def __init__(self) -> None:
+                self.identification = {"id": 1, "nested": {"labels": ["original"]}}
+
+        instance = Instance()
+        instance_ref = weakref.ref(instance)
+        callbacks: list[Callable[[], None]] = []
+        with (
+            patch(
+                "general_manager.api.remote_invalidation.transaction.on_commit"
+            ) as on_commit,
+            patch(
+                "general_manager.api.remote_invalidation._publish_remote_invalidation"
+            ) as publish,
+        ):
+            on_commit.side_effect = lambda callback, **_kwargs: callbacks.append(
+                callback
+            )
+            emit_remote_invalidation(Project, instance=instance, action="update")
+            instance.identification["nested"]["labels"].append("mutated")
+            del instance
+            gc.collect()
+
+            self.assertIsNone(instance_ref())
+            publish.assert_not_called()
+            callbacks[0]()
+
+        _, action, captured = publish.call_args.args
+        self.assertEqual(action, "update")
+        self.assertEqual(captured, {"id": 1, "nested": {"labels": ["original"]}})
 
     def test_publish_remote_invalidation_logs_delivery_failure(self) -> None:
         class Project:

--- a/tests/unit/test_remote_invalidation.py
+++ b/tests/unit/test_remote_invalidation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from datetime import date, datetime
 from types import SimpleNamespace
 from typing import ClassVar
@@ -10,17 +11,21 @@ from uuid import UUID
 from asgiref.sync import async_to_sync
 from channels.auth import AuthMiddlewareStack  # type: ignore[import-untyped]
 from channels.routing import ProtocolTypeRouter, URLRouter  # type: ignore[import-untyped]
+from django.db import transaction
 from django.test import SimpleTestCase
+from django.test import TransactionTestCase
 from django.test import override_settings
 from django.urls import re_path
 
 from general_manager.api import bulk_data_change_notifications
 from general_manager.api.graphql import GraphQL
 from general_manager.api.remote_invalidation import (
+    _publish_remote_invalidation,
     clear_remote_invalidation_routes,
     emit_remote_invalidation,
     ensure_remote_invalidation_route,
 )
+from general_manager.api.remote_api import get_remote_api_config
 from general_manager.manager.general_manager import GeneralManager
 
 from tests import testing_asgi
@@ -174,7 +179,9 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
         self.assertIn(existing_route, router.routes)
         self.assertEqual(len(router.routes), 2)
 
-    def test_emit_remote_invalidation_serializes_identification_values(self) -> None:
+    def test_publish_remote_invalidation_serializes_identification_values(
+        self,
+    ) -> None:
         class Project:
             class RemoteAPI:
                 enabled = True
@@ -203,7 +210,9 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
                 side_effect=lambda fn: fn,
             ),
         ):
-            emit_remote_invalidation(Project, instance=instance, action="update")
+            config = get_remote_api_config(Project)
+            assert config is not None
+            _publish_remote_invalidation(config, "update", instance.identification)
 
         _, payload = channel_layer.group_send.call_args.args
         self.assertEqual(
@@ -214,7 +223,7 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
         self.assertEqual(payload["identification"]["updated_at"], "2026-03-18T12:30:00")
         self.assertEqual(payload["identification"]["name"], "Alpha")
 
-    def test_emit_remote_invalidation_uses_delete_identification_metadata(
+    def test_publish_remote_invalidation_uses_delete_identification_metadata(
         self,
     ) -> None:
         class Project:
@@ -237,11 +246,12 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
                 side_effect=lambda fn: fn,
             ),
         ):
-            emit_remote_invalidation(
-                Project,
-                instance=None,
-                identification={"id": UUID("12345678-1234-5678-1234-567812345678")},
-                action="delete",
+            config = get_remote_api_config(Project)
+            assert config is not None
+            _publish_remote_invalidation(
+                config,
+                "delete",
+                {"id": UUID("12345678-1234-5678-1234-567812345678")},
             )
 
         _, payload = channel_layer.group_send.call_args.args
@@ -250,6 +260,131 @@ class RemoteInvalidationRouteTests(SimpleTestCase):
             payload["identification"],
             {"id": "12345678-1234-5678-1234-567812345678"},
         )
+
+    def test_emit_remote_invalidation_defers_publish_until_commit(self) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        source = {"id": 1, "nested": {"labels": ["original"]}}
+        callbacks: list[Callable[[], None]] = []
+        with (
+            patch(
+                "general_manager.api.remote_invalidation.transaction.on_commit"
+            ) as on_commit,
+            patch(
+                "general_manager.api.remote_invalidation._publish_remote_invalidation"
+            ) as publish,
+        ):
+            on_commit.side_effect = lambda callback, **_kwargs: callbacks.append(
+                callback
+            )
+            emit_remote_invalidation(
+                Project,
+                identification=source,
+                action="create",
+                database_alias="secondary",
+            )
+            source["nested"]["labels"].append("mutated")
+            publish.assert_not_called()
+            self.assertEqual(on_commit.call_args.kwargs, {"using": "secondary"})
+            callbacks[0]()
+
+        config, action, captured = publish.call_args.args
+        self.assertEqual(config.resource_name, "projects")
+        self.assertEqual(action, "create")
+        self.assertEqual(captured, {"id": 1, "nested": {"labels": ["original"]}})
+
+    def test_emit_remote_invalidation_defaults_commit_alias(self) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        callbacks: list[Callable[[], None]] = []
+        with (
+            patch(
+                "general_manager.api.remote_invalidation.transaction.on_commit"
+            ) as on_commit,
+            patch(
+                "general_manager.api.remote_invalidation._publish_remote_invalidation"
+            ) as publish,
+        ):
+            on_commit.side_effect = lambda callback, **_kwargs: callbacks.append(
+                callback
+            )
+            emit_remote_invalidation(Project, identification={"id": 1}, action="create")
+            self.assertEqual(on_commit.call_args.kwargs, {"using": "default"})
+            callbacks[0]()
+
+        publish.assert_called_once()
+
+    def test_publish_remote_invalidation_logs_delivery_failure(self) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        redis_error = RuntimeError("redis down")
+
+        async def group_send(_group: str, _message: dict[str, object]) -> None:
+            raise redis_error
+
+        config = get_remote_api_config(Project)
+        assert config is not None
+        channel_layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe",
+                return_value=channel_layer,
+            ),
+            patch(
+                "general_manager.api.remote_invalidation.async_to_sync",
+                side_effect=lambda fn: lambda *args: asyncio.run(fn(*args)),
+            ),
+            patch("general_manager.api.remote_invalidation.logger") as logger,
+        ):
+            _publish_remote_invalidation(config, "update", {"id": 1})
+
+        logger.warning.assert_called_once()
+
+    def test_publish_remote_invalidation_propagates_memory_error(self) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        async def group_send(_group: str, _message: dict[str, object]) -> None:
+            raise MemoryError
+
+        config = get_remote_api_config(Project)
+        assert config is not None
+        channel_layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe",
+                return_value=channel_layer,
+            ),
+            patch(
+                "general_manager.api.remote_invalidation.async_to_sync",
+                side_effect=lambda fn: lambda *args: asyncio.run(fn(*args)),
+            ),
+            self.assertRaises(MemoryError),
+        ):
+            _publish_remote_invalidation(config, "update", {"id": 1})
 
 
 class RemoteInvalidationBatchTests(SimpleTestCase):
@@ -269,6 +404,8 @@ class RemoteInvalidationBatchTests(SimpleTestCase):
             sent.append((group, message))
 
         channel_layer = SimpleNamespace(group_send=group_send)
+        config = get_remote_api_config(Project)
+        assert config is not None
         with (
             patch(
                 "general_manager.api.remote_invalidation._get_channel_layer_safe",
@@ -280,11 +417,7 @@ class RemoteInvalidationBatchTests(SimpleTestCase):
         ):
             with bulk_data_change_notifications():
                 for identification in ({"id": 1}, {"id": 2}, {"id": 3}):
-                    emit_remote_invalidation(
-                        Project,
-                        identification=identification,
-                        action="update",
-                    )
+                    _publish_remote_invalidation(config, "update", identification)
                 self.assertEqual(sent, [])
                 immediate_bridge.assert_not_called()
 
@@ -328,15 +461,17 @@ class RemoteInvalidationBatchTests(SimpleTestCase):
             sent.append((group, message))
 
         channel_layer = SimpleNamespace(group_send=group_send)
+        project_config = get_remote_api_config(Project)
+        task_config = get_remote_api_config(Task)
+        assert project_config is not None
+        assert task_config is not None
         with patch(
             "general_manager.api.remote_invalidation._get_channel_layer_safe",
             return_value=channel_layer,
         ):
             with bulk_data_change_notifications():
-                emit_remote_invalidation(
-                    Task, identification={"id": 2}, action="delete"
-                )
-                emit_remote_invalidation(Project, instance=None, action="update")
+                _publish_remote_invalidation(task_config, "delete", {"id": 2})
+                _publish_remote_invalidation(project_config, "update", None)
 
         self.assertEqual(
             [
@@ -384,6 +519,8 @@ class RemoteInvalidationBatchTests(SimpleTestCase):
                 allow_update = True
                 websocket_invalidation = True
 
+        config = get_remote_api_config(Project)
+        assert config is not None
         with (
             patch(
                 "general_manager.api.remote_invalidation._get_channel_layer_safe",
@@ -392,7 +529,7 @@ class RemoteInvalidationBatchTests(SimpleTestCase):
             patch("general_manager.api.notification_batching.async_to_sync") as bridge,
         ):
             with bulk_data_change_notifications():
-                emit_remote_invalidation(Project, action="update")
+                _publish_remote_invalidation(config, "update", None)
 
         bridge.assert_not_called()
 
@@ -421,6 +558,8 @@ class RemoteInvalidationBatchTests(SimpleTestCase):
         graphql_layer = SimpleNamespace(group_send=graphql_group_send)
         remote_layer = SimpleNamespace(group_send=remote_group_send)
         project = Project()
+        remote_config = get_remote_api_config(Project)
+        assert remote_config is not None
         with (
             patch.object(GraphQL, "manager_registry", {"Project": Project}),
             patch.object(GraphQL, "_get_channel_layer", return_value=graphql_layer),
@@ -438,15 +577,15 @@ class RemoteInvalidationBatchTests(SimpleTestCase):
             ) as batch_bridge,
         ):
             with bulk_data_change_notifications():
-                GraphQL._handle_data_change(
-                    sender=Project,
-                    instance=project,
-                    action="update",
-                )
-                emit_remote_invalidation(
+                GraphQL._publish_data_change(
                     Project,
-                    instance=project,
-                    action="update",
+                    "update",
+                    project.identification,
+                )
+                _publish_remote_invalidation(
+                    remote_config,
+                    "update",
+                    project.identification,
                 )
 
         batch_bridge.assert_called_once()
@@ -462,3 +601,92 @@ class RemoteInvalidationBatchTests(SimpleTestCase):
                 ("remote", "gm.remote.remote.projects", "refresh"),
             ],
         )
+
+
+class RemoteInvalidationTransactionTests(TransactionTestCase):
+    databases: ClassVar[set[str]] = {"default", "secondary"}
+
+    def test_emit_remote_invalidation_publishes_only_after_successful_commit(
+        self,
+    ) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        with patch(
+            "general_manager.api.remote_invalidation._publish_remote_invalidation"
+        ) as publish:
+            with transaction.atomic(using="secondary"):
+                emit_remote_invalidation(
+                    Project,
+                    identification={"id": 1},
+                    action="create",
+                    database_alias="secondary",
+                )
+                publish.assert_not_called()
+                transaction.set_rollback(True, using="secondary")
+
+            publish.assert_not_called()
+
+            with transaction.atomic(using="secondary"):
+                emit_remote_invalidation(
+                    Project,
+                    identification={"id": 2},
+                    action="create",
+                    database_alias="secondary",
+                )
+                publish.assert_not_called()
+
+            publish.assert_called_once()
+            _, action, identification = publish.call_args.args
+            self.assertEqual(action, "create")
+            self.assertEqual(identification, {"id": 2})
+
+    def test_emit_remote_invalidation_batches_after_commit_within_bulk_context(
+        self,
+    ) -> None:
+        class Project:
+            class RemoteAPI:
+                enabled = True
+                base_path = "/remote"
+                resource_name = "projects"
+                allow_update = True
+                websocket_invalidation = True
+
+        sent: list[tuple[str, dict[str, object]]] = []
+
+        async def group_send(group: str, message: dict[str, object]) -> None:
+            sent.append((group, message))
+
+        channel_layer = SimpleNamespace(group_send=group_send)
+        with (
+            patch(
+                "general_manager.api.remote_invalidation._get_channel_layer_safe",
+                return_value=channel_layer,
+            ),
+            patch(
+                "general_manager.api.notification_batching.async_to_sync",
+                side_effect=async_to_sync,
+            ),
+        ):
+            with bulk_data_change_notifications():
+                with transaction.atomic():
+                    for identification in ({"id": 1}, {"id": 2}, {"id": 3}):
+                        emit_remote_invalidation(
+                            Project,
+                            identification=identification,
+                            action="update",
+                        )
+                    self.assertEqual(sent, [])
+
+                self.assertEqual(sent, [])
+
+        self.assertEqual(len(sent), 1)
+        group, payload = sent[0]
+        self.assertEqual(group, "gm.remote.remote.projects")
+        self.assertEqual(payload["action"], "refresh")
+        self.assertIsNone(payload["identification"])


### PR DESCRIPTION
## Summary

GraphQL class-change subscriptions and RemoteAPI websocket invalidations could be delivered before their database transaction committed. A consumer could then fail to rehydrate a newly created row, suppress the event permanently, or observe a notification for a transaction that later rolled back.

This change captures immutable notification data during `post_data_change` and schedules external publication with Django's alias-aware `transaction.on_commit()`. Internal signal consumers such as cache invalidation and workflows retain their existing immediate timing.

## Related issue

No related issue.

## What changed

- Split GraphQL and RemoteAPI receivers into transaction-aware scheduling and focused publication helpers.
- Publish only after the outermost transaction commits and discard callbacks on transaction or savepoint rollback.
- Preserve existing payloads, groups, action names, object-level permission filtering, batching, and `MemoryError` behavior.
- Log and suppress ordinary post-commit transport failures so committed mutations are not reported as failed.
- Added real cross-system tests for commit, rollback, nested savepoint rollback, and correctly ordered bulk refresh aggregation.
- Added immutable instance-capture coverage for RemoteAPI invalidations.

## Validation

```text
PYTHONPATH=src python -m pytest -q — 5631 passed, 3 skipped, 1 existing warning
ruff format --check <changed Python files> — 6 files already formatted
ruff check <changed Python files> — all checks passed
mypy --strict src/general_manager/api/graphql.py src/general_manager/api/remote_invalidation.py — success
```

## Documentation

Updated the GraphQL subscription guide, RemoteAPI end-to-end example, and bulk notification how-to. The docs now distinguish immediate signal receipt from post-commit transport delivery, document rollback behavior and required batching order, and preserve the aggregate-refresh permission-check exemption.

## Reviewer notes

Suggested review order:

1. GraphQL scheduling/publication split.
2. RemoteAPI scheduling/publication split.
3. Cross-system transaction integration tests.
4. Timing and batching documentation.

There are no schema, migration, dependency, or wire-format changes. The work remains best-effort transport delivery after a successful database commit.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket notifications are now delivered only after successful transaction commits.
  * Notifications are discarded when transactions or savepoints roll back.
  * Event data is safely preserved for post-commit delivery.
  * Delivery failures no longer disrupt application transactions.

* **Improvements**
  * Bulk changes now combine refresh notifications after commit, reducing duplicate updates.
  * Documentation clarifies commit timing, rollback behavior, batching, permissions, and best-effort delivery.

* **Tests**
  * Added coverage for commit safety, rollback handling, batching, database routing, and delivery failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->