### PR TITLE
docs: document recent public API changes

### DIFF
--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -607,6 +607,44 @@ exits a temporary `CalculationRunContext`. Use it only in `with` statements:
 manager, not a decorator or generator context manager; `__enter__()` yields a
 `CalculationRunContext` and `__exit__()` returns `None`.
 
+::: general_manager.cache.data_change_context.DataChangeTransactionContext
+
+`DataChangeTransactionContext(database_alias, caller_in_atomic_block)` is the
+mutable transaction-local state shared by the outermost ORM data-change
+lifecycle signals. Its identity fields are the database alias and whether the
+caller already owned an atomic block. `changed_classes` is a deduplicated
+`set[str]`; `metadata` is a caller-owned `dict[str, object]`; and
+`phase_seconds` is an additive `dict[str, float]` of recorded lifecycle work.
+
+::: general_manager.cache.data_change_context.DataChangeTransactionScope
+
+`DataChangeTransactionScope(transaction, is_outermost)` is the context-manager
+entry view used by the data-change signal envelope. It is not needed by ordinary
+signal consumers; receivers receive the `transaction` value directly as
+`transaction_context`.
+
+::: general_manager.cache.data_change_context.current_data_change_transaction
+
+`current_data_change_transaction(database_alias)` returns the live
+`DataChangeTransactionContext` for that alias, or `None` when no framework-owned
+envelope is active. It does not search other aliases.
+
+::: general_manager.cache.data_change_context.register_data_change_class
+
+`register_data_change_class(class_name, database_alias)` adds the class name to
+the matching framework-owned context's `changed_classes` set and returns
+`True`. It returns `False` for a missing alias, a caller-owned outer
+transaction, or no active envelope. It only checks the requested alias and does
+not raise a package-specific exception.
+
+::: general_manager.cache.data_change_context.record_data_change_phase
+
+`record_data_change_phase(phase, duration_seconds, database_alias)` records a
+finite duration for one of the documented lifecycle phases and returns `None`.
+Negative finite durations are clamped to zero; non-finite durations and calls
+without a matching live context are ignored. The helper is intended for
+framework receivers and observability integrations.
+
 ::: general_manager.cache.signals.pre_data_change
 
 ::: general_manager.cache.signals.post_data_change

--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -142,8 +142,10 @@ discards only events registered after that savepoint; events registered before
 it remain queued and publish when the outer transaction commits. When no
 transaction is active, Django executes the `on_commit()` callback immediately.
 GraphQL class-wide ordinary events hydrate the changed object and apply
-`can_read_instance()` after commit; aggregate `refresh` events have no row
-identification and yield `item = null` without object-level hydration.
+`can_read_instance()` in an async-safe worker using the user captured when the
+subscription starts. Unreadable or missing objects are suppressed, while an
+unexpected permission exception propagates; aggregate `refresh` events have no
+row identification and yield `item = null` without object-level hydration.
 
 RemoteAPI delivery is best-effort after commit: a missing channel layer emits
 no message, and ordinary channel-layer failures are logged while other queued
@@ -364,15 +366,20 @@ truncation toward zero for those inputs.
 
 For pagination, treat the generated GraphQL `pageInfo` response field as the
 user-facing contract. `totalCount` is counted after permission filters, user
-filters, excludes, sorting, and grouping, but before page slicing. Supplying
+filters, excludes, grouping, and sorting, but before page slicing. Without
+`groupBy`, sorting applies to records; with `groupBy`, sorting applies to the
+grouped manager objects after grouping and before pagination. Supplying
 only one of `page` or `pageSize` defaults the missing value to page 1 or size 10
 for slicing. Falsey explicit values such as `page: 0` or `pageSize: 0` follow
 the same fallbacks for slicing; `currentPage` is `page || 1`. The reported
 `pageSize` is the original argument value, not the effective slicing default, so
 it can be `null` when only `page` is supplied and `0` when `pageSize: 0` is
 supplied. `totalPages` is `1` when the original `pageSize` is omitted or falsey.
