### PR TITLE
docs: document commit-safe websocket delivery

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -112,15 +112,41 @@ snapshot into the next. Historical failures use stable public extension codes:
 context deduplicates targets and flushes one `refresh` event per affected
 GraphQL manager class or RemoteAPI resource after the body exits. Individual
 ordinary channel-layer send failures are logged and do not abort the remaining
-flushes; `MemoryError` and other non-ordinary flush failures propagate.
+flushes; `MemoryError` and other `BaseException` failures propagate.
 
-The context is not transaction-aware. Put it outside the true outermost
-`transaction.atomic()` block so refresh delivery follows the completed commit
-or rollback. Body exceptions are re-raised after the queued notifications are
+The context does not open, commit, or roll back a database transaction. Put it
+outside the true outermost `transaction.atomic()` block: a successful commit
+runs the GraphQL and RemoteAPI `transaction.on_commit()` callbacks while the
+batch is still accepting targets, and context exit then flushes the aggregate
+refreshes. A rollback, including a savepoint rollback, discards those
+callbacks, so no refresh is queued. Reversing the contexts remains commit-safe
+but does not guarantee aggregation because the batch closes before the commit
+callbacks run. Body exceptions are re-raised after any queued notifications are
 flushed; if flushing also raises, both failures are reported in a
-`BaseExceptionGroup`. The stable import is available from `general_manager.api`
-in 0.64.0 and later; the notification batching module is an implementation
-location rather than a separate package-level compatibility promise.
+`BaseExceptionGroup`.
+
+The stable import is available from `general_manager.api` in 0.64.0 and later;
+the notification batching module is an implementation location rather than a
+separate package-level compatibility promise. See the [subscription delivery
+concept](../concepts/graphql/subscriptions.md#signals-and-channels), the [bulk
+notification how-to](../howto/bulk_data_change_notifications.md), and the
+[runnable recipe](../examples/bulk_data_change_notifications.md).
+
+## Commit-bound websocket delivery
+
+GraphQL ordinary row-level subscription events and RemoteAPI invalidations are
+published after the outermost transaction on the originating database alias
+commits. Rollbacks and savepoint rollbacks publish nothing. When no transaction
+is active, Django executes the `on_commit()` callback immediately. GraphQL
+class-wide ordinary events hydrate the changed object and apply
+`can_read_instance()` after commit; aggregate `refresh` events have no row
+identification and yield `item = null` without object-level hydration.
+
+RemoteAPI delivery is best-effort after commit: a missing channel layer emits
+no message, and ordinary channel-layer failures are logged while other queued
+targets continue. The [RemoteAPI websocket concept](../concepts/interfaces/remote_api.md)
+explains the event model and the [end-to-end recipe](../examples/remote_manager_interface_end_to_end.md)
+shows the client/server setup.
 
 ## Relation annotation compatibility
 
@@ -556,6 +582,31 @@ a directly usable resolver and client-handling pattern.
 ::: general_manager.api.remote_invalidation.remote_invalidation_group_name
 
 ::: general_manager.api.remote_invalidation.emit_remote_invalidation
+
+`emit_remote_invalidation(sender, *, instance=None, identification=None,
+action, database_alias="default", **_) -> None` is the `post_data_change`
+receiver for an enabled RemoteAPI manager. `sender` is the manager class;
+`instance` supplies fallback identification; explicit `identification` takes
+priority; `action` is forwarded without validation; and `database_alias`
+selects the Django connection whose successful commit triggers publication, or
+the connection used for immediate callback execution when no transaction is
+active.
+The extra signal keyword arguments accepted by `**_` are ignored.
+
+The function returns `None` and returns without scheduling when the manager has
+no enabled websocket RemoteAPI configuration. Before registration,
+`RemoteAPIConfigurationError`, identification-copy errors, and transaction
+registration errors propagate. After commit, missing channel layers produce no
+message, ordinary channel-layer delivery errors are logged, and `MemoryError`
+propagates. The callback uses the deep-copied identification captured at signal
+time, so rolled-back transactions and later instance mutations cannot publish
+stale or uncommitted row data.
+
+Compatibility: `database_alias` and commit-bound delivery are available in
+GeneralManager 0.67.7 and later. Earlier versions attempted websocket delivery
+immediately from the signal receiver. Callers should use the documented
+`post_data_change` integration rather than treating the underscored publisher
+helper as public.
 
 ::: general_manager.api.remote_invalidation.RemoteInvalidationConsumer
 

