### PR TITLE
perf: reduce capped run-context overhead

### DIFF
--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -513,14 +513,27 @@ a positive integer sets the shared byte budget. Negative integers, booleans,
 and non-integer values raise a Django configuration error when a
 `CalculationRunContext` is created.
 
-The budget uses an insertion-time estimate and evicts the least-recently-used
-eviction-safe entry across live contexts when necessary. Values whose estimate
+The budget uses an insertion-time estimate and evicts approximately
+least-recently-used eviction-safe entries across live contexts when necessary.
+Successful reads update recency in small internal batches to avoid a
+process-wide lock on every cache hit. A write flushes recency already observed
+by that same context before admission, while another context may observe up to
+one internal batch of stale recency. This batching changes only which safe
+entry is selected under pressure; misses, reloads, publication pinning, and the
+configured byte budget retain their existing behavior. Values whose estimate
 exceeds the complete budget are returned to the caller but bypass retention.
 Pending dependency-cache publications, and their same-run hits, remain pinned
 until a flush attempt removes the pending entries or publication state is
 discarded. Flush attempts unpin after success, guarded abort, unexpected publish
 failure, or lease-release failure, so eviction never loses a pending publication
 or its compute lease.
+
+Small built-in containers are traversed completely. Large built-in containers
+use a bounded representative sample whose projected child size includes a 5%
+upward safety margin. This keeps admission cost bounded for large ORM results
+and indexes. The estimate targets approximately 5% accuracy for representative
+payloads, but unusual heterogeneous or heavily shared object graphs can differ
+by more; this remains an estimated cache budget rather than a hard RSS limit.
 
 This setting is not a hard cap on total process RSS. In particular, Python and
 native allocation overhead, other application memory, and caller-owned mutable

--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -515,25 +515,29 @@ and non-integer values raise a Django configuration error when a
 
 The budget uses an insertion-time estimate and evicts approximately
 least-recently-used eviction-safe entries across live contexts when necessary.
-Successful reads update recency in small internal batches to avoid a
-process-wide lock on every cache hit. A write flushes recency already observed
-by that same context before admission, while another context may observe up to
-one internal batch of stale recency. This batching changes only which safe
-entry is selected under pressure; misses, reloads, publication pinning, and the
-configured byte budget retain their existing behavior. Values whose estimate
-exceeds the complete budget are returned to the caller but bypass retention.
+Successful reads from the thread that entered the context update recency in
+small internal batches to avoid a process-wide lock on every cache hit. Reads
+from another thread update recency immediately. A write flushes recency already
+observed by that same context before admission, while another context may
+observe up to one internal batch of stale recency. This batching changes only
+which safe entry is selected under pressure; misses, reloads, publication
+pinning, and the configured byte budget retain their existing behavior. Values
+whose estimate exceeds the complete budget are returned to the caller but
+bypass retention.
 Pending dependency-cache publications, and their same-run hits, remain pinned
 until a flush attempt removes the pending entries or publication state is
 discarded. Flush attempts unpin after success, guarded abort, unexpected publish
 failure, or lease-release failure, so eviction never loses a pending publication
 or its compute lease.
 
-Small built-in containers are traversed completely. Large built-in containers
-use a bounded representative sample whose projected child size includes a 5%
-upward safety margin. This keeps admission cost bounded for large ORM results
-and indexes. The estimate targets approximately 5% accuracy for representative
-payloads, but unusual heterogeneous or heavily shared object graphs can differ
-by more; this remains an estimated cache budget rather than a hard RSS limit.
+Built-in containers at or below `RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD` (128) are
+traversed completely. Larger built-in containers use
+`RUN_CONTEXT_SIZE_SAMPLE_COUNT` (64) representatives whose projected child size
+includes a 5% upward safety margin. This keeps admission cost bounded for large
+ORM results and indexes. The estimate targets approximately 5% accuracy for
+representative payloads, but unusual heterogeneous or heavily shared object
+graphs can differ by more; this remains an estimated cache budget rather than a
+hard RSS limit.
 
 This setting is not a hard cap on total process RSS. In particular, Python and
 native allocation overhead, other application memory, and caller-owned mutable

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -247,12 +247,12 @@ active.
 For long-lived or concurrent runs, applications can configure the optional
 `GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"]` setting to give eviction-safe
 run-cache entries a process-local estimated-memory budget. Enabling the cap
-adds bounded sampled estimation and approximate-LRU bookkeeping, while
-primitive sizing, large-container sampling, and batched recency avoid work
-proportional to the complete object graph on every insertion or global
-coordination on every hit. Plan fleet capacity by multiplying that value by the
-number of worker processes: each Gunicorn, Celery, or other Python worker has
-its own budget. The estimate is taken when a value is inserted, so caller-owned
+adds bounded sampled estimation and approximate-LRU bookkeeping. Primitive
+sizing, large-container sampling, and batched recency avoid work proportional
+to the complete object graph on every insertion or global coordination on every
+hit. Plan fleet capacity by multiplying that value by the number of worker
+processes: each Gunicorn, Celery, or other Python worker has its own budget. The
+estimate is taken when a value is inserted, so caller-owned
 mutable values can later grow beyond their recorded size. This is not a hard
 worker-memory or RSS limit; applications that need a hard worker ceiling should
 also configure deployment-level memory limits and worker recycling.

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -246,13 +246,16 @@ active.
 
 For long-lived or concurrent runs, applications can configure the optional
 `GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"]` setting to give eviction-safe
-run-cache entries a process-local, least-recently-used estimated-memory budget.
-Plan fleet capacity by multiplying that value by the number of worker
-processes: each Gunicorn, Celery, or other Python worker has its own budget.
-The estimate is taken when a value is inserted, so caller-owned mutable values
-can later grow beyond their recorded size. This is not a hard worker-memory or
-RSS limit; applications that need a hard worker ceiling should also configure
-deployment-level memory limits and worker recycling.
+run-cache entries a process-local estimated-memory budget. Enabling the cap
+adds bounded sampled estimation and approximate-LRU bookkeeping, while
+primitive sizing, large-container sampling, and batched recency avoid work
+proportional to the complete object graph on every insertion or global
+coordination on every hit. Plan fleet capacity by multiplying that value by the
+number of worker processes: each Gunicorn, Celery, or other Python worker has
+its own budget. The estimate is taken when a value is inserted, so caller-owned
+mutable values can later grow beyond their recorded size. This is not a hard
+worker-memory or RSS limit; applications that need a hard worker ceiling should
+also configure deployment-level memory limits and worker recycling.
 
 Callable `Input.possible_values` providers are also cached automatically inside
 an active `CalculationRunContext` when the caller can identify the owning manager