+With a positive explicit `pageSize`, an empty result has `totalPages: 0`.
 Negative `page` or `pageSize` values raise a GraphQL `BAD_USER_INPUT` error
-before slicing. Do not import generated/internal Python pagination classes
+before slicing. An already-empty grouped result with pagination returns an empty
+`items` list and its normal page metadata; it does not raise the grouped-bucket
+empty-slice error. Do not import generated/internal Python pagination classes
 directly.
 
 ::: general_manager.api.mutation.graph_ql_mutation

--- a/docs/concepts/graphql/filters_pagination.md
+++ b/docs/concepts/graphql/filters_pagination.md
@@ -34,14 +34,16 @@ dictionary key named `none` at any depth under `exclude`, including a top-level
 `UnsupportedExcludeNoneRelationFilterError` because the resolver cannot invert
 that relation shape safely. Permission filters are applied before user filters,
 and any permission plan that still needs per-instance checks runs its row gate
-before user filters, sorting, grouping, and pagination.
+before user filters, grouping, sorting, and pagination.
 
 The resolver applies query arguments in a fixed order: permission prefilters and
-the row gate run first, then explicit filters, normalized filter-side excludes,
-explicit excludes, normalized exclude-side excludes, sorting, grouping, and
-pagination. Filter normalizers receive the parsed object mapping for the current
-`filter` or `exclude` input and must return both `filter` and `exclude`
-mappings; missing keys propagate the resulting Python `KeyError`.
+the row gate run first, then explicit filters and excludes. When `groupBy` is
+omitted, sorting follows those filters and precedes pagination. When grouping is
+active, grouping precedes sorting so `sortBy` orders the returned group managers,
+then pagination slices that sorted group bucket. Filter normalizers receive the
+parsed object mapping for the current `filter` or `exclude` input and must return
+both `filter` and `exclude` mappings; missing keys propagate the resulting Python
+`KeyError`.
 
 ## Pagination model
 
@@ -52,15 +54,18 @@ Pagination is page-based. Responses include a `pageInfo` object with:
 - `total_pages`
 - `page_size`
 
-`total_count` is computed after permission filtering, user filters, excludes, sorting, and grouping, but before pagination. If only one pagination argument is supplied, slicing defaults the other to `page=1` or `page_size=10`.
+`total_count` is computed after permission filtering, user filters, excludes,
+grouping, and sorting, but before pagination. If only one pagination argument is
+supplied, slicing defaults the other to `page=1` or `page_size=10`.
 Falsey explicit pagination values such as `page: 0` or `pageSize: 0` follow the
 same Python fallback for slicing. `currentPage` is reported as `page || 1`.
 `pageSize` reports the original GraphQL argument value, not the effective
 slicing default, so it remains `null` when only `page` is supplied and remains
 `0` for `pageSize: 0`. `totalPages` is computed from a truthy original
 `pageSize`; when `pageSize` is omitted or falsey it is reported as `1`, including
-empty result sets. Negative `page` or `pageSize` values are rejected before
-slicing and surface as GraphQL `BAD_USER_INPUT` errors.
+empty result sets; with a positive explicit `pageSize`, an empty result has
+`totalPages: 0`. Negative `page` or `pageSize` values are rejected before slicing
+and surface as GraphQL `BAD_USER_INPUT` errors.
 
 ## Grouping
 
@@ -84,6 +89,11 @@ properties. Capability warmup is triggered for ungrouped pages only when
 capabilities. Invalid group keys propagate the bucket's validation error through
 GraphQL execution.
 
+If filtering produces no groups, a paginated grouped query returns an empty
+`items` list with the normal page metadata instead of raising the grouped-bucket
+empty-slice error. Negative `page` or `pageSize` values are still rejected before
+this empty-result shortcut.
+
 ## Sorting
 
 Use the generated `sortBy` enum together with `reverse` for descending order.
@@ -91,6 +101,8 @@ Python-side tests and helper calls use `sort_by`. Buckets validate the requested
 fields; invalid names trigger `ValidationError` with descriptive messages.
 Invalid GraphQL enum values are rejected by Graphene before the resolver runs.
 When `sortBy` is omitted or `null`, sorting is skipped even if `reverse` is true.
