### PR TITLE
fix: sort GraphQL lists after grouping

### DIFF
--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -173,13 +173,32 @@ query ActiveProjects($filters: ProjectFilterInput) {
 ```
 
 Use `groupBy: [""]` to call the bucket's default grouping behavior, or pass
-explicit field names such as `groupBy: ["status"]`. `totalCount` is computed
-after permission filtering, user filters, excludes, sorting, and grouping, but
-before page slicing. Invalid `sortBy` enum values are rejected by Graphene;
-invalid filter, grouping, or slicing values propagate the corresponding bucket
-or resolver error. When grouping is active, pagination slices grouped manager
-objects rather than the original ungrouped rows, and the GraphQL `items` field
-still uses the manager's generated item type.
+explicit field names such as `groupBy: ["status"]`. Filtering and exclusion run
+before grouping; `sortBy` runs after grouping and before pagination. Without
+`groupBy`, `sortBy` orders records as usual. With `groupBy`, it orders the
+returned grouped manager objects, so sorting by a grouping key honors `reverse`,
+while sorting by another exposed field uses that field's aggregated group value.
+`totalCount` is computed after permission filtering, user filters, excludes,
+grouping, and sorting, but before page slicing.
+
+```graphql
+query ProjectsByDescendingStatus {
+  projectList(groupBy: ["status"], sortBy: STATUS, reverse: true) {
+    items {
+      status
+    }
+    pageInfo {
+      totalCount
+    }
+  }
+}
+```
+
+Invalid `sortBy` enum values are rejected by Graphene; invalid filter, grouping,
+or slicing values propagate the corresponding bucket or resolver error. When
+grouping is active, pagination slices grouped manager objects rather than the
+original ungrouped rows, and the GraphQL `items` field still uses the manager's
+generated item type.
 
 ## Expose authorization hints
 

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -157,7 +157,7 @@ bucket-like values are used as returned.
 
 ```graphql
 query ActiveProjects($filters: ProjectFilterInput) {
-  projectList(filter: $filters, sortBy: NAME, page: 1, pageSize: 20) {
+  projectList(filter: $filters, sortBy: name, page: 1, pageSize: 20) {
     items {
       id
       name
@@ -183,7 +183,7 @@ grouping, and sorting, but before page slicing.
 
 ```graphql
 query ProjectsByDescendingStatus {
-  projectList(groupBy: ["status"], sortBy: STATUS, reverse: true) {
+  projectList(groupBy: ["status"], sortBy: status, reverse: true) {
     items {
       status
     }

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -2,7 +2,7 @@
 Resolver-construction helpers extracted from ``api/graphql.py``.
 
 These standalone functions build Graphene resolver callables and apply
-query modifiers (filtering, pagination, grouping). They hold no reference to the
+query modifiers (filtering, grouping, sorting, pagination). They hold no reference to the
 ``GraphQL`` class and can therefore be imported freely inside the package's
 internal GraphQL implementation without circular imports. This module is not a
 stable public import path.
@@ -660,9 +660,11 @@ def create_list_resolver(
     capability warmups. The resolver applies permission prefilters and the
     permission row gate before user-supplied query arguments,
     then explicit filters, normalized filter-side excludes, explicit excludes,
-    normalized exclude-side excludes, sorting, optional grouping, and pagination.
-    It computes ``total_count`` after grouping and before pagination. Non-grouped
-    page items are materialized to a list; grouped results remain a
+    normalized exclude-side excludes, optional grouping, sorting, and pagination.
+    Sorting therefore applies to records when grouping is omitted and to grouped
+    manager objects when grouping is active. It computes ``total_count`` after
+    grouping and sorting and before pagination. Non-grouped page items are
+    materialized to a list; grouped results remain a
     ``GroupBucket`` and are returned as the Python-side ``items`` value. When
     grouping is active, pagination slices the group bucket before it is returned.
     Dependency-cache prefetch runs only for materialized item lists when the
@@ -730,15 +732,16 @@ def create_list_resolver(
             qs,
             filter,
             exclude,
-            sort_by,
+            None,
             reverse,
             filter_normalizer=bound_filter_normalizer,
         )
         qs_grouped = apply_grouping(qs, group_by)
+        qs_sorted = apply_sorting(qs_grouped, sort_by, reverse)
 
-        total_count = len(qs_grouped)
+        total_count = len(qs_sorted)
 
-        qs_paginated = apply_pagination(qs_grouped, page, page_size)
+        qs_paginated = apply_pagination(qs_sorted, page, page_size)
         items: object
         if hasattr(qs_paginated, "groups"):
             items = qs_paginated

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -143,6 +143,18 @@ def contains_none_relation_filter(input_val: object) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def apply_sorting(
+    queryset: Bucket[GeneralManager] | GroupBucket[GeneralManager],
+    sort_by: graphene.Enum | None,
+    reverse: bool,
+) -> Bucket[GeneralManager] | GroupBucket[GeneralManager]:
+    """Sort a record or group bucket when a GraphQL sort key is present."""
+    if not sort_by:
+        return queryset
+    sort_by_str = cast(str, getattr(sort_by, "value", sort_by))
+    return queryset.sort(sort_by_str, reverse=reverse)
+
+
 def apply_query_parameters(
     queryset: Bucket[GeneralManager],
     filter_input: GraphQLFilterInput,
@@ -204,11 +216,10 @@ def apply_query_parameters(
     if normalized_excludes:
         queryset = queryset.exclude(**normalized_excludes)
 
-    if sort_by:
-        sort_by_str = cast(str, getattr(sort_by, "value", sort_by))
-        queryset = queryset.sort(sort_by_str, reverse=reverse)
-
-    return queryset
+    return cast(
+        Bucket[GeneralManager],
+        apply_sorting(queryset, sort_by, reverse),
+    )
 
 
 def apply_permission_filters(

--- a/src/general_manager/bucket/group_bucket.py
+++ b/src/general_manager/bucket/group_bucket.py
@@ -502,7 +502,11 @@ class GroupBucket(Generic[GeneralManagerType]):
                     new_base_data = new_base_data | manager._data
             if new_base_data is None:
                 raise EmptyGroupBucketSliceError()
-            return GroupBucket(self._manager_class, self._group_by_keys, new_base_data)
+            new_bucket = GroupBucket(
+                self._manager_class, self._group_by_keys, new_base_data
+            )
+            new_bucket._data = new_data
+            return new_bucket
         raise InvalidGroupBucketIndexError(type(item))
 
     def __len__(self) -> int:

--- a/tests/docs/test_public_api_docs_coverage.py
+++ b/tests/docs/test_public_api_docs_coverage.py
@@ -152,3 +152,10 @@ def test_file_upload_guides_cover_required_security_and_operation_topics() -> No
     }
     missing_terms = sorted(term for term in required_terms if term not in corpus)
     assert missing_terms == []
+
+
+def test_graphql_sort_examples_use_generated_lowercase_enum_values() -> None:
+    guide = (DOCS_ROOT / "howto" / "expose_via_graphql.md").read_text(encoding="utf-8")
+
+    assert "projectList(filter: $filters, sortBy: name, page: 1, pageSize: 20)" in guide
+    assert 'projectList(groupBy: ["status"], sortBy: status, reverse: true)' in guide

--- a/tests/integration/test_graphql_query.py
+++ b/tests/integration/test_graphql_query.py
@@ -143,6 +143,29 @@ class TestGraphQLQueryPagination(GeneralManagerTransactionTestCase):
         self.assertEqual(data["commercialsList"]["pageInfo"]["totalCount"], 10)
         self.assertEqual(data["commercialsList"]["pageInfo"]["totalPages"], 2)
 
+    def test_grouped_query_sorts_groups_by_the_same_key_in_reverse(self):
+        query = """
+        query {
+            commercialsList(groupBy: ["name"], sortBy: name, reverse: true) {
+                items {
+                    name
+                }
+                pageInfo {
+                    totalCount
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        payload = response.json()["data"]["commercialsList"]
+        names = [item["name"] for item in payload["items"]]
+        self.assertGreaterEqual(len(names), 2)
+        self.assertEqual(names, sorted(names, reverse=True))
+        self.assertEqual(payload["pageInfo"]["totalCount"], len(names))
+
     def test_query_commercials_with_project_list(self):
         """
         Tests that querying the commercials list with nested project lists returns correct items and pagination metadata for both levels.

--- a/tests/integration/test_graphql_query.py
+++ b/tests/integration/test_graphql_query.py
@@ -166,6 +166,39 @@ class TestGraphQLQueryPagination(GeneralManagerTransactionTestCase):
         self.assertEqual(names, sorted(names, reverse=True))
         self.assertEqual(payload["pageInfo"]["totalCount"], len(names))
 
+    def test_grouped_query_keeps_reverse_sort_order_when_paginated(self):
+        grouped_names = sorted(
+            {commercial.name for commercial in self.commercials.all()}, reverse=True
+        )
+        self.assertGreaterEqual(len(grouped_names), 6)
+        query = """
+        query {
+            commercialsList(
+                groupBy: ["name"]
+                sortBy: name
+                reverse: true
+                page: 2
+                pageSize: 3
+            ) {
+                items {
+                    name
+                }
+                pageInfo {
+                    totalCount
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        payload = response.json()["data"]["commercialsList"]
+        names = [item["name"] for item in payload["items"]]
+        self.assertEqual(names, sorted(names, reverse=True))
+        self.assertEqual(names, grouped_names[3:6])
+        self.assertEqual(payload["pageInfo"]["totalCount"], len(grouped_names))
+
     def test_query_commercials_with_project_list(self):
         """
         Tests that querying the commercials list with nested project lists returns correct items and pagination metadata for both levels.

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -43,7 +43,9 @@ from general_manager.utils.format_string import snake_to_camel
 from general_manager.api.graphql_resolvers import (
     apply_grouping,
     apply_pagination,
+    apply_query_parameters,
     apply_read_authorization,
+    apply_sorting,
     parse_input,
     resolve_instance_check_reasons,
     selection_includes_path,
@@ -283,6 +285,42 @@ class GraphQLHelperTests(SimpleTestCase):
         grouped = apply_grouping(queryset, ["name"])
 
         assert grouped._group_by_keys == ("name",)
+
+    def test_apply_sorting_normalizes_enum_and_propagates_reverse(self) -> None:
+        queryset = mock.Mock()
+        sorted_queryset = mock.Mock()
+        queryset.sort.return_value = sorted_queryset
+        sort_by = type("SortBy", (), {"value": "name"})()
+
+        result = apply_sorting(queryset, sort_by, reverse=True)
+
+        assert result is sorted_queryset
+        queryset.sort.assert_called_once_with("name", reverse=True)
+
+    def test_apply_sorting_is_noop_without_sort_key(self) -> None:
+        queryset = mock.Mock()
+
+        result = apply_sorting(queryset, None, reverse=True)
+
+        assert result is queryset
+        queryset.sort.assert_not_called()
+
+    def test_apply_query_parameters_still_sorts_direct_calls(self) -> None:
+        queryset = mock.Mock()
+        sorted_queryset = mock.Mock()
+        queryset.sort.return_value = sorted_queryset
+        sort_by = type("SortBy", (), {"value": "name"})()
+
+        result = apply_query_parameters(
+            queryset,
+            filter_input=None,
+            exclude_input=None,
+            sort_by=sort_by,
+            reverse=True,
+        )
+
+        assert result is sorted_queryset
+        queryset.sort.assert_called_once_with("name", reverse=True)
 
     def test_apply_pagination_defaults_only_the_missing_argument(self) -> None:
         """


### PR DESCRIPTION
## Summary

Grouped GraphQL list queries now apply `sortBy` after `groupBy`, so the returned groups honor the requested order and `reverse` flag. The change also preserves sorted group order when pagination slices a `GroupBucket`.

## Related issue

No issue linked; this is a focused GraphQL query-ordering fix.

## What changed

- Extracted shared GraphQL bucket sorting while preserving direct-call compatibility.
- Reordered generated list resolvers to filter/exclude, group, sort, count, then paginate.
- Preserved group ordering when slicing a sorted `GroupBucket`.
- Added integration coverage for same-key grouped sorting and paginated descending groups.
- Updated GraphQL examples and added documentation regression coverage.

## Validation

```text
python -m pytest — 5624 passed, 3 skipped, 1 pre-existing warning
ruff format --check src/general_manager/api/graphql_resolvers.py src/general_manager/bucket/group_bucket.py tests/unit/test_graphql_helpers.py tests/integration/test_graphql_query.py tests/docs/test_public_api_docs_coverage.py — 5 files already formatted
ruff check src/general_manager/api/graphql_resolvers.py src/general_manager/bucket/group_bucket.py tests/unit/test_graphql_helpers.py tests/integration/test_graphql_query.py tests/docs/test_public_api_docs_coverage.py — all checks passed
mypy src/general_manager/api/graphql_resolvers.py src/general_manager/bucket/group_bucket.py — success
git diff --check — clean
```

## Documentation

Updated `docs/howto/expose_via_graphql.md` to describe group-before-sort semantics, aggregate group sorting, and valid lowercase generated enum values.

## Reviewer notes

The existing falsey non-`None` sort-key no-op behavior is intentionally preserved for compatibility. The only full-suite warning is the pre-existing Django duplicate model-registration warning.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL list query behavior so filtering, grouping, sorting, pagination, and total counts are applied consistently.
  * Added reliable descending sorting for grouped results, including across paginated responses.
  * Preserved grouped data when slicing results.

* **Documentation**
  * Updated GraphQL examples to use the correct lowercase sort values.
  * Clarified list-query operation ordering and added a grouped sorting example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->