--- a/scripts/benchmark_run_context_cache_budget.py
+++ b/scripts/benchmark_run_context_cache_budget.py
@@ -1,0 +1,148 @@
+"""Benchmark run-context cache budget accounting overhead."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+from pathlib import Path
+from statistics import median
+import sys
+from time import perf_counter
+from typing import Callable
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_settings")
+
+import django
+from django.test import override_settings
+
+from general_manager.cache.run_context import CalculationRunContext
+
+DEFAULT_CAP_BYTES = 1024 * 1024 * 1024
+POSITIVE_INTEGER_ERROR_MESSAGE = "must be a positive integer"
+
+
+def positive_integer(value: str) -> int:
+    """Parse an integer command-line value greater than zero."""
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(POSITIVE_INTEGER_ERROR_MESSAGE) from error
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(POSITIVE_INTEGER_ERROR_MESSAGE)
+    return parsed
+
+
+def measure(callback: Callable[[], None], repeats: int) -> float:
+    """Return the median runtime in seconds for repeated callback runs."""
+    samples: list[float] = []
+    for _ in range(repeats):
+        gc.collect()
+        gc.disable()
+        started = perf_counter()
+        try:
+            callback()
+        finally:
+            samples.append(perf_counter() - started)
+            gc.enable()
+    return median(samples)
+
+
+def run_hits(*, cap_bytes: int | None, count: int) -> None:
+    """Exercise hot-key run-context cache hits."""
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": cap_bytes}),
+        CalculationRunContext() as context,
+    ):
+        context.set("hot-key", 1)
+        for _ in range(count):
+            context.get("hot-key")
+
+
+def run_scalar_inserts(*, cap_bytes: int | None, count: int) -> None:
+    """Exercise scalar run-context cache inserts."""
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": cap_bytes}),
+        CalculationRunContext() as context,
+    ):
+        for value in range(count):
+            context.set(value, value)
+
+
+def run_container_inserts(
+    *,
+    cap_bytes: int | None,
+    payloads: tuple[list[int], ...],
+) -> None:
+    """Exercise run-context cache inserts of prebuilt container payloads."""
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": cap_bytes}),
+        CalculationRunContext() as context,
+    ):
+        for key, payload in enumerate(payloads):
+            context.set(key, payload)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse benchmark workload sizes."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repeats", type=positive_integer, default=5)
+    parser.add_argument("--hits", type=positive_integer, default=300_000)
+    parser.add_argument("--scalar-inserts", type=positive_integer, default=20_000)
+    parser.add_argument("--container-inserts", type=positive_integer, default=200)
+    parser.add_argument("--container-width", type=positive_integer, default=2_000)
+    return parser.parse_args()
+
+
+def print_result(name: str, uncapped: float, capped: float) -> None:
+    """Print one stable benchmark result row."""
+    print(f"{name:<20}{uncapped:>12.6f}{capped:>12.6f}{capped / uncapped:>10.2f}x")
+
+
+def main() -> None:
+    """Run each workload with uncapped and capped run-context caches."""
+    args = parse_args()
+    django.setup()
+    payloads = tuple(
+        list(range(args.container_width)) for _ in range(args.container_inserts)
+    )
+
+    print(f"{'workload':<20}{'uncapped_s':>12}{'capped_s':>12}{'ratio':>11}")
+
+    uncapped = measure(lambda: run_hits(cap_bytes=None, count=args.hits), args.repeats)
+    capped = measure(
+        lambda: run_hits(cap_bytes=DEFAULT_CAP_BYTES, count=args.hits), args.repeats
+    )
+    print_result("hits", uncapped, capped)
+
+    uncapped = measure(
+        lambda: run_scalar_inserts(cap_bytes=None, count=args.scalar_inserts),
+        args.repeats,
+    )
+    capped = measure(
+        lambda: run_scalar_inserts(
+            cap_bytes=DEFAULT_CAP_BYTES,
+            count=args.scalar_inserts,
+        ),
+        args.repeats,
+    )
+    print_result("scalar_inserts", uncapped, capped)
+
+    uncapped = measure(
+        lambda: run_container_inserts(cap_bytes=None, payloads=payloads),
+        args.repeats,
+    )
+    capped = measure(
+        lambda: run_container_inserts(
+            cap_bytes=DEFAULT_CAP_BYTES,
+            payloads=payloads,
+        ),
+        args.repeats,
+    )
+    print_result("container_inserts", uncapped, capped)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Callable, Hashable, Iterable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
-from threading import get_ident
+from threading import RLock, get_ident
 from types import TracebackType
 from typing import TYPE_CHECKING, Optional, TypeVar, cast
 
@@ -107,6 +107,7 @@ class CalculationRunContext:
         ] = {}
         self._dependency_cache_publish_batch_size = dependency_cache_publish_batch_size
         self._tokens: list[Token[CalculationRunContext | None]] = []
+        self._run_cache_touch_lock = RLock()
         self._pending_run_cache_touches: dict[PendingRunCacheTouch, None] = {}
         self._last_pending_run_cache_touch: PendingRunCacheTouch | None = None
         self._run_cache_touch_count = 0
@@ -129,12 +130,13 @@ class CalculationRunContext:
                 yield "dependency_hits", key, hit
 
     def _set_run_cache_budget_enabled(self, enabled: bool) -> None:
-        """Refresh the lock-free owner hint after a coordinator transition."""
-        self._run_cache_budget_enabled = enabled
-        if not enabled:
-            self._pending_run_cache_touches.clear()
-            self._last_pending_run_cache_touch = None
-            self._run_cache_touch_count = 0
+        """Refresh the owner hint after a coordinator transition."""
+        with self._run_cache_touch_lock:
+            self._run_cache_budget_enabled = enabled
+            if not enabled:
+                self._pending_run_cache_touches.clear()
+                self._last_pending_run_cache_touch = None
+                self._run_cache_touch_count = 0
 
     def _evict_run_cache_entry(
         self,
@@ -205,50 +207,75 @@ class CalculationRunContext:
         namespace: RunCacheNamespace,
         key: Hashable,
     ) -> None:
-        if not self._run_cache_budget_enabled:
-            return
         pending_key = (namespace, key)
-        if pending_key != self._last_pending_run_cache_touch:
-            self._pending_run_cache_touches.pop(pending_key, None)
-            self._pending_run_cache_touches[pending_key] = None
-            self._last_pending_run_cache_touch = pending_key
+        with self._run_cache_touch_lock:
+            if not self._run_cache_budget_enabled:
+                return
+            if pending_key != self._last_pending_run_cache_touch:
+                self._pending_run_cache_touches.pop(pending_key, None)
+                self._pending_run_cache_touches[pending_key] = None
+                self._last_pending_run_cache_touch = pending_key
         self._queue_repeated_run_cache_touch(pending_key)
 
     def _queue_repeated_run_cache_touch(
         self,
         pending_key: PendingRunCacheTouch,
     ) -> bool:
-        if not self._run_cache_budget_enabled:
-            return False
-        if self._run_cache_touch_thread_id != get_ident():
+        touch_immediately = False
+        touches_to_flush: tuple[PendingRunCacheTouch, ...] = ()
+        with self._run_cache_touch_lock:
+            if not self._run_cache_budget_enabled:
+                return False
+            if self._run_cache_touch_thread_id != get_ident():
+                touch_immediately = True
+            elif pending_key != self._last_pending_run_cache_touch:
+                return False
+            else:
+                count = self._run_cache_touch_count + 1
+                if count < RUN_CONTEXT_TOUCH_BATCH_SIZE:
+                    self._run_cache_touch_count = count
+                    return True
+                touches_to_flush = self._take_run_cache_touches_locked()
+        if touch_immediately:
             run_context_cache_budget.touch(self, *pending_key)
             return True
-        if pending_key != self._last_pending_run_cache_touch:
-            return False
-        count = self._run_cache_touch_count + 1
-        if count < RUN_CONTEXT_TOUCH_BATCH_SIZE:
-            self._run_cache_touch_count = count
-            return True
-        self._flush_run_cache_touches()
+        run_context_cache_budget.touch_many(self, touches_to_flush)
         return True
 
-    def _discard_run_cache_touch(self, pending_key: PendingRunCacheTouch) -> None:
-        self._pending_run_cache_touches.pop(pending_key, None)
-        if pending_key == self._last_pending_run_cache_touch:
-            self._last_pending_run_cache_touch = next(
-                reversed(self._pending_run_cache_touches),
-                None,
-            )
+    def _touch_run_cache_entry(
+        self,
+        namespace: RunCacheNamespace,
+        key: Hashable,
+    ) -> None:
+        pending_key: PendingRunCacheTouch = (namespace, key)
+        if not self._queue_repeated_run_cache_touch(pending_key):
+            self._queue_run_cache_touch(namespace, key)
 
-    def _flush_run_cache_touches(self) -> None:
-        if not self._pending_run_cache_touches:
-            self._last_pending_run_cache_touch = None
-            self._run_cache_touch_count = 0
-            return
+    def _discard_run_cache_touch(self, pending_key: PendingRunCacheTouch) -> None:
+        with self._run_cache_touch_lock:
+            self._pending_run_cache_touches.pop(pending_key, None)
+            if pending_key == self._last_pending_run_cache_touch:
+                self._last_pending_run_cache_touch = next(
+                    reversed(self._pending_run_cache_touches),
+                    None,
+                )
+
+    def _take_run_cache_touches_locked(
+        self,
+    ) -> tuple[PendingRunCacheTouch, ...]:
         touches = tuple(self._pending_run_cache_touches)
         self._pending_run_cache_touches.clear()
         self._last_pending_run_cache_touch = None
         self._run_cache_touch_count = 0
+        return touches
+
+    def _flush_run_cache_touches(self) -> None:
+        with self._run_cache_touch_lock:
+            if not self._pending_run_cache_touches:
+                self._last_pending_run_cache_touch = None
+                self._run_cache_touch_count = 0
+                return
+            touches = self._take_run_cache_touches_locked()
         run_context_cache_budget.touch_many(self, touches)
 
     @staticmethod
@@ -262,12 +289,13 @@ class CalculationRunContext:
     def __enter__(self) -> "CalculationRunContext":
         """Activate this context and return it for the `with` block."""
         if not self._tokens:
-            self._pending_run_cache_touches.clear()
-            self._last_pending_run_cache_touch = None
-            self._run_cache_touch_count = 0
-            self._run_cache_touch_thread_id = get_ident()
             max_bytes = resolve_run_context_cache_max_bytes()
-            self._run_cache_budget_enabled = max_bytes is not None
+            with self._run_cache_touch_lock:
+                self._pending_run_cache_touches.clear()
+                self._last_pending_run_cache_touch = None
+                self._run_cache_touch_count = 0
+                self._run_cache_touch_thread_id = get_ident()
+                self._run_cache_budget_enabled = max_bytes is not None
             run_context_cache_budget.register(
                 self,
                 max_bytes,
@@ -306,10 +334,11 @@ class CalculationRunContext:
         token = self._tokens.pop()
         is_outermost_exit = not self._tokens
         if is_outermost_exit:
-            self._pending_run_cache_touches.clear()
-            self._last_pending_run_cache_touch = None
-            self._run_cache_touch_count = 0
-            self._run_cache_touch_thread_id = None
+            with self._run_cache_touch_lock:
+                self._pending_run_cache_touches.clear()
+                self._last_pending_run_cache_touch = None
+                self._run_cache_touch_count = 0
+                self._run_cache_touch_thread_id = None
         try:
             if is_outermost_exit:
                 if exc_type is None:
@@ -344,9 +373,7 @@ class CalculationRunContext:
             value = loader()
             self._store_run_value(scoped_key, value)
             return value
-        pending_key: PendingRunCacheTouch = ("values", scoped_key)
-        if not self._queue_repeated_run_cache_touch(pending_key):
-            self._queue_run_cache_touch("values", scoped_key)
+        self._touch_run_cache_entry("values", scoped_key)
         return cast(T, value)
 
     def get(self, key: Hashable, default: object = None) -> object:
@@ -356,9 +383,7 @@ class CalculationRunContext:
             value = self._values[scoped_key]
         except KeyError:
             return default
-        pending_key: PendingRunCacheTouch = ("values", scoped_key)
-        if not self._queue_repeated_run_cache_touch(pending_key):
-            self._queue_run_cache_touch("values", scoped_key)
+        self._touch_run_cache_entry("values", scoped_key)
         return value
 
     def set(self, key: Hashable, value: object) -> None:
@@ -390,9 +415,7 @@ class CalculationRunContext:
         except KeyError:
             return default
         if key not in self._dependency_cache_pending_publications:
-            pending_key: PendingRunCacheTouch = ("dependency_hits", key)
-            if not self._queue_repeated_run_cache_touch(pending_key):
-                self._queue_run_cache_touch("dependency_hits", key)
+            self._touch_run_cache_entry("dependency_hits", key)
         return hit
 
     def buffer_dependency_cache_publication(
@@ -815,9 +838,7 @@ class CalculationRunContext:
         scoped_key = self._scoped_key(key)
         if scoped_key not in self._values:
             return False
-        pending_key: PendingRunCacheTouch = ("values", scoped_key)
-        if not self._queue_repeated_run_cache_touch(pending_key):
-            self._queue_run_cache_touch("values", scoped_key)
+        self._touch_run_cache_entry("values", scoped_key)
         return True
 
     def __contains__(self, key: Hashable) -> bool:

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Callable, Hashable, Iterable, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
+from threading import get_ident
 from types import TracebackType
 from typing import TYPE_CHECKING, Optional, TypeVar, cast
 
@@ -109,6 +110,7 @@ class CalculationRunContext:
         self._pending_run_cache_touches: dict[PendingRunCacheTouch, None] = {}
         self._last_pending_run_cache_touch: PendingRunCacheTouch | None = None
         self._run_cache_touch_count = 0
+        self._run_cache_touch_thread_id: int | None = None
         max_bytes = resolve_run_context_cache_max_bytes()
         self._run_cache_budget_enabled = max_bytes is not None
         run_context_cache_budget.register(
@@ -125,6 +127,14 @@ class CalculationRunContext:
         for key, hit in self._dependency_cache_hits.items():
             if key not in self._dependency_cache_pending_publications:
                 yield "dependency_hits", key, hit
+
+    def _set_run_cache_budget_enabled(self, enabled: bool) -> None:
+        """Refresh the lock-free owner hint after a coordinator transition."""
+        self._run_cache_budget_enabled = enabled
+        if not enabled:
+            self._pending_run_cache_touches.clear()
+            self._last_pending_run_cache_touch = None
+            self._run_cache_touch_count = 0
 
     def _evict_run_cache_entry(
         self,
@@ -208,10 +218,12 @@ class CalculationRunContext:
         self,
         pending_key: PendingRunCacheTouch,
     ) -> bool:
-        if (
-            not self._run_cache_budget_enabled
-            or pending_key != self._last_pending_run_cache_touch
-        ):
+        if not self._run_cache_budget_enabled:
+            return False
+        if self._run_cache_touch_thread_id != get_ident():
+            run_context_cache_budget.touch(self, *pending_key)
+            return True
+        if pending_key != self._last_pending_run_cache_touch:
             return False
         count = self._run_cache_touch_count + 1
         if count < RUN_CONTEXT_TOUCH_BATCH_SIZE:
@@ -253,6 +265,7 @@ class CalculationRunContext:
             self._pending_run_cache_touches.clear()
             self._last_pending_run_cache_touch = None
             self._run_cache_touch_count = 0
+            self._run_cache_touch_thread_id = get_ident()
             max_bytes = resolve_run_context_cache_max_bytes()
             self._run_cache_budget_enabled = max_bytes is not None
             run_context_cache_budget.register(
@@ -296,6 +309,7 @@ class CalculationRunContext:
             self._pending_run_cache_touches.clear()
             self._last_pending_run_cache_touch = None
             self._run_cache_touch_count = 0
+            self._run_cache_touch_thread_id = None
         try:
             if is_outermost_exit:
                 if exc_type is None:

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -43,8 +43,10 @@ ORM_BUCKET_EXISTS_PREFIX = "orm_bucket_exists"
 BUCKET_INDEX_PREFIX = "bucket_index"
 TRUSTED_ORM_MANAGER_PREFIX = "trusted_orm_manager"
 DEFAULT_DEPENDENCY_CACHE_PUBLISH_BATCH_SIZE = 1000
+RUN_CONTEXT_TOUCH_BATCH_SIZE = 64
 logger = get_logger("cache.run_context")
 OrmModelRowKey = tuple[Hashable, Hashable | None]
+PendingRunCacheTouch = tuple[RunCacheNamespace, Hashable]
 
 
 @dataclass(frozen=True)
@@ -104,9 +106,14 @@ class CalculationRunContext:
         ] = {}
         self._dependency_cache_publish_batch_size = dependency_cache_publish_batch_size
         self._tokens: list[Token[CalculationRunContext | None]] = []
+        self._pending_run_cache_touches: dict[PendingRunCacheTouch, None] = {}
+        self._last_pending_run_cache_touch: PendingRunCacheTouch | None = None
+        self._run_cache_touch_count = 0
+        max_bytes = resolve_run_context_cache_max_bytes()
+        self._run_cache_budget_enabled = max_bytes is not None
         run_context_cache_budget.register(
             self,
-            resolve_run_context_cache_max_bytes(),
+            max_bytes,
         )
 
     def _iter_run_cache_entries(
@@ -125,25 +132,30 @@ class CalculationRunContext:
         key: Hashable,
     ) -> None:
         """Remove one entry selected by the process-wide coordinator."""
+        self._discard_run_cache_touch((namespace, key))
         if namespace == "values":
             self._values.pop(key, None)
         elif key not in self._dependency_cache_pending_publications:
             self._dependency_cache_hits.pop(cast(str, key), None)
 
     def _store_run_value(self, scoped_key: Hashable, value: object) -> None:
+        self._flush_run_cache_touches()
         self._values[scoped_key] = value
         run_context_cache_budget.track(self, "values", scoped_key, value)
 
     def _remove_run_value(self, scoped_key: Hashable) -> None:
+        self._discard_run_cache_touch(("values", scoped_key))
         if scoped_key in self._values:
             del self._values[scoped_key]
             run_context_cache_budget.remove(self, "values", scoped_key)
 
     def _refresh_run_value(self, scoped_key: Hashable) -> None:
+        self._discard_run_cache_touch(("values", scoped_key))
         try:
             value = self._values[scoped_key]
         except KeyError:
             return
+        self._flush_run_cache_touches()
         run_context_cache_budget.refresh(self, "values", scoped_key, value)
 
     def _store_dependency_cache_hit(
@@ -151,25 +163,81 @@ class CalculationRunContext:
         key: str,
         hit: DependencyCacheHit,
     ) -> None:
+        is_pending_publication = key in self._dependency_cache_pending_publications
+        if not is_pending_publication:
+            self._flush_run_cache_touches()
         self._dependency_cache_hits[key] = hit
-        if key in self._dependency_cache_pending_publications:
+        if is_pending_publication:
+            self._discard_run_cache_touch(("dependency_hits", key))
             run_context_cache_budget.remove(self, "dependency_hits", key)
         else:
             run_context_cache_budget.track(self, "dependency_hits", key, hit)
 
     def _remove_dependency_cache_hit(self, key: str) -> None:
+        self._discard_run_cache_touch(("dependency_hits", key))
         if key in self._dependency_cache_hits:
             del self._dependency_cache_hits[key]
             run_context_cache_budget.remove(self, "dependency_hits", key)
 
     def _refresh_dependency_cache_hit(self, key: str) -> None:
+        self._discard_run_cache_touch(("dependency_hits", key))
         if key in self._dependency_cache_pending_publications:
             return
         try:
             hit = self._dependency_cache_hits[key]
         except KeyError:
             return
+        self._flush_run_cache_touches()
         run_context_cache_budget.refresh(self, "dependency_hits", key, hit)
+
+    def _queue_run_cache_touch(
+        self,
+        namespace: RunCacheNamespace,
+        key: Hashable,
+    ) -> None:
+        if not self._run_cache_budget_enabled:
+            return
+        pending_key = (namespace, key)
+        if pending_key != self._last_pending_run_cache_touch:
+            self._pending_run_cache_touches.pop(pending_key, None)
+            self._pending_run_cache_touches[pending_key] = None
+            self._last_pending_run_cache_touch = pending_key
+        self._queue_repeated_run_cache_touch(pending_key)
+
+    def _queue_repeated_run_cache_touch(
+        self,
+        pending_key: PendingRunCacheTouch,
+    ) -> bool:
+        if (
+            not self._run_cache_budget_enabled
+            or pending_key != self._last_pending_run_cache_touch
+        ):
+            return False
+        count = self._run_cache_touch_count + 1
+        if count < RUN_CONTEXT_TOUCH_BATCH_SIZE:
+            self._run_cache_touch_count = count
+            return True
+        self._flush_run_cache_touches()
+        return True
+
+    def _discard_run_cache_touch(self, pending_key: PendingRunCacheTouch) -> None:
+        self._pending_run_cache_touches.pop(pending_key, None)
+        if pending_key == self._last_pending_run_cache_touch:
+            self._last_pending_run_cache_touch = next(
+                reversed(self._pending_run_cache_touches),
+                None,
+            )
+
+    def _flush_run_cache_touches(self) -> None:
+        if not self._pending_run_cache_touches:
+            self._last_pending_run_cache_touch = None
+            self._run_cache_touch_count = 0
+            return
+        touches = tuple(self._pending_run_cache_touches)
+        self._pending_run_cache_touches.clear()
+        self._last_pending_run_cache_touch = None
+        self._run_cache_touch_count = 0
+        run_context_cache_budget.touch_many(self, touches)
 
     @staticmethod
     def _scoped_key(key: Hashable) -> Hashable:
@@ -182,9 +250,14 @@ class CalculationRunContext:
     def __enter__(self) -> "CalculationRunContext":
         """Activate this context and return it for the `with` block."""
         if not self._tokens:
+            self._pending_run_cache_touches.clear()
+            self._last_pending_run_cache_touch = None
+            self._run_cache_touch_count = 0
+            max_bytes = resolve_run_context_cache_max_bytes()
+            self._run_cache_budget_enabled = max_bytes is not None
             run_context_cache_budget.register(
                 self,
-                resolve_run_context_cache_max_bytes(),
+                max_bytes,
             )
         self._tokens.append(_active_context.set(self))
         return self
@@ -219,6 +292,10 @@ class CalculationRunContext:
 
         token = self._tokens.pop()
         is_outermost_exit = not self._tokens
+        if is_outermost_exit:
+            self._pending_run_cache_touches.clear()
+            self._last_pending_run_cache_touch = None
+            self._run_cache_touch_count = 0
         try:
             if is_outermost_exit:
                 if exc_type is None:
@@ -253,7 +330,9 @@ class CalculationRunContext:
             value = loader()
             self._store_run_value(scoped_key, value)
             return value
-        run_context_cache_budget.touch(self, "values", scoped_key)
+        pending_key: PendingRunCacheTouch = ("values", scoped_key)
+        if not self._queue_repeated_run_cache_touch(pending_key):
+            self._queue_run_cache_touch("values", scoped_key)
         return cast(T, value)
 
     def get(self, key: Hashable, default: object = None) -> object:
@@ -263,7 +342,9 @@ class CalculationRunContext:
             value = self._values[scoped_key]
         except KeyError:
             return default
-        run_context_cache_budget.touch(self, "values", scoped_key)
+        pending_key: PendingRunCacheTouch = ("values", scoped_key)
+        if not self._queue_repeated_run_cache_touch(pending_key):
+            self._queue_run_cache_touch("values", scoped_key)
         return value
 
     def set(self, key: Hashable, value: object) -> None:
@@ -295,7 +376,9 @@ class CalculationRunContext:
         except KeyError:
             return default
         if key not in self._dependency_cache_pending_publications:
-            run_context_cache_budget.touch(self, "dependency_hits", key)
+            pending_key: PendingRunCacheTouch = ("dependency_hits", key)
+            if not self._queue_repeated_run_cache_touch(pending_key):
+                self._queue_run_cache_touch("dependency_hits", key)
         return hit
 
     def buffer_dependency_cache_publication(
@@ -718,7 +801,9 @@ class CalculationRunContext:
         scoped_key = self._scoped_key(key)
         if scoped_key not in self._values:
             return False
-        run_context_cache_budget.touch(self, "values", scoped_key)
+        pending_key: PendingRunCacheTouch = ("values", scoped_key)
+        if not self._queue_repeated_run_cache_touch(pending_key):
+            self._queue_run_cache_touch("values", scoped_key)
         return True
 
     def __contains__(self, key: Hashable) -> bool:

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -32,6 +32,7 @@ MIN_TRACKED_ENTRY_BYTES = 256
 RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD = 128
 RUN_CONTEXT_SIZE_SAMPLE_COUNT = 64
 RUN_CONTEXT_SIZE_SAFETY_MARGIN = Fraction(21, 20)
+RUN_CONTEXT_TRACK_MAX_REESTIMATES = 3
 _INVALID_MAX_BYTES_MESSAGE = (
     'GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"] must be None or a '
     "non-negative integer number of bytes."
@@ -196,6 +197,7 @@ class ProcessRunContextCacheBudget:
             entry_attempt_generation = self._next_admission_generation_locked()
             self._entry_attempt_generations[tracked_key] = entry_attempt_generation
 
+        reestimate_count = 0
         while True:
             try:
                 estimated_bytes = estimate_cache_entry_size(
@@ -224,6 +226,16 @@ class ProcessRunContextCacheBudget:
                 ):
                     return
                 if configuration_generation != self._configuration_generation:
+                    if reestimate_count >= RUN_CONTEXT_TRACK_MAX_REESTIMATES:
+                        self._entry_attempt_generations.pop(tracked_key, None)
+                        self._remove_entry_locked(tracked_key)
+                        owner._evict_run_cache_entry(namespace, key)
+                        logger.debug(
+                            "run cache entry skipped after repeated budget changes",
+                            context={"namespace": namespace},
+                        )
+                        return
+                    reestimate_count += 1
                     max_bytes = self._max_bytes
                     configuration_generation = self._configuration_generation
                     if max_bytes is None:
@@ -574,6 +586,8 @@ def _static_storage_plan(
 def _stratified_indexes(length: int, sample_count: int) -> tuple[int, ...]:
     if sample_count >= length:
         return tuple(range(length))
+    if sample_count == 1:
+        return (0,)
     return tuple(
         (index * (length - 1)) // (sample_count - 1) for index in range(sample_count)
     )

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections import OrderedDict
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass
+from itertools import islice
+import math
 import sys
 from threading import RLock
 from types import (
@@ -26,12 +28,26 @@ from general_manager.logging import get_logger
 
 RUN_CONTEXT_CACHE_MAX_BYTES_SETTING = "RUN_CONTEXT_CACHE_MAX_BYTES"
 MIN_TRACKED_ENTRY_BYTES = 256
+RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD = 128
+RUN_CONTEXT_SIZE_SAMPLE_COUNT = 64
+RUN_CONTEXT_SIZE_SAFETY_MARGIN = 1.05
 _INVALID_MAX_BYTES_MESSAGE = (
     'GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"] must be None or a '
     "non-negative integer number of bytes."
 )
 
 _SHALLOW_LEAF_TYPES = (ModuleType, type, FunctionType, MethodType, CodeType)
+_ATOMIC_LEAF_TYPES = (
+    type(None),
+    bool,
+    int,
+    float,
+    complex,
+    str,
+    bytes,
+    bytearray,
+    range,
+)
 _SIZED_BUILTIN_TYPES = (
     type(None),
     bool,
@@ -77,6 +93,18 @@ class _TrackedEntry:
     namespace: RunCacheNamespace
     key: Hashable
     size: int
+
+
+@dataclass(frozen=True)
+class _StaticStoragePlan:
+    instance_dict_descriptors: tuple[GetSetDescriptorType, ...]
+    slot_descriptors: tuple[MemberDescriptorType, ...]
+
+
+@dataclass(frozen=True)
+class _WeightedCandidate:
+    value: object
+    weight: float
 
 
 class ProcessRunContextCacheBudget:
@@ -367,6 +395,124 @@ def _get_static_class_metadata(
     return tuple(metadata)
 
 
+def _static_storage_plan(
+    candidate_type: type[object],
+) -> _StaticStoragePlan | None:
+    candidate_mro = _get_static_type_mro(candidate_type)
+    if candidate_mro is None:
+        return None
+    if any(
+        base_type is leaf_type
+        for base_type in candidate_mro
+        for leaf_type in _SHALLOW_LEAF_TYPES
+    ):
+        return _StaticStoragePlan((), ())
+    class_metadata = _get_static_class_metadata(candidate_mro)
+    if class_metadata is None:
+        return None
+
+    instance_dict_descriptors: list[GetSetDescriptorType] = []
+    slot_descriptors: list[MemberDescriptorType] = []
+    for cls, class_dict in class_metadata:
+        descriptor = class_dict.get("__dict__")
+        if _is_native_descriptor_for_storage(
+            descriptor, GetSetDescriptorType, cls, "__dict__"
+        ):
+            instance_dict_descriptors.append(cast(GetSetDescriptorType, descriptor))
+        for storage_name, slot_descriptor in class_dict.items():
+            if _is_native_descriptor_for_storage(
+                slot_descriptor, MemberDescriptorType, cls, storage_name
+            ):
+                slot_descriptors.append(cast(MemberDescriptorType, slot_descriptor))
+    return _StaticStoragePlan(tuple(instance_dict_descriptors), tuple(slot_descriptors))
+
+
+def _stratified_indexes(length: int, sample_count: int) -> tuple[int, ...]:
+    if sample_count >= length:
+        return tuple(range(length))
+    return tuple(
+        (index * (length - 1)) // (sample_count - 1) for index in range(sample_count)
+    )
+
+
+def _is_exact_type(
+    candidate_type: type[object], types: tuple[type[object], ...]
+) -> bool:
+    return any(candidate_type is expected_type for expected_type in types)
+
+
+def _sample_container_children(
+    candidate: _WeightedCandidate,
+) -> tuple[_WeightedCandidate, ...]:
+    value = candidate.value
+    value_type = type(value)
+    if _is_exact_type(value_type, (list, tuple)):
+        sequence = cast(list[object] | tuple[object, ...], value)
+        length = len(sequence)
+        if length <= RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD:
+            return tuple(
+                _WeightedCandidate(item, candidate.weight) for item in sequence
+            )
+        sample_indexes = _stratified_indexes(length, RUN_CONTEXT_SIZE_SAMPLE_COUNT)
+        sample_weight = (
+            candidate.weight
+            * length
+            / len(sample_indexes)
+            * RUN_CONTEXT_SIZE_SAFETY_MARGIN
+        )
+        return tuple(
+            _WeightedCandidate(sequence[index], sample_weight)
+            for index in sample_indexes
+        )
+
+    if value_type is dict:
+        mapping = cast(dict[object, object], value)
+        if len(mapping) <= RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD:
+            return tuple(
+                _WeightedCandidate(item, candidate.weight)
+                for entry in mapping.items()
+                for item in entry
+            )
+        first_entries = tuple(
+            islice(mapping.items(), RUN_CONTEXT_SIZE_SAMPLE_COUNT // 2)
+        )
+        last_entries = tuple(
+            islice(reversed(mapping.items()), RUN_CONTEXT_SIZE_SAMPLE_COUNT // 2)
+        )
+        sample_entries: list[tuple[object, object]] = []
+        for item_key, item_value in (*first_entries, *last_entries):
+            if all(item_key is not existing_key for existing_key, _ in sample_entries):
+                sample_entries.append((item_key, item_value))
+        sample_weight = (
+            candidate.weight
+            * len(mapping)
+            / len(sample_entries)
+            * RUN_CONTEXT_SIZE_SAFETY_MARGIN
+        )
+        return tuple(
+            _WeightedCandidate(item, sample_weight)
+            for entry in sample_entries
+            for item in entry
+        )
+
+    if _is_exact_type(value_type, (set, frozenset)):
+        container = cast(set[object] | frozenset[object], value)
+        if len(container) <= RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD:
+            return tuple(
+                _WeightedCandidate(item, candidate.weight) for item in container
+            )
+        sample_items = tuple(islice(container, RUN_CONTEXT_SIZE_SAMPLE_COUNT))
+        sample_weight = (
+            candidate.weight
+            * len(container)
+            / len(sample_items)
+            * RUN_CONTEXT_SIZE_SAFETY_MARGIN
+        )
+        return tuple(_WeightedCandidate(item, sample_weight) for item in sample_items)
+
+    return ()
+
+
 def estimate_cache_entry_size(
     key: object,
     value: object,
@@ -375,84 +521,78 @@ def estimate_cache_entry_size(
 ) -> int:
     """Estimate owned bytes for one cache entry without unbounded traversal."""
     measured_bytes = 0
-    seen: set[int] = set()
-    candidates = [key, value]
+    seen_weights: dict[int, float] = {}
+    candidates = [_WeightedCandidate(key, 1.0), _WeightedCandidate(value, 1.0)]
+    storage_plans: dict[int, _StaticStoragePlan | None] = {}
 
     while candidates:
         candidate = candidates.pop()
-        candidate_id = id(candidate)
-        if candidate_id in seen:
+        candidate_id = id(candidate.value)
+        previous_weight = seen_weights.get(candidate_id, 0.0)
+        incremental_weight = candidate.weight - previous_weight
+        if incremental_weight <= 0:
             continue
-        seen.add(candidate_id)
+        seen_weights[candidate_id] = candidate.weight
 
-        candidate_type = type(candidate)
+        candidate_value = candidate.value
+        candidate_type = type(candidate_value)
         try:
-            if candidate_type in _SIZED_BUILTIN_TYPES:
-                measured_bytes += sys.getsizeof(candidate)
+            if _is_exact_type(candidate_type, _SIZED_BUILTIN_TYPES):
+                shallow_size = sys.getsizeof(candidate_value)
             else:
-                measured_bytes += object.__sizeof__(candidate)
+                shallow_size = object.__sizeof__(candidate_value)
         except Exception:  # noqa: BLE001 - conservative accounting must survive sizing errors.
-            measured_bytes += MIN_TRACKED_ENTRY_BYTES
+            shallow_size = MIN_TRACKED_ENTRY_BYTES
+        measured_bytes += math.ceil(shallow_size * incremental_weight)
 
         if stop_after is not None and measured_bytes > stop_after:
             return stop_after + 1
 
-        candidate_mro = _get_static_type_mro(candidate_type)
-        if candidate_mro is None:
+        if _is_exact_type(candidate_type, _ATOMIC_LEAF_TYPES):
             continue
-        if any(
-            base_type is leaf_type
-            for base_type in candidate_mro
-            for leaf_type in _SHALLOW_LEAF_TYPES
-        ):
-            continue
-        if candidate_type is dict:
-            mapping = cast(dict[object, object], candidate)
-            for item_key, item_value in mapping.items():
-                candidates.extend((item_key, item_value))
-        elif candidate_type in (tuple, list, set, frozenset):
-            candidates.extend(cast(Iterable[object], candidate))
-        else:
-            class_metadata = _get_static_class_metadata(candidate_mro)
-            if class_metadata is None:
-                continue
-            for cls, class_dict in class_metadata:
-                instance_dict_descriptor = class_dict.get("__dict__")
-                if _is_native_descriptor_for_storage(
-                    instance_dict_descriptor,
-                    GetSetDescriptorType,
-                    cls,
-                    "__dict__",
-                ):
-                    try:
-                        candidates.append(
-                            GetSetDescriptorType.__get__(
-                                cast(GetSetDescriptorType, instance_dict_descriptor),
-                                candidate,
-                                candidate_type,
-                            )
-                        )
-                    except (AttributeError, TypeError):
-                        pass
 
-                for storage_name, descriptor in class_dict.items():
-                    if not _is_native_descriptor_for_storage(
-                        descriptor,
-                        MemberDescriptorType,
-                        cls,
-                        storage_name,
-                    ):
-                        continue
-                    try:
-                        candidates.append(
-                            MemberDescriptorType.__get__(
-                                cast(MemberDescriptorType, descriptor),
-                                candidate,
+        if _is_exact_type(candidate_type, (dict, tuple, list, set, frozenset)):
+            candidates.extend(
+                _sample_container_children(
+                    _WeightedCandidate(candidate_value, incremental_weight)
+                )
+            )
+        else:
+            candidate_type_id = id(candidate_type)
+            if candidate_type_id not in storage_plans:
+                storage_plans[candidate_type_id] = _static_storage_plan(candidate_type)
+            storage_plan = storage_plans[candidate_type_id]
+            if storage_plan is None:
+                continue
+            for instance_dict_descriptor in storage_plan.instance_dict_descriptors:
+                try:
+                    candidates.append(
+                        _WeightedCandidate(
+                            GetSetDescriptorType.__get__(
+                                instance_dict_descriptor,
+                                candidate_value,
                                 candidate_type,
-                            )
+                            ),
+                            incremental_weight,
                         )
-                    except (AttributeError, TypeError):
-                        pass
+                    )
+                except (AttributeError, TypeError):
+                    pass
+
+            for slot_descriptor in storage_plan.slot_descriptors:
+                try:
+                    candidates.append(
+                        _WeightedCandidate(
+                            MemberDescriptorType.__get__(
+                                slot_descriptor,
+                                candidate_value,
+                                candidate_type,
+                            ),
+                            incremental_weight,
+                        )
+                    )
+                except (AttributeError, TypeError):
+                    pass
 
     return max(MIN_TRACKED_ENTRY_BYTES, measured_bytes)
 

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -105,6 +105,7 @@ class _StaticStoragePlan:
 class _WeightedCandidate:
     value: object
     weight: float
+    ancestor_ids: frozenset[int] = frozenset()
 
 
 class ProcessRunContextCacheBudget:
@@ -446,12 +447,14 @@ def _sample_container_children(
 ) -> tuple[_WeightedCandidate, ...]:
     value = candidate.value
     value_type = type(value)
+    child_ancestor_ids = candidate.ancestor_ids | frozenset((id(value),))
     if _is_exact_type(value_type, (list, tuple)):
         sequence = cast(list[object] | tuple[object, ...], value)
         length = len(sequence)
         if length <= RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD:
             return tuple(
-                _WeightedCandidate(item, candidate.weight) for item in sequence
+                _WeightedCandidate(item, candidate.weight, child_ancestor_ids)
+                for item in sequence
             )
         sample_indexes = _stratified_indexes(length, RUN_CONTEXT_SIZE_SAMPLE_COUNT)
         sample_weight = (
@@ -461,7 +464,7 @@ def _sample_container_children(
             * RUN_CONTEXT_SIZE_SAFETY_MARGIN
         )
         return tuple(
-            _WeightedCandidate(sequence[index], sample_weight)
+            _WeightedCandidate(sequence[index], sample_weight, child_ancestor_ids)
             for index in sample_indexes
         )
 
@@ -469,7 +472,7 @@ def _sample_container_children(
         mapping = cast(dict[object, object], value)
         if len(mapping) <= RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD:
             return tuple(
-                _WeightedCandidate(item, candidate.weight)
+                _WeightedCandidate(item, candidate.weight, child_ancestor_ids)
                 for entry in mapping.items()
                 for item in entry
             )
@@ -490,7 +493,7 @@ def _sample_container_children(
             * RUN_CONTEXT_SIZE_SAFETY_MARGIN
         )
         return tuple(
-            _WeightedCandidate(item, sample_weight)
+            _WeightedCandidate(item, sample_weight, child_ancestor_ids)
             for entry in sample_entries
             for item in entry
         )
@@ -499,7 +502,8 @@ def _sample_container_children(
         container = cast(set[object] | frozenset[object], value)
         if len(container) <= RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD:
             return tuple(
-                _WeightedCandidate(item, candidate.weight) for item in container
+                _WeightedCandidate(item, candidate.weight, child_ancestor_ids)
+                for item in container
             )
         sample_items = tuple(islice(container, RUN_CONTEXT_SIZE_SAMPLE_COUNT))
         sample_weight = (
@@ -508,7 +512,10 @@ def _sample_container_children(
             / len(sample_items)
             * RUN_CONTEXT_SIZE_SAFETY_MARGIN
         )
-        return tuple(_WeightedCandidate(item, sample_weight) for item in sample_items)
+        return tuple(
+            _WeightedCandidate(item, sample_weight, child_ancestor_ids)
+            for item in sample_items
+        )
 
     return ()
 
@@ -528,6 +535,8 @@ def estimate_cache_entry_size(
     while candidates:
         candidate = candidates.pop()
         candidate_id = id(candidate.value)
+        if candidate_id in candidate.ancestor_ids:
+            continue
         previous_weight = seen_weights.get(candidate_id, 0.0)
         incremental_weight = candidate.weight - previous_weight
         if incremental_weight <= 0:
@@ -574,6 +583,7 @@ def estimate_cache_entry_size(
                                 candidate_type,
                             ),
                             incremental_weight,
+                            candidate.ancestor_ids | frozenset((candidate_id,)),
                         )
                     )
                 except (AttributeError, TypeError):
@@ -589,6 +599,7 @@ def estimate_cache_entry_size(
                                 candidate_type,
                             ),
                             incremental_weight,
+                            candidate.ancestor_ids | frozenset((candidate_id,)),
                         )
                     )
                 except (AttributeError, TypeError):

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -656,6 +656,24 @@ def estimate_cache_entry_size(
     stop_after: int | None,
 ) -> int:
     """Estimate owned bytes for one cache entry without unbounded traversal."""
+    if _is_exact_type(type(key), _ATOMIC_LEAF_TYPES) and _is_exact_type(
+        type(value), _ATOMIC_LEAF_TYPES
+    ):
+        try:
+            measured_bytes = sys.getsizeof(value)
+        except Exception:  # noqa: BLE001 - preserve conservative sizing fallback.
+            measured_bytes = MIN_TRACKED_ENTRY_BYTES
+        if stop_after is not None and measured_bytes > stop_after:
+            return stop_after + 1
+        if key is not value:
+            try:
+                measured_bytes += sys.getsizeof(key)
+            except Exception:  # noqa: BLE001 - preserve conservative sizing fallback.
+                measured_bytes += MIN_TRACKED_ENTRY_BYTES
+        if stop_after is not None and measured_bytes > stop_after:
+            return stop_after + 1
+        return max(MIN_TRACKED_ENTRY_BYTES, measured_bytes)
+
     measured_bytes = 0
     seen_weights: dict[int, float] = {}
     candidates = [_WeightedCandidate(key, 1.0), _WeightedCandidate(value, 1.0)]

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -119,6 +119,7 @@ class ProcessRunContextCacheBudget:
         self._total_bytes = 0
         self._max_bytes: int | None = None
         self._configuration_generation = 0
+        self._owner_mutation_generations: dict[int, int] = {}
 
     @property
     def estimated_bytes(self) -> int:
@@ -163,13 +164,15 @@ class ProcessRunContextCacheBudget:
         """Record a stored entry and evict least-recently-used entries if needed."""
         if self._max_bytes is None:
             return
-        while True:
-            with self._lock:
-                max_bytes = self._max_bytes
-                generation = self._configuration_generation
+        with self._lock:
+            max_bytes = self._max_bytes
+            configuration_generation = self._configuration_generation
             if max_bytes is None:
                 return
+            owner_id = id(owner)
+            owner_mutation_generation = self._invalidate_owner_locked(owner_id)
 
+        while True:
             estimated_bytes = estimate_cache_entry_size(
                 key,
                 value,
@@ -177,7 +180,15 @@ class ProcessRunContextCacheBudget:
             )
 
             with self._lock:
-                if generation != self._configuration_generation:
+                if owner_mutation_generation != self._owner_mutation_generations.get(
+                    owner_id, 0
+                ):
+                    return
+                if configuration_generation != self._configuration_generation:
+                    max_bytes = self._max_bytes
+                    configuration_generation = self._configuration_generation
+                    if max_bytes is None:
+                        return
                     continue
                 self._track_estimated_locked(
                     owner,
@@ -216,6 +227,7 @@ class ProcessRunContextCacheBudget:
         with self._lock:
             if self._max_bytes is None:
                 return
+            self._invalidate_owner_locked(id(owner))
             self._remove_entry_locked((id(owner), namespace, key))
 
     def refresh(
@@ -234,9 +246,11 @@ class ProcessRunContextCacheBudget:
         """Remove one owner's accounting without changing its cache storage."""
         with self._lock:
             owner_id = id(owner)