--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -118,12 +118,13 @@ The context does not open, commit, or roll back a database transaction. Put it
 outside the true outermost `transaction.atomic()` block: a successful commit
 runs the GraphQL and RemoteAPI `transaction.on_commit()` callbacks while the
 batch is still accepting targets, and context exit then flushes the aggregate
-refreshes. A rollback, including a savepoint rollback, discards those
-callbacks, so no refresh is queued. Reversing the contexts remains commit-safe
-but does not guarantee aggregation because the batch closes before the commit
-callbacks run. Body exceptions are re-raised after any queued notifications are
-flushed; if flushing also raises, both failures are reported in a
-`BaseExceptionGroup`.
+refreshes. A full transaction rollback discards all callbacks. Rolling back to
+an inner savepoint discards only callbacks registered after that savepoint;
+callbacks registered before it remain queued and run if the outer transaction
+commits. Reversing the contexts remains commit-safe but does not guarantee
+aggregation because the batch closes before the commit callbacks run. Body
+exceptions are re-raised after any queued notifications are flushed; if
+flushing also raises, both failures are reported in a `BaseExceptionGroup`.
 
 The stable import is available from `general_manager.api` in 0.64.0 and later;
 the notification batching module is an implementation location rather than a
@@ -136,9 +137,11 @@ notification how-to](../howto/bulk_data_change_notifications.md), and the
 
 GraphQL ordinary row-level subscription events and RemoteAPI invalidations are
 published after the outermost transaction on the originating database alias
-commits. Rollbacks and savepoint rollbacks publish nothing. When no transaction
-is active, Django executes the `on_commit()` callback immediately. GraphQL
-class-wide ordinary events hydrate the changed object and apply
+commits. A full transaction rollback publishes nothing. A savepoint rollback
+discards only events registered after that savepoint; events registered before
+it remain queued and publish when the outer transaction commits. When no
+transaction is active, Django executes the `on_commit()` callback immediately.
+GraphQL class-wide ordinary events hydrate the changed object and apply
 `can_read_instance()` after commit; aggregate `refresh` events have no row
 identification and yield `item = null` without object-level hydration.
 

--- a/docs/concepts/interfaces/index.md
+++ b/docs/concepts/interfaces/index.md
@@ -2,7 +2,7 @@
 
 Interfaces define how managers store or compute data. They encapsulate persistence logic, conversion between Django models and managers, and the inputs required to instantiate a manager.
 
-GeneralManager ships with four main interface flavours:
+GeneralManager ships with these interface flavours:
 
 - [Database interfaces](db_based_interface.md) persist records to relational databases.
 - [Existing model interfaces](existing_model_interface.md) wrap legacy Django models without generating new tables.