+With `groupBy`, sorting runs on grouped manager objects after grouping; without
+`groupBy`, it runs on the individual records.
 
 ## Extending filters
 

--- a/docs/examples/bulk_data_change_notifications.md
+++ b/docs/examples/bulk_data_change_notifications.md
@@ -28,3 +28,32 @@ flushes queued targets even when the body raises, then re-raises the body
 exception. If both the body and notification flush fail, the context raises a
 `BaseExceptionGroup` containing both failures. Ordinary channel-layer send
 errors are logged while other queued targets continue flushing.
+
+To observe the surrounding ORM transaction lifecycle, register a started
+receiver and collect changed classes from the ordinary post-change signal:
+
+```python
+from general_manager.cache.data_change_context import register_data_change_class
+from general_manager.cache.signals import (
+    data_change_transaction_started,
+    post_data_change,
+)
+
+
+def started(sender, transaction_context, **kwargs):
+    transaction_context.metadata["batch"] = begin_coordination()
+
+
+def changed(sender, database_alias, **kwargs):
+    register_data_change_class(sender.__name__, database_alias)
+
+
+data_change_transaction_started.connect(started, weak=False)
+post_data_change.connect(changed, weak=False)
+```
+
+`data_change_transaction_finished` reports `committed` for GeneralManager's
+own block or savepoint and `rolled_back` for failures. When the caller owns an
+outer transaction, register durable completion work with
+`transaction.on_commit(using=database_alias)`; the lifecycle's `committed`
+outcome alone does not prove that outer transaction committed.

--- a/docs/examples/graphql_queries.md
+++ b/docs/examples/graphql_queries.md
@@ -18,6 +18,29 @@ query ProjectList($page: Int!, $pageSize: Int!) {
 }
 ```
 
+## Sort grouped pages
+
+`sortBy` orders grouped manager objects after `groupBy` and before pagination.
+This keeps descending group order stable across pages:
+
+```graphql
+query ProjectsByStatus {
+  projectList(
+    groupBy: ["status"]
+    sortBy: status
+    reverse: true
+    page: 1
+    pageSize: 10
+  ) {
+    items { status }
+    pageInfo { totalCount currentPage totalPages pageSize }
+  }
+}
+```
+
+If the filter produces no groups, the same query shape returns `items: []` and
+page metadata rather than an empty-group slicing error.
+
 ## Nested buckets
 
 ```graphql