+            self._invalidate_owner_locked(owner_id)
             self._remove_owner_entries_locked(owner_id)
             self._owner_references.pop(owner_id, None)
             self._owners.discard(owner)
+            self._owner_mutation_generations.pop(owner_id, None)
 
     def _rebuild_locked(self) -> None:
         self._entries.clear()
@@ -288,6 +302,7 @@ class ProcessRunContextCacheBudget:
         self._remove_entry_locked(tracked_key)
         owner_reference = self._owner_reference_locked(owner)
         if estimated_bytes > max_bytes:
+            self._invalidate_owner_locked(id(owner))
             owner._evict_run_cache_entry(namespace, key)
             logger.debug(
                 "run cache entry skipped because it exceeds the process budget",
@@ -318,6 +333,7 @@ class ProcessRunContextCacheBudget:
             owner = entry.owner()
             if owner is None:
                 continue
+            self._invalidate_owner_locked(id(owner))
             owner._evict_run_cache_entry(entry.namespace, entry.key)
             logger.debug(
                 "run cache entry evicted by process-wide LRU budget",
@@ -337,6 +353,11 @@ class ProcessRunContextCacheBudget:
         for tracked_key in tuple(self._entries):
             if tracked_key[0] == owner_id:
                 self._remove_entry_locked(tracked_key)
+
+    def _invalidate_owner_locked(self, owner_id: int) -> int:
+        generation = self._owner_mutation_generations.get(owner_id, 0) + 1
+        self._owner_mutation_generations[owner_id] = generation
+        return generation
 
     def _owner_reference_locked(
         self,
@@ -365,6 +386,7 @@ class ProcessRunContextCacheBudget:
                     return
                 self._remove_owner_entries_locked(owner_id)
                 self._owner_references.pop(owner_id, None)
+                self._owner_mutation_generations.pop(owner_id, None)
 
         return remove_dead_owner
 

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -118,6 +118,7 @@ class ProcessRunContextCacheBudget:
         self._entries: OrderedDict[TrackedKey, _TrackedEntry] = OrderedDict()
         self._total_bytes = 0
         self._max_bytes: int | None = None
+        self._configuration_generation = 0
 
     @property
     def estimated_bytes(self) -> int:
@@ -138,6 +139,7 @@ class ProcessRunContextCacheBudget:
 
             previous_max_bytes = self._max_bytes
             self._max_bytes = max_bytes
+            self._configuration_generation += 1
             if max_bytes is None:
                 self._entries.clear()
                 self._total_bytes = 0
@@ -161,10 +163,30 @@ class ProcessRunContextCacheBudget:
         """Record a stored entry and evict least-recently-used entries if needed."""
         if self._max_bytes is None:
             return
-        with self._lock:
-            if self._max_bytes is None:
+        while True:
+            with self._lock:
+                max_bytes = self._max_bytes
+                generation = self._configuration_generation
+            if max_bytes is None:
                 return
-            self._track_locked(owner, namespace, key, value)
+
+            estimated_bytes = estimate_cache_entry_size(
+                key,
+                value,
+                stop_after=max_bytes,
+            )
+
+            with self._lock:
+                if generation != self._configuration_generation:
+                    continue
+                self._track_estimated_locked(
+                    owner,
+                    namespace,
+                    key,
+                    estimated_bytes,
+                    max_bytes,
+                )
+                return
 
     def touch(
         self,
@@ -225,27 +247,46 @@ class ProcessRunContextCacheBudget:
     def _track_owner_entries_locked(self, owner: RunContextCacheOwner) -> None:
         entries = tuple(owner._iter_run_cache_entries())
         for namespace, key, value in entries:
-            self._track_locked(owner, namespace, key, value)
+            self._track_value_locked(owner, namespace, key, value)
 
-    def _track_locked(
+    def _track_value_locked(
         self,
         owner: RunContextCacheOwner,
         namespace: RunCacheNamespace,
         key: Hashable,
         value: object,
     ) -> None:
+        """Estimate rebuild entries while locked; normal track() admission is unlocked.
+
+        Only configuration rebuilds estimate while holding the coordinator lock.
+        """
         max_bytes = self._max_bytes
         if max_bytes is None:
             return
-
-        tracked_key = (id(owner), namespace, key)
-        self._remove_entry_locked(tracked_key)
-        owner_reference = self._owner_reference_locked(owner)
         estimated_bytes = estimate_cache_entry_size(
             key,
             value,
             stop_after=max_bytes,
         )
+        self._track_estimated_locked(
+            owner,
+            namespace,
+            key,
+            estimated_bytes,
+            max_bytes,
+        )
+
+    def _track_estimated_locked(
+        self,
+        owner: RunContextCacheOwner,
+        namespace: RunCacheNamespace,
+        key: Hashable,
+        estimated_bytes: int,
+        max_bytes: int,
+    ) -> None:
+        tracked_key = (id(owner), namespace, key)
+        self._remove_entry_locked(tracked_key)
+        owner_reference = self._owner_reference_locked(owner)
         if estimated_bytes > max_bytes:
             owner._evict_run_cache_entry(namespace, key)
             logger.debug(

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -116,6 +116,7 @@ class ProcessRunContextCacheBudget:
         self._owners: WeakSet[RunContextCacheOwner] = WeakSet()
         self._owner_references: dict[int, ReferenceType[RunContextCacheOwner]] = {}
         self._entries: OrderedDict[TrackedKey, _TrackedEntry] = OrderedDict()
+        self._mru_key: TrackedKey | None = None
         self._total_bytes = 0
         self._max_bytes: int | None = None
         self._configuration_generation = 0
@@ -128,6 +129,11 @@ class ProcessRunContextCacheBudget:
         """Return the coordinator's current estimated cache footprint."""
         with self._lock:
             return self._total_bytes
+
+    @property
+    def is_enabled(self) -> bool:
+        """Return whether process-wide run-cache accounting is enabled."""
+        return self._max_bytes is not None
 
     def register(self, owner: RunContextCacheOwner, max_bytes: int | None) -> None:
         """Register an owner and rebuild tracked state when the limit changes."""
@@ -145,6 +151,7 @@ class ProcessRunContextCacheBudget:
             self._configuration_generation += 1
             if max_bytes is None:
                 self._entries.clear()
+                self._mru_key = None
                 self._entry_attempt_generations.clear()
                 self._total_bytes = 0
                 return
@@ -216,14 +223,32 @@ class ProcessRunContextCacheBudget:
         key: Hashable,
     ) -> None:
         """Mark one tracked entry as most recently used."""
+        self.touch_many(owner, ((namespace, key),))
+
+    def touch_many(
+        self,
+        owner: RunContextCacheOwner,
+        entries: Iterable[tuple[RunCacheNamespace, Hashable]],
+    ) -> None:
+        """Mark tracked entries as recently used in caller-provided order."""
         if self._max_bytes is None:
+            return
+        owner_id = id(owner)
+        tracked_keys = tuple((owner_id, namespace, key) for namespace, key in entries)
+        if not tracked_keys:
+            return
+        if len(tracked_keys) == 1 and tracked_keys[0] == self._mru_key:
             return
         with self._lock:
             if self._max_bytes is None:
                 return
-            tracked_key = (id(owner), namespace, key)
-            if tracked_key in self._entries:
-                self._entries.move_to_end(tracked_key)
+            last_moved_key = None
+            for tracked_key in tracked_keys:
+                if tracked_key in self._entries:
+                    self._entries.move_to_end(tracked_key)
+                    last_moved_key = tracked_key
+            if last_moved_key is not None:
+                self._mru_key = last_moved_key
 
     def remove(
         self,
@@ -264,6 +289,7 @@ class ProcessRunContextCacheBudget:
 
     def _rebuild_locked(self) -> None:
         self._entries.clear()
+        self._mru_key = None
         self._total_bytes = 0
         for owner in tuple(self._owners):
             self._track_owner_entries_locked(owner)
@@ -330,6 +356,7 @@ class ProcessRunContextCacheBudget:
             key=key,
             size=estimated_bytes,
         )
+        self._mru_key = tracked_key
         self._total_bytes += estimated_bytes
         self._evict_excess_locked()
 
@@ -339,6 +366,8 @@ class ProcessRunContextCacheBudget:
             if max_bytes is None or self._total_bytes <= max_bytes:
                 return
             tracked_key, entry = self._entries.popitem(last=False)
+            if tracked_key == self._mru_key:
+                self._refresh_mru_key_locked()
             self._total_bytes -= entry.size
             owner = entry.owner()
             if owner is None:
@@ -357,7 +386,12 @@ class ProcessRunContextCacheBudget:
     def _remove_entry_locked(self, tracked_key: TrackedKey) -> None:
         entry = self._entries.pop(tracked_key, None)
         if entry is not None:
+            if tracked_key == self._mru_key:
+                self._refresh_mru_key_locked()
             self._total_bytes -= entry.size
+
+    def _refresh_mru_key_locked(self) -> None:
+        self._mru_key = next(reversed(self._entries), None)
 
     def _remove_owner_entries_locked(self, owner_id: int) -> None:
         for tracked_key in tuple(self._entries):

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -119,7 +119,9 @@ class ProcessRunContextCacheBudget:
         self._total_bytes = 0
         self._max_bytes: int | None = None
         self._configuration_generation = 0
-        self._owner_mutation_generations: dict[int, int] = {}
+        self._next_admission_generation = 0
+        self._owner_lifecycle_generations: dict[int, int] = {}
+        self._entry_attempt_generations: dict[TrackedKey, int] = {}
 
     @property
     def estimated_bytes(self) -> int:
@@ -170,7 +172,12 @@ class ProcessRunContextCacheBudget:
             if max_bytes is None:
                 return
             owner_id = id(owner)
-            owner_mutation_generation = self._invalidate_owner_locked(owner_id)
+            owner_lifecycle_generation = self._owner_lifecycle_generation_locked(
+                owner_id
+            )
+            tracked_key = (owner_id, namespace, key)
+            entry_attempt_generation = self._next_admission_generation_locked()
+            self._entry_attempt_generations[tracked_key] = entry_attempt_generation
 
         while True:
             estimated_bytes = estimate_cache_entry_size(
@@ -180,8 +187,10 @@ class ProcessRunContextCacheBudget:
             )
 
             with self._lock:
-                if owner_mutation_generation != self._owner_mutation_generations.get(
+                if owner_lifecycle_generation != self._owner_lifecycle_generations.get(
                     owner_id, 0
+                ) or entry_attempt_generation != self._entry_attempt_generations.get(
+                    tracked_key, 0
                 ):
                     return
                 if configuration_generation != self._configuration_generation:
@@ -227,8 +236,9 @@ class ProcessRunContextCacheBudget:
         with self._lock:
             if self._max_bytes is None:
                 return
-            self._invalidate_owner_locked(id(owner))
-            self._remove_entry_locked((id(owner), namespace, key))
+            tracked_key = (id(owner), namespace, key)
+            self._entry_attempt_generations.pop(tracked_key, None)
+            self._remove_entry_locked(tracked_key)
 
     def refresh(
         self,
@@ -246,11 +256,10 @@ class ProcessRunContextCacheBudget:
         """Remove one owner's accounting without changing its cache storage."""
         with self._lock:
             owner_id = id(owner)
-            self._invalidate_owner_locked(owner_id)
+            self._clear_owner_attempts_locked(owner_id)
             self._remove_owner_entries_locked(owner_id)
             self._owner_references.pop(owner_id, None)
             self._owners.discard(owner)
-            self._owner_mutation_generations.pop(owner_id, None)
 
     def _rebuild_locked(self) -> None:
         self._entries.clear()
@@ -302,7 +311,7 @@ class ProcessRunContextCacheBudget:
         self._remove_entry_locked(tracked_key)
         owner_reference = self._owner_reference_locked(owner)
         if estimated_bytes > max_bytes:
-            self._invalidate_owner_locked(id(owner))
+            self._entry_attempt_generations.pop(tracked_key, None)
             owner._evict_run_cache_entry(namespace, key)
             logger.debug(
                 "run cache entry skipped because it exceeds the process budget",
@@ -328,12 +337,12 @@ class ProcessRunContextCacheBudget:
             max_bytes = self._max_bytes
             if max_bytes is None or self._total_bytes <= max_bytes:
                 return
-            _, entry = self._entries.popitem(last=False)
+            tracked_key, entry = self._entries.popitem(last=False)
             self._total_bytes -= entry.size
             owner = entry.owner()
             if owner is None:
                 continue
-            self._invalidate_owner_locked(id(owner))
+            self._entry_attempt_generations.pop(tracked_key, None)
             owner._evict_run_cache_entry(entry.namespace, entry.key)
             logger.debug(
                 "run cache entry evicted by process-wide LRU budget",
@@ -354,10 +363,23 @@ class ProcessRunContextCacheBudget:
             if tracked_key[0] == owner_id:
                 self._remove_entry_locked(tracked_key)
 
-    def _invalidate_owner_locked(self, owner_id: int) -> int:
-        generation = self._owner_mutation_generations.get(owner_id, 0) + 1
-        self._owner_mutation_generations[owner_id] = generation
+    def _next_admission_generation_locked(self) -> int:
+        self._next_admission_generation += 1
+        return self._next_admission_generation
+
+    def _owner_lifecycle_generation_locked(self, owner_id: int) -> int:
+        generation = self._owner_lifecycle_generations.get(owner_id)
+        if generation is not None:
+            return generation
+        generation = self._next_admission_generation_locked()
+        self._owner_lifecycle_generations[owner_id] = generation
         return generation
+
+    def _clear_owner_attempts_locked(self, owner_id: int) -> None:
+        for tracked_key in tuple(self._entry_attempt_generations):
+            if tracked_key[0] == owner_id:
+                self._entry_attempt_generations.pop(tracked_key)
+        self._owner_lifecycle_generations.pop(owner_id, None)
 
     def _owner_reference_locked(
         self,
@@ -370,6 +392,7 @@ class ProcessRunContextCacheBudget:
 
         if owner_reference is not None:
             self._remove_owner_entries_locked(owner_id)
+            self._clear_owner_attempts_locked(owner_id)
         owner_reference = ref(owner, self._owner_finalizer(owner_id))
         self._owner_references[owner_id] = owner_reference
         return owner_reference
@@ -385,8 +408,8 @@ class ProcessRunContextCacheBudget:
                 if self._owner_references.get(owner_id) is not owner_reference:
                     return
                 self._remove_owner_entries_locked(owner_id)
+                self._clear_owner_attempts_locked(owner_id)
                 self._owner_references.pop(owner_id, None)
-                self._owner_mutation_generations.pop(owner_id, None)
 
         return remove_dead_owner
 

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass
+from fractions import Fraction
 from itertools import islice
 import math
 import sys
@@ -30,7 +31,7 @@ RUN_CONTEXT_CACHE_MAX_BYTES_SETTING = "RUN_CONTEXT_CACHE_MAX_BYTES"
 MIN_TRACKED_ENTRY_BYTES = 256
 RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD = 128
 RUN_CONTEXT_SIZE_SAMPLE_COUNT = 64
-RUN_CONTEXT_SIZE_SAFETY_MARGIN = 1.05
+RUN_CONTEXT_SIZE_SAFETY_MARGIN = Fraction(21, 20)
 _INVALID_MAX_BYTES_MESSAGE = (
     'GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"] must be None or a '
     "non-negative integer number of bytes."
@@ -107,7 +108,7 @@ class _StaticStoragePlan:
 @dataclass(frozen=True)
 class _WeightedCandidate:
     value: object
-    weight: float
+    weight: Fraction
     ancestor_ids: frozenset[int] = frozenset()
 
 
@@ -196,11 +197,24 @@ class ProcessRunContextCacheBudget:
             self._entry_attempt_generations[tracked_key] = entry_attempt_generation
 
         while True:
-            estimated_bytes = estimate_cache_entry_size(
-                key,
-                value,
-                stop_after=max_bytes,
-            )
+            try:
+                estimated_bytes = estimate_cache_entry_size(
+                    key,
+                    value,
+                    stop_after=max_bytes,
+                )
+            except BaseException:
+                with self._lock:
+                    if (
+                        owner_lifecycle_generation
+                        == self._owner_lifecycle_generations.get(owner_id, 0)
+                        and entry_attempt_generation
+                        == self._entry_attempt_generations.get(tracked_key, 0)
+                    ):
+                        self._entry_attempt_generations.pop(tracked_key, None)
+                        self._remove_entry_locked(tracked_key)
+                        owner._evict_run_cache_entry(namespace, key)
+                raise
 
             with self._lock:
                 if owner_lifecycle_generation != self._owner_lifecycle_generations.get(
@@ -675,8 +689,11 @@ def estimate_cache_entry_size(
         return max(MIN_TRACKED_ENTRY_BYTES, measured_bytes)
 
     measured_bytes = 0
-    seen_weights: dict[int, float] = {}
-    candidates = [_WeightedCandidate(key, 1.0), _WeightedCandidate(value, 1.0)]
+    seen_weights: dict[int, Fraction] = {}
+    candidates = [
+        _WeightedCandidate(key, Fraction(1)),
+        _WeightedCandidate(value, Fraction(1)),
+    ]
     storage_plans: dict[int, _StaticStoragePlan | None] = {}
 
     while candidates:
@@ -684,7 +701,7 @@ def estimate_cache_entry_size(
         candidate_id = id(candidate.value)
         if candidate_id in candidate.ancestor_ids:
             continue
-        previous_weight = seen_weights.get(candidate_id, 0.0)
+        previous_weight = seen_weights.get(candidate_id, Fraction(0))
         incremental_weight = candidate.weight - previous_weight
         if incremental_weight <= 0:
             continue
@@ -710,7 +727,11 @@ def estimate_cache_entry_size(
         if _is_exact_type(candidate_type, (dict, tuple, list, set, frozenset)):
             candidates.extend(
                 _sample_container_children(
-                    _WeightedCandidate(candidate_value, incremental_weight)
+                    _WeightedCandidate(
+                        candidate_value,
+                        incremental_weight,
+                        candidate.ancestor_ids,
+                    )
                 )
             )
         else:

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -76,6 +76,9 @@ logger = get_logger("cache.run_context_lru")
 class RunContextCacheOwner(Protocol):
     """Storage that participates in process-wide run-cache budgeting."""
 
+    def _set_run_cache_budget_enabled(self, enabled: bool) -> None:
+        """Refresh the owner's cached process-budget mode."""
+
     def _iter_run_cache_entries(
         self,
     ) -> Iterable[tuple[RunCacheNamespace, Hashable, object]]:
@@ -142,6 +145,8 @@ class ProcessRunContextCacheBudget:
             self._owners.add(owner)
             self._owner_reference_locked(owner)
             if max_bytes == self._max_bytes:
+                if is_new_owner:
+                    owner._set_run_cache_budget_enabled(max_bytes is not None)
                 if is_new_owner and max_bytes is not None:
                     self._track_owner_entries_locked(owner)
                 return
@@ -149,6 +154,9 @@ class ProcessRunContextCacheBudget:
             previous_max_bytes = self._max_bytes
             self._max_bytes = max_bytes
             self._configuration_generation += 1
+            enabled = max_bytes is not None
+            for registered_owner in tuple(self._owners):
+                registered_owner._set_run_cache_budget_enabled(enabled)
             if max_bytes is None:
                 self._entries.clear()
                 self._mru_key = None

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -145,6 +145,7 @@ class ProcessRunContextCacheBudget:
             self._configuration_generation += 1
             if max_bytes is None:
                 self._entries.clear()
+                self._entry_attempt_generations.clear()
                 self._total_bytes = 0
                 return
 
@@ -231,13 +232,13 @@ class ProcessRunContextCacheBudget:
         key: Hashable,
     ) -> None:
         """Discard bookkeeping for an entry removed from owner storage."""
-        if self._max_bytes is None:
+        if self._max_bytes is None and not self._entry_attempt_generations:
             return
         with self._lock:
-            if self._max_bytes is None:
-                return
             tracked_key = (id(owner), namespace, key)
             self._entry_attempt_generations.pop(tracked_key, None)
+            if self._max_bytes is None:
+                return
             self._remove_entry_locked(tracked_key)
 
     def refresh(

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -16,12 +16,14 @@ from general_manager.cache.dependency_publish import (
     PendingDependencyCachePublication,
 )
 from general_manager.cache.run_context import (
+    RUN_CONTEXT_TOUCH_BATCH_SIZE,
     CalculationRunContext,
     current_calculation_run_context,
     ensure_calculation_run_context,
 )
 from general_manager.cache.run_context_lru import (
     MIN_TRACKED_ENTRY_BYTES,
+    ProcessRunContextCacheBudget,
     estimate_cache_entry_size,
     run_context_cache_budget,
 )
@@ -228,12 +230,216 @@ def test_run_context_budget_evicts_lru_value_across_contexts() -> None:
         with CalculationRunContext() as first, CalculationRunContext() as second:
             first.set("a", "A")
             second.set("b", "B")
-            assert first.get("a") == "A"
+            for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+                assert first.get("a") == "A"
             second.set("c", "C")
 
             assert first.get("a") == "A"
             assert second.get("b") is None
             assert second.get("c") == "C"
+
+
+def test_run_context_budget_allows_one_batch_of_recency_staleness() -> None:
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    with override_settings(
+        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+    ):
+        with CalculationRunContext() as first, CalculationRunContext() as second:
+            first.set("a", "A")
+            second.set("b", "B")
+            assert first.get("a") == "A"
+            second.set("c", "C")
+
+            assert first.get("a") is None
+            assert second.get("b") == "B"
+            assert second.get("c") == "C"
+
+
+def test_run_context_batches_capped_value_touches() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set("key", "value")
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE - 1):
+            assert context.get("key") == "value"
+        touch_many.assert_not_called()
+
+        assert context.get("key") == "value"
+        touch_many.assert_called_once_with(context, (("values", "key"),))
+
+
+def test_run_context_repeated_touch_fast_path_avoids_pending_key_rehashes() -> None:
+    key = CountingHashKey()
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set(key, "value")
+        key.hash_calls = 0
+
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+            assert context.get(key) == "value"
+
+        touch_many.assert_called_once_with(context, (("values", key),))
+        assert key.hash_calls <= RUN_CONTEXT_TOUCH_BATCH_SIZE + 2
+
+
+def test_run_context_hot_reads_use_cached_budget_enabled_state() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set("key", "value")
+        with mock.patch.object(
+            ProcessRunContextCacheBudget,
+            "is_enabled",
+            new_callable=mock.PropertyMock,
+            side_effect=AssertionError("hot reads must use cached enabled state"),
+        ):
+            for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+                assert context.get("key") == "value"
+
+        touch_many.assert_called_once_with(context, (("values", "key"),))
+
+
+def test_run_context_batches_capped_touches_in_latest_access_order() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set("first", "first")
+        context.set("second", "second")
+        assert context.get("first") == "first"
+        assert context.get("second") == "second"
+        assert context.get("first") == "first"
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE - 3):
+            assert context.get("first") == "first"
+
+        touch_many.assert_called_once_with(
+            context,
+            (("values", "second"), ("values", "first")),
+        )
+
+
+def test_run_context_does_not_publish_a_removed_pending_touch() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set(("removed",), "removed")
+        context.set("kept", "kept")
+        assert context.get(("removed",)) == "removed"
+
+        context.discard_prefix(("removed",))
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE - 1):
+            assert context.get("kept") == "kept"
+
+        touch_many.assert_called_once_with(context, (("values", "kept"),))
+
+
+def test_run_context_flushes_earlier_touches_before_refresh() -> None:
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    with (
+        override_settings(
+            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+        ),
+        CalculationRunContext() as context,
+    ):
+        context.set("a", "A")
+        context.set("b", "B")
+        assert context.get("b") == "B"
+
+        context._refresh_run_value("a")
+        context.set("c", "C")
+
+        assert context.get("a") == "A"
+        assert context.get("b") is None
+        assert context.get("c") == "C"
+
+
+def test_pending_dependency_publication_hits_do_not_queue_recency_touches() -> None:
+    entry = make_pending_publication("cache-a")
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch(
+            "general_manager.cache.dependency_publish.publish_dependency_cache_entries"
+        ),
+        mock.patch("general_manager.cache.dependency_publish.release_compute_lease"),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.buffer_dependency_cache_publication(entry)
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+            assert context.get_dependency_cache_hit(entry.cache_key) is not None
+
+        touch_many.assert_not_called()
+
+
+def test_run_context_touch_batch_does_not_leak_across_reuse() -> None:
+    context = CalculationRunContext()
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+    ):
+        with context:
+            context.set("old", "old")
+            assert context.get("old") == "old"
+
+        with context:
+            context.set("new", "new")
+            for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+                assert context.get("new") == "new"
+
+        touch_many.assert_called_once_with(context, (("values", "new"),))
+
+
+def test_inactive_run_context_discards_touches_before_setting_transition() -> None:
+    with override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}):
+        context = CalculationRunContext()
+        context.set("old", "old")
+        assert context.get("old") == "old"
+
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 20_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        context,
+    ):
+        context.set("new", "new")
+
+    touch_many.assert_not_called()
+
+
+def test_reused_run_context_refreshes_cached_budget_enabled_state() -> None:
+    with override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": None}):
+        context = CalculationRunContext()
+
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        context,
+    ):
+        context.set("key", "value")
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+            assert context.get("key") == "value"
+
+    touch_many.assert_called_once_with(context, (("values", "key"),))
+
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": None}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        context,
+    ):
+        context.set("key", "value")
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+            assert context.get("key") == "value"
+
+    touch_many.assert_not_called()
 
 
 def test_run_context_does_not_retain_value_larger_than_budget() -> None:

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -1,4 +1,6 @@
 from collections.abc import Iterator
+from contextvars import copy_context
+from threading import Event, Thread
 from unittest import mock
 from types import SimpleNamespace
 
@@ -270,6 +272,49 @@ def test_run_context_batches_capped_value_touches() -> None:
         touch_many.assert_called_once_with(context, (("values", "key"),))
 
 
+def test_run_context_batches_capped_get_or_set_touches() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set("key", "value")
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+            assert context.get_or_set("key", lambda: "replacement") == "value"
+
+        touch_many.assert_called_once_with(context, (("values", "key"),))
+
+
+def test_run_context_batches_capped_has_touches() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set("key", "value")
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+            assert context.has("key")
+
+        touch_many.assert_called_once_with(context, (("values", "key"),))
+
+
+def test_run_context_batches_capped_dependency_hit_touches() -> None:
+    hit = DependencyCacheHit(value="value", dependencies=frozenset())
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set_dependency_cache_hits({"cache-key": hit})
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+            assert context.get_dependency_cache_hit("cache-key") == hit
+
+        touch_many.assert_called_once_with(
+            context,
+            (("dependency_hits", "cache-key"),),
+        )
+
+
 def test_run_context_repeated_touch_fast_path_avoids_pending_key_rehashes() -> None:
     key = CountingHashKey()
     with (
@@ -440,6 +485,76 @@ def test_reused_run_context_refreshes_cached_budget_enabled_state() -> None:
             assert context.get("key") == "value"
 
     touch_many.assert_not_called()
+
+
+def test_active_run_context_refreshes_cached_state_when_another_enables_budget() -> (
+    None
+):
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    with override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": None}):
+        with CalculationRunContext() as first:
+            first.set("a", "A")
+            first.set("b", "B")
+
+            with override_settings(
+                GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+            ):
+                with CalculationRunContext() as second:
+                    for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+                        assert first.get("a") == "A"
+                    second.set("c", "C")
+
+                    assert first.get("a") == "A"
+                    assert first.get("b") is None
+                    assert second.get("c") == "C"
+
+
+def test_foreign_thread_touch_bypasses_owner_local_batch() -> None:
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    worker_started = Event()
+    allow_worker_touch = Event()
+    worker_errors: list[BaseException] = []
+
+    with override_settings(
+        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+    ):
+        with CalculationRunContext() as first:
+            first.set("a", "A")
+            propagated_context = copy_context()
+
+            with CalculationRunContext() as second:
+                second.set("b", "B")
+
+                def touch_from_propagated_context() -> None:
+                    try:
+                        worker_started.set()
+                        assert allow_worker_touch.wait(timeout=1)
+                        assert current_calculation_run_context() is first
+                        assert first.get("a") == "A"
+                    except BaseException as error:  # noqa: BLE001
+                        worker_errors.append(error)
+
+                worker = Thread(
+                    target=lambda: propagated_context.run(touch_from_propagated_context)
+                )
+                worker.start()
+                try:
+                    assert worker_started.wait(timeout=1)
+                    allow_worker_touch.set()
+                    worker.join(timeout=1)
+                finally:
+                    allow_worker_touch.set()
+                    worker.join(timeout=1)
+
+                assert not worker.is_alive()
+                if worker_errors:
+                    raise worker_errors[0]
+
+                second.set("c", "C")
+
+                assert first.get("a") == "A"
+                assert second.get("b") is None
+                assert second.get("c") == "C"
 
 
 def test_run_context_does_not_retain_value_larger_than_budget() -> None:

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -257,6 +257,23 @@ def test_run_context_budget_allows_one_batch_of_recency_staleness() -> None:
             assert second.get("c") == "C"
 
 
+def test_same_owner_write_flushes_partial_recency_batch_before_eviction() -> None:
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    with override_settings(
+        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+    ):
+        with CalculationRunContext() as context:
+            context.set("a", "A")
+            context.set("b", "B")
+            assert context.get("a") == "A"
+
+            context.set("c", "C")
+
+            assert context.get("a") == "A"
+            assert context.get("b") is None
+            assert context.get("c") == "C"
+
+
 def test_run_context_batches_capped_value_touches() -> None:
     with (
         override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -18,6 +18,7 @@ from general_manager.cache.dependency_publish import (
     PendingDependencyCachePublication,
 )
 from general_manager.cache.run_context import (
+    PendingRunCacheTouch,
     RUN_CONTEXT_TOUCH_BATCH_SIZE,
     CalculationRunContext,
     current_calculation_run_context,
@@ -592,6 +593,74 @@ def test_foreign_thread_touch_bypasses_owner_local_batch() -> None:
                 assert first.get("a") == "A"
                 assert second.get("b") is None
                 assert second.get("c") == "C"
+
+
+def test_disabling_budget_from_foreign_thread_does_not_mutate_touch_iteration() -> None:
+    iteration_started = Event()
+    allow_iteration_to_finish = Event()
+    disable_callback_started = Event()
+    disable_completed = Event()
+    reader_errors: list[BaseException] = []
+    disabler_errors: list[BaseException] = []
+
+    class BlockingIterationTouches(dict[PendingRunCacheTouch, None]):
+        def __iter__(self) -> Iterator[PendingRunCacheTouch]:
+            iterator = super().__iter__()
+            iteration_started.set()
+            assert allow_iteration_to_finish.wait(timeout=5)
+            yield from iterator
+
+    with override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}):
+        context = CalculationRunContext()
+        original_set_budget_enabled = context._set_run_cache_budget_enabled
+
+        def signal_budget_change(enabled: bool) -> None:
+            if not enabled:
+                disable_callback_started.set()
+            original_set_budget_enabled(enabled)
+
+        context._set_run_cache_budget_enabled = signal_budget_change  # type: ignore[method-assign]
+
+        def read_repeatedly() -> None:
+            try:
+                with context:
+                    context.set("key", "value")
+                    context._pending_run_cache_touches = BlockingIterationTouches(
+                        context._pending_run_cache_touches
+                    )
+                    for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
+                        assert context.get("key") == "value"
+            except BaseException as error:  # noqa: BLE001
+                reader_errors.append(error)
+
+        def disable_budget() -> None:
+            try:
+                run_context_cache_budget.register(context, None)
+            except BaseException as error:  # noqa: BLE001
+                disabler_errors.append(error)
+            finally:
+                disable_completed.set()
+
+        reader = Thread(target=read_repeatedly)
+        disabler = Thread(target=disable_budget)
+        reader.start()
+        try:
+            assert iteration_started.wait(timeout=5)
+            disabler.start()
+            assert disable_callback_started.wait(timeout=5)
+            assert not disable_completed.wait(timeout=0.1)
+        finally:
+            allow_iteration_to_finish.set()
+            reader.join(timeout=5)
+            if disabler.ident is not None:
+                disabler.join(timeout=5)
+
+    assert not reader.is_alive()
+    assert not disabler.is_alive()
+    if reader_errors:
+        raise reader_errors[0]
+    if disabler_errors:
+        raise disabler_errors[0]
 
 
 def test_run_context_does_not_retain_value_larger_than_budget() -> None:

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -224,6 +224,26 @@ def test_zero_run_context_budget_disables_value_retention() -> None:
     assert calls == 2
 
 
+def test_estimator_exception_does_not_retain_untracked_run_value() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        CalculationRunContext() as context,
+        mock.patch(
+            "general_manager.cache.run_context_lru.estimate_cache_entry_size",
+            side_effect=RuntimeError("estimation failed"),
+        ),
+    ):
+        tracked_key = (id(context), "values", "key")
+
+        with pytest.raises(RuntimeError, match="estimation failed"):
+            context.set("key", "value")
+
+        assert context.get("key") is None
+        assert tracked_key not in run_context_cache_budget._entries
+        assert tracked_key not in run_context_cache_budget._entry_attempt_generations
+        assert run_context_cache_budget.estimated_bytes == 0
+
+
 def test_run_context_budget_evicts_lru_value_across_contexts() -> None:
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
     with override_settings(

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -1,6 +1,9 @@
 from collections.abc import Hashable, Iterable, Iterator
+from unittest import mock
+import math
 import sys
 from types import ModuleType
+from typing import cast
 from weakref import ref
 
 import pytest
@@ -15,6 +18,7 @@ from general_manager.cache.run_context_lru import (
     estimate_cache_entry_size,
     resolve_run_context_cache_max_bytes,
 )
+from general_manager.cache import run_context_lru
 
 
 class CacheOwner:
@@ -136,6 +140,22 @@ def test_estimate_cache_entry_size_handles_cycles() -> None:
     assert size >= MIN_TRACKED_ENTRY_BYTES
 
 
+@pytest.mark.parametrize(
+    "value",
+    [None, False, 1, 1.5, 2j, "value", b"value", bytearray(b"value"), range(3)],
+)
+def test_estimate_cache_entry_size_does_not_inspect_atomic_leaf_metadata(
+    value: object,
+) -> None:
+    with mock.patch(
+        "general_manager.cache.run_context_lru._get_static_type_mro",
+        side_effect=AssertionError("atomic leaves must not inspect type metadata"),
+    ):
+        size = estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert size >= MIN_TRACKED_ENTRY_BYTES
+
+
 def test_estimate_cache_entry_size_counts_shared_object_once_per_entry() -> None:
     shared = [bytearray(1024)]
 
@@ -145,6 +165,103 @@ def test_estimate_cache_entry_size_counts_shared_object_once_per_entry() -> None
     )
 
     assert shared_size < copied_size
+
+
+def test_estimate_cache_entry_size_reuses_storage_plan_for_same_type() -> None:
+    class Value:
+        __slots__ = ("payload",)
+
+        def __init__(self, payload: object) -> None:
+            self.payload = payload
+
+    values = [Value(bytearray(64)) for _ in range(20)]
+    original = run_context_lru._get_static_class_metadata
+    with mock.patch(
+        "general_manager.cache.run_context_lru._get_static_class_metadata",
+        wraps=original,
+    ) as get_metadata:
+        size = estimate_cache_entry_size("key", values, stop_after=None)
+
+    assert size > MIN_TRACKED_ENTRY_BYTES
+    assert get_metadata.call_count == 1
+
+
+@pytest.mark.parametrize("container_type", [list, tuple, set, frozenset])
+def test_estimate_cache_entry_size_samples_large_uniform_container_with_margin(
+    container_type: object,
+) -> None:
+    key = "key"
+    if container_type in (list, tuple):
+        items: list[object] = [bytearray(64) for _ in range(2_000)]
+    else:
+        items = [f"{index:06}".encode().ljust(64, b"x") for index in range(2_000)]
+    value = cast(type[object], container_type)(items)
+    exact = (
+        sys.getsizeof(key)
+        + sys.getsizeof(value)
+        + sum(sys.getsizeof(item) for item in cast(Iterable[object], value))
+    )
+
+    estimated = estimate_cache_entry_size(key, value, stop_after=None)
+
+    assert exact <= estimated <= math.ceil(exact * 1.06)
+
+
+def test_estimate_cache_entry_size_samples_large_uniform_mapping_with_margin() -> None:
+    key = "key"
+    value = {f"key-{index:04}": bytearray(64) for index in range(2_000)}
+    exact = (
+        sys.getsizeof(key)
+        + sys.getsizeof(value)
+        + sum(
+            sys.getsizeof(item_key) + sys.getsizeof(item_value)
+            for item_key, item_value in value.items()
+        )
+    )
+
+    estimated = estimate_cache_entry_size(key, value, stop_after=None)
+
+    assert exact <= estimated <= math.ceil(exact * 1.06)
+
+
+def test_estimate_cache_entry_size_samples_mapping_without_rehashing_keys() -> None:
+    class Key:
+        def __hash__(self) -> int:
+            return id(self)
+
+    value = {Key(): bytearray(64) for _ in range(129)}
+
+    def raise_if_rehashed(self: Key) -> int:
+        raise AssertionError("sampled keys must not be rehashed")  # noqa: TRY003
+
+    Key.__hash__ = raise_if_rehashed
+
+    size = estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert size > MIN_TRACKED_ENTRY_BYTES
+
+
+def test_estimate_cache_entry_size_samples_large_sequence_with_bounded_work() -> None:
+    value = list(range(10_000))
+    with mock.patch(
+        "general_manager.cache.run_context_lru.sys.getsizeof",
+        wraps=sys.getsizeof,
+    ) as getsizeof:
+        estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert getsizeof.call_count <= 64 + 2
+
+
+def test_estimate_cache_entry_size_stratifies_large_sequence_samples() -> None:
+    small = [bytearray(1) for _ in range(2_001)]
+    large = [bytearray(1) for _ in range(2_001)]
+    for index in (0, len(large) // 2, len(large) - 1):
+        large[index] = bytearray(4_096)
+
+    small_estimate = estimate_cache_entry_size("key", small, stop_after=None)
+    large_estimate = estimate_cache_entry_size("key", large, stop_after=None)
+
+    assert large_estimate > small_estimate
 
 
 def test_estimate_cache_entry_size_stops_after_budget() -> None:
@@ -349,6 +466,38 @@ def test_estimate_cache_entry_size_avoids_custom_metaclass_metadata_hooks() -> N
 
     assert size > MIN_TRACKED_ENTRY_BYTES
     assert metadata_accesses == []
+
+
+def test_estimate_cache_entry_size_avoids_custom_metaclass_hash_hook() -> None:
+    class HostileMeta(type):
+        def __hash__(cls) -> int:
+            raise AssertionError("unexpected metaclass hash")  # noqa: TRY003
+
+    class Value(metaclass=HostileMeta):
+        __slots__ = ("payload",)
+
+        def __init__(self) -> None:
+            self.payload = bytearray(1024)
+
+    size = estimate_cache_entry_size("key", Value(), stop_after=None)
+
+    assert size > MIN_TRACKED_ENTRY_BYTES
+
+
+def test_estimate_cache_entry_size_avoids_custom_metaclass_equality_hook() -> None:
+    class HostileMeta(type):
+        def __eq__(cls, other: object) -> bool:
+            raise AssertionError("unexpected metaclass equality")  # noqa: TRY003
+
+    class Value(metaclass=HostileMeta):
+        __slots__ = ("payload",)
+
+        def __init__(self) -> None:
+            self.payload = bytearray(1024)
+
+    size = estimate_cache_entry_size("key", Value(), stop_after=None)
+
+    assert size > MIN_TRACKED_ENTRY_BYTES
 
 
 @pytest.mark.parametrize("metadata_name", ["__mro__", "__dict__"])

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -1229,6 +1229,96 @@ def test_budget_touch_refreshes_recency() -> None:
     assert ("values", "b") not in owner.entries
 
 
+def test_budget_touch_many_preserves_latest_access_order() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    budget.register(owner, entry_size * 3)
+    for key, value in (("a", "A"), ("b", "B"), ("c", "C")):
+        owner.store("values", key, value)
+        budget.track(owner, "values", key, value)
+
+    budget.touch_many(
+        owner,
+        (("values", "a"), ("values", "b"), ("values", "a")),
+    )
+    owner.store("values", "d", "D")
+    budget.track(owner, "values", "d", "D")
+
+    assert ("values", "a") in owner.entries
+    assert ("values", "b") in owner.entries
+    assert ("values", "c") not in owner.entries
+    assert ("values", "d") in owner.entries
+
+
+def test_budget_touch_skips_lock_for_current_mru_entry() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "value")
+    budget.track(owner, "values", "key", "value")
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+
+    try:
+        budget.touch(owner, "values", "key")
+    finally:
+        budget._lock = original_lock
+
+
+def test_budget_touch_skips_lock_for_mru_after_current_entry_is_removed() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    for key in ("first", "second"):
+        owner.store("values", key, key)
+        budget.track(owner, "values", key, key)
+    owner.entries.pop(("values", "second"))
+    budget.remove(owner, "values", "second")
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+
+    try:
+        budget.touch(owner, "values", "first")
+    finally:
+        budget._lock = original_lock
+
+
+def test_budget_touch_skips_lock_for_mru_after_limit_setting_transition() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    for key in ("first", "second"):
+        owner.store("values", key, key)
+        budget.track(owner, "values", key, key)
+    budget.register(owner, None)
+    budget.register(owner, 10_000)
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+
+    try:
+        budget.touch(owner, "values", "second")
+    finally:
+        budget._lock = original_lock
+
+
+def test_budget_touch_locks_when_entry_is_not_current_mru() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    for key in ("first", "second"):
+        owner.store("values", key, key)
+        budget.track(owner, "values", key, key)
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+
+    try:
+        with pytest.raises(AssertionError, match="unexpected coordinator lock entry"):
+            budget.touch(owner, "values", "first")
+    finally:
+        budget._lock = original_lock
+
+
 def test_budget_does_not_admit_entry_larger_than_limit() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -25,6 +25,10 @@ from general_manager.cache import run_context_lru
 class CacheOwner:
     def __init__(self) -> None:
         self.entries: dict[tuple[RunCacheNamespace, Hashable], object] = {}
+        self.budget_enabled = False
+
+    def _set_run_cache_budget_enabled(self, enabled: bool) -> None:
+        self.budget_enabled = enabled
 
     def store(
         self,
@@ -1298,6 +1302,138 @@ def test_budget_touch_skips_lock_for_mru_after_limit_setting_transition() -> Non
 
     try:
         budget.touch(owner, "values", "second")
+    finally:
+        budget._lock = original_lock
+
+
+def test_budget_notifies_live_owners_when_enabled_mode_changes() -> None:
+    budget = ProcessRunContextCacheBudget()
+    first = CacheOwner()
+    second = CacheOwner()
+    budget.register(first, None)
+    budget.register(second, 10_000)
+
+    assert first.budget_enabled
+    assert second.budget_enabled
+
+    budget.register(first, None)
+
+    assert not first.budget_enabled
+    assert not second.budget_enabled
+
+
+def test_budget_refreshes_mru_after_eviction() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    budget.register(owner, entry_size)
+    for key, value in (("a", "A"), ("b", "B")):
+        owner.store("values", key, value)
+        budget.track(owner, "values", key, value)
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+
+    try:
+        budget.touch(owner, "values", "b")
+        with pytest.raises(AssertionError, match="unexpected coordinator lock entry"):
+            budget.touch(owner, "values", "a")
+    finally:
+        budget._lock = original_lock
+
+
+def test_budget_refreshes_mru_after_clear_context() -> None:
+    budget = ProcessRunContextCacheBudget()
+    first = CacheOwner()
+    second = CacheOwner()
+    budget.register(first, 10_000)
+    budget.register(second, 10_000)
+    first.store("values", "a", "A")
+    budget.track(first, "values", "a", "A")
+    second.store("values", "b", "B")
+    budget.track(second, "values", "b", "B")
+    budget.clear_context(second)
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+
+    try:
+        budget.touch(first, "values", "a")
+        with pytest.raises(AssertionError, match="unexpected coordinator lock entry"):
+            budget.touch(second, "values", "b")
+    finally:
+        budget._lock = original_lock
+
+
+def test_budget_refreshes_mru_after_weak_owner_finalization() -> None:
+    import gc
+
+    budget = ProcessRunContextCacheBudget()
+    survivor = CacheOwner()
+    dead_owner = CacheOwner()
+    budget.register(survivor, 10_000)
+    budget.register(dead_owner, 10_000)
+    survivor.store("values", "a", "A")
+    budget.track(survivor, "values", "a", "A")
+    dead_owner.store("values", "b", "B")
+    budget.track(dead_owner, "values", "b", "B")
+    dead_reference = ref(dead_owner)
+
+    del dead_owner
+    gc.collect()
+
+    assert dead_reference() is None
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+    try:
+        budget.touch(survivor, "values", "a")
+    finally:
+        budget._lock = original_lock
+
+
+def test_budget_stale_owner_finalizer_preserves_replacement_mru() -> None:
+    budget = ProcessRunContextCacheBudget()
+    stale_owner = CacheOwner()
+    stale_reference = ref(stale_owner)
+    replacement_owner = CacheOwner()
+    replacement_reference = ref(replacement_owner)
+    owner_id = id(stale_owner)
+    tracked_key = (owner_id, "values", "replacement")
+    entry_size = estimate_cache_entry_size("replacement", "R", stop_after=None)
+    replacement_owner.store("values", "replacement", "R")
+    budget._owner_references = {owner_id: replacement_reference}
+    budget._entries[tracked_key] = _TrackedEntry(
+        owner=replacement_reference,
+        namespace="values",
+        key="replacement",
+        size=entry_size,
+    )
+    budget._mru_key = tracked_key
+    budget._total_bytes = entry_size
+
+    budget._owner_finalizer(owner_id)(stale_reference)
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+    try:
+        budget.touch(replacement_owner, "values", "replacement")
+    finally:
+        budget._lock = original_lock
+
+
+def test_budget_refreshes_mru_after_oversized_rejection() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    budget.register(owner, entry_size)
+    owner.store("values", "a", "A")
+    budget.track(owner, "values", "a", "A")
+    owner.store("values", "oversized", b"x" * 1024)
+    budget.track(owner, "values", "oversized", b"x" * 1024)
+    original_lock = budget._lock
+    budget._lock = RaisingLock()
+
+    try:
+        budget.touch(owner, "values", "a")
+        with pytest.raises(AssertionError, match="unexpected coordinator lock entry"):
+            budget.touch(owner, "values", "oversized")
     finally:
         budget._lock = original_lock
 

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -189,6 +189,26 @@ def test_estimate_cache_entry_size_does_not_inspect_atomic_leaf_metadata(
     assert size >= MIN_TRACKED_ENTRY_BYTES
 
 
+def test_estimate_cache_entry_size_counts_same_atomic_object_once() -> None:
+    value = b"x" * 1_024
+
+    size = estimate_cache_entry_size(value, value, stop_after=None)
+
+    assert size == sys.getsizeof(value)
+
+
+def test_estimate_cache_entry_size_stops_after_atomic_value_exceeds_budget() -> None:
+    value = b"x" * 1_024
+    with mock.patch(
+        "general_manager.cache.run_context_lru.sys.getsizeof",
+        wraps=sys.getsizeof,
+    ) as getsizeof:
+        size = estimate_cache_entry_size("key", value, stop_after=1)
+
+    assert size == 2
+    getsizeof.assert_called_once_with(value)
+
+
 def test_estimate_cache_entry_size_counts_shared_object_once_per_entry() -> None:
     shared = [bytearray(1024)]
 
@@ -283,6 +303,76 @@ def test_estimate_cache_entry_size_samples_large_sequence_with_bounded_work() ->
         estimate_cache_entry_size("key", value, stop_after=None)
 
     assert getsizeof.call_count <= 64 + 2
+
+
+def test_estimate_cache_entry_size_traverses_sequence_at_exact_sample_threshold() -> (
+    None
+):
+    value = [bytearray(1) for _ in range(128)]
+    with mock.patch(
+        "general_manager.cache.run_context_lru.sys.getsizeof",
+        wraps=sys.getsizeof,
+    ) as getsizeof:
+        estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert getsizeof.call_count == 128 + 2
+
+
+def test_estimate_cache_entry_size_samples_sequence_above_threshold() -> None:
+    value = [bytearray(1) for _ in range(129)]
+    with mock.patch(
+        "general_manager.cache.run_context_lru.sys.getsizeof",
+        wraps=sys.getsizeof,
+    ) as getsizeof:
+        estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert getsizeof.call_count == 64 + 2
+
+
+def test_estimate_cache_entry_size_traverses_mapping_at_exact_sample_threshold() -> (
+    None
+):
+    value = {f"item-{index}".encode(): bytearray(1) for index in range(128)}
+    with mock.patch(
+        "general_manager.cache.run_context_lru.sys.getsizeof",
+        wraps=sys.getsizeof,
+    ) as getsizeof:
+        estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert getsizeof.call_count == (128 * 2) + 2
+
+
+def test_estimate_cache_entry_size_samples_mapping_above_threshold() -> None:
+    value = {f"item-{index}".encode(): bytearray(1) for index in range(129)}
+    with mock.patch(
+        "general_manager.cache.run_context_lru.sys.getsizeof",
+        wraps=sys.getsizeof,
+    ) as getsizeof:
+        estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert getsizeof.call_count == (64 * 2) + 2
+
+
+def test_estimate_cache_entry_size_traverses_set_at_exact_sample_threshold() -> None:
+    value = {f"item-{index}".encode() for index in range(128)}
+    with mock.patch(
+        "general_manager.cache.run_context_lru.sys.getsizeof",
+        wraps=sys.getsizeof,
+    ) as getsizeof:
+        estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert getsizeof.call_count == 128 + 2
+
+
+def test_estimate_cache_entry_size_samples_set_above_threshold() -> None:
+    value = {f"item-{index}".encode() for index in range(129)}
+    with mock.patch(
+        "general_manager.cache.run_context_lru.sys.getsizeof",
+        wraps=sys.getsizeof,
+    ) as getsizeof:
+        estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert getsizeof.call_count == 64 + 2
 
 
 def test_estimate_cache_entry_size_stratifies_large_sequence_samples() -> None:

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -1,4 +1,5 @@
 from collections.abc import Hashable, Iterable, Iterator
+from threading import Event, Thread
 from unittest import mock
 import math
 import sys
@@ -681,6 +682,135 @@ def test_unlimited_budget_operations_do_not_enter_lock_or_hash_key() -> None:
     budget.refresh(owner, "values", key, "value")
 
     assert key.hash_calls == 0
+
+
+def test_estimation_does_not_hold_coordinator_lock() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "initial", "value")
+    budget.track(owner, "values", "initial", "value")
+
+    estimator_started = Event()
+    allow_estimator_to_finish = Event()
+    worker_errors: list[BaseException] = []
+    reader_errors: list[BaseException] = []
+
+    def blocking_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        assert key == "blocked"
+        assert value == "value"
+        assert stop_after == 10_000
+        estimator_started.set()
+        assert allow_estimator_to_finish.wait(timeout=1)
+        return MIN_TRACKED_ENTRY_BYTES
+
+    def track_entry() -> None:
+        try:
+            budget.track(owner, "values", "blocked", "value")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    read_completed = Event()
+
+    def read_budget() -> None:
+        try:
+            _ = budget.estimated_bytes
+        except BaseException as error:  # noqa: BLE001
+            reader_errors.append(error)
+        finally:
+            read_completed.set()
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=blocking_estimator,
+    ):
+        worker = Thread(target=track_entry)
+        reader = Thread(target=read_budget)
+        reader_started = False
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            reader.start()
+            reader_started = True
+            assert read_completed.wait(timeout=1), (
+                "estimation held the coordinator lock"
+            )
+        finally:
+            allow_estimator_to_finish.set()
+            worker.join(timeout=1)
+            if reader_started:
+                reader.join(timeout=1)
+
+    assert not worker.is_alive()
+    if reader_started:
+        assert not reader.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    if reader_errors:
+        raise reader_errors[0]
+
+
+def test_track_retries_estimation_after_limit_change() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    old_limit = 10_000
+    new_limit = MIN_TRACKED_ENTRY_BYTES
+    budget.register(owner, old_limit)
+    owner.store("values", "key", "value")
+
+    estimator_started = Event()
+    allow_estimator_to_finish = Event()
+    stop_after_values: list[int | None] = []
+    worker_errors: list[BaseException] = []
+
+    def blocking_first_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        assert key == "key"
+        assert value == "value"
+        stop_after_values.append(stop_after)
+        if len(stop_after_values) == 1:
+            estimator_started.set()
+            assert allow_estimator_to_finish.wait(timeout=1)
+        return MIN_TRACKED_ENTRY_BYTES
+
+    def track_entry() -> None:
+        try:
+            budget.track(owner, "values", "key", "value")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=blocking_first_estimator,
+    ):
+        worker = Thread(target=track_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            with budget._lock:
+                budget._max_bytes = new_limit
+                budget._configuration_generation += 1
+            allow_estimator_to_finish.set()
+        finally:
+            allow_estimator_to_finish.set()
+            worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert stop_after_values == [old_limit, new_limit]
+    assert budget.estimated_bytes <= new_limit
 
 
 def test_budget_evicts_oldest_entry_across_owners() -> None:

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -140,6 +140,34 @@ def test_estimate_cache_entry_size_handles_cycles() -> None:
     assert size >= MIN_TRACKED_ENTRY_BYTES
 
 
+@pytest.mark.parametrize("stop_after", [None, 10**400])
+def test_estimate_cache_entry_size_handles_sampled_sequence_cycles(
+    stop_after: int | None,
+) -> None:
+    value: list[object] = [None] * 2_000
+    value[-1] = value
+
+    size = estimate_cache_entry_size("cycle", value, stop_after=stop_after)
+
+    assert MIN_TRACKED_ENTRY_BYTES <= size
+    if stop_after is not None:
+        assert size <= stop_after
+
+
+@pytest.mark.parametrize("stop_after", [None, 10**400])
+def test_estimate_cache_entry_size_handles_sampled_mapping_cycles(
+    stop_after: int | None,
+) -> None:
+    value: dict[int, object] = {index: None for index in range(2_000)}
+    value[max(value)] = value
+
+    size = estimate_cache_entry_size("cycle", value, stop_after=stop_after)
+
+    assert MIN_TRACKED_ENTRY_BYTES <= size
+    if stop_after is not None:
+        assert size <= stop_after
+
+
 @pytest.mark.parametrize(
     "value",
     [None, False, 1, 1.5, 2j, "value", b"value", bytearray(b"value"), range(3)],

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -926,6 +926,119 @@ def test_track_keeps_latest_same_key_replacement_accounting() -> None:
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
 
 
+def test_track_admits_distinct_entry_after_other_entry_is_tracked() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "a", "A")
+
+    estimator_started = Event()
+    allow_estimator_to_finish = Event()
+    worker_errors: list[BaseException] = []
+
+    def blocking_a_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        assert stop_after == 10_000
+        if key == "a":
+            assert value == "A"
+            estimator_started.set()
+            assert allow_estimator_to_finish.wait(timeout=1)
+        else:
+            assert key == "b"
+            assert value == "B"
+        return MIN_TRACKED_ENTRY_BYTES
+
+    def track_a() -> None:
+        try:
+            budget.track(owner, "values", "a", "A")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=blocking_a_estimator,
+    ):
+        worker = Thread(target=track_a)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            owner.store("values", "b", "B")
+            budget.track(owner, "values", "b", "B")
+            allow_estimator_to_finish.set()
+        finally:
+            allow_estimator_to_finish.set()
+            worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert owner.entries == {("values", "a"): "A", ("values", "b"): "B"}
+    assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES * 2
+
+
+def test_track_rejects_pre_clear_attempt_after_owner_lifecycle_restarts() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "old")
+
+    estimator_started = Event()
+    allow_estimator_to_finish = Event()
+    worker_errors: list[BaseException] = []
+
+    def delayed_old_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        assert key == "key"
+        assert stop_after == 10_000
+        if value == "old":
+            estimator_started.set()
+            assert allow_estimator_to_finish.wait(timeout=1)
+            return MIN_TRACKED_ENTRY_BYTES * 2
+        assert value == "new"
+        return MIN_TRACKED_ENTRY_BYTES
+
+    def track_old_entry() -> None:
+        try:
+            budget.track(owner, "values", "key", "old")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=delayed_old_estimator,
+    ):
+        worker = Thread(target=track_old_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            budget.clear_context(owner)
+            owner._evict_run_cache_entry("values", "key")
+            budget.register(owner, 10_000)
+            owner.store("values", "key", "new")
+            budget.track(owner, "values", "key", "new")
+            allow_estimator_to_finish.set()
+        finally:
+            allow_estimator_to_finish.set()
+            worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert owner.entries[("values", "key")] == "new"
+    assert budget._entries[(id(owner), "values", "key")].size == MIN_TRACKED_ENTRY_BYTES
+    assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
+
+
 def test_track_does_not_admit_entry_evicted_while_estimation_is_blocked() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -810,7 +810,194 @@ def test_track_retries_estimation_after_limit_change() -> None:
     if worker_errors:
         raise worker_errors[0]
     assert stop_after_values == [old_limit, new_limit]
-    assert budget.estimated_bytes <= new_limit
+    assert owner.entries[("values", "key")] == "value"
+    assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
+
+
+@pytest.mark.parametrize("mutation", ["remove", "clear_context"])
+def test_track_does_not_reintroduce_accounting_after_owner_mutation(
+    mutation: str,
+) -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "value")
+
+    estimator_started = Event()
+    allow_estimator_to_finish = Event()
+    worker_errors: list[BaseException] = []
+
+    def blocking_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        assert key == "key"
+        assert value == "value"
+        assert stop_after == 10_000
+        estimator_started.set()
+        assert allow_estimator_to_finish.wait(timeout=1)
+        return MIN_TRACKED_ENTRY_BYTES
+
+    def track_entry() -> None:
+        try:
+            budget.track(owner, "values", "key", "value")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=blocking_estimator,
+    ):
+        worker = Thread(target=track_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            if mutation == "remove":
+                owner._evict_run_cache_entry("values", "key")
+                budget.remove(owner, "values", "key")
+            else:
+                budget.clear_context(owner)
+            allow_estimator_to_finish.set()
+        finally:
+            allow_estimator_to_finish.set()
+            worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert budget.estimated_bytes == 0
+
+
+def test_track_keeps_latest_same_key_replacement_accounting() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "old")
+
+    estimator_started = Event()
+    allow_estimator_to_finish = Event()
+    worker_errors: list[BaseException] = []
+
+    def delayed_old_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        assert key == "key"
+        assert stop_after == 10_000
+        if value == "old":
+            estimator_started.set()
+            assert allow_estimator_to_finish.wait(timeout=1)
+            return MIN_TRACKED_ENTRY_BYTES * 2
+        assert value == "new"
+        return MIN_TRACKED_ENTRY_BYTES
+
+    def track_old_entry() -> None:
+        try:
+            budget.track(owner, "values", "key", "old")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=delayed_old_estimator,
+    ):
+        worker = Thread(target=track_old_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            owner.store("values", "key", "new")
+            budget.track(owner, "values", "key", "new")
+            allow_estimator_to_finish.set()
+        finally:
+            allow_estimator_to_finish.set()
+            worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert owner.entries[("values", "key")] == "new"
+    assert budget._entries[(id(owner), "values", "key")].size == MIN_TRACKED_ENTRY_BYTES
+    assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
+
+
+def test_track_does_not_admit_entry_evicted_while_estimation_is_blocked() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
+    budget.register(owner, entry_size * 2)
+    for key, value in (("a", "A"), ("b", "B")):
+        owner.store("values", key, value)
+        budget.track(owner, "values", key, value)
+
+    estimator_started = Event()
+    allow_estimator_to_finish = Event()
+    worker_errors: list[BaseException] = []
+    estimator_calls = 0
+
+    def blocking_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        nonlocal estimator_calls
+        assert key == "a"
+        assert value == "A"
+        assert stop_after in {entry_size, entry_size * 2}
+        estimator_calls += 1
+        if estimator_calls == 1:
+            estimator_started.set()
+            assert allow_estimator_to_finish.wait(timeout=1)
+        return entry_size
+
+    def refresh_entry() -> None:
+        try:
+            budget.refresh(owner, "values", "a", "A")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=blocking_estimator,
+    ):
+        worker = Thread(target=refresh_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            budget.register(owner, entry_size)
+            allow_estimator_to_finish.set()
+        finally:
+            allow_estimator_to_finish.set()
+            worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert ("values", "a") not in owner.entries
+    assert (id(owner), "values", "a") not in budget._entries
+    assert budget.estimated_bytes == entry_size
+
+
+def test_register_only_advances_configuration_generation_for_limit_changes() -> None:
+    budget = ProcessRunContextCacheBudget()
+    first = CacheOwner()
+    second = CacheOwner()
+
+    assert budget._configuration_generation == 0
+    budget.register(first, 10_000)
+    assert budget._configuration_generation == 1
+    budget.register(first, 10_000)
+    budget.register(second, 10_000)
+    assert budget._configuration_generation == 1
+    budget.register(first, 20_000)
+    assert budget._configuration_generation == 2
 
 
 def test_budget_evicts_oldest_entry_across_owners() -> None:

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -160,6 +160,33 @@ def test_estimate_cache_entry_size_handles_sampled_sequence_cycles(
 
 
 @pytest.mark.parametrize("stop_after", [None, 10**400])
+def test_estimate_cache_entry_size_handles_mutually_cyclic_sampled_sequences(
+    stop_after: int | None,
+) -> None:
+    first: list[object] = [None] * 200
+    second: list[object] = [None] * 200
+    first[-1] = second
+    second[-1] = first
+
+    size = estimate_cache_entry_size("cycle", first, stop_after=stop_after)
+
+    assert MIN_TRACKED_ENTRY_BYTES <= size
+    if stop_after is not None:
+        assert size <= stop_after
+
+
+def test_estimate_cache_entry_size_handles_deep_sampled_identity_sharing() -> None:
+    value: object = None
+    for _ in range(1_200):
+        value = [value] * 129
+    stop_after = 10**400
+
+    size = estimate_cache_entry_size("deep", value, stop_after=stop_after)
+
+    assert MIN_TRACKED_ENTRY_BYTES <= size <= stop_after
+
+
+@pytest.mark.parametrize("stop_after", [None, 10**400])
 def test_estimate_cache_entry_size_handles_sampled_mapping_cycles(
     stop_after: int | None,
 ) -> None:
@@ -905,6 +932,87 @@ def test_track_retries_estimation_after_limit_change() -> None:
         raise worker_errors[0]
     assert stop_after_values == [old_limit, new_limit]
     assert owner.entries[("values", "key")] == "value"
+    assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
+
+
+def test_track_discards_current_entry_after_estimator_exception() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "old")
+    budget.track(owner, "values", "key", "old")
+    owner.store("values", "key", "new")
+    tracked_key = (id(owner), "values", "key")
+
+    with (
+        mock.patch.object(
+            run_context_lru,
+            "estimate_cache_entry_size",
+            side_effect=RuntimeError("estimation failed"),
+        ),
+        pytest.raises(RuntimeError, match="estimation failed"),
+    ):
+        budget.track(owner, "values", "key", "new")
+
+    assert ("values", "key") not in owner.entries
+    assert tracked_key not in budget._entries
+    assert tracked_key not in budget._entry_attempt_generations
+    assert budget.estimated_bytes == 0
+
+
+def test_failed_track_does_not_evict_newer_same_key_replacement() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "old")
+
+    estimator_started = Event()
+    allow_estimator_to_fail = Event()
+    worker_errors: list[BaseException] = []
+
+    def delayed_old_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        assert key == "key"
+        assert stop_after == 10_000
+        if value == "old":
+            estimator_started.set()
+            assert allow_estimator_to_fail.wait(timeout=1)
+            raise RuntimeError
+        assert value == "new"
+        return MIN_TRACKED_ENTRY_BYTES
+
+    def track_old_entry() -> None:
+        try:
+            budget.track(owner, "values", "key", "old")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=delayed_old_estimator,
+    ):
+        worker = Thread(target=track_old_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            owner.store("values", "key", "new")
+            budget.track(owner, "values", "key", "new")
+        finally:
+            allow_estimator_to_fail.set()
+            worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    assert len(worker_errors) == 1
+    assert isinstance(worker_errors[0], RuntimeError)
+    assert owner.entries[("values", "key")] == "new"
+    assert budget._entries[(id(owner), "values", "key")].size == (
+        MIN_TRACKED_ENTRY_BYTES
+    )
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
 
 

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -16,10 +16,13 @@ from general_manager.cache.run_context_lru import (
     ProcessRunContextCacheBudget,
     RunCacheNamespace,
     _TrackedEntry,
+    _stratified_indexes,
     estimate_cache_entry_size,
     resolve_run_context_cache_max_bytes,
 )
 from general_manager.cache import run_context_lru
+
+HANDOFF_TIMEOUT_SECONDS = 5
 
 
 class CacheOwner:
@@ -412,6 +415,10 @@ def test_estimate_cache_entry_size_stratifies_large_sequence_samples() -> None:
     large_estimate = estimate_cache_entry_size("key", large, stop_after=None)
 
     assert large_estimate > small_estimate
+
+
+def test_stratified_indexes_returns_one_representative() -> None:
+    assert _stratified_indexes(129, 1) == (0,)
 
 
 def test_estimate_cache_entry_size_stops_after_budget() -> None:
@@ -827,7 +834,7 @@ def test_estimation_does_not_hold_coordinator_lock() -> None:
         assert value == "value"
         assert stop_after == 10_000
         estimator_started.set()
-        assert allow_estimator_to_finish.wait(timeout=1)
+        assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
         return MIN_TRACKED_ENTRY_BYTES
 
     def track_entry() -> None:
@@ -856,17 +863,17 @@ def test_estimation_does_not_hold_coordinator_lock() -> None:
         reader_started = False
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             reader.start()
             reader_started = True
-            assert read_completed.wait(timeout=1), (
+            assert read_completed.wait(timeout=HANDOFF_TIMEOUT_SECONDS), (
                 "estimation held the coordinator lock"
             )
         finally:
             allow_estimator_to_finish.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
             if reader_started:
-                reader.join(timeout=1)
+                reader.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     if reader_started:
@@ -901,7 +908,7 @@ def test_track_retries_estimation_after_limit_change() -> None:
         stop_after_values.append(stop_after)
         if len(stop_after_values) == 1:
             estimator_started.set()
-            assert allow_estimator_to_finish.wait(timeout=1)
+            assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
         return MIN_TRACKED_ENTRY_BYTES
 
     def track_entry() -> None:
@@ -918,14 +925,14 @@ def test_track_retries_estimation_after_limit_change() -> None:
         worker = Thread(target=track_entry)
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             with budget._lock:
                 budget._max_bytes = new_limit
                 budget._configuration_generation += 1
             allow_estimator_to_finish.set()
         finally:
             allow_estimator_to_finish.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     if worker_errors:
@@ -933,6 +940,44 @@ def test_track_retries_estimation_after_limit_change() -> None:
     assert stop_after_values == [old_limit, new_limit]
     assert owner.entries[("values", "key")] == "value"
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
+
+
+def test_track_abandons_admission_during_continuous_limit_changes() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "value")
+    estimator_calls = 0
+
+    def changing_configuration_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        nonlocal estimator_calls
+        assert key == "key"
+        assert value == "value"
+        assert stop_after is not None
+        estimator_calls += 1
+        if estimator_calls <= 100:
+            with budget._lock:
+                assert budget._max_bytes is not None
+                budget._max_bytes += 1
+                budget._configuration_generation += 1
+        return MIN_TRACKED_ENTRY_BYTES
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=changing_configuration_estimator,
+    ):
+        budget.track(owner, "values", "key", "value")
+
+    assert estimator_calls == 4
+    assert ("values", "key") not in owner.entries
+    assert (id(owner), "values", "key") not in budget._entry_attempt_generations
+    assert budget.estimated_bytes == 0
 
 
 def test_track_discards_current_entry_after_estimator_exception() -> None:
