### PR TITLE
fix: preserve empty grouped GraphQL pages

### DIFF
--- a/docs/superpowers/specs/2026-08-12-empty-grouped-graphql-pagination-design.md
+++ b/docs/superpowers/specs/2026-08-12-empty-grouped-graphql-pagination-design.md
@@ -1,0 +1,49 @@
+# Empty Grouped GraphQL Pagination
+
+## Problem
+
+Generated GraphQL list resolvers apply grouping before pagination. When filters
+produce no records, grouping returns an empty `GroupBucket`. Supplying `page` or
+`pageSize` then causes `apply_pagination()` to slice that bucket, but
+`GroupBucket.__getitem__()` intentionally raises `EmptyGroupBucketSliceError`
+for an empty slice. The exception escapes through GraphQL, making the list field
+`null` instead of returning an empty page.
+
+## Public behavior
+
+A generated list query that combines `groupBy` with pagination and has no
+matching records resolves successfully. Its `items` field is an empty list and
+its pagination metadata continues to report zero total items. Pagination of
+non-empty grouped and ungrouped buckets retains its current behavior.
+
+## Design
+
+Keep the fix in `apply_pagination()`, where GraphQL pagination policy is
+implemented. After validating pagination arguments and determining that
+pagination was requested, detect an already-empty `GroupBucket` and return it
+unchanged instead of slicing it. This preserves the grouped bucket shape needed
+by GraphQL serialization while avoiding the invalid empty slice.
+
+Do not change `GroupBucket.__getitem__()`: its empty-slice error remains part of
+the bucket-level contract. Do not catch `EmptyGroupBucketSliceError` broadly,
+because slices of non-empty grouped buckets that select no groups are outside
+this issue and should retain their current behavior.
+
+## Error handling and compatibility
+
+Negative `page` and `pageSize` values must still raise
+`InvalidPaginationValueError`, including when the bucket is empty. Default page
+and page-size behavior remains unchanged for non-empty buckets. No schema,
+storage, dependency, or public API changes are required.
+
+## Verification
+
+Add a unit regression test that creates an empty grouped bucket, paginates it,
+and asserts that the same empty `GroupBucket` is returned without an exception.
+Add a GraphQL integration test that filters a generated list to zero records,
+passes both `groupBy` and `pageSize`, and asserts that the response has no errors,
+contains `items: []`, and reports `totalCount: 0`.
+
+Run each regression test before implementation to confirm the expected failure,
+then rerun the focused unit and integration tests after the fix. Finish with
+Ruff, mypy, and the broader test suite if the focused checks pass.

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -499,6 +499,8 @@ def apply_pagination(
     Negative ``page`` or ``page_size`` values raise ``ValueError`` before
     slicing. Falsey explicit values such as ``page=0`` or ``page_size=0`` also
     fall back through those defaults for slicing.
+    Already-empty grouped buckets are returned unchanged when pagination is
+    requested, preserving their shape without invoking an invalid empty slice.
     The returned object keeps the same bucket/group-bucket shape as the slice
     operation exposes. Slice errors from the bucket implementation propagate
     unchanged.
@@ -508,6 +510,8 @@ def apply_pagination(
     if page_size is not None and page_size < 0:
         raise InvalidPaginationValueError
     if page is not None or page_size is not None:
+        if isinstance(queryset, GroupBucket) and len(queryset) == 0:
+            return queryset
         page = page or 1
         page_size = page_size or 10
         offset = (page - 1) * page_size

--- a/tests/integration/test_graphql_query.py
+++ b/tests/integration/test_graphql_query.py
@@ -199,6 +199,36 @@ class TestGraphQLQueryPagination(GeneralManagerTransactionTestCase):
         self.assertEqual(names, grouped_names[3:6])
         self.assertEqual(payload["pageInfo"]["totalCount"], len(grouped_names))
 
+    def test_empty_grouped_query_with_pagination_returns_empty_page(self):
+        """Grouped pagination returns an empty GraphQL page when no rows match."""
+        query = """
+        query {
+            commercialsList(
+                filter: {name: "No matching commercial"}
+                groupBy: ["name"]
+                pageSize: 5
+            ) {
+                items {
+                    name
+                }
+                pageInfo {
+                    totalCount
+                    currentPage
+                    totalPages
+                }
+            }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        payload = response.json()["data"]["commercialsList"]
+        self.assertEqual(payload["items"], [])
+        self.assertEqual(payload["pageInfo"]["totalCount"], 0)
+        self.assertEqual(payload["pageInfo"]["currentPage"], 1)
+        self.assertEqual(payload["pageInfo"]["totalPages"], 0)
+
     def test_query_commercials_with_project_list(self):
         """
         Tests that querying the commercials list with nested project lists returns correct items and pagination metadata for both levels.

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -336,17 +336,30 @@ class GraphQLHelperTests(SimpleTestCase):
 
         assert [item.identification["id"] for item in first_page] == [0, 1, 2, 3, 4]
 
+    def test_apply_pagination_preserves_empty_group_bucket(self) -> None:
+        """An empty grouped page must not invoke GroupBucket's invalid empty slice."""
+        grouped = SimpleBucket(_DummyManager).group_by("name")
+
+        result = apply_pagination(grouped, page=1, page_size=5)
+
+        assert result is grouped
+        assert len(result) == 0
+
     def test_apply_pagination_rejects_negative_values(self) -> None:
         queryset = SimpleBucket(
             _DummyManager,
             [_DummyManager(id=value) for value in range(3)],
         )
+        empty_grouped = SimpleBucket(_DummyManager).group_by("name")
 
         with pytest.raises(ValueError, match="pagination values"):
             apply_pagination(queryset, page=-1, page_size=10)
 
         with pytest.raises(ValueError, match="pagination values"):
             apply_pagination(queryset, page=1, page_size=-10)
+
+        with pytest.raises(ValueError, match="pagination values"):
+            apply_pagination(empty_grouped, page=-1, page_size=10)
 
     def test_measurement_scalar_invalid(self) -> None:
         """

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -361,6 +361,9 @@ class GraphQLHelperTests(SimpleTestCase):
         with pytest.raises(ValueError, match="pagination values"):
             apply_pagination(empty_grouped, page=-1, page_size=10)
 
+        with pytest.raises(ValueError, match="pagination values"):
+            apply_pagination(empty_grouped, page=1, page_size=-10)
+
     def test_measurement_scalar_invalid(self) -> None:
         """
         Verify that serializing a non-measurement string with MeasurementScalar raises an InvalidMeasurementValueError.


### PR DESCRIPTION
## Summary

Fix grouped GraphQL list pagination when filters produce no records. An empty grouped result now resolves as an empty page instead of surfacing `Cannot slice an empty GroupBucket.`

The guard lives in the GraphQL pagination helper so the lower-level `GroupBucket` empty-slice contract remains unchanged.

## Related issue

Closes #446.

## What changed

- Return an already-empty `GroupBucket` unchanged when GraphQL pagination is requested.
- Add a helper regression test for empty grouped pagination and negative-value validation order.
- Add an integration test covering a generated list query with `filter`, `groupBy`, and `pageSize`.
- Record the approved design for the focused fix.

## Validation

```text
PYTHONPATH=src python -m pytest tests/unit/test_graphql_helpers.py tests/integration/test_graphql_query.py — 58 passed
ruff check src/general_manager/api/graphql_resolvers.py tests/unit/test_graphql_helpers.py tests/integration/test_graphql_query.py — passed
ruff format --check src/general_manager/api/graphql_resolvers.py tests/unit/test_graphql_helpers.py tests/integration/test_graphql_query.py — 3 files already formatted
mypy src/general_manager/api/graphql_resolvers.py — no issues found
PYTHONPATH=src python -m pytest — 5716 passed, 3 skipped
```

## Documentation

No user-facing documentation change is required: this restores the existing empty-page contract without changing the GraphQL schema or pagination API. The implementation design is recorded in `docs/superpowers/specs/2026-08-12-empty-grouped-graphql-pagination-design.md`.

## Reviewer notes

Rebased onto `origin/main` at `110f622c`. The integration-test conflict was resolved by preserving the upstream grouped reverse-sort tests and adding the empty-page regression beside them.

The guard intentionally applies only to an already-empty `GroupBucket`. Slicing a non-empty grouped bucket to an out-of-range empty page retains its existing behavior and is outside issue #446.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [ ] User-facing documentation is updated where behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grouped GraphQL queries with no matching results so they return an empty page correctly instead of producing an error.
  * Preserved accurate pagination details, including zero items, zero total count, page 1, and zero total pages.
  * Continued rejecting negative pagination values with the appropriate validation error.

* **Tests**
  * Added unit and integration coverage for empty grouped results and pagination validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->