@@ -69,6 +92,36 @@ For the Python annotation forms and the generated mutation/subscription
 contracts, see the [GraphQL concept guide](../concepts/graphql/schema_autogen.md#relation-annotation-compatibility),
 the [task guide](../howto/expose_via_graphql.md#declare-manager-relations), and
 the [API reference](../api/graphql.md#relation-annotation-compatibility).
+
+## Subscribe to committed class changes
+
+```graphql
+subscription ProjectChanges {
+  onProjectClassChange {
+    action
+    item { id name }
+  }
+}
+```
+
+Identified class-wide events are checked against the subscribing user's read
+permission in an async-safe worker after commit; unreadable objects are omitted.
+Aggregate `refresh` events have `item: null` and do not disclose a row ID.
+
+## Bound run-scoped cache memory
+
+For a worker that serves long-lived GraphQL requests, configure the optional
+process-local run-cache budget:
+
+```python
+GENERAL_MANAGER = {
+    "RUN_CONTEXT_CACHE_MAX_BYTES": 256 * 1024 * 1024,
+}
+```
+
+The value is an estimated-memory LRU budget shared by live run contexts in that
+worker. Omit it or use `None` for unlimited retention; pending dependency-cache
+publications remain pinned until their lifecycle completes.
 
 ## Filter a calculation by manager input
 

--- a/docs/howto/bulk_data_change_notifications.md
+++ b/docs/howto/bulk_data_change_notifications.md
@@ -75,6 +75,47 @@ Nested notification contexts join the already-active outer batch instead of
 flushing independently. Outside the context, existing row-level notification
 delivery remains commit-bound and rollback-safe.
 
+## Observe the data-change lifecycle
+
+Use the lifecycle signals when an integration needs to coordinate work around
+the outermost ORM mutation, rather than around every nested `pre_data_change`
+or `post_data_change` callback:
+
+```python
+from django.db import transaction
+
+from general_manager.cache.data_change_context import register_data_change_class
+from general_manager.cache.signals import (
+    data_change_transaction_started,
+    post_data_change,
+)
+
+
+def on_transaction_started(sender, transaction_context, database_alias, **kwargs):
+    transaction_context.metadata["consumer"] = begin_coordination()
+    if transaction_context.caller_in_atomic_block:
+        transaction.on_commit(
+            lambda: finish_coordination(transaction_context.metadata["consumer"]),
+            using=database_alias,
+        )
+
+
+def on_manager_changed(sender, database_alias, **kwargs):
+    register_data_change_class(sender.__name__, database_alias)
+
+
+data_change_transaction_started.connect(on_transaction_started, weak=False)
+post_data_change.connect(on_manager_changed, weak=False)
+```
+
+`data_change_transaction_finished` reports `committed` when GeneralManager's
+own block or savepoint exits successfully and `rolled_back` otherwise. If the
+caller already owns the outer transaction, `committed` is not the durable
+commit; use `transaction.on_commit(using=database_alias)` as shown. Nested
+same-alias mutations share one lifecycle context, and
+`transaction_context.changed_classes` deduplicates the classes registered by
+the post-change receiver.
+
 For the full callable signature and exception contract, see the
 [GraphQL API reference](../api/graphql.md#bulk-notification-context). The
 [cookbook recipe](../examples/bulk_data_change_notifications.md) is a compact

--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -100,6 +100,27 @@ read-only after class definition. `GraphQLPropertyReturnAnnotationError`,
 from `general_manager.api`. `GraphQLProperty` itself remains an implementation
 descriptor unless it appears in the public API registry.
 
+### Bound long-lived run caches
+
+Run-scoped values are unlimited by default. For long-lived or concurrent
+requests, set a process-local estimated-memory budget shared by live
+`CalculationRunContext` instances:
+
+```python
+GENERAL_MANAGER = {
+    "RUN_CONTEXT_CACHE_MAX_BYTES": 256 * 1024 * 1024,
+}
+```
+
+`None` or an omitted setting keeps unlimited retention; `0` retains no
+eviction-safe entries; and a positive integer enables least-recently-used
+eviction across the worker's live run contexts. Negative integers, booleans,
+and other non-integer values raise `django.core.exceptions.ImproperlyConfigured`
+when a run context is created. Pending dependency-cache publications remain
+pinned until they are flushed or discarded. The estimate is taken at insertion
+time, so this setting is a cache-retention guardrail rather than a hard process
+RSS limit. Give each worker process its own capacity allowance.
+
 ## Step 3: Verify invalidation
 
 For dependency-aware properties, update a derivative that contributes to the summary. The dependency tracker captures the relationship and invalidates the cache entry automatically.

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -198,7 +198,20 @@ Invalid `sortBy` enum values are rejected by Graphene; invalid filter, grouping,
 or slicing values propagate the corresponding bucket or resolver error. When
 grouping is active, pagination slices grouped manager objects rather than the
 original ungrouped rows, and the GraphQL `items` field still uses the manager's
-generated item type.
+generated item type. If no rows match, a paginated grouped query returns an
+empty `items` list with `totalCount: 0`; negative `page` or `pageSize` values
+still raise the normal input error.
+
+## Class-wide subscription permission checks
+
+Class-wide subscriptions receive committed row-level events for any instance of
+the manager class. Before an identified event is yielded, GeneralManager
+rehydrates the manager and checks object-level read permission in an
+`asyncio.to_thread` worker using the user captured when the subscription starts.
+An unreadable or no-longer-existing object is suppressed, while an unexpected
+permission exception propagates through the subscription error path. Aggregate
+`refresh` events have no identification and yield `item = null` without this
+object-level check.
 
 ## Expose authorization hints
 


### PR DESCRIPTION
## Summary

Reviewed the complete diffs for all 49 commits reachable from `origin/main` and timestamped in the rolling window `2026-08-12T04:01:02Z` through `2026-08-13T04:01:02Z`. The reviewed `origin/main` tip was `c2ff589e3a59eaf2603e991aee3ab7b9d2cb531f`.

This documentation-only change brings the public API documentation into parity across concept, how-to, cookbook, and API-reference forms.

## Reviewed commits

```text
c2ff589e3a59eaf2603e991aee3ab7b9d2cb531f  0.69.0
6e3445572d8f5c67d277146dcd3b402b199242f6  fix(cache): address lifecycle review feedback
915e9e6b8f452b6a3c9fa45e648fb27c2449114b  test(cache): cover data-change lifecycle attribution
e35eca5b63ae15ecfaf67737a0d235c2dc0ce708  docs(cache): correct cross-alias lifecycle registration
b0e1aa46fe0670b5587218de38dd8f54e43c6af7  docs(cache): describe transaction lifecycle hooks
9954649493161e69d473eed4dd2c5b92f0064816  feat(observability): attribute mutation phase latency
4b92f97cd3712bf469bc1b0db28703e7243377b8  feat(cache): emit data-change transaction lifecycle
bbaae49dda73b656d56b29f5d31a0200168fe72a  fix(cache): freeze data-change transaction identity
0c3512b949ed985c608efeb0f58669d598ccb32f  feat(cache): expose data-change transaction context
01bf200e1af8a0de385a82e29b93b411a546581f  0.68.3
79fef14ca3c6f7ce37793512fd1e9c7f9903eca6  test: cover empty grouped page size validation
e436860ec001ac132183e5836ecc8e4a73d0fd1c  fix: preserve empty grouped GraphQL pages
74c69fc5bbb1797ce8d3e56170382beeaac405c8  docs: design empty grouped pagination fix
a7bf90c457b02c0456b4a1be0b9340401abf9c27  0.68.2
110f622cf7341cc3a0207bc7828e4c9556c5818d  test: bound subscription permission wait
b23428a56da4f627dd112b3808da74bca96dcd05  test: harden async subscription permission coverage
00b6edec7a421ba66842a227a2abb0a64ac84a25  fix: propagate subscription permission failures
0054d4541b5ec80bb8df05823745d140636abd98  fix: run subscription permissions off event loop
1c5cbee3f570f0817041fa1b235679484f5f0404  test: reproduce async subscription permission failure
e0962e87da83ec7812ba539093a7806d773751a8  docs: design async-safe subscription permissions
27c97f5fa665bb82dd0c07d2ba2897ce41434ed3  0.68.1
2aadce09d3d3b8e2e42ca973cbb0921702af054f  docs: fix graphql sort enum examples
34c471676a04321870b95665362487699c0de089  fix: preserve grouped sort order when paginating
9f8d286c510c12402f605c0f794f7332eaaaaae6  fix: sort graphql lists after grouping
90218d678bb50a9197de72a05ab0e0e5683dffd9  refactor: extract graphql list sorting helper
3f162821a4e35d5d6acaf662969e982a73b5bd22  0.68.0
94213a70b63b6f755a2dac8bd311084d788d25c9  fix: address run-context cache review
ee956e868c9ba208a2161f86de67345cc0c3ffd6  fix: enumerate native slot storage directly
0f9b9c522dc2b33eb86bdea1ebd38f25255fcd04  fix: make private slot provenance unambiguous
12baf3ecbebb71b6188b2ec688e43c1410ec24bf  fix: preserve private slot descriptor provenance
d827dd3b574b8fe778fd19237dde3106c104c35f  fix: harden cache estimator metadata safety
ef4057a173af23c50c1bd34bb216baf0c9baed59  fix: harden run-context cache budgeting
b1eaf46c17f7cbd1a860b0eb50902109cc29e022  docs: explain run-context memory budget
d0236d000a3c623802ec8b5f5f835a9af764e602  test: cover first lease release failures
3a1b7f22ec6fe6b2e5f3f2f6307e0d6b62c3f734  test: cover run-cache hit lifecycle failures
c2d1de80dafb1ab32d6efc16b154fdfae55a7131  feat: account for run-cache hits and mutable indexes
a366e684a388c0486b35cf7b73d4dd4d2d97cb8f  feat: bound calculation run values
f5151964d967df4501eac88833e833e1e33a3ac2  fix: admit same-limit run-cache owners
93d94de6788ecdbc1b590405e5b2efe63aaffc8a  fix: account prepopulated run-cache owners
c01f1ae4ed990c8cd2fcf62e563f8ff8bd3f857d  fix: preserve run-cache budget coordination
50f66873344be0284dfbfb8b383144fdc10b67da  feat: coordinate process-wide run-cache eviction
dcee0b6f9d9e31c83dca8d98cfe8cd30ff10272f  fix: isolate hostile slot metadata
6da6fcc0fc7a912a1dbf31831e6919eece1c90b5  fix: harden run-context size estimation
b3783b666715e8f6461e942e4b32ee3648464056  feat: estimate run-context cache memory
3bfbe806819ec0f2f05c6eed55216be64453f98b  docs: correct run-cache mutation test plan
8d8de76dec1447e05707828ce0fe1ed47b7076cf  docs: plan run-context cache memory budget
3c3a2c990aad733b79fa635c7cbbebcd9ed3ddaf  docs: design run-context cache memory budget
1a558077466ef9257f52bd5a47cb6763929ce71c  docs: clarify transaction callback scopes
b77b8664be3048f76c8e532f5f9ebde54d74d6d5  docs: document commit-safe websocket delivery
```

## Affected public APIs and behavior

- `GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"]` and the run-context cache: documented None/unlimited, zero, positive LRU budgets, invalid values, pinned pending publications, insertion-time estimates, and process-local scope.
- GraphQL grouped list `groupBy`/`sortBy`/pagination behavior: documented post-group sorting, stable page order, empty grouped pages, and `totalPages: 0` for an explicitly positive page size.
- Class-wide GraphQL subscription permission checks: documented the captured subscription user, worker-thread permission evaluation, suppression of unreadable/missing rows, propagation of unexpected permission failures, and refresh behavior.
- Data-change lifecycle API: documented `data_change_transaction_started`, `data_change_transaction_finishing`, `data_change_transaction_finished`, `DataChangeTransactionContext`, `DataChangeTransactionScope`, `current_data_change_transaction`, `register_data_change_class`, and `record_data_change_phase`, including nested-alias, outcome, and phase-accounting semantics.

## Documentation changed

- `docs/api/cache.md`
- `docs/api/graphql.md`
- `docs/concepts/graphql/filters_pagination.md`
- `docs/examples/bulk_data_change_notifications.md`
- `docs/examples/graphql_queries.md`
- `docs/howto/bulk_data_change_notifications.md`
- `docs/howto/cache_dependent_calculation.md`
- `docs/howto/expose_via_graphql.md`

No navigation changes were needed; all edited pages were already in the configured navigation.

## Validation

- `git diff --check` and commit-time hooks passed.
- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py tests/integration/test_request_docs_examples.py -q` — 7 passed.
- Grouped pagination integration checks — 2 passed, 11 deselected.
- GraphQL subscription unit suite — 82 passed.
- Run-context, data-change-context, and signal unit suites — 90 passed.
- Embedded example parsing — 26 Python blocks and 17 GraphQL blocks parsed.
- `python -m mkdocs build --strict` — passed; only pre-existing unnav notices were reported.

## Open PR overlap check

Inspected open PRs immediately before creating this PR. Existing PR #448 covers a separate preferred-item-ordering cookbook recipe and does not overlap these APIs or files.

## Limitations

This PR changes documentation only. The full test suite was not rerun; Ruff and mypy were skipped by pre-commit because no Python files changed.