@@ -980,7 +1025,7 @@ def test_failed_track_does_not_evict_newer_same_key_replacement() -> None:
         assert stop_after == 10_000
         if value == "old":
             estimator_started.set()
-            assert allow_estimator_to_fail.wait(timeout=1)
+            assert allow_estimator_to_fail.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             raise RuntimeError
         assert value == "new"
         return MIN_TRACKED_ENTRY_BYTES
@@ -999,12 +1044,12 @@ def test_failed_track_does_not_evict_newer_same_key_replacement() -> None:
         worker = Thread(target=track_old_entry)
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             owner.store("values", "key", "new")
             budget.track(owner, "values", "key", "new")
         finally:
             allow_estimator_to_fail.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     assert len(worker_errors) == 1
@@ -1039,7 +1084,7 @@ def test_track_does_not_reintroduce_accounting_after_owner_mutation(
         assert value == "value"
         assert stop_after == 10_000
         estimator_started.set()
-        assert allow_estimator_to_finish.wait(timeout=1)
+        assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
         return MIN_TRACKED_ENTRY_BYTES
 
     def track_entry() -> None:
@@ -1056,7 +1101,7 @@ def test_track_does_not_reintroduce_accounting_after_owner_mutation(
         worker = Thread(target=track_entry)
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             if mutation == "remove":
                 owner._evict_run_cache_entry("values", "key")
                 budget.remove(owner, "values", "key")
@@ -1065,7 +1110,7 @@ def test_track_does_not_reintroduce_accounting_after_owner_mutation(
             allow_estimator_to_finish.set()
         finally:
             allow_estimator_to_finish.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     if worker_errors:
@@ -1093,7 +1138,7 @@ def test_track_keeps_latest_same_key_replacement_accounting() -> None:
         assert stop_after == 10_000
         if value == "old":
             estimator_started.set()
-            assert allow_estimator_to_finish.wait(timeout=1)
+            assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             return MIN_TRACKED_ENTRY_BYTES * 2
         assert value == "new"
         return MIN_TRACKED_ENTRY_BYTES
@@ -1112,13 +1157,13 @@ def test_track_keeps_latest_same_key_replacement_accounting() -> None:
         worker = Thread(target=track_old_entry)
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             owner.store("values", "key", "new")
             budget.track(owner, "values", "key", "new")
             allow_estimator_to_finish.set()
         finally:
             allow_estimator_to_finish.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     if worker_errors:
@@ -1148,7 +1193,7 @@ def test_track_admits_distinct_entry_after_other_entry_is_tracked() -> None:
         if key == "a":
             assert value == "A"
             estimator_started.set()
-            assert allow_estimator_to_finish.wait(timeout=1)
+            assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
         else:
             assert key == "b"
             assert value == "B"
@@ -1168,13 +1213,13 @@ def test_track_admits_distinct_entry_after_other_entry_is_tracked() -> None:
         worker = Thread(target=track_a)
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             owner.store("values", "b", "B")
             budget.track(owner, "values", "b", "B")
             allow_estimator_to_finish.set()
         finally:
             allow_estimator_to_finish.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     if worker_errors:
@@ -1203,7 +1248,7 @@ def test_track_rejects_pre_clear_attempt_after_owner_lifecycle_restarts() -> Non
         assert stop_after == 10_000
         if value == "old":
             estimator_started.set()
-            assert allow_estimator_to_finish.wait(timeout=1)
+            assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             return MIN_TRACKED_ENTRY_BYTES * 2
         assert value == "new"
         return MIN_TRACKED_ENTRY_BYTES
@@ -1222,7 +1267,7 @@ def test_track_rejects_pre_clear_attempt_after_owner_lifecycle_restarts() -> Non
         worker = Thread(target=track_old_entry)
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             budget.clear_context(owner)
             owner._evict_run_cache_entry("values", "key")
             budget.register(owner, 10_000)
@@ -1231,7 +1276,7 @@ def test_track_rejects_pre_clear_attempt_after_owner_lifecycle_restarts() -> Non
             allow_estimator_to_finish.set()
         finally:
             allow_estimator_to_finish.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     if worker_errors:
@@ -1268,7 +1313,7 @@ def test_track_does_not_admit_entry_evicted_while_estimation_is_blocked() -> Non
         estimator_calls += 1
         if estimator_calls == 1:
             estimator_started.set()
-            assert allow_estimator_to_finish.wait(timeout=1)
+            assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
         return entry_size
 
     def refresh_entry() -> None:
@@ -1285,12 +1330,12 @@ def test_track_does_not_admit_entry_evicted_while_estimation_is_blocked() -> Non
         worker = Thread(target=refresh_entry)
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             budget.register(owner, entry_size)
             allow_estimator_to_finish.set()
         finally:
             allow_estimator_to_finish.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     if worker_errors:
@@ -1359,7 +1404,7 @@ def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
         invocation = estimator_calls
         if invocation == 1:
             estimator_started.set()
-            assert allow_estimator_to_finish.wait(timeout=1)
+            assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             return MIN_TRACKED_ENTRY_BYTES * 2
         return MIN_TRACKED_ENTRY_BYTES
 
@@ -1377,14 +1422,14 @@ def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
         worker = Thread(target=track_entry)
         worker.start()
         try:
-            assert estimator_started.wait(timeout=1)
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             budget.register(owner, None)
             assert not budget._entry_attempt_generations
             budget.register(owner, 10_000)
             allow_estimator_to_finish.set()
         finally:
             allow_estimator_to_finish.set()
-            worker.join(timeout=1)
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
 
     assert not worker.is_alive()
     if worker_errors:

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -1113,6 +1113,84 @@ def test_register_only_advances_configuration_generation_for_limit_changes() -> 
     assert budget._configuration_generation == 2
 
 
+def test_disabling_budget_releases_attempt_tokens_for_removed_entries() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+
+    for key in ("first", "second", "third"):
+        budget.register(owner, 10_000)
+        owner.store("values", key, "value")
+        budget.track(owner, "values", key, "value")
+        tracked_key = (id(owner), "values", key)
+        assert tracked_key in budget._entry_attempt_generations
+
+        budget.register(owner, None)
+        owner._evict_run_cache_entry("values", key)
+        budget.remove(owner, "values", key)
+
+        assert tracked_key not in budget._entry_attempt_generations
+        assert not budget._entry_attempt_generations
+
+
+def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "value")
+
+    estimator_started = Event()
+    allow_estimator_to_finish = Event()
+    worker_errors: list[BaseException] = []
+    estimator_calls = 0
+
+    def blocking_first_estimator(
+        key: Hashable,
+        value: object,
+        *,
+        stop_after: int | None,
+    ) -> int:
+        nonlocal estimator_calls
+        assert key == "key"
+        assert value == "value"
+        assert stop_after == 10_000
+        estimator_calls += 1
+        if estimator_calls == 1:
+            estimator_started.set()
+            assert allow_estimator_to_finish.wait(timeout=1)
+        if estimator_calls == 2:
+            return MIN_TRACKED_ENTRY_BYTES
+        return MIN_TRACKED_ENTRY_BYTES * 2
+
+    def track_entry() -> None:
+        try:
+            budget.track(owner, "values", "key", "value")
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=blocking_first_estimator,
+    ):
+        worker = Thread(target=track_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=1)
+            budget.register(owner, None)
+            assert not budget._entry_attempt_generations
+            budget.register(owner, 10_000)
+            allow_estimator_to_finish.set()
+        finally:
+            allow_estimator_to_finish.set()
+            worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert budget._entries[(id(owner), "values", "key")].size == MIN_TRACKED_ENTRY_BYTES
+    assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
+
+
 def test_budget_evicts_oldest_entry_across_owners() -> None:
     budget = ProcessRunContextCacheBudget()
     first = CacheOwner()

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -1154,12 +1154,12 @@ def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
         assert value == "value"
         assert stop_after == 10_000
         estimator_calls += 1
-        if estimator_calls == 1:
+        invocation = estimator_calls
+        if invocation == 1:
             estimator_started.set()
             assert allow_estimator_to_finish.wait(timeout=1)
-        if estimator_calls == 2:
-            return MIN_TRACKED_ENTRY_BYTES
-        return MIN_TRACKED_ENTRY_BYTES * 2
+            return MIN_TRACKED_ENTRY_BYTES * 2
+        return MIN_TRACKED_ENTRY_BYTES
 
     def track_entry() -> None:
         try:
@@ -1187,6 +1187,7 @@ def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
     assert not worker.is_alive()
     if worker_errors:
         raise worker_errors[0]
+    assert estimator_calls == 2
     assert budget._entries[(id(owner), "values", "key")].size == MIN_TRACKED_ENTRY_BYTES
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
 


### PR DESCRIPTION
## Summary

The optional run-context memory cap introduced synchronous recursive sizing and global LRU coordination on hot cache operations, causing approximately 2× hit latency and much larger insertion regressions. This change keeps the process-wide estimated-memory budget while bounding estimator work, moving normal sizing outside the coordinator lock, and batching recency updates safely.

## Related issue

No linked issue.

## What changed

- Added a standalone capped-versus-uncapped run-context benchmark.
- Kept exact sizing for small containers and added bounded representative sampling for large containers with a 5% upward projection margin.
- Added atomic-value sizing fast paths and safe per-estimate storage-plan reuse.
- Moved normal entry sizing outside the global coordinator lock with configuration, lifecycle, and per-key freshness guards.
- Batched owning-thread recency updates in groups of 64, added an MRU fast path, and retained locked immediate touches for foreign threads.
- Preserved pending dependency-publication pinning, cross-context eviction, weak owner cleanup, and historical cache scoping.
- Hardened sampled cycles, huge finite budgets, exception cleanup, and concurrent same-key replacement behavior.
- Updated cache API and deployment documentation.

## Validation

```text
PYTHONPATH=src python -m pytest — 5821 passed, 3 skipped, 1 pre-existing warning
python -m pytest tests/perf -q — 93 passed
ruff check — passed
ruff format --check — passed
mypy — passed
pre-commit run --all-files — passed
git diff --check c2ff589e..HEAD — passed
PYTHONPATH=src DJANGO_SETTINGS_MODULE=tests.test_settings python scripts/benchmark_run_context_cache_budget.py --repeats 5 --hits 300000 --scalar-inserts 20000 --container-inserts 200 --container-width 2000 — hits 1.27x capped/uncapped; capped scalar 0.046392s; capped containers 0.034150s
```

Compared with the v0.69.0 analysis baseline, capped hit time fell from about 0.108s to 0.058s, scalar insertion from about 0.116s to 0.046s, and container insertion from about 1.62s to 0.034s.

## Documentation

Updated `docs/api/cache.md` and `docs/concepts/caching.md` to describe bounded sampled estimation, approximate batched recency, cross-context staleness, and the distinction between an estimated cache budget and a hard RSS limit.

## Reviewer notes

- Large-container sizing is deliberately approximate. Containers with at most 128 children are fully traversed; larger built-in containers sample at most 64 representative children and apply an exact 5% upward projection margin.
- The 5% accuracy goal applies to representative payloads, not adversarial heterogeneous graphs.
- Recency can lag by at most one internal 64-access batch for the owning thread. Foreign-thread hits update the locked coordinator immediately.
- Exact rational projection prevents overflow in deeply nested sampled graphs. It is slower than the earlier float prototype but remains roughly 47× faster than the v0.69.0 capped container baseline.
- No runtime telemetry, new settings, dependencies, public exports, migrations, or version changes were added.
- Suggested review order: `run_context_lru.py`, then `run_context.py`, then their focused tests and docs.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved run-context cache budgeting with approximate LRU eviction and batched recency tracking.
  * Added bounded, safety-margined memory estimation for large and complex container values.
  * Improved cache consistency during concurrent access, eviction, cleanup, and configuration changes.

* **Documentation**
  * Updated caching guidance to explain approximate budgeting, sampled estimation, and reduced cache-hit overhead.

* **Tools**
  * Added a benchmark utility for measuring run-context cache performance across common workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->