--- a/docs/concepts/interfaces/index.md
+++ b/docs/concepts/interfaces/index.md
@@ -9,6 +9,7 @@ GeneralManager ships with four main interface flavours:
 - [Read-only interfaces](db_based_interface.md#read-only-data) synchronise static datasets from JSON.
 - [Calculation interfaces](computed_data_interfaces.md) compute values on the fly from inputs and related managers.
 - [Request interfaces](request_interface.md) connect managers to remote HTTP-style services through declarative request operations and filter mappings.
+- [RemoteAPI websocket invalidation](remote_api.md) keeps remote clients aligned with committed server-side changes.
 
 All interfaces inherit from `general_manager.interface.base_interface.InterfaceBase`, which provides shared behaviour such as identification, validation, and integration with the dependency tracker.
 

--- a/docs/concepts/interfaces/remote_api.md
+++ b/docs/concepts/interfaces/remote_api.md
@@ -1,0 +1,50 @@
+# RemoteAPI Websocket Invalidation
+
+RemoteAPI websocket invalidation is a commit-safe hint that a REST resource
+changed. A manager opts in with `RemoteAPI.enabled = True` and
+`RemoteAPI.websocket_invalidation = True`. Clients use the websocket event to
+decide when to refetch the resource over REST; the event is not a second data
+transport and does not contain a complete resource snapshot.
+
+## Mental model
+
+The server-side flow has four stages:
+
+1. A manager mutation emits `post_data_change`.
+2. `emit_remote_invalidation()` resolves the normalized `RemoteAPIConfig`,
+   deep-copies the selected identification, and registers a callback with
+   Django's `transaction.on_commit()` for the changed database alias.
+3. A successful outermost commit publishes the row-level invalidation. A
+   rollback, including a savepoint rollback, discards the callback.
+4. `bulk_data_change_notifications()` can deduplicate committed changes into
+   one `refresh` event per resource. Put that context outside the true
+   outermost transaction so the callbacks run while the batch is open.
+
+This ordering prevents clients from refetching data that is not committed yet.
+When no transaction is active, Django executes the `on_commit()` callback
+immediately, so ordinary non-transactional mutations keep immediate delivery.
+It also means a callback observes the identification from signal time rather
+than later mutations to the manager instance. Explicit `identification` takes
+priority over `instance.identification`; omitted identification is sent as
+`null`.
+
+## Delivery contract
+
+An ordinary event carries the resource's `base_path`, `resource_name`,
+`protocol_version`, action, identification, and a UUID4 `event_id`. UUIDs,
+dates, and datetimes in the top-level identification mapping are serialized as
+strings; other non-JSON values fall back to `str(value)`. A bulk `refresh` has
+no row identification, so clients should treat it as resource-wide and
+requery the REST endpoint.
+
+Delivery is best-effort after commit. A missing channel layer produces no
+message, and ordinary channel-layer delivery failures are logged rather than
+raised. `MemoryError` still propagates. Configuration, identification-copy,
+and transaction-registration failures raised before the callback is installed
+remain visible to the caller.
+
+For the task-oriented transaction and batching instructions, see the [bulk
+notification how-to](../../howto/bulk_data_change_notifications.md). The
+[Remote manager end-to-end recipe](../../examples/remote_manager_interface_end_to_end.md)
+shows the server and client setup, and the [API reference](../../api/graphql.md)
+records the callable contract for `emit_remote_invalidation()`.

--- a/docs/concepts/interfaces/remote_api.md
+++ b/docs/concepts/interfaces/remote_api.md
@@ -14,19 +14,23 @@ The server-side flow has four stages:
 2. `emit_remote_invalidation()` resolves the normalized `RemoteAPIConfig`,
    deep-copies the selected identification, and registers a callback with
    Django's `transaction.on_commit()` for the changed database alias.
-3. A successful outermost commit publishes the row-level invalidation. A
-   rollback, including a savepoint rollback, discards the callback.
+3. A successful outermost commit publishes the row-level invalidation. A full
+   transaction rollback discards all callbacks. Rolling back to a savepoint
+   discards only callbacks registered after that savepoint; callbacks registered
+   before it remain queued for execution when the outer transaction commits.
 4. `bulk_data_change_notifications()` can deduplicate committed changes into
    one `refresh` event per resource. Put that context outside the true
    outermost transaction so the callbacks run while the batch is open.
 
 This ordering prevents clients from refetching data that is not committed yet.
-When no transaction is active, Django executes the `on_commit()` callback
-immediately, so ordinary non-transactional mutations keep immediate delivery.
-It also means a callback observes the identification from signal time rather
-than later mutations to the manager instance. Explicit `identification` takes
-priority over `instance.identification`; omitted identification is sent as
-`null`.
+When no transaction is active and the connection is in autocommit mode, Django
+executes the `on_commit()` callback immediately, so ordinary non-transactional
+mutations keep immediate delivery. If autocommit is disabled outside an
+`atomic()` block, `on_commit()` raises `TransactionManagementError` instead of
+registering or executing the callback. A callback observes the identification
+from signal time rather than later mutations to the manager instance. Explicit
+`identification` takes priority over `instance.identification`; omitted
+identification is sent as `null`.
 
 ## Delivery contract
 

--- a/docs/examples/bulk_data_change_notifications.md
+++ b/docs/examples/bulk_data_change_notifications.md
@@ -25,5 +25,6 @@ cache invalidation or other per-write signals.
 
 Keep the notification context outside any pre-existing outer transaction. It
 flushes queued targets even when the body raises, then re-raises the body
-exception. Ordinary channel-layer send errors are logged while other queued
-targets continue flushing.
+exception. If both the body and notification flush fail, the context raises a
+`BaseExceptionGroup` containing both failures. Ordinary channel-layer send
+errors are logged while other queued targets continue flushing.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
           - concepts/interfaces/computed_data_interfaces.md
           - concepts/interfaces/dependency_graph.md
           - concepts/interfaces/request_interface.md
+          - concepts/interfaces/remote_api.md
       - Observability:
           - concepts/observability/index.md
           - concepts/observability/logging.md


### PR DESCRIPTION
## Summary

Documents the public websocket delivery behavior introduced in GeneralManager 0.67.7. GraphQL subscription events and RemoteAPI invalidations now respect the originating database transaction, capture identification at signal time, and deliver best-effort after commit.

## Reviewed commits

The exact rolling window was 2026-08-11T04:01:03Z through 2026-08-12T04:01:03Z. Complete diffs were inspected for these commits reachable from `origin/main`:

- `2bc33254f3c0d8582811bc4435cacd54fbe55a9b` — fix: publish GraphQL changes after commit
- `f3165ab72dc249bebdd7bcfe6f1fbf994d696042` — test: cover skipped GraphQL event scheduling
- `ce7f825e3307e8072b1118f495e38f08374b3c2f` — fix: publish remote invalidations after commit
- `738165574936aabbaeedbf4e739456577f24d98e` — test: cover commit-safe websocket notifications
- `756bd019f165e2591108b49b5ce55e66ab7557cc` — docs: explain commit-safe websocket delivery
- `962d21d20ad0185495064dcf29b8b8dd434788c1` — docs: clarify class subscription refresh permissions
- `e7f810fa6bcf9b745ba1ab1475531b2fc1b3a599` — test: cover remote invalidation instance capture
- `bbd0911e25c8fcbb90c78d4bfbfaf7a4eeebf83d` — fix: address websocket notification review feedback
- `2d70e6763354b0fd477314fd75cfecc8c016f569` — 0.67.7 release metadata

## Affected public APIs

- GraphQL generated subscriptions: ordinary row events publish after the outermost commit on the originating database alias; rollbacks and savepoint rollbacks publish nothing; class-wide events hydrate and permission-check after commit, while aggregate refresh events yield `item = null`.
- `emit_remote_invalidation(sender, *, instance=None, identification=None, action, database_alias="default", **_)`: schedules commit-bound delivery, deep-copies identification, honors the database alias, and logs ordinary post-commit channel delivery failures while propagating `MemoryError`.
- `bulk_data_change_notifications()`: its documented placement now explains how commit callbacks enter the active batch and how rollback, nesting, and combined body/flush failures behave.

## Documentation changed

- `docs/api/graphql.md`
- `docs/concepts/interfaces/remote_api.md` (new)
- `docs/concepts/interfaces/index.md`
- `docs/examples/bulk_data_change_notifications.md`
- `mkdocs.yml`

Existing GraphQL concept, bulk how-to, and RemoteAPI end-to-end cookbook coverage from the reviewed commits was audited and cross-linked.

## Validation

- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py -q` — 4 passed
- `PYTHONPATH=src python -m pytest tests/integration/test_request_docs_examples.py -q` — 2 passed
- Affected GraphQL/RemoteAPI unit and integration tests — 131 passed
- `python -m mkdocs build --strict --site-dir /tmp/general-manager-docs-review-20260812` — passed; only existing unnav-linked planning/ADR notices and the expected uncommitted-page timestamp notice
- File-scoped `pre-commit` — passed
- `git diff --check` — passed

## Limitations

The full test suite was not rerun because this branch changes documentation only. The local cached `gh` token is invalid; the branch push succeeded and this PR is being created through the connected GitHub app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded notification guidance for transaction commits, savepoints, failure handling, aggregation, and delivery behavior.
  * Documented RemoteAPI websocket invalidation, including configuration, event payloads, permissions, refresh behavior, and error handling.
  * Added the RemoteAPI invalidation guide to the documentation navigation.
  * Clarified the `emit_remote_invalidation` API and bulk notification exception behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->