### PR TITLE
perf: calibrate run-context cache budgeting

### DIFF
--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -513,35 +513,40 @@ a positive integer sets the shared byte budget. Negative integers, booleans,
 and non-integer values raise a Django configuration error when a
 `CalculationRunContext` is created.
 
-The budget uses an insertion-time estimate and evicts approximately
-least-recently-used eviction-safe entries across live contexts when necessary.
-Successful reads from the thread that entered the context update recency in
-small internal batches to avoid a process-wide lock on every cache hit. Reads
-from another thread update recency immediately. A write flushes recency already
-observed by that same context before admission, while another context may
-observe up to one internal batch of stale recency. This batching changes only
-which safe entry is selected under pressure; misses, reloads, publication
-pinning, and the configured byte budget retain their existing behavior. Values
-whose estimate exceeds the complete budget are returned to the caller but
-bypass retention.
+The budget uses an insertion-time estimate and keeps a 5% modeled reserve while
+evicting eviction-safe entries across live contexts. Ordinary admissions use
+shallow signals and coarse aggregate calibration instead of traversing every
+stored object graph. The first entry and sparse later entries for each storage
+family are bounded deep samples; admissions between samples use the calibrated
+aggregate estimate.
+
+Read recency is inactive below budget pressure, so earlier accesses retain
+insertion order. Near the cap, recency becomes a batched approximate LRU: reads
+from the thread that entered the context are published in small internal
+batches, while reads from another thread publish immediately. A write flushes
+recency already observed by that same context before admission, while another
+context may observe up to one internal batch of stale recency. This approximation
+changes only which safe entry is selected under pressure; misses, reloads, and
+publication pinning retain their existing behavior. Values whose estimate
+exceeds the complete configured budget are returned to the caller but bypass
+retention.
 Pending dependency-cache publications, and their same-run hits, remain pinned
 until a flush attempt removes the pending entries or publication state is
 discarded. Flush attempts unpin after success, guarded abort, unexpected publish
 failure, or lease-release failure, so eviction never loses a pending publication
 or its compute lease.
 
-Built-in containers at or below `RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD` (128) are
-traversed completely. Larger built-in containers use
-`RUN_CONTEXT_SIZE_SAMPLE_COUNT` (64) representatives whose projected child size
-includes a 5% upward safety margin. This keeps admission cost bounded for large
-ORM results and indexes. The estimate targets approximately 5% accuracy for
-representative payloads, but unusual heterogeneous or heavily shared object
-graphs can differ by more; this remains an estimated cache budget rather than a
-hard RSS limit.
+Deep calibration samples traverse built-in containers at or below an internal
+threshold completely. Larger containers use a bounded set of representatives.
+This keeps the occasional calibration cost bounded for large ORM results and
+indexes. The resulting aggregate estimate targets approximately 5% accuracy for
+representative payloads, not adversarial graphs or process RSS. Unusual
+heterogeneous or heavily shared object graphs can differ by more.
 
 This setting is not a hard cap on total process RSS. In particular, Python and
 native allocation overhead, other application memory, and caller-owned mutable
-values that grow after insertion are outside the insertion-time estimate.
+values that grow after insertion are outside the insertion-time estimate. The
+budgeting mechanism collects no telemetry.
 
 `get_or_set(key, loader)` stores the first successful loader result under the
 hashable key and returns that same object for later calls with the same key.

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -246,16 +246,23 @@ active.
 
 For long-lived or concurrent runs, applications can configure the optional
 `GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"]` setting to give eviction-safe
-run-cache entries a process-local estimated-memory budget. Enabling the cap
-adds bounded sampled estimation and approximate-LRU bookkeeping. Primitive
-sizing, large-container sampling, and batched recency avoid work proportional
-to the complete object graph on every insertion or global coordination on every
-hit. Plan fleet capacity by multiplying that value by the number of worker
+run-cache entries a process-local estimated-memory budget. Enabling the cap uses
+shallow admission signals and coarse aggregate calibration: the first and
+sparse later entries for each storage family are bounded deep samples, while
+ordinary admissions reuse their calibrated estimate. The estimate targets 5%
+accuracy for representative aggregates, not adversarial object graphs or RSS,
+and eviction keeps a 5% modeled reserve.
+
+Read recency is inactive below pressure, where insertion order remains in
+effect. Near the cap it becomes a batched approximate LRU, avoiding global
+coordination on every hit. Pending dependency-cache publications remain pinned.
+Plan fleet capacity by multiplying the configured value by the number of worker
 processes: each Gunicorn, Celery, or other Python worker has its own budget. The
-estimate is taken when a value is inserted, so caller-owned
-mutable values can later grow beyond their recorded size. This is not a hard
-worker-memory or RSS limit; applications that need a hard worker ceiling should
-also configure deployment-level memory limits and worker recycling.
+estimate is taken when a value is inserted, so post-insert caller mutation,
+native allocations, and other process memory remain outside it. The mechanism
+collects no telemetry and is not a hard worker-memory or RSS limit; applications
+that need a hard worker ceiling should also configure deployment-level memory
+limits and worker recycling.
 
 Callable `Input.possible_values` providers are also cached automatically inside
 an active `CalculationRunContext` when the caller can identify the owning manager

--- a/scripts/benchmark_run_context_cache_budget.py
+++ b/scripts/benchmark_run_context_cache_budget.py
@@ -12,6 +12,7 @@ from time import perf_counter
 from typing import Callable
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
 sys.path.insert(0, str(PROJECT_ROOT))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_settings")
 

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -113,7 +113,9 @@ class CalculationRunContext:
         self._run_cache_touch_count = 0
         self._run_cache_touch_thread_id: int | None = None
         max_bytes = resolve_run_context_cache_max_bytes()
+        self._run_cache_mode_generation = -1
         self._run_cache_budget_enabled = max_bytes is not None
+        self._run_cache_recency_enabled = False
         run_context_cache_budget.register(
             self,
             max_bytes,
@@ -129,11 +131,20 @@ class CalculationRunContext:
             if key not in self._dependency_cache_pending_publications:
                 yield "dependency_hits", key, hit
 
-    def _set_run_cache_budget_enabled(self, enabled: bool) -> None:
-        """Refresh the owner hint after a coordinator transition."""
+    def _set_run_cache_modes(
+        self,
+        budget_enabled: bool,
+        recency_enabled: bool,
+        generation: int,
+    ) -> None:
+        """Refresh owner hints after a generated coordinator transition."""
         with self._run_cache_touch_lock:
-            self._run_cache_budget_enabled = enabled
-            if not enabled:
+            if generation < self._run_cache_mode_generation:
+                return
+            self._run_cache_mode_generation = generation
+            self._run_cache_budget_enabled = budget_enabled
+            self._run_cache_recency_enabled = recency_enabled
+            if not budget_enabled or not recency_enabled:
                 self._pending_run_cache_touches.clear()
                 self._last_pending_run_cache_touch = None
                 self._run_cache_touch_count = 0
@@ -296,6 +307,7 @@ class CalculationRunContext:
                 self._run_cache_touch_count = 0
                 self._run_cache_touch_thread_id = get_ident()
                 self._run_cache_budget_enabled = max_bytes is not None
+                self._run_cache_recency_enabled = False
             run_context_cache_budget.register(
                 self,
                 max_bytes,
@@ -373,7 +385,8 @@ class CalculationRunContext:
             value = loader()
             self._store_run_value(scoped_key, value)
             return value
-        self._touch_run_cache_entry("values", scoped_key)
+        if self._run_cache_recency_enabled:
+            self._touch_run_cache_entry("values", scoped_key)
         return cast(T, value)
 
     def get(self, key: Hashable, default: object = None) -> object:
@@ -383,7 +396,8 @@ class CalculationRunContext:
             value = self._values[scoped_key]
         except KeyError:
             return default
-        self._touch_run_cache_entry("values", scoped_key)
+        if self._run_cache_recency_enabled:
+            self._touch_run_cache_entry("values", scoped_key)
         return value
 
     def set(self, key: Hashable, value: object) -> None:
@@ -414,7 +428,10 @@ class CalculationRunContext:
             hit = self._dependency_cache_hits[key]
         except KeyError:
             return default
-        if key not in self._dependency_cache_pending_publications:
+        if (
+            self._run_cache_recency_enabled
+            and key not in self._dependency_cache_pending_publications
+        ):
             self._touch_run_cache_entry("dependency_hits", key)
         return hit
 
@@ -838,7 +855,8 @@ class CalculationRunContext:
         scoped_key = self._scoped_key(key)
         if scoped_key not in self._values:
             return False
-        self._touch_run_cache_entry("values", scoped_key)
+        if self._run_cache_recency_enabled:
+            self._touch_run_cache_entry("values", scoped_key)
         return True
 
     def __contains__(self, key: Hashable) -> bool:

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -220,7 +220,10 @@ class CalculationRunContext:
     ) -> None:
         pending_key = (namespace, key)
         with self._run_cache_touch_lock:
-            if not self._run_cache_budget_enabled:
+            if (
+                not self._run_cache_budget_enabled
+                or not self._run_cache_recency_enabled
+            ):
                 return
             if pending_key != self._last_pending_run_cache_touch:
                 self._pending_run_cache_touches.pop(pending_key, None)
@@ -235,7 +238,10 @@ class CalculationRunContext:
         touch_immediately = False
         touches_to_flush: tuple[PendingRunCacheTouch, ...] = ()
         with self._run_cache_touch_lock:
-            if not self._run_cache_budget_enabled:
+            if (
+                not self._run_cache_budget_enabled
+                or not self._run_cache_recency_enabled
+            ):
                 return False
             if self._run_cache_touch_thread_id != get_ident():
                 touch_immediately = True

--- a/src/general_manager/cache/run_context.py
+++ b/src/general_manager/cache/run_context.py
@@ -237,6 +237,7 @@ class CalculationRunContext:
     ) -> bool:
         touch_immediately = False
         touches_to_flush: tuple[PendingRunCacheTouch, ...] = ()
+        mode_generation = -1
         with self._run_cache_touch_lock:
             if (
                 not self._run_cache_budget_enabled
@@ -245,6 +246,7 @@ class CalculationRunContext:
                 return False
             if self._run_cache_touch_thread_id != get_ident():
                 touch_immediately = True
+                mode_generation = self._run_cache_mode_generation
             elif pending_key != self._last_pending_run_cache_touch:
                 return False
             else:
@@ -252,11 +254,21 @@ class CalculationRunContext:
                 if count < RUN_CONTEXT_TOUCH_BATCH_SIZE:
                     self._run_cache_touch_count = count
                     return True
-                touches_to_flush = self._take_run_cache_touches_locked()
+                touches_to_flush, mode_generation = (
+                    self._take_run_cache_touches_locked()
+                )
         if touch_immediately:
-            run_context_cache_budget.touch(self, *pending_key)
+            run_context_cache_budget.touch(
+                self,
+                *pending_key,
+                mode_generation=mode_generation,
+            )
             return True
-        run_context_cache_budget.touch_many(self, touches_to_flush)
+        run_context_cache_budget.touch_many(
+            self,
+            touches_to_flush,
+            mode_generation=mode_generation,
+        )
         return True
 
     def _touch_run_cache_entry(
@@ -279,12 +291,13 @@ class CalculationRunContext:
 
     def _take_run_cache_touches_locked(
         self,
-    ) -> tuple[PendingRunCacheTouch, ...]:
+    ) -> tuple[tuple[PendingRunCacheTouch, ...], int]:
         touches = tuple(self._pending_run_cache_touches)
+        mode_generation = self._run_cache_mode_generation
         self._pending_run_cache_touches.clear()
         self._last_pending_run_cache_touch = None
         self._run_cache_touch_count = 0
-        return touches
+        return touches, mode_generation
 
     def _flush_run_cache_touches(self) -> None:
         with self._run_cache_touch_lock:
@@ -292,8 +305,12 @@ class CalculationRunContext:
                 self._last_pending_run_cache_touch = None
                 self._run_cache_touch_count = 0
                 return
-            touches = self._take_run_cache_touches_locked()
-        run_context_cache_budget.touch_many(self, touches)
+            touches, mode_generation = self._take_run_cache_touches_locked()
+        run_context_cache_budget.touch_many(
+            self,
+            touches,
+            mode_generation=mode_generation,
+        )
 
     @staticmethod
     def _scoped_key(key: Hashable) -> Hashable:

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass
-from fractions import Fraction
 from itertools import islice
-import math
 import sys
 from threading import RLock
 from types import (
@@ -31,7 +29,10 @@ RUN_CONTEXT_CACHE_MAX_BYTES_SETTING = "RUN_CONTEXT_CACHE_MAX_BYTES"
 MIN_TRACKED_ENTRY_BYTES = 256
 RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD = 128
 RUN_CONTEXT_SIZE_SAMPLE_COUNT = 64
-RUN_CONTEXT_SIZE_SAFETY_MARGIN = Fraction(21, 20)
+RUN_CONTEXT_CALIBRATION_INTERVAL = 256
+RUN_CONTEXT_CALIBRATION_WINDOW = 8
+RUN_CONTEXT_CALIBRATION_CANDIDATE_LIMIT = 2_048
+RUN_CONTEXT_FIXED_POINT_SCALE = 1 << 20
 RUN_CONTEXT_TRACK_MAX_REESTIMATES = 3
 _INVALID_MAX_BYTES_MESSAGE = (
     'GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"] must be None or a '
@@ -70,6 +71,18 @@ _TYPE_MRO_DESCRIPTOR = cast(GetSetDescriptorType, type.__dict__["__mro__"])
 _TYPE_DICT_DESCRIPTOR = cast(GetSetDescriptorType, type.__dict__["__dict__"])
 
 RunCacheNamespace = Literal["values", "dependency_hits"]
+StorageFamily = Literal[
+    "dict",
+    "list",
+    "tuple",
+    "set",
+    "frozenset",
+    "instance_dict",
+    "slots",
+    "shallow_leaf",
+    "opaque",
+]
+StratumKey = tuple[RunCacheNamespace, StorageFamily, int]
 TrackedKey = tuple[int, RunCacheNamespace, Hashable]
 
 logger = get_logger("cache.run_context_lru")
@@ -107,10 +120,25 @@ class _StaticStoragePlan:
 
 
 @dataclass(frozen=True)
+class _AdmissionSignal:
+    stratum: StratumKey | None
+    shallow_bytes: int
+    exact_bytes: int | None
+
+
+@dataclass(frozen=True)
 class _WeightedCandidate:
     value: object
-    weight: Fraction
+    weight: int
     ancestor_ids: frozenset[int] = frozenset()
+
+
+_storage_plan_cache_lock = RLock()
+_storage_plan_cache: dict[
+    int,
+    tuple[ReferenceType[type[object]], _StaticStoragePlan | None],
+] = {}
+_calibration_visit_observer: Callable[[object], None] | None = None
 
 
 class ProcessRunContextCacheBudget:
@@ -583,6 +611,162 @@ def _static_storage_plan(
     return _StaticStoragePlan(tuple(instance_dict_descriptors), tuple(slot_descriptors))
 
 
+def _storage_plan_finalizer(
+    candidate_type_id: int,
+) -> Callable[[ReferenceType[type[object]]], None]:
+    def remove_finalized_plan(candidate_reference: ReferenceType[type[object]]) -> None:
+        with _storage_plan_cache_lock:
+            cached = _storage_plan_cache.get(candidate_type_id)
+            if cached is not None and cached[0] is candidate_reference:
+                _storage_plan_cache.pop(candidate_type_id, None)
+
+    return remove_finalized_plan
+
+
+def _cached_static_storage_plan(
+    candidate_type: type[object],
+) -> _StaticStoragePlan | None:
+    candidate_type_id = id(candidate_type)
+    with _storage_plan_cache_lock:
+        cached = _storage_plan_cache.get(candidate_type_id)
+        if cached is not None and cached[0]() is candidate_type:
+            return cached[1]
+    plan = _static_storage_plan(candidate_type)
+    try:
+        candidate_reference = ref(
+            candidate_type,
+            _storage_plan_finalizer(candidate_type_id),
+        )
+    except TypeError:
+        return plan
+    with _storage_plan_cache_lock:
+        cached = _storage_plan_cache.get(candidate_type_id)
+        if cached is not None and cached[0]() is candidate_type:
+            return cached[1]
+        _storage_plan_cache[candidate_type_id] = (candidate_reference, plan)
+    return plan
+
+
+def _length_bucket(length: int) -> int:
+    return 1 if length <= 1 else 1 << (length - 1).bit_length()
+
+
+def _safe_shallow_size(value: object) -> int:
+    value_type = type(value)
+    try:
+        if _is_exact_type(value_type, _SIZED_BUILTIN_TYPES):
+            return sys.getsizeof(value)
+        return object.__sizeof__(value)
+    except Exception:  # noqa: BLE001 - admission must survive hostile objects.
+        return MIN_TRACKED_ENTRY_BYTES
+
+
+def _is_shallow_leaf_type(candidate_type: type[object]) -> bool:
+    candidate_mro = _get_static_type_mro(candidate_type)
+    if candidate_mro is None:
+        return False
+    return any(
+        base_type is leaf_type
+        for base_type in candidate_mro
+        for leaf_type in _SHALLOW_LEAF_TYPES
+    )
+
+
+def _admission_signal(
+    namespace: RunCacheNamespace,
+    key: object,
+    value: object,
+) -> _AdmissionSignal:
+    """Return a bounded, hook-free signal used to calibrate cache entries."""
+    key_type = type(key)
+    value_type = type(value)
+    if _is_exact_type(key_type, _ATOMIC_LEAF_TYPES) and _is_exact_type(
+        value_type, _ATOMIC_LEAF_TYPES
+    ):
+        exact_bytes = _safe_shallow_size(value)
+        if key is not value:
+            exact_bytes += _safe_shallow_size(key)
+        return _AdmissionSignal(
+            stratum=None,
+            shallow_bytes=exact_bytes,
+            exact_bytes=max(MIN_TRACKED_ENTRY_BYTES, exact_bytes),
+        )
+
+    shallow_bytes = _safe_shallow_size(value)
+    if key is not value:
+        shallow_bytes += _safe_shallow_size(key)
+    shallow_bytes = max(1, shallow_bytes)
+
+    builtin_families: tuple[tuple[type[object], StorageFamily], ...] = (
+        (dict, "dict"),
+        (list, "list"),
+        (tuple, "tuple"),
+        (set, "set"),
+        (frozenset, "frozenset"),
+    )
+    for builtin_type, builtin_family in builtin_families:
+        if value_type is builtin_type:
+            builtin_value = cast(
+                dict[object, object]
+                | list[object]
+                | tuple[object, ...]
+                | set[object]
+                | frozenset[object],
+                value,
+            )
+            return _AdmissionSignal(
+                stratum=(namespace, builtin_family, _length_bucket(len(builtin_value))),
+                shallow_bytes=shallow_bytes,
+                exact_bytes=None,
+            )
+
+    storage_plan = _cached_static_storage_plan(value_type)
+    if storage_plan is None:
+        return _AdmissionSignal((namespace, "opaque", 1), shallow_bytes, None)
+
+    for instance_dict_descriptor in storage_plan.instance_dict_descriptors:
+        try:
+            instance_dict = GetSetDescriptorType.__get__(
+                instance_dict_descriptor,
+                value,
+                value_type,
+            )
+        except (AttributeError, TypeError):
+            continue
+        if type(instance_dict) is dict:
+            return _AdmissionSignal(
+                stratum=(
+                    namespace,
+                    "instance_dict",
+                    _length_bucket(len(instance_dict)),
+                ),
+                shallow_bytes=shallow_bytes + sys.getsizeof(instance_dict),
+                exact_bytes=None,
+            )
+
+    if storage_plan.slot_descriptors:
+        return _AdmissionSignal(
+            stratum=(
+                namespace,
+                "slots",
+                _length_bucket(len(storage_plan.slot_descriptors)),
+            ),
+            shallow_bytes=shallow_bytes,
+            exact_bytes=None,
+        )
+    if _is_shallow_leaf_type(value_type):
+        return _AdmissionSignal(
+            stratum=(namespace, "shallow_leaf", 1),
+            shallow_bytes=shallow_bytes,
+            exact_bytes=None,
+        )
+    return _AdmissionSignal(
+        stratum=(namespace, "opaque", 1),
+        shallow_bytes=shallow_bytes,
+        exact_bytes=None,
+    )
+
+
 def _stratified_indexes(length: int, sample_count: int) -> tuple[int, ...]:
     if sample_count >= length:
         return tuple(range(length))
@@ -597,6 +781,13 @@ def _is_exact_type(
     candidate_type: type[object], types: tuple[type[object], ...]
 ) -> bool:
     return any(candidate_type is expected_type for expected_type in types)
+
+
+def _mul_weight(weight: int, numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        return weight
+    projected = (weight * numerator + denominator - 1) // denominator
+    return min(projected, sys.maxsize * RUN_CONTEXT_FIXED_POINT_SCALE)
 
 
 def _sample_container_children(
@@ -614,11 +805,10 @@ def _sample_container_children(
                 for item in sequence
             )
         sample_indexes = _stratified_indexes(length, RUN_CONTEXT_SIZE_SAMPLE_COUNT)
-        sample_weight = (
-            candidate.weight
-            * length
-            / len(sample_indexes)
-            * RUN_CONTEXT_SIZE_SAFETY_MARGIN
+        sample_weight = _mul_weight(
+            candidate.weight,
+            length * 21,
+            len(sample_indexes) * 20,
         )
         return tuple(
             _WeightedCandidate(sequence[index], sample_weight, child_ancestor_ids)
@@ -643,11 +833,10 @@ def _sample_container_children(
         for item_key, item_value in (*first_entries, *last_entries):
             if all(item_key is not existing_key for existing_key, _ in sample_entries):
                 sample_entries.append((item_key, item_value))
-        sample_weight = (
-            candidate.weight
-            * len(mapping)
-            / len(sample_entries)
-            * RUN_CONTEXT_SIZE_SAFETY_MARGIN
+        sample_weight = _mul_weight(
+            candidate.weight,
+            len(mapping) * 21,
+            len(sample_entries) * 20,
         )
         return tuple(
             _WeightedCandidate(item, sample_weight, child_ancestor_ids)
@@ -663,11 +852,10 @@ def _sample_container_children(
                 for item in container
             )
         sample_items = tuple(islice(container, RUN_CONTEXT_SIZE_SAMPLE_COUNT))
-        sample_weight = (
-            candidate.weight
-            * len(container)
-            / len(sample_items)
-            * RUN_CONTEXT_SIZE_SAFETY_MARGIN
+        sample_weight = _mul_weight(
+            candidate.weight,
+            len(container) * 21,
+            len(sample_items) * 20,
         )
         return tuple(
             _WeightedCandidate(item, sample_weight, child_ancestor_ids)
@@ -702,20 +890,42 @@ def estimate_cache_entry_size(
             return stop_after + 1
         return max(MIN_TRACKED_ENTRY_BYTES, measured_bytes)
 
+    saturation_limit = stop_after + 1 if stop_after is not None else sys.maxsize
     measured_bytes = 0
-    seen_weights: dict[int, Fraction] = {}
+    seen_weights: dict[int, int] = {}
     candidates = [
-        _WeightedCandidate(key, Fraction(1)),
-        _WeightedCandidate(value, Fraction(1)),
+        _WeightedCandidate(key, RUN_CONTEXT_FIXED_POINT_SCALE),
+        _WeightedCandidate(value, RUN_CONTEXT_FIXED_POINT_SCALE),
     ]
-    storage_plans: dict[int, _StaticStoragePlan | None] = {}
+    visited_candidates = 0
+    positive_shallow_sizes: list[int] = []
 
     while candidates:
+        if visited_candidates >= RUN_CONTEXT_CALIBRATION_CANDIDATE_LIMIT:
+            remaining_weight = min(
+                sum(candidate.weight for candidate in candidates),
+                sys.maxsize * RUN_CONTEXT_FIXED_POINT_SCALE,
+            )
+            if positive_shallow_sizes:
+                mean_shallow_size = (
+                    sum(positive_shallow_sizes) + len(positive_shallow_sizes) - 1
+                ) // len(positive_shallow_sizes)
+            else:
+                mean_shallow_size = MIN_TRACKED_ENTRY_BYTES
+            projected_bytes = (
+                mean_shallow_size * remaining_weight + RUN_CONTEXT_FIXED_POINT_SCALE - 1
+            ) // RUN_CONTEXT_FIXED_POINT_SCALE
+            measured_bytes = min(saturation_limit, measured_bytes + projected_bytes)
+            break
+
         candidate = candidates.pop()
+        visited_candidates += 1
+        if _calibration_visit_observer is not None:
+            _calibration_visit_observer(candidate.value)
         candidate_id = id(candidate.value)
         if candidate_id in candidate.ancestor_ids:
             continue
-        previous_weight = seen_weights.get(candidate_id, Fraction(0))
+        previous_weight = seen_weights.get(candidate_id, 0)
         incremental_weight = candidate.weight - previous_weight
         if incremental_weight <= 0:
             continue
@@ -730,10 +940,15 @@ def estimate_cache_entry_size(
                 shallow_size = object.__sizeof__(candidate_value)
         except Exception:  # noqa: BLE001 - conservative accounting must survive sizing errors.
             shallow_size = MIN_TRACKED_ENTRY_BYTES
-        measured_bytes += math.ceil(shallow_size * incremental_weight)
+        if shallow_size > 0:
+            positive_shallow_sizes.append(shallow_size)
+        incremental_bytes = (
+            shallow_size * incremental_weight + RUN_CONTEXT_FIXED_POINT_SCALE - 1
+        ) // RUN_CONTEXT_FIXED_POINT_SCALE
+        measured_bytes = min(saturation_limit, measured_bytes + incremental_bytes)
 
-        if stop_after is not None and measured_bytes > stop_after:
-            return stop_after + 1
+        if measured_bytes >= saturation_limit:
+            return saturation_limit
 
         if _is_exact_type(candidate_type, _ATOMIC_LEAF_TYPES):
             continue
@@ -749,10 +964,7 @@ def estimate_cache_entry_size(
                 )
             )
         else:
-            candidate_type_id = id(candidate_type)
-            if candidate_type_id not in storage_plans:
-                storage_plans[candidate_type_id] = _static_storage_plan(candidate_type)
-            storage_plan = storage_plans[candidate_type_id]
+            storage_plan = _cached_static_storage_plan(candidate_type)
             if storage_plan is None:
                 continue
             for instance_dict_descriptor in storage_plan.instance_dict_descriptors:

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -256,53 +256,76 @@ class ProcessRunContextCacheBudget:
         )
 
     def _publish_modes(self) -> None:
+        if not self._mode_publications:
+            return
         is_owned = getattr(self._lock, "_is_owned", None)
         if is_owned is not None and is_owned():
             return
+        first_error: BaseException | None = None
         while True:
             with self._lock:
                 if not self._mode_publications:
+                    if first_error is not None:
+                        raise first_error
                     return
                 publication = self._mode_publications.popleft()
             owners, budget_enabled, recency_enabled, generation = publication
             for owner in owners:
-                owner._set_run_cache_modes(
-                    budget_enabled,
-                    recency_enabled,
-                    generation,
-                )
+                try:
+                    owner._set_run_cache_modes(
+                        budget_enabled,
+                        recency_enabled,
+                        generation,
+                    )
+                except BaseException as error:  # noqa: BLE001
+                    if first_error is None:
+                        first_error = error
+
+    def _reconcile_modes_after_error(self, operation_error: BaseException) -> None:
+        with self._lock:
+            self._capture_mode_publication_locked()
+        try:
+            self._publish_modes()
+        except BaseException as publication_error:  # noqa: BLE001
+            operation_error.add_note(
+                f"run-cache mode publication also failed: {publication_error!r}"
+            )
 
     def register(self, owner: RunContextCacheOwner, max_bytes: int | None) -> None:
         """Register an owner and rebuild tracked state when the limit changes."""
-        with self._lock:
-            is_new_owner = owner not in self._owners
-            self._owners.add(owner)
-            self._owner_reference_locked(owner)
-            if max_bytes == self._max_bytes:
-                if is_new_owner and max_bytes is not None:
-                    self._track_owner_entries_locked(owner)
-                self._capture_mode_publication_locked(
-                    new_owner=owner if is_new_owner else None
-                )
-            else:
-                previous_max_bytes = self._max_bytes
-                self._max_bytes = max_bytes
-                self._configuration_generation += 1
-                if max_bytes is None:
-                    self._entries.clear()
-                    self._strata.clear()
-                    self._mru_key = None
-                    self._entry_attempt_generations.clear()
-                    self._exact_total_bytes = 0
-                    self._total_bytes = 0
-                elif previous_max_bytes is None:
-                    self._rebuild_locked()
-                elif is_new_owner:
-                    self._track_owner_entries_locked(owner)
-                    self._evict_excess_locked()
+        try:
+            with self._lock:
+                is_new_owner = owner not in self._owners
+                self._owners.add(owner)
+                self._owner_reference_locked(owner)
+                if max_bytes == self._max_bytes:
+                    if is_new_owner and max_bytes is not None:
+                        self._track_owner_entries_locked(owner)
+                    self._capture_mode_publication_locked(
+                        new_owner=owner if is_new_owner else None
+                    )
                 else:
-                    self._evict_excess_locked()
-                self._capture_mode_publication_locked()
+                    previous_max_bytes = self._max_bytes
+                    self._max_bytes = max_bytes
+                    self._configuration_generation += 1
+                    if max_bytes is None:
+                        self._entries.clear()
+                        self._strata.clear()
+                        self._mru_key = None
+                        self._entry_attempt_generations.clear()
+                        self._exact_total_bytes = 0
+                        self._total_bytes = 0
+                    elif previous_max_bytes is None:
+                        self._rebuild_locked()
+                    elif is_new_owner:
+                        self._track_owner_entries_locked(owner)
+                        self._evict_excess_locked()
+                    else:
+                        self._evict_excess_locked()
+                    self._capture_mode_publication_locked()
+        except BaseException as error:
+            self._reconcile_modes_after_error(error)
+            raise
         self._publish_modes()
 
     def track(
@@ -317,8 +340,10 @@ class ProcessRunContextCacheBudget:
             return
         try:
             self._track_accounting(owner, namespace, key, value)
-        finally:
-            self._publish_modes()
+        except BaseException as error:
+            self._reconcile_modes_after_error(error)
+            raise
+        self._publish_modes()
 
     def _track_accounting(
         self,

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from collections.abc import Hashable, Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import islice
 import sys
 from threading import RLock
@@ -84,8 +84,13 @@ StorageFamily = Literal[
 ]
 StratumKey = tuple[RunCacheNamespace, StorageFamily, int]
 TrackedKey = tuple[int, RunCacheNamespace, Hashable]
+CalibrationPair = tuple[int, int]
 
 logger = get_logger("cache.run_context_lru")
+
+
+def _eviction_target(max_bytes: int) -> int:
+    return max_bytes * 95 // 100
 
 
 class RunContextCacheOwner(Protocol):
@@ -110,7 +115,38 @@ class _TrackedEntry:
     owner: ReferenceType[RunContextCacheOwner]
     namespace: RunCacheNamespace
     key: Hashable
-    size: int
+    exact_bytes: int
+    stratum: StratumKey | None
+    shallow_bytes: int
+
+
+@dataclass
+class _StratumState:
+    entry_count: int = 0
+    shallow_total: int = 0
+    admission_count: int = 0
+    samples: deque[CalibrationPair] = field(
+        default_factory=lambda: deque(maxlen=RUN_CONTEXT_CALIBRATION_WINDOW)
+    )
+
+    def modeled_bytes(self) -> int:
+        if self.entry_count == 0:
+            return 0
+        assert self.samples
+        sampled_shallow = sum(shallow for shallow, _deep in self.samples)
+        sampled_residual = sum(
+            max(0, deep - MIN_TRACKED_ENTRY_BYTES) for _shallow, deep in self.samples
+        )
+        projected_residual = (
+            self.shallow_total * sampled_residual + max(1, sampled_shallow) - 1
+        ) // max(1, sampled_shallow)
+        return self.entry_count * MIN_TRACKED_ENTRY_BYTES + projected_residual
+
+    def should_calibrate_next(self) -> bool:
+        next_admission = self.admission_count + 1
+        return self.admission_count == 0 or (
+            next_admission % RUN_CONTEXT_CALIBRATION_INTERVAL == 0
+        )
 
 
 @dataclass(frozen=True)
@@ -149,7 +185,9 @@ class ProcessRunContextCacheBudget:
         self._owners: WeakSet[RunContextCacheOwner] = WeakSet()
         self._owner_references: dict[int, ReferenceType[RunContextCacheOwner]] = {}
         self._entries: OrderedDict[TrackedKey, _TrackedEntry] = OrderedDict()
+        self._strata: dict[StratumKey, _StratumState] = {}
         self._mru_key: TrackedKey | None = None
+        self._exact_total_bytes = 0
         self._total_bytes = 0
         self._max_bytes: int | None = None
         self._configuration_generation = 0
@@ -189,8 +227,10 @@ class ProcessRunContextCacheBudget:
                 registered_owner._set_run_cache_budget_enabled(enabled)
             if max_bytes is None:
                 self._entries.clear()
+                self._strata.clear()
                 self._mru_key = None
                 self._entry_attempt_generations.clear()
+                self._exact_total_bytes = 0
                 self._total_bytes = 0
                 return
 
@@ -212,16 +252,39 @@ class ProcessRunContextCacheBudget:
         """Record a stored entry and evict least-recently-used entries if needed."""
         if self._max_bytes is None:
             return
+        signal = _admission_signal(namespace, key, value)
         with self._lock:
             max_bytes = self._max_bytes
-            configuration_generation = self._configuration_generation
             if max_bytes is None:
                 return
             owner_id = id(owner)
+            tracked_key = (owner_id, namespace, key)
+            if max_bytes == 0:
+                self._entry_attempt_generations.pop(tracked_key, None)
+                self._remove_entry_accounting_locked(tracked_key)
+                owner._evict_run_cache_entry(namespace, key)
+                return
+
+            requires_calibration = False
+            if signal.stratum is not None:
+                state = self._strata.get(signal.stratum)
+                requires_calibration = state is None or state.should_calibrate_next()
+            if not requires_calibration:
+                self._entry_attempt_generations.pop(tracked_key, None)
+                self._publish_entry_locked(
+                    owner,
+                    namespace,
+                    key,
+                    signal,
+                    estimated_bytes=None,
+                    max_bytes=max_bytes,
+                )
+                return
+
+            configuration_generation = self._configuration_generation
             owner_lifecycle_generation = self._owner_lifecycle_generation_locked(
                 owner_id
             )
-            tracked_key = (owner_id, namespace, key)
             entry_attempt_generation = self._next_admission_generation_locked()
             self._entry_attempt_generations[tracked_key] = entry_attempt_generation
 
@@ -254,6 +317,15 @@ class ProcessRunContextCacheBudget:
                 ):
                     return
                 if configuration_generation != self._configuration_generation:
+                    max_bytes = self._max_bytes
+                    configuration_generation = self._configuration_generation
+                    if max_bytes is None:
+                        return
+                    if max_bytes == 0:
+                        self._entry_attempt_generations.pop(tracked_key, None)
+                        self._remove_entry_accounting_locked(tracked_key)
+                        owner._evict_run_cache_entry(namespace, key)
+                        return
                     if reestimate_count >= RUN_CONTEXT_TRACK_MAX_REESTIMATES:
                         self._entry_attempt_generations.pop(tracked_key, None)
                         self._remove_entry_locked(tracked_key)
@@ -264,17 +336,14 @@ class ProcessRunContextCacheBudget:
                         )
                         return
                     reestimate_count += 1
-                    max_bytes = self._max_bytes
-                    configuration_generation = self._configuration_generation
-                    if max_bytes is None:
-                        return
                     continue
-                self._track_estimated_locked(
+                self._publish_entry_locked(
                     owner,
                     namespace,
                     key,
-                    estimated_bytes,
-                    max_bytes,
+                    signal,
+                    estimated_bytes=estimated_bytes,
+                    max_bytes=max_bytes,
                 )
                 return
 
@@ -326,7 +395,7 @@ class ProcessRunContextCacheBudget:
             self._entry_attempt_generations.pop(tracked_key, None)
             if self._max_bytes is None:
                 return
-            self._remove_entry_locked(tracked_key)
+            self._remove_entry_accounting_locked(tracked_key)
 
     def refresh(
         self,
@@ -351,7 +420,9 @@ class ProcessRunContextCacheBudget:
 
     def _rebuild_locked(self) -> None:
         self._entries.clear()
+        self._strata.clear()
         self._mru_key = None
+        self._exact_total_bytes = 0
         self._total_bytes = 0
         for owner in tuple(self._owners):
             self._track_owner_entries_locked(owner)
@@ -375,62 +446,173 @@ class ProcessRunContextCacheBudget:
         max_bytes = self._max_bytes
         if max_bytes is None:
             return
-        estimated_bytes = estimate_cache_entry_size(
-            key,
-            value,
-            stop_after=max_bytes,
-        )
-        self._track_estimated_locked(
+        tracked_key = (id(owner), namespace, key)
+        if max_bytes == 0:
+            self._remove_entry_accounting_locked(tracked_key)
+            owner._evict_run_cache_entry(namespace, key)
+            return
+        signal = _admission_signal(namespace, key, value)
+        estimated_bytes = None
+        if signal.stratum is not None:
+            state = self._strata.get(signal.stratum)
+            if state is None or state.should_calibrate_next():
+                estimated_bytes = estimate_cache_entry_size(
+                    key,
+                    value,
+                    stop_after=max_bytes,
+                )
+        self._publish_entry_locked(
             owner,
             namespace,
             key,
-            estimated_bytes,
-            max_bytes,
+            signal,
+            estimated_bytes=estimated_bytes,
+            max_bytes=max_bytes,
         )
 
-    def _track_estimated_locked(
+    def _publish_entry_locked(
         self,
         owner: RunContextCacheOwner,
         namespace: RunCacheNamespace,
         key: Hashable,
-        estimated_bytes: int,
+        signal: _AdmissionSignal,
+        *,
+        estimated_bytes: int | None,
         max_bytes: int,
     ) -> None:
         tracked_key = (id(owner), namespace, key)
-        self._remove_entry_locked(tracked_key)
-        owner_reference = self._owner_reference_locked(owner)
-        if estimated_bytes > max_bytes:
-            self._entry_attempt_generations.pop(tracked_key, None)
+        old_entry = self._entries.get(tracked_key)
+        preserved_state = None
+        if (
+            old_entry is not None
+            and old_entry.stratum is not None
+            and old_entry.stratum == signal.stratum
+        ):
+            preserved_state = self._strata[old_entry.stratum]
+        self._remove_entry_accounting_locked(tracked_key)
+        if (
+            preserved_state is not None
+            and signal.stratum is not None
+            and signal.stratum not in self._strata
+        ):
+            self._strata[signal.stratum] = preserved_state
+
+        if signal.stratum is not None and estimated_bytes is not None:
+            state = self._strata.get(signal.stratum)
+            if state is None or state.should_calibrate_next():
+                self._publish_calibration_locked(
+                    signal.stratum,
+                    signal.shallow_bytes,
+                    estimated_bytes,
+                )
+
+        entry = _TrackedEntry(
+            owner=self._owner_reference_locked(owner),
+            namespace=namespace,
+            key=key,
+            exact_bytes=signal.exact_bytes or 0,
+            stratum=signal.stratum,
+            shallow_bytes=signal.shallow_bytes if signal.stratum is not None else 0,
+        )
+        self._add_entry_accounting_locked(tracked_key, entry)
+        if signal.stratum is not None:
+            self._strata[signal.stratum].admission_count += 1
+        self._mru_key = tracked_key
+        modeled_entry_bytes = self._modeled_entry_bytes_locked(entry)
+        self._entry_attempt_generations.pop(tracked_key, None)
+        if modeled_entry_bytes > max_bytes:
+            self._remove_entry_accounting_locked(tracked_key)
             owner._evict_run_cache_entry(namespace, key)
             logger.debug(
                 "run cache entry skipped because it exceeds the process budget",
                 context={
                     "namespace": namespace,
-                    "estimated_bytes": estimated_bytes,
+                    "estimated_bytes": modeled_entry_bytes,
                     "configured_bytes": max_bytes,
                 },
             )
             return
-
-        self._entries[tracked_key] = _TrackedEntry(
-            owner=owner_reference,
-            namespace=namespace,
-            key=key,
-            size=estimated_bytes,
-        )
-        self._mru_key = tracked_key
-        self._total_bytes += estimated_bytes
         self._evict_excess_locked()
+
+    def _modeled_entry_bytes_locked(self, entry: _TrackedEntry) -> int:
+        if entry.stratum is None:
+            return entry.exact_bytes
+        state = self._strata[entry.stratum]
+        sampled_shallow = sum(shallow for shallow, _deep in state.samples)
+        sampled_residual = sum(
+            max(0, deep - MIN_TRACKED_ENTRY_BYTES) for _shallow, deep in state.samples
+        )
+        projected_residual = (
+            entry.shallow_bytes * sampled_residual + max(1, sampled_shallow) - 1
+        ) // max(1, sampled_shallow)
+        return MIN_TRACKED_ENTRY_BYTES + projected_residual
+
+    def _add_entry_accounting_locked(
+        self,
+        tracked_key: TrackedKey,
+        entry: _TrackedEntry,
+    ) -> None:
+        assert tracked_key not in self._entries
+        self._entries[tracked_key] = entry
+        if entry.stratum is None:
+            self._exact_total_bytes += entry.exact_bytes
+            self._total_bytes += entry.exact_bytes
+            return
+
+        state = self._strata[entry.stratum]
+        old_modeled_bytes = state.modeled_bytes()
+        state.entry_count += 1
+        state.shallow_total += entry.shallow_bytes
+        self._total_bytes += state.modeled_bytes() - old_modeled_bytes
+
+    def _remove_entry_accounting_locked(
+        self,
+        tracked_key: TrackedKey,
+    ) -> _TrackedEntry | None:
+        entry = self._entries.pop(tracked_key, None)
+        if entry is None:
+            return None
+        if tracked_key == self._mru_key:
+            self._refresh_mru_key_locked()
+        if entry.stratum is None:
+            self._exact_total_bytes -= entry.exact_bytes
+            self._total_bytes -= entry.exact_bytes
+        else:
+            state = self._strata[entry.stratum]
+            old_modeled_bytes = state.modeled_bytes()
+            state.entry_count -= 1
+            state.shallow_total -= entry.shallow_bytes
+            if state.entry_count == 0:
+                self._strata.pop(entry.stratum)
+                new_modeled_bytes = 0
+            else:
+                new_modeled_bytes = state.modeled_bytes()
+            self._total_bytes += new_modeled_bytes - old_modeled_bytes
+        assert self._exact_total_bytes >= 0
+        assert self._total_bytes >= 0
+        return entry
+
+    def _publish_calibration_locked(
+        self,
+        stratum: StratumKey,
+        shallow_bytes: int,
+        estimated_bytes: int,
+    ) -> None:
+        state = self._strata.setdefault(stratum, _StratumState())
+        old_modeled_bytes = state.modeled_bytes()
+        state.samples.append((shallow_bytes, estimated_bytes))
+        self._total_bytes += state.modeled_bytes() - old_modeled_bytes
 
     def _evict_excess_locked(self) -> None:
         while self._entries:
             max_bytes = self._max_bytes
-            if max_bytes is None or self._total_bytes <= max_bytes:
+            if max_bytes is None or self._total_bytes <= _eviction_target(max_bytes):
                 return
-            tracked_key, entry = self._entries.popitem(last=False)
-            if tracked_key == self._mru_key:
-                self._refresh_mru_key_locked()
-            self._total_bytes -= entry.size
+            tracked_key = next(iter(self._entries))
+            before = self._total_bytes
+            entry = self._remove_entry_accounting_locked(tracked_key)
+            assert entry is not None
+            removed_bytes = before - self._total_bytes
             owner = entry.owner()
             if owner is None:
                 continue
@@ -440,17 +622,13 @@ class ProcessRunContextCacheBudget:
                 "run cache entry evicted by process-wide LRU budget",
                 context={
                     "namespace": entry.namespace,
-                    "estimated_bytes": entry.size,
+                    "estimated_bytes": removed_bytes,
                     "configured_bytes": max_bytes,
                 },
             )
 
     def _remove_entry_locked(self, tracked_key: TrackedKey) -> None:
-        entry = self._entries.pop(tracked_key, None)
-        if entry is not None:
-            if tracked_key == self._mru_key:
-                self._refresh_mru_key_locked()
-            self._total_bytes -= entry.size
+        self._remove_entry_accounting_locked(tracked_key)
 
     def _refresh_mru_key_locked(self) -> None:
         self._mru_key = next(reversed(self._entries), None)

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -31,6 +31,7 @@ RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD = 128
 RUN_CONTEXT_SIZE_SAMPLE_COUNT = 64
 RUN_CONTEXT_CALIBRATION_INTERVAL = 256
 RUN_CONTEXT_CALIBRATION_WINDOW = 8
+RUN_CONTEXT_CALIBRATION_HISTORY_LIMIT = 256
 RUN_CONTEXT_CALIBRATION_CANDIDATE_LIMIT = 2_048
 RUN_CONTEXT_FIXED_POINT_SCALE = 1 << 20
 RUN_CONTEXT_TRACK_MAX_REESTIMATES = 3
@@ -69,6 +70,15 @@ _SIZED_BUILTIN_TYPES = (
     set,
     frozenset,
 )
+_ATOMIC_LEAF_TYPE_IDS = frozenset(
+    id(candidate_type) for candidate_type in _ATOMIC_LEAF_TYPES
+)
+_SIZED_BUILTIN_TYPE_IDS = frozenset(
+    id(candidate_type) for candidate_type in _SIZED_BUILTIN_TYPES
+)
+_SEQUENCE_TYPE_IDS = frozenset((id(list), id(tuple)))
+_SET_TYPE_IDS = frozenset((id(set), id(frozenset)))
+_CONTAINER_TYPE_IDS = frozenset((id(dict), id(tuple), id(list), id(set), id(frozenset)))
 _TYPE_MRO_DESCRIPTOR = cast(GetSetDescriptorType, type.__dict__["__mro__"])
 _TYPE_DICT_DESCRIPTOR = cast(GetSetDescriptorType, type.__dict__["__dict__"])
 
@@ -135,19 +145,37 @@ class _StratumState:
     samples: deque[CalibrationPair] = field(
         default_factory=lambda: deque(maxlen=RUN_CONTEXT_CALIBRATION_WINDOW)
     )
+    sampled_shallow: int = field(init=False)
+    sampled_residual: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.sampled_shallow = sum(shallow for shallow, _deep in self.samples)
+        self.sampled_residual = sum(
+            max(0, deep - MIN_TRACKED_ENTRY_BYTES) for _shallow, deep in self.samples
+        )
 
     def modeled_bytes(self) -> int:
         if self.entry_count == 0:
             return 0
         assert self.samples
-        sampled_shallow = sum(shallow for shallow, _deep in self.samples)
-        sampled_residual = sum(
-            max(0, deep - MIN_TRACKED_ENTRY_BYTES) for _shallow, deep in self.samples
-        )
         projected_residual = (
-            self.shallow_total * sampled_residual + max(1, sampled_shallow) - 1
-        ) // max(1, sampled_shallow)
+            self.shallow_total * self.sampled_residual
+            + max(1, self.sampled_shallow)
+            - 1
+        ) // max(1, self.sampled_shallow)
         return self.entry_count * MIN_TRACKED_ENTRY_BYTES + projected_residual
+
+    def should_calibrate_next(self) -> bool:
+        next_admission = self.admission_count + 1
+        return self.admission_count == 0 or (
+            next_admission % RUN_CONTEXT_CALIBRATION_INTERVAL == 0
+        )
+
+
+@dataclass(frozen=True)
+class _CalibrationMetadata:
+    admission_count: int
+    samples: tuple[CalibrationPair, ...]
 
     def should_calibrate_next(self) -> bool:
         next_admission = self.admission_count + 1
@@ -193,6 +221,9 @@ class ProcessRunContextCacheBudget:
         self._owner_references: dict[int, ReferenceType[RunContextCacheOwner]] = {}
         self._entries: OrderedDict[TrackedKey, _TrackedEntry] = OrderedDict()
         self._strata: dict[StratumKey, _StratumState] = {}
+        self._calibration_history: OrderedDict[StratumKey, _CalibrationMetadata] = (
+            OrderedDict()
+        )
         self._mru_key: TrackedKey | None = None
         self._exact_total_bytes = 0
         self._total_bytes = 0
@@ -308,6 +339,7 @@ class ProcessRunContextCacheBudget:
                     previous_max_bytes = self._max_bytes
                     self._max_bytes = max_bytes
                     self._configuration_generation += 1
+                    self._calibration_history.clear()
                     if max_bytes is None:
                         self._entries.clear()
                         self._strata.clear()
@@ -370,7 +402,9 @@ class ProcessRunContextCacheBudget:
 
             requires_calibration = False
             if signal.stratum is not None:
-                state = self._strata.get(signal.stratum)
+                state = self._strata.get(
+                    signal.stratum
+                ) or self._calibration_history.get(signal.stratum)
                 requires_calibration = state is None or state.should_calibrate_next()
             if not requires_calibration:
                 self._entry_attempt_generations.pop(tracked_key, None)
@@ -533,6 +567,7 @@ class ProcessRunContextCacheBudget:
     def _rebuild_locked(self) -> None:
         self._entries.clear()
         self._strata.clear()
+        self._calibration_history.clear()
         self._mru_key = None
         self._exact_total_bytes = 0
         self._total_bytes = 0
@@ -607,11 +642,12 @@ class ProcessRunContextCacheBudget:
             and signal.stratum is not None
             and signal.stratum not in self._strata
         ):
+            self._calibration_history.pop(signal.stratum, None)
             self._strata[signal.stratum] = preserved_state
 
-        if signal.stratum is not None and estimated_bytes is not None:
-            state = self._strata.get(signal.stratum)
-            if state is None or state.should_calibrate_next():
+        if signal.stratum is not None:
+            state = self._activate_stratum_locked(signal.stratum)
+            if estimated_bytes is not None and state.should_calibrate_next():
                 self._publish_calibration_locked(
                     signal.stratum,
                     signal.shallow_bytes,
@@ -650,13 +686,11 @@ class ProcessRunContextCacheBudget:
         if entry.stratum is None:
             return entry.exact_bytes
         state = self._strata[entry.stratum]
-        sampled_shallow = sum(shallow for shallow, _deep in state.samples)
-        sampled_residual = sum(
-            max(0, deep - MIN_TRACKED_ENTRY_BYTES) for _shallow, deep in state.samples
-        )
         projected_residual = (
-            entry.shallow_bytes * sampled_residual + max(1, sampled_shallow) - 1
-        ) // max(1, sampled_shallow)
+            entry.shallow_bytes * state.sampled_residual
+            + max(1, state.sampled_shallow)
+            - 1
+        ) // max(1, state.sampled_shallow)
         return MIN_TRACKED_ENTRY_BYTES + projected_residual
 
     def _add_entry_accounting_locked(
@@ -696,6 +730,7 @@ class ProcessRunContextCacheBudget:
             state.shallow_total -= entry.shallow_bytes
             if state.entry_count == 0:
                 self._strata.pop(entry.stratum)
+                self._retain_calibration_locked(entry.stratum, state)
                 new_modeled_bytes = 0
             else:
                 new_modeled_bytes = state.modeled_bytes()
@@ -703,6 +738,39 @@ class ProcessRunContextCacheBudget:
         assert self._exact_total_bytes >= 0
         assert self._total_bytes >= 0
         return entry
+
+    def _activate_stratum_locked(self, stratum: StratumKey) -> _StratumState:
+        state = self._strata.get(stratum)
+        if state is not None:
+            return state
+        retained = self._calibration_history.pop(stratum, None)
+        if retained is None:
+            state = _StratumState()
+        else:
+            state = _StratumState(
+                admission_count=retained.admission_count,
+                samples=deque(
+                    retained.samples,
+                    maxlen=RUN_CONTEXT_CALIBRATION_WINDOW,
+                ),
+            )
+        self._strata[stratum] = state
+        return state
+
+    def _retain_calibration_locked(
+        self,
+        stratum: StratumKey,
+        state: _StratumState,
+    ) -> None:
+        if not state.samples:
+            return
+        self._calibration_history[stratum] = _CalibrationMetadata(
+            admission_count=state.admission_count,
+            samples=tuple(state.samples),
+        )
+        self._calibration_history.move_to_end(stratum)
+        while len(self._calibration_history) > RUN_CONTEXT_CALIBRATION_HISTORY_LIMIT:
+            self._calibration_history.popitem(last=False)
 
     def _publish_calibration_locked(
         self,
@@ -712,7 +780,16 @@ class ProcessRunContextCacheBudget:
     ) -> None:
         state = self._strata.setdefault(stratum, _StratumState())
         old_modeled_bytes = state.modeled_bytes()
+        if len(state.samples) == state.samples.maxlen:
+            old_shallow, old_deep = state.samples[0]
+            state.sampled_shallow -= old_shallow
+            state.sampled_residual -= max(0, old_deep - MIN_TRACKED_ENTRY_BYTES)
         state.samples.append((shallow_bytes, estimated_bytes))
+        state.sampled_shallow += shallow_bytes
+        state.sampled_residual += max(
+            0,
+            estimated_bytes - MIN_TRACKED_ENTRY_BYTES,
+        )
         self._total_bytes += state.modeled_bytes() - old_modeled_bytes
 
     def _evict_excess_locked(self) -> None:
@@ -946,7 +1023,7 @@ def _length_bucket(length: int) -> int:
 def _safe_shallow_size(value: object) -> int:
     value_type = type(value)
     try:
-        if _is_exact_type(value_type, _SIZED_BUILTIN_TYPES):
+        if _is_exact_type(value_type, _SIZED_BUILTIN_TYPE_IDS):
             return sys.getsizeof(value)
         return object.__sizeof__(value)
     except Exception:  # noqa: BLE001 - admission must survive hostile objects.
@@ -972,8 +1049,8 @@ def _admission_signal(
     """Return a bounded, hook-free signal used to calibrate cache entries."""
     key_type = type(key)
     value_type = type(value)
-    if _is_exact_type(key_type, _ATOMIC_LEAF_TYPES) and _is_exact_type(
-        value_type, _ATOMIC_LEAF_TYPES
+    if _is_exact_type(key_type, _ATOMIC_LEAF_TYPE_IDS) and _is_exact_type(
+        value_type, _ATOMIC_LEAF_TYPE_IDS
     ):
         exact_bytes = _safe_shallow_size(value)
         if key is not value:
@@ -1069,10 +1146,8 @@ def _stratified_indexes(length: int, sample_count: int) -> tuple[int, ...]:
     )
 
 
-def _is_exact_type(
-    candidate_type: type[object], types: tuple[type[object], ...]
-) -> bool:
-    return any(candidate_type is expected_type for expected_type in types)
+def _is_exact_type(candidate_type: type[object], type_ids: frozenset[int]) -> bool:
+    return id(candidate_type) in type_ids
 
 
 def _mul_weight(weight: int, numerator: int, denominator: int) -> int:
@@ -1088,7 +1163,7 @@ def _sample_container_children(
     value = candidate.value
     value_type = type(value)
     child_ancestor_ids = candidate.ancestor_ids | frozenset((id(value),))
-    if _is_exact_type(value_type, (list, tuple)):
+    if _is_exact_type(value_type, _SEQUENCE_TYPE_IDS):
         sequence = cast(list[object] | tuple[object, ...], value)
         length = len(sequence)
         if length <= RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD:
@@ -1136,7 +1211,7 @@ def _sample_container_children(
             for item in entry
         )
 
-    if _is_exact_type(value_type, (set, frozenset)):
+    if _is_exact_type(value_type, _SET_TYPE_IDS):
         container = cast(set[object] | frozenset[object], value)
         if len(container) <= RUN_CONTEXT_SIZE_SAMPLE_THRESHOLD:
             return tuple(
@@ -1164,8 +1239,8 @@ def estimate_cache_entry_size(
     stop_after: int | None,
 ) -> int:
     """Estimate owned bytes for one cache entry without unbounded traversal."""
-    if _is_exact_type(type(key), _ATOMIC_LEAF_TYPES) and _is_exact_type(
-        type(value), _ATOMIC_LEAF_TYPES
+    if _is_exact_type(type(key), _ATOMIC_LEAF_TYPE_IDS) and _is_exact_type(
+        type(value), _ATOMIC_LEAF_TYPE_IDS
     ):
         try:
             measured_bytes = sys.getsizeof(value)
@@ -1226,7 +1301,7 @@ def estimate_cache_entry_size(
         candidate_value = candidate.value
         candidate_type = type(candidate_value)
         try:
-            if _is_exact_type(candidate_type, _SIZED_BUILTIN_TYPES):
+            if _is_exact_type(candidate_type, _SIZED_BUILTIN_TYPE_IDS):
                 shallow_size = sys.getsizeof(candidate_value)
             else:
                 shallow_size = object.__sizeof__(candidate_value)
@@ -1242,10 +1317,10 @@ def estimate_cache_entry_size(
         if measured_bytes >= saturation_limit:
             return saturation_limit
 
-        if _is_exact_type(candidate_type, _ATOMIC_LEAF_TYPES):
+        if _is_exact_type(candidate_type, _ATOMIC_LEAF_TYPE_IDS):
             continue
 
-        if _is_exact_type(candidate_type, (dict, tuple, list, set, frozenset)):
+        if _is_exact_type(candidate_type, _CONTAINER_TYPE_IDS):
             candidates.extend(
                 _sample_container_children(
                     _WeightedCandidate(

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -34,6 +34,8 @@ RUN_CONTEXT_CALIBRATION_WINDOW = 8
 RUN_CONTEXT_CALIBRATION_CANDIDATE_LIMIT = 2_048
 RUN_CONTEXT_FIXED_POINT_SCALE = 1 << 20
 RUN_CONTEXT_TRACK_MAX_REESTIMATES = 3
+RUN_CONTEXT_RECENCY_ENABLE_PERCENT = 80
+RUN_CONTEXT_RECENCY_DISABLE_PERCENT = 70
 _INVALID_MAX_BYTES_MESSAGE = (
     'GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"] must be None or a '
     "non-negative integer number of bytes."
@@ -96,8 +98,13 @@ def _eviction_target(max_bytes: int) -> int:
 class RunContextCacheOwner(Protocol):
     """Storage that participates in process-wide run-cache budgeting."""
 
-    def _set_run_cache_budget_enabled(self, enabled: bool) -> None:
-        """Refresh the owner's cached process-budget mode."""
+    def _set_run_cache_modes(
+        self,
+        budget_enabled: bool,
+        recency_enabled: bool,
+        generation: int,
+    ) -> None:
+        """Refresh the owner's cached process-budget and recency modes."""
 
     def _iter_run_cache_entries(
         self,
@@ -194,6 +201,12 @@ class ProcessRunContextCacheBudget:
         self._next_admission_generation = 0
         self._owner_lifecycle_generations: dict[int, int] = {}
         self._entry_attempt_generations: dict[TrackedKey, int] = {}
+        self._recency_enabled = False
+        self._mode_generation = 0
+        self._published_modes: tuple[bool, bool] | None = None
+        self._mode_publications: deque[
+            tuple[tuple[RunContextCacheOwner, ...], bool, bool, int]
+        ] = deque()
 
     @property
     def estimated_bytes(self) -> int:
@@ -206,6 +219,59 @@ class ProcessRunContextCacheBudget:
         """Return whether process-wide run-cache accounting is enabled."""
         return self._max_bytes is not None
 
+    @property
+    def is_recency_enabled(self) -> bool:
+        """Return whether reads should currently publish LRU recency."""
+        return self._recency_enabled
+
+    def _desired_recency_locked(self) -> bool:
+        max_bytes = self._max_bytes
+        if max_bytes is None or max_bytes <= 0:
+            return False
+        if self._recency_enabled:
+            return (
+                self._total_bytes * 100
+                >= max_bytes * RUN_CONTEXT_RECENCY_DISABLE_PERCENT
+            )
+        return self._total_bytes * 100 >= max_bytes * RUN_CONTEXT_RECENCY_ENABLE_PERCENT
+
+    def _capture_mode_publication_locked(
+        self,
+        *,
+        new_owner: RunContextCacheOwner | None = None,
+    ) -> None:
+        recency_enabled = self._desired_recency_locked()
+        modes = (self._max_bytes is not None, recency_enabled)
+        if modes != self._published_modes:
+            self._recency_enabled = recency_enabled
+            self._published_modes = modes
+            self._mode_generation += 1
+            owners = tuple(self._owners)
+        elif new_owner is not None:
+            owners = (new_owner,)
+        else:
+            return
+        self._mode_publications.append(
+            (owners, modes[0], modes[1], self._mode_generation)
+        )
+
+    def _publish_modes(self) -> None:
+        is_owned = getattr(self._lock, "_is_owned", None)
+        if is_owned is not None and is_owned():
+            return
+        while True:
+            with self._lock:
+                if not self._mode_publications:
+                    return
+                publication = self._mode_publications.popleft()
+            owners, budget_enabled, recency_enabled, generation = publication
+            for owner in owners:
+                owner._set_run_cache_modes(
+                    budget_enabled,
+                    recency_enabled,
+                    generation,
+                )
+
     def register(self, owner: RunContextCacheOwner, max_bytes: int | None) -> None:
         """Register an owner and rebuild tracked state when the limit changes."""
         with self._lock:
@@ -213,34 +279,31 @@ class ProcessRunContextCacheBudget:
             self._owners.add(owner)
             self._owner_reference_locked(owner)
             if max_bytes == self._max_bytes:
-                if is_new_owner:
-                    owner._set_run_cache_budget_enabled(max_bytes is not None)
                 if is_new_owner and max_bytes is not None:
                     self._track_owner_entries_locked(owner)
-                return
-
-            previous_max_bytes = self._max_bytes
-            self._max_bytes = max_bytes
-            self._configuration_generation += 1
-            enabled = max_bytes is not None
-            for registered_owner in tuple(self._owners):
-                registered_owner._set_run_cache_budget_enabled(enabled)
-            if max_bytes is None:
-                self._entries.clear()
-                self._strata.clear()
-                self._mru_key = None
-                self._entry_attempt_generations.clear()
-                self._exact_total_bytes = 0
-                self._total_bytes = 0
-                return
-
-            if previous_max_bytes is None:
-                self._rebuild_locked()
-            elif is_new_owner:
-                self._track_owner_entries_locked(owner)
-                self._evict_excess_locked()
+                self._capture_mode_publication_locked(
+                    new_owner=owner if is_new_owner else None
+                )
             else:
-                self._evict_excess_locked()
+                previous_max_bytes = self._max_bytes
+                self._max_bytes = max_bytes
+                self._configuration_generation += 1
+                if max_bytes is None:
+                    self._entries.clear()
+                    self._strata.clear()
+                    self._mru_key = None
+                    self._entry_attempt_generations.clear()
+                    self._exact_total_bytes = 0
+                    self._total_bytes = 0
+                elif previous_max_bytes is None:
+                    self._rebuild_locked()
+                elif is_new_owner:
+                    self._track_owner_entries_locked(owner)
+                    self._evict_excess_locked()
+                else:
+                    self._evict_excess_locked()
+                self._capture_mode_publication_locked()
+        self._publish_modes()
 
     def track(
         self,
@@ -250,6 +313,20 @@ class ProcessRunContextCacheBudget:
         value: object,
     ) -> None:
         """Record a stored entry and evict least-recently-used entries if needed."""
+        if self._max_bytes is None:
+            return
+        try:
+            self._track_accounting(owner, namespace, key, value)
+        finally:
+            self._publish_modes()
+
+    def _track_accounting(
+        self,
+        owner: RunContextCacheOwner,
+        namespace: RunCacheNamespace,
+        key: Hashable,
+        value: object,
+    ) -> None:
         if self._max_bytes is None:
             return
         signal = _admission_signal(namespace, key, value)
@@ -263,6 +340,7 @@ class ProcessRunContextCacheBudget:
                 self._entry_attempt_generations.pop(tracked_key, None)
                 self._remove_entry_accounting_locked(tracked_key)
                 owner._evict_run_cache_entry(namespace, key)
+                self._capture_mode_publication_locked()
                 return
 
             requires_calibration = False
@@ -279,6 +357,7 @@ class ProcessRunContextCacheBudget:
                     estimated_bytes=None,
                     max_bytes=max_bytes,
                 )
+                self._capture_mode_publication_locked()
                 return
 
             configuration_generation = self._configuration_generation
@@ -307,6 +386,7 @@ class ProcessRunContextCacheBudget:
                         self._entry_attempt_generations.pop(tracked_key, None)
                         self._remove_entry_locked(tracked_key)
                         owner._evict_run_cache_entry(namespace, key)
+                        self._capture_mode_publication_locked()
                 raise
 
             with self._lock:
@@ -325,6 +405,7 @@ class ProcessRunContextCacheBudget:
                         self._entry_attempt_generations.pop(tracked_key, None)
                         self._remove_entry_accounting_locked(tracked_key)
                         owner._evict_run_cache_entry(namespace, key)
+                        self._capture_mode_publication_locked()
                         return
                     if reestimate_count >= RUN_CONTEXT_TRACK_MAX_REESTIMATES:
                         self._entry_attempt_generations.pop(tracked_key, None)
@@ -334,6 +415,7 @@ class ProcessRunContextCacheBudget:
                             "run cache entry skipped after repeated budget changes",
                             context={"namespace": namespace},
                         )
+                        self._capture_mode_publication_locked()
                         return
                     reestimate_count += 1
                     continue
@@ -345,6 +427,7 @@ class ProcessRunContextCacheBudget:
                     estimated_bytes=estimated_bytes,
                     max_bytes=max_bytes,
                 )
+                self._capture_mode_publication_locked()
                 return
 
     def touch(
@@ -396,6 +479,8 @@ class ProcessRunContextCacheBudget:
             if self._max_bytes is None:
                 return
             self._remove_entry_accounting_locked(tracked_key)
+            self._capture_mode_publication_locked()
+        self._publish_modes()
 
     def refresh(
         self,
@@ -417,6 +502,8 @@ class ProcessRunContextCacheBudget:
             self._remove_owner_entries_locked(owner_id)
             self._owner_references.pop(owner_id, None)
             self._owners.discard(owner)
+            self._capture_mode_publication_locked()
+        self._publish_modes()
 
     def _rebuild_locked(self) -> None:
         self._entries.clear()
@@ -685,6 +772,8 @@ class ProcessRunContextCacheBudget:
                 self._remove_owner_entries_locked(owner_id)
                 self._clear_owner_attempts_locked(owner_id)
                 self._owner_references.pop(owner_id, None)
+                self._capture_mode_publication_locked()
+            self._publish_modes()
 
         return remove_dead_owner
 

--- a/src/general_manager/cache/run_context_lru.py
+++ b/src/general_manager/cache/run_context_lru.py
@@ -37,6 +37,8 @@ RUN_CONTEXT_FIXED_POINT_SCALE = 1 << 20
 RUN_CONTEXT_TRACK_MAX_REESTIMATES = 3
 RUN_CONTEXT_RECENCY_ENABLE_PERCENT = 80
 RUN_CONTEXT_RECENCY_DISABLE_PERCENT = 70
+RUN_CONTEXT_SAMPLE_MARGIN_NUMERATOR = 21
+RUN_CONTEXT_SAMPLE_MARGIN_DENOMINATOR = 20
 _INVALID_MAX_BYTES_MESSAGE = (
     'GENERAL_MANAGER["RUN_CONTEXT_CACHE_MAX_BYTES"] must be None or a '
     "non-negative integer number of bytes."
@@ -94,6 +96,13 @@ StorageFamily = Literal[
     "shallow_leaf",
     "opaque",
 ]
+_BUILTIN_STORAGE_FAMILIES: dict[int, StorageFamily] = {
+    id(dict): "dict",
+    id(list): "list",
+    id(tuple): "tuple",
+    id(set): "set",
+    id(frozenset): "frozenset",
+}
 StratumKey = tuple[RunCacheNamespace, StorageFamily, int]
 TrackedKey = tuple[int, RunCacheNamespace, Hashable]
 CalibrationPair = tuple[int, int]
@@ -102,7 +111,15 @@ logger = get_logger("cache.run_context_lru")
 
 
 def _eviction_target(max_bytes: int) -> int:
+    """Return the 95% eviction threshold that preserves a 5% reserve."""
     return max_bytes * 95 // 100
+
+
+def _should_calibrate_next(admission_count: int) -> bool:
+    next_admission = admission_count + 1
+    return admission_count == 0 or (
+        next_admission % RUN_CONTEXT_CALIBRATION_INTERVAL == 0
+    )
 
 
 class RunContextCacheOwner(Protocol):
@@ -166,10 +183,7 @@ class _StratumState:
         return self.entry_count * MIN_TRACKED_ENTRY_BYTES + projected_residual
 
     def should_calibrate_next(self) -> bool:
-        next_admission = self.admission_count + 1
-        return self.admission_count == 0 or (
-            next_admission % RUN_CONTEXT_CALIBRATION_INTERVAL == 0
-        )
+        return _should_calibrate_next(self.admission_count)
 
 
 @dataclass(frozen=True)
@@ -178,10 +192,7 @@ class _CalibrationMetadata:
     samples: tuple[CalibrationPair, ...]
 
     def should_calibrate_next(self) -> bool:
-        next_admission = self.admission_count + 1
-        return self.admission_count == 0 or (
-            next_admission % RUN_CONTEXT_CALIBRATION_INTERVAL == 0
-        )
+        return _should_calibrate_next(self.admission_count)
 
 
 @dataclass(frozen=True)
@@ -494,14 +505,22 @@ class ProcessRunContextCacheBudget:
         owner: RunContextCacheOwner,
         namespace: RunCacheNamespace,
         key: Hashable,
+        *,
+        mode_generation: int | None = None,
     ) -> None:
         """Mark one tracked entry as most recently used."""
-        self.touch_many(owner, ((namespace, key),))
+        self.touch_many(
+            owner,
+            ((namespace, key),),
+            mode_generation=mode_generation,
+        )
 
     def touch_many(
         self,
         owner: RunContextCacheOwner,
         entries: Iterable[tuple[RunCacheNamespace, Hashable]],
+        *,
+        mode_generation: int | None = None,
     ) -> None:
         """Mark tracked entries as recently used in caller-provided order."""
         if self._max_bytes is None:
@@ -515,6 +534,10 @@ class ProcessRunContextCacheBudget:
         with self._lock:
             if self._max_bytes is None:
                 return
+            if mode_generation is not None and (
+                mode_generation != self._mode_generation or not self._recency_enabled
+            ):
+                return
             last_moved_key = None
             for tracked_key in tracked_keys:
                 if tracked_key in self._entries:
@@ -522,6 +545,7 @@ class ProcessRunContextCacheBudget:
                     last_moved_key = tracked_key
             if last_moved_key is not None:
                 self._mru_key = last_moved_key
+        self._publish_modes()
 
     def remove(
         self,
@@ -1066,28 +1090,21 @@ def _admission_signal(
         shallow_bytes += _safe_shallow_size(key)
     shallow_bytes = max(1, shallow_bytes)
 
-    builtin_families: tuple[tuple[type[object], StorageFamily], ...] = (
-        (dict, "dict"),
-        (list, "list"),
-        (tuple, "tuple"),
-        (set, "set"),
-        (frozenset, "frozenset"),
-    )
-    for builtin_type, builtin_family in builtin_families:
-        if value_type is builtin_type:
-            builtin_value = cast(
-                dict[object, object]
-                | list[object]
-                | tuple[object, ...]
-                | set[object]
-                | frozenset[object],
-                value,
-            )
-            return _AdmissionSignal(
-                stratum=(namespace, builtin_family, _length_bucket(len(builtin_value))),
-                shallow_bytes=shallow_bytes,
-                exact_bytes=None,
-            )
+    builtin_family = _BUILTIN_STORAGE_FAMILIES.get(id(value_type))
+    if builtin_family is not None:
+        builtin_value = cast(
+            dict[object, object]
+            | list[object]
+            | tuple[object, ...]
+            | set[object]
+            | frozenset[object],
+            value,
+        )
+        return _AdmissionSignal(
+            stratum=(namespace, builtin_family, _length_bucket(len(builtin_value))),
+            shallow_bytes=shallow_bytes,
+            exact_bytes=None,
+        )
 
     storage_plan = _cached_static_storage_plan(value_type)
     if storage_plan is None:
@@ -1174,8 +1191,8 @@ def _sample_container_children(
         sample_indexes = _stratified_indexes(length, RUN_CONTEXT_SIZE_SAMPLE_COUNT)
         sample_weight = _mul_weight(
             candidate.weight,
-            length * 21,
-            len(sample_indexes) * 20,
+            length * RUN_CONTEXT_SAMPLE_MARGIN_NUMERATOR,
+            len(sample_indexes) * RUN_CONTEXT_SAMPLE_MARGIN_DENOMINATOR,
         )
         return tuple(
             _WeightedCandidate(sequence[index], sample_weight, child_ancestor_ids)
@@ -1202,8 +1219,8 @@ def _sample_container_children(
                 sample_entries.append((item_key, item_value))
         sample_weight = _mul_weight(
             candidate.weight,
-            len(mapping) * 21,
-            len(sample_entries) * 20,
+            len(mapping) * RUN_CONTEXT_SAMPLE_MARGIN_NUMERATOR,
+            len(sample_entries) * RUN_CONTEXT_SAMPLE_MARGIN_DENOMINATOR,
         )
         return tuple(
             _WeightedCandidate(item, sample_weight, child_ancestor_ids)
@@ -1221,8 +1238,8 @@ def _sample_container_children(
         sample_items = tuple(islice(container, RUN_CONTEXT_SIZE_SAMPLE_COUNT))
         sample_weight = _mul_weight(
             candidate.weight,
-            len(container) * 21,
-            len(sample_items) * 20,
+            len(container) * RUN_CONTEXT_SAMPLE_MARGIN_NUMERATOR,
+            len(sample_items) * RUN_CONTEXT_SAMPLE_MARGIN_DENOMINATOR,
         )
         return tuple(
             _WeightedCandidate(item, sample_weight, child_ancestor_ids)

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -237,7 +237,7 @@ def test_estimator_exception_does_not_retain_untracked_run_value() -> None:
         tracked_key = (id(context), "values", "key")
 
         with pytest.raises(RuntimeError, match="estimation failed"):
-            context.set("key", "value")
+            context.set("key", ["value"])
 
         assert context.get("key") is None
         assert tracked_key not in run_context_cache_budget._entries
@@ -248,7 +248,7 @@ def test_estimator_exception_does_not_retain_untracked_run_value() -> None:
 def test_run_context_budget_evicts_lru_value_across_contexts() -> None:
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
     with override_settings(
-        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 3}
     ):
         with CalculationRunContext() as first, CalculationRunContext() as second:
             first.set("a", "A")
@@ -265,7 +265,7 @@ def test_run_context_budget_evicts_lru_value_across_contexts() -> None:
 def test_run_context_budget_allows_one_batch_of_recency_staleness() -> None:
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
     with override_settings(
-        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 3}
     ):
         with CalculationRunContext() as first, CalculationRunContext() as second:
             first.set("a", "A")
@@ -281,7 +281,7 @@ def test_run_context_budget_allows_one_batch_of_recency_staleness() -> None:
 def test_same_owner_write_flushes_partial_recency_batch_before_eviction() -> None:
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
     with override_settings(
-        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 3}
     ):
         with CalculationRunContext() as context:
             context.set("a", "A")
@@ -430,7 +430,7 @@ def test_run_context_flushes_earlier_touches_before_refresh() -> None:
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
     with (
         override_settings(
-            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 3}
         ),
         CalculationRunContext() as context,
     ):
@@ -535,7 +535,7 @@ def test_active_run_context_refreshes_cached_state_when_another_enables_budget()
             first.set("b", "B")
 
             with override_settings(
-                GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+                GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 3}
             ):
                 with CalculationRunContext() as second:
                     for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
@@ -554,7 +554,7 @@ def test_foreign_thread_touch_bypasses_owner_local_batch() -> None:
     worker_errors: list[BaseException] = []
 
     with override_settings(
-        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+        GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 3}
     ):
         with CalculationRunContext() as first:
             first.set("a", "A")
@@ -726,7 +726,7 @@ def test_finite_budget_set_ignores_unrelated_native_dict_descriptor() -> None:
     with (
         override_settings(
             GENERAL_MANAGER={
-                "RUN_CONTEXT_CACHE_MAX_BYTES": MIN_TRACKED_ENTRY_BYTES,
+                "RUN_CONTEXT_CACHE_MAX_BYTES": MIN_TRACKED_ENTRY_BYTES * 2,
             }
         ),
         CalculationRunContext() as context,
@@ -802,7 +802,11 @@ def test_run_context_budget_keeps_historical_namespaces_independent() -> None:
 
     with (
         override_settings(
-            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": first_size + second_size}
+            GENERAL_MANAGER={
+                "RUN_CONTEXT_CACHE_MAX_BYTES": (
+                    (first_size + second_size) * 100 // 95 + 1
+                )
+            }
         ),
         CalculationRunContext() as context,
     ):
@@ -887,7 +891,7 @@ def test_dependency_cache_hits_share_lru_recency() -> None:
     entry_size = estimate_cache_entry_size("cache-a", first, stop_after=None)
     with (
         override_settings(
-            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 3}
         ),
         CalculationRunContext() as context,
     ):
@@ -905,7 +909,7 @@ def test_run_values_and_dependency_hits_share_global_lru_across_contexts() -> No
     second_hit = DependencyCacheHit(value="B", dependencies=frozenset())
     hit_size = estimate_cache_entry_size("cache-a", first_hit, stop_after=None)
     value_size = estimate_cache_entry_size("ordinary", "value", stop_after=None)
-    two_entry_budget = hit_size + max(hit_size, value_size)
+    two_entry_budget = (hit_size + max(hit_size, value_size)) * 100 // 95 + 1
     with (
         override_settings(
             GENERAL_MANAGER={
@@ -980,7 +984,9 @@ def test_publish_failure_tracks_unpinned_hit_under_finite_budget() -> None:
         stop_after=None,
     )
     with (
-        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size}),
+        override_settings(
+            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 2}
+        ),
         mock.patch(
             "general_manager.cache.dependency_publish.publish_dependency_cache_entries",
             side_effect=PublishFailed,
@@ -1297,7 +1303,7 @@ def test_replacing_pending_hit_stays_pinned_under_finite_budget() -> None:
     pressure_size = estimate_cache_entry_size("pressure", pressure, stop_after=None)
     with (
         override_settings(
-            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": pressure_size}
+            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": pressure_size * 2}
         ),
         mock.patch(
             "general_manager.cache.dependency_publish.publish_dependency_cache_entries"
@@ -1343,7 +1349,7 @@ def test_failed_prior_lease_release_preserves_pinned_pending_replacement_state()
     pressure_size = estimate_cache_entry_size("pressure", pressure, stop_after=None)
     with (
         override_settings(
-            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": pressure_size}
+            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": pressure_size * 2}
         ),
         mock.patch(
             "general_manager.cache.dependency_publish.release_compute_lease",
@@ -1672,7 +1678,9 @@ def test_run_context_retains_reweighed_orm_index_that_fits_budget() -> None:
     )
 
     with (
-        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": index_size}),
+        override_settings(
+            GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": index_size * 2}
+        ),
         CalculationRunContext() as context,
     ):
         context.set_orm_bucket_rows(("query", "rows"), (row,))

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -318,7 +318,11 @@ def test_run_context_batches_capped_value_touches() -> None:
         touch_many.assert_not_called()
 
         assert context.get("key") == "value"
-        touch_many.assert_called_once_with(context, (("values", "key"),))
+        touch_many.assert_called_once_with(
+            context,
+            (("values", "key"),),
+            mode_generation=context._run_cache_mode_generation,
+        )
 
 
 def test_run_context_batches_capped_get_or_set_touches() -> None:
@@ -332,7 +336,11 @@ def test_run_context_batches_capped_get_or_set_touches() -> None:
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get_or_set("key", lambda: "replacement") == "value"
 
-        touch_many.assert_called_once_with(context, (("values", "key"),))
+        touch_many.assert_called_once_with(
+            context,
+            (("values", "key"),),
+            mode_generation=context._run_cache_mode_generation,
+        )
 
 
 def test_run_context_batches_capped_has_touches() -> None:
@@ -346,7 +354,11 @@ def test_run_context_batches_capped_has_touches() -> None:
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.has("key")
 
-        touch_many.assert_called_once_with(context, (("values", "key"),))
+        touch_many.assert_called_once_with(
+            context,
+            (("values", "key"),),
+            mode_generation=context._run_cache_mode_generation,
+        )
 
 
 def test_run_context_batches_capped_dependency_hit_touches() -> None:
@@ -364,6 +376,7 @@ def test_run_context_batches_capped_dependency_hit_touches() -> None:
         touch_many.assert_called_once_with(
             context,
             (("dependency_hits", "cache-key"),),
+            mode_generation=context._run_cache_mode_generation,
         )
 
 
@@ -464,6 +477,129 @@ def test_disabling_recency_discards_partial_touch_batch() -> None:
             assert context.get("key") == "value"
 
         touch_many.assert_not_called()
+
+
+def test_extracted_owner_touch_batch_rejects_delayed_aba_generation() -> None:
+    publication_started = Event()
+    allow_publication = Event()
+    worker_errors: list[BaseException] = []
+    original_touch_many = run_context_cache_budget.touch_many
+
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        CalculationRunContext() as context,
+    ):
+        context.set("first", "first")
+        context.set("second", "second")
+        activate_run_cache_recency(context)
+        active_limit = run_context_cache_budget._max_bytes
+        assert active_limit is not None
+        stale_generation = context._run_cache_mode_generation
+        assert context.get("first") == "first"
+
+        def delayed_touch_many(
+            owner: object,
+            entries: object,
+            *,
+            mode_generation: int | None = None,
+        ) -> None:
+            publication_started.set()
+            assert allow_publication.wait(timeout=5)
+            original_touch_many(
+                owner,  # type: ignore[arg-type]
+                entries,  # type: ignore[arg-type]
+                mode_generation=mode_generation,
+            )
+
+        def flush() -> None:
+            try:
+                context._flush_run_cache_touches()
+            except BaseException as error:  # noqa: BLE001
+                worker_errors.append(error)
+
+        with mock.patch.object(
+            run_context_cache_budget,
+            "touch_many",
+            delayed_touch_many,
+        ):
+            worker = Thread(target=flush)
+            worker.start()
+            try:
+                assert publication_started.wait(timeout=5)
+                run_context_cache_budget.register(context, active_limit * 2)
+                run_context_cache_budget.register(context, active_limit)
+                assert context._run_cache_mode_generation > stale_generation
+            finally:
+                allow_publication.set()
+                worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        if worker_errors:
+            raise worker_errors[0]
+        assert tuple(entry[2] for entry in run_context_cache_budget._entries) == (
+            "first",
+            "second",
+        )
+
+
+def test_foreign_immediate_touch_rejects_delayed_aba_generation() -> None:
+    publication_started = Event()
+    allow_publication = Event()
+    worker_errors: list[BaseException] = []
+    original_touch = run_context_cache_budget.touch
+
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        CalculationRunContext() as context,
+    ):
+        context.set("first", "first")
+        context.set("second", "second")
+        activate_run_cache_recency(context)
+        active_limit = run_context_cache_budget._max_bytes
+        assert active_limit is not None
+        stale_generation = context._run_cache_mode_generation
+
+        def delayed_touch(
+            owner: object,
+            namespace: object,
+            key: object,
+            *,
+            mode_generation: int | None = None,
+        ) -> None:
+            publication_started.set()
+            assert allow_publication.wait(timeout=5)
+            original_touch(
+                owner,  # type: ignore[arg-type]
+                namespace,  # type: ignore[arg-type]
+                key,  # type: ignore[arg-type]
+                mode_generation=mode_generation,
+            )
+
+        def touch_from_foreign_thread() -> None:
+            try:
+                context._touch_run_cache_entry("values", "first")
+            except BaseException as error:  # noqa: BLE001
+                worker_errors.append(error)
+
+        with mock.patch.object(run_context_cache_budget, "touch", delayed_touch):
+            worker = Thread(target=touch_from_foreign_thread)
+            worker.start()
+            try:
+                assert publication_started.wait(timeout=5)
+                run_context_cache_budget.register(context, active_limit * 2)
+                run_context_cache_budget.register(context, active_limit)
+                assert context._run_cache_mode_generation > stale_generation
+            finally:
+                allow_publication.set()
+                worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        if worker_errors:
+            raise worker_errors[0]
+        assert tuple(entry[2] for entry in run_context_cache_budget._entries) == (
+            "first",
+            "second",
+        )
 
 
 @pytest.mark.parametrize("prequeue_touch", [False, True])
@@ -583,7 +719,11 @@ def test_run_context_repeated_touch_fast_path_avoids_pending_key_rehashes() -> N
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get(key) == "value"
 
-        touch_many.assert_called_once_with(context, (("values", key),))
+        touch_many.assert_called_once_with(
+            context,
+            (("values", key),),
+            mode_generation=context._run_cache_mode_generation,
+        )
         assert key.hash_calls <= RUN_CONTEXT_TOUCH_BATCH_SIZE + 2
 
 
@@ -604,7 +744,11 @@ def test_run_context_hot_reads_use_cached_budget_enabled_state() -> None:
             for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
                 assert context.get("key") == "value"
 
-        touch_many.assert_called_once_with(context, (("values", "key"),))
+        touch_many.assert_called_once_with(
+            context,
+            (("values", "key"),),
+            mode_generation=context._run_cache_mode_generation,
+        )
 
 
 def test_run_context_batches_capped_touches_in_latest_access_order() -> None:
@@ -625,6 +769,7 @@ def test_run_context_batches_capped_touches_in_latest_access_order() -> None:
         touch_many.assert_called_once_with(
             context,
             (("values", "second"), ("values", "first")),
+            mode_generation=context._run_cache_mode_generation,
         )
 
 
@@ -644,7 +789,11 @@ def test_run_context_does_not_publish_a_removed_pending_touch() -> None:
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get("kept") == "kept"
 
-        touch_many.assert_called_once_with(context, (("values", "kept"),))
+        touch_many.assert_called_once_with(
+            context,
+            (("values", "kept"),),
+            mode_generation=context._run_cache_mode_generation,
+        )
 
 
 def test_run_context_flushes_earlier_touches_before_refresh() -> None:
@@ -705,7 +854,11 @@ def test_run_context_touch_batch_does_not_leak_across_reuse() -> None:
             for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
                 assert context.get("new") == "new"
 
-        touch_many.assert_called_once_with(context, (("values", "new"),))
+        touch_many.assert_called_once_with(
+            context,
+            (("values", "new"),),
+            mode_generation=context._run_cache_mode_generation,
+        )
 
 
 def test_inactive_run_context_discards_touches_before_setting_transition() -> None:
@@ -738,7 +891,11 @@ def test_reused_run_context_refreshes_cached_budget_enabled_state() -> None:
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get("key") == "value"
 
-    touch_many.assert_called_once_with(context, (("values", "key"),))
+    touch_many.assert_called_once_with(
+        context,
+        (("values", "key"),),
+        mode_generation=context._run_cache_mode_generation,
+    )
 
     with (
         override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": None}),

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -55,6 +55,13 @@ def make_pending_publication(cache_key: str) -> PendingDependencyCachePublicatio
     )
 
 
+def activate_run_cache_recency(context: CalculationRunContext) -> None:
+    modeled_bytes = run_context_cache_budget.estimated_bytes
+    assert modeled_bytes > 0
+    run_context_cache_budget.register(context, modeled_bytes * 5 // 4)
+    assert run_context_cache_budget.is_recency_enabled
+
+
 class CountingHashKey:
     def __init__(self) -> None:
         self.hash_calls = 0
@@ -253,6 +260,7 @@ def test_run_context_budget_evicts_lru_value_across_contexts() -> None:
         with CalculationRunContext() as first, CalculationRunContext() as second:
             first.set("a", "A")
             second.set("b", "B")
+            activate_run_cache_recency(second)
             for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
                 assert first.get("a") == "A"
             second.set("c", "C")
@@ -270,6 +278,7 @@ def test_run_context_budget_allows_one_batch_of_recency_staleness() -> None:
         with CalculationRunContext() as first, CalculationRunContext() as second:
             first.set("a", "A")
             second.set("b", "B")
+            activate_run_cache_recency(second)
             assert first.get("a") == "A"
             second.set("c", "C")
 
@@ -286,6 +295,7 @@ def test_same_owner_write_flushes_partial_recency_batch_before_eviction() -> Non
         with CalculationRunContext() as context:
             context.set("a", "A")
             context.set("b", "B")
+            activate_run_cache_recency(context)
             assert context.get("a") == "A"
 
             context.set("c", "C")
@@ -302,6 +312,7 @@ def test_run_context_batches_capped_value_touches() -> None:
         CalculationRunContext() as context,
     ):
         context.set("key", "value")
+        activate_run_cache_recency(context)
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE - 1):
             assert context.get("key") == "value"
         touch_many.assert_not_called()
@@ -317,6 +328,7 @@ def test_run_context_batches_capped_get_or_set_touches() -> None:
         CalculationRunContext() as context,
     ):
         context.set("key", "value")
+        activate_run_cache_recency(context)
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get_or_set("key", lambda: "replacement") == "value"
 
@@ -330,6 +342,7 @@ def test_run_context_batches_capped_has_touches() -> None:
         CalculationRunContext() as context,
     ):
         context.set("key", "value")
+        activate_run_cache_recency(context)
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.has("key")
 
@@ -344,6 +357,7 @@ def test_run_context_batches_capped_dependency_hit_touches() -> None:
         CalculationRunContext() as context,
     ):
         context.set_dependency_cache_hits({"cache-key": hit})
+        activate_run_cache_recency(context)
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get_dependency_cache_hit("cache-key") == hit
 
@@ -351,6 +365,105 @@ def test_run_context_batches_capped_dependency_hit_touches() -> None:
             context,
             (("dependency_hits", "cache-key"),),
         )
+
+
+def test_capped_value_reads_do_no_touch_work_below_pressure() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 1_000_000}),
+        CalculationRunContext() as context,
+    ):
+        context.set("value", 1)
+        accounted_bytes = run_context_cache_budget.estimated_bytes
+        with (
+            mock.patch.object(
+                context,
+                "_touch_run_cache_entry",
+                side_effect=AssertionError(
+                    "below-pressure read must bypass touch path"
+                ),
+            ),
+            mock.patch(
+                "general_manager.cache.run_context.get_ident",
+                side_effect=AssertionError("below-pressure read must bypass get_ident"),
+            ),
+        ):
+            assert context.get("value") == 1
+            assert context.get_or_set("value", lambda: 2) == 1
+            assert context.has("value") is True
+            assert context.get("missing", "default") == "default"
+
+        assert run_context_cache_budget.estimated_bytes == accounted_bytes
+
+
+def test_capped_dependency_hits_do_no_touch_work_below_pressure() -> None:
+    hit = DependencyCacheHit(value="value", dependencies=frozenset())
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 1_000_000}),
+        CalculationRunContext() as context,
+    ):
+        context.set_dependency_cache_hits({"cache-key": hit})
+        with mock.patch.object(
+            context,
+            "_touch_run_cache_entry",
+            side_effect=AssertionError("below-pressure hit must bypass touch path"),
+        ):
+            assert context.get_dependency_cache_hit("cache-key") == hit
+            assert context.get_dependency_cache_hit("missing", "default") == "default"
+
+
+def test_capped_reads_do_not_acquire_owner_touch_lock_below_pressure() -> None:
+    class RaisingTouchLock:
+        def __enter__(self) -> None:
+            raise AssertionError(  # noqa: TRY003
+                "below-pressure read must bypass owner lock"
+            )
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 1_000_000}),
+        CalculationRunContext() as context,
+    ):
+        context.set("value", 1)
+        original_lock = context._run_cache_touch_lock
+        context._run_cache_touch_lock = RaisingTouchLock()  # type: ignore[assignment]
+        try:
+            assert context.get("value") == 1
+            assert context.get_or_set("value", lambda: 2) == 1
+            assert context.has("value") is True
+        finally:
+            context._run_cache_touch_lock = original_lock
+
+
+def test_older_mode_generation_cannot_disable_active_recency() -> None:
+    context = CalculationRunContext()
+    context._set_run_cache_modes(True, True, 20)
+
+    context._set_run_cache_modes(False, False, 19)
+
+    assert context._run_cache_mode_generation == 20
+    assert context._run_cache_budget_enabled is True
+    assert context._run_cache_recency_enabled is True
+
+
+def test_disabling_recency_discards_partial_touch_batch() -> None:
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set("key", "value")
+        activate_run_cache_recency(context)
+        assert context.get("key") == "value"
+
+        run_context_cache_budget.register(context, 10_000)
+        assert run_context_cache_budget.is_recency_enabled is False
+        activate_run_cache_recency(context)
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE - 1):
+            assert context.get("key") == "value"
+
+        touch_many.assert_not_called()
 
 
 def test_run_context_repeated_touch_fast_path_avoids_pending_key_rehashes() -> None:
@@ -361,6 +474,7 @@ def test_run_context_repeated_touch_fast_path_avoids_pending_key_rehashes() -> N
         CalculationRunContext() as context,
     ):
         context.set(key, "value")
+        activate_run_cache_recency(context)
         key.hash_calls = 0
 
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
@@ -377,6 +491,7 @@ def test_run_context_hot_reads_use_cached_budget_enabled_state() -> None:
         CalculationRunContext() as context,
     ):
         context.set("key", "value")
+        activate_run_cache_recency(context)
         with mock.patch.object(
             ProcessRunContextCacheBudget,
             "is_enabled",
@@ -397,6 +512,7 @@ def test_run_context_batches_capped_touches_in_latest_access_order() -> None:
     ):
         context.set("first", "first")
         context.set("second", "second")
+        activate_run_cache_recency(context)
         assert context.get("first") == "first"
         assert context.get("second") == "second"
         assert context.get("first") == "first"
@@ -417,10 +533,12 @@ def test_run_context_does_not_publish_a_removed_pending_touch() -> None:
     ):
         context.set(("removed",), "removed")
         context.set("kept", "kept")
+        activate_run_cache_recency(context)
         assert context.get(("removed",)) == "removed"
 
         context.discard_prefix(("removed",))
-        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE - 1):
+        activate_run_cache_recency(context)
+        for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get("kept") == "kept"
 
         touch_many.assert_called_once_with(context, (("values", "kept"),))
@@ -436,6 +554,7 @@ def test_run_context_flushes_earlier_touches_before_refresh() -> None:
     ):
         context.set("a", "A")
         context.set("b", "B")
+        activate_run_cache_recency(context)
         assert context.get("b") == "B"
 
         context._refresh_run_value("a")
@@ -457,6 +576,8 @@ def test_pending_dependency_publication_hits_do_not_queue_recency_touches() -> N
         mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
         CalculationRunContext() as context,
     ):
+        context.set("pressure", "value")
+        activate_run_cache_recency(context)
         context.buffer_dependency_cache_publication(entry)
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get_dependency_cache_hit(entry.cache_key) is not None
@@ -472,10 +593,12 @@ def test_run_context_touch_batch_does_not_leak_across_reuse() -> None:
     ):
         with context:
             context.set("old", "old")
+            activate_run_cache_recency(context)
             assert context.get("old") == "old"
 
         with context:
             context.set("new", "new")
+            activate_run_cache_recency(context)
             for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
                 assert context.get("new") == "new"
 
@@ -508,6 +631,7 @@ def test_reused_run_context_refreshes_cached_budget_enabled_state() -> None:
         context,
     ):
         context.set("key", "value")
+        activate_run_cache_recency(context)
         for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
             assert context.get("key") == "value"
 
@@ -538,6 +662,7 @@ def test_active_run_context_refreshes_cached_state_when_another_enables_budget()
                 GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": entry_size * 3}
             ):
                 with CalculationRunContext() as second:
+                    activate_run_cache_recency(second)
                     for _ in range(RUN_CONTEXT_TOUCH_BATCH_SIZE):
                         assert first.get("a") == "A"
                     second.set("c", "C")
@@ -562,6 +687,7 @@ def test_foreign_thread_touch_bypasses_owner_local_batch() -> None:
 
             with CalculationRunContext() as second:
                 second.set("b", "B")
+                activate_run_cache_recency(second)
 
                 def touch_from_propagated_context() -> None:
                     try:
@@ -612,19 +738,24 @@ def test_disabling_budget_from_foreign_thread_does_not_mutate_touch_iteration() 
 
     with override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}):
         context = CalculationRunContext()
-        original_set_budget_enabled = context._set_run_cache_budget_enabled
+        original_set_modes = context._set_run_cache_modes
 
-        def signal_budget_change(enabled: bool) -> None:
-            if not enabled:
+        def signal_budget_change(
+            budget_enabled: bool,
+            recency_enabled: bool,
+            generation: int,
+        ) -> None:
+            if not budget_enabled:
                 disable_callback_started.set()
-            original_set_budget_enabled(enabled)
+            original_set_modes(budget_enabled, recency_enabled, generation)
 
-        context._set_run_cache_budget_enabled = signal_budget_change  # type: ignore[method-assign]
+        context._set_run_cache_modes = signal_budget_change  # type: ignore[method-assign]
 
         def read_repeatedly() -> None:
             try:
                 with context:
                     context.set("key", "value")
+                    activate_run_cache_recency(context)
                     context._pending_run_cache_touches = BlockingIterationTouches(
                         context._pending_run_cache_touches
                     )
@@ -896,6 +1027,7 @@ def test_dependency_cache_hits_share_lru_recency() -> None:
         CalculationRunContext() as context,
     ):
         context.set_dependency_cache_hits({"cache-a": first, "cache-b": second})
+        activate_run_cache_recency(context)
         assert context.get_dependency_cache_hit("cache-a") == first
         context.set_dependency_cache_hits({"cache-c": third})
 

--- a/tests/unit/test_calculation_run_context.py
+++ b/tests/unit/test_calculation_run_context.py
@@ -466,6 +466,109 @@ def test_disabling_recency_discards_partial_touch_batch() -> None:
         touch_many.assert_not_called()
 
 
+@pytest.mark.parametrize("prequeue_touch", [False, True])
+def test_paused_owner_read_cannot_queue_after_recency_is_disabled(
+    prequeue_touch: bool,
+) -> None:
+    read_entered_touch_path = Event()
+    allow_read_to_continue = Event()
+    disabler_errors: list[BaseException] = []
+
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set("key", "value")
+        activate_run_cache_recency(context)
+        if prequeue_touch:
+            assert context.get("key") == "value"
+            assert context._pending_run_cache_touches
+
+        original_touch = context._touch_run_cache_entry
+
+        def paused_touch(namespace: str, key: object) -> None:
+            read_entered_touch_path.set()
+            assert allow_read_to_continue.wait(timeout=5)
+            original_touch(namespace, key)  # type: ignore[arg-type]
+
+        def disable_recency() -> None:
+            try:
+                assert read_entered_touch_path.wait(timeout=5)
+                run_context_cache_budget.register(context, 10_000)
+            except BaseException as error:  # noqa: BLE001
+                disabler_errors.append(error)
+            finally:
+                allow_read_to_continue.set()
+
+        disabler = Thread(target=disable_recency)
+        disabler.start()
+        try:
+            with mock.patch.object(
+                context,
+                "_touch_run_cache_entry",
+                side_effect=paused_touch,
+            ):
+                assert context.get("key") == "value"
+        finally:
+            allow_read_to_continue.set()
+            disabler.join(timeout=5)
+
+        assert not disabler.is_alive()
+        if disabler_errors:
+            raise disabler_errors[0]
+        assert context._pending_run_cache_touches == {}
+        touch_many.assert_not_called()
+
+
+def test_paused_foreign_read_cannot_touch_after_recency_is_disabled() -> None:
+    read_entered_touch_path = Event()
+    allow_read_to_continue = Event()
+    worker_errors: list[BaseException] = []
+
+    with (
+        override_settings(GENERAL_MANAGER={"RUN_CONTEXT_CACHE_MAX_BYTES": 10_000}),
+        mock.patch.object(run_context_cache_budget, "touch") as touch,
+        mock.patch.object(run_context_cache_budget, "touch_many") as touch_many,
+        CalculationRunContext() as context,
+    ):
+        context.set("key", "value")
+        activate_run_cache_recency(context)
+        original_touch = context._touch_run_cache_entry
+
+        def paused_touch(namespace: str, key: object) -> None:
+            read_entered_touch_path.set()
+            assert allow_read_to_continue.wait(timeout=5)
+            original_touch(namespace, key)  # type: ignore[arg-type]
+
+        def read_from_foreign_thread() -> None:
+            try:
+                with mock.patch.object(
+                    context,
+                    "_touch_run_cache_entry",
+                    side_effect=paused_touch,
+                ):
+                    assert context.get("key") == "value"
+            except BaseException as error:  # noqa: BLE001
+                worker_errors.append(error)
+
+        worker = Thread(target=read_from_foreign_thread)
+        worker.start()
+        try:
+            assert read_entered_touch_path.wait(timeout=5)
+            run_context_cache_budget.register(context, 10_000)
+        finally:
+            allow_read_to_continue.set()
+            worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        if worker_errors:
+            raise worker_errors[0]
+        assert context._pending_run_cache_touches == {}
+        touch.assert_not_called()
+        touch_many.assert_not_called()
+
+
 def test_run_context_repeated_touch_fast_path_avoids_pending_key_rehashes() -> None:
     key = CountingHashKey()
     with (

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -1,10 +1,11 @@
+from collections import OrderedDict, deque
 from collections.abc import Hashable, Iterable, Iterator
 from threading import Event, Thread
 from unittest import mock
 import math
 import sys
 from types import ModuleType
-from typing import cast
+from typing import Callable, cast
 from weakref import ref
 
 import pytest
@@ -113,6 +114,782 @@ class CountingHashKey:
     def __hash__(self) -> int:
         self.hash_calls += 1
         return 1
+
+
+class RepresentativeRow:
+    def __init__(self, index: int) -> None:
+        self.identifier = index
+        self.name = f"row-{index}"
+        self.active = index % 2 == 0
+        self.score = index * 3
+
+
+class RepresentativeManager:
+    __slots__ = ("inputs", "label")
+
+    def __init__(self, index: int) -> None:
+        self.inputs = (index, index + 1)
+        self.label = f"manager-{index % 8}"
+
+
+class RepresentativeMetric:
+    __slots__ = ("count", "name", "value")
+
+    def __init__(self, count: int, name: str, value: float) -> None:
+        self.count = count
+        self.name = name
+        self.value = value
+
+
+def _exhaustive_representative_entry_size(key: object, value: object) -> int:
+    """Test-owned v0.69-style exhaustive ownership traversal."""
+    atomic_types = (
+        type(None),
+        bool,
+        int,
+        float,
+        complex,
+        str,
+        bytes,
+        bytearray,
+        range,
+    )
+    sized_builtin_types = (*atomic_types, dict, tuple, list, set, frozenset)
+    candidates = [key, value]
+    seen: set[int] = set()
+    measured_bytes = 0
+
+    while candidates:
+        candidate = candidates.pop()
+        candidate_id = id(candidate)
+        if candidate_id in seen:
+            continue
+        seen.add(candidate_id)
+        candidate_type = type(candidate)
+        if candidate_type in sized_builtin_types:
+            measured_bytes += sys.getsizeof(candidate)
+        else:
+            measured_bytes += object.__sizeof__(candidate)
+
+        if candidate_type in atomic_types:
+            continue
+        if candidate_type is dict:
+            for item_key, item_value in cast(dict[object, object], candidate).items():
+                candidates.extend((item_key, item_value))
+            continue
+        if candidate_type in (tuple, list, set, frozenset):
+            candidates.extend(cast(Iterable[object], candidate))
+            continue
+
+        try:
+            instance_dict = vars(candidate)
+        except TypeError:
+            instance_dict = None
+        if instance_dict is not None:
+            candidates.append(instance_dict)
+        for cls in candidate_type.__mro__:
+            declared_slots = cls.__dict__.get("__slots__", ())
+            if isinstance(declared_slots, str):
+                slot_names = (declared_slots,)
+            else:
+                slot_names = tuple(declared_slots)
+            for slot_name in slot_names:
+                if slot_name in {"__dict__", "__weakref__"}:
+                    continue
+                try:
+                    candidates.append(object.__getattribute__(candidate, slot_name))
+                except AttributeError:
+                    pass
+
+    return max(256, measured_bytes)
+
+
+def _representative_homogeneous_bytearray_lists() -> list[tuple[Hashable, object]]:
+    return [(index, [bytearray(96)]) for index in range(512)]
+
+
+def _representative_heterogeneous_lists() -> list[tuple[Hashable, object]]:
+    entries = []
+    for index in range(512):
+        value: list[object] = [index] * 9
+        value[0] = bytearray(32)
+        value[4] = bytearray(160)
+        value[8] = bytearray(288)
+        entries.append((index, value))
+    return entries
+
+
+def _representative_builtin_mappings_and_sets() -> list[tuple[Hashable, object]]:
+    mappings = [
+        (
+            ("mapping", index),
+            {offset: bytearray(24 + offset) for offset in range(4)},
+        )
+        for index in range(256)
+    ]
+    sets = [
+        (("set", index), {index * 4 + offset for offset in range(4)})
+        for index in range(256)
+    ]
+    return [*mappings, *sets]
+
+
+def _representative_orm_rows() -> list[tuple[Hashable, object]]:
+    return [(index, RepresentativeRow(index)) for index in range(512)]
+
+
+def _representative_slotted_managers() -> list[tuple[Hashable, object]]:
+    return [(index, RepresentativeManager(index)) for index in range(512)]
+
+
+def _representative_metric_series() -> list[tuple[Hashable, object]]:
+    entries = []
+    for index in range(512):
+        records = (
+            RepresentativeMetric(index, "actual", index / 10),
+            RepresentativeMetric(index + 1, "forecast", index / 8),
+        )
+        series = {day: records[day % 2] for day in range(120)}
+        entries.append((index, series))
+    return entries
+
+
+def _representative_shared_aggregate() -> list[tuple[Hashable, object]]:
+    aggregate = {index: [bytearray(24)] for index in range(120)}
+    references = [(("value", index), value) for index, value in aggregate.items()]
+    return [("aggregate", aggregate), *references]
+
+
+def _representative_cycles() -> list[tuple[Hashable, object]]:
+    entries: list[tuple[Hashable, object]] = []
+    for index in range(256):
+        direct: list[object] = []
+        direct.append(direct)
+        entries.append((("direct", index), direct))
+    for index in range(256):
+        first: list[object] = []
+        second: list[object] = [first]
+        first.append(second)
+        entries.append((("mutual", index), first))
+    return entries
+
+
+REPRESENTATIVE_CORPUS_BUILDERS = (
+    _representative_homogeneous_bytearray_lists,
+    _representative_heterogeneous_lists,
+    _representative_builtin_mappings_and_sets,
+    _representative_orm_rows,
+    _representative_slotted_managers,
+    _representative_metric_series,
+    _representative_shared_aggregate,
+    _representative_cycles,
+)
+
+
+@pytest.mark.parametrize(
+    "build_entries",
+    REPRESENTATIVE_CORPUS_BUILDERS,
+    ids=lambda builder: builder.__name__.removeprefix("_representative_"),
+)
+def test_representative_aggregate_is_within_five_percent(
+    build_entries: object,
+) -> None:
+    entries = cast(Callable[[], list[tuple[Hashable, object]]], build_entries)()
+    exact_total = sum(
+        _exhaustive_representative_entry_size(key, value) for key, value in entries
+    )
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 1_000_000_000)
+
+    groups: dict[object, list[tuple[Hashable, object]]] = {}
+    for key, value in entries:
+        owner.store("values", key, value)
+        budget.track(owner, "values", key, value)
+        stratum = budget._entries[(id(owner), "values", key)].stratum
+        if stratum is not None:
+            groups.setdefault(stratum, []).append((key, value))
+
+    for stratum, grouped_entries in groups.items():
+        next_index = 0
+        while len(budget._strata[cast(tuple, stratum)].samples) < 8:
+            key, value = grouped_entries[next_index % len(grouped_entries)]
+            owner.store("values", key, value)
+            budget.track(owner, "values", key, value)
+            next_index += 1
+
+    assert math.ceil(exact_total * 0.95) <= budget.estimated_bytes
+    assert budget.estimated_bytes <= math.ceil(exact_total * 1.05)
+
+
+def test_representative_pressure_retains_between_ninety_and_one_hundred_percent() -> (
+    None
+):
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    configured_bytes = 2_560
+    budget.register(owner, configured_bytes)
+    first_value = [bytearray(96)]
+    owner.store("values", 0, first_value)
+    budget.track(owner, "values", 0, first_value)
+    stratum = budget._entries[(id(owner), "values", 0)].stratum
+    assert stratum is not None
+
+    while len(budget._strata[stratum].samples) < 8:
+        owner.store("values", 0, first_value)
+        budget.track(owner, "values", 0, first_value)
+
+    for index in range(1, 10):
+        value = [bytearray(96)]
+        owner.store("values", index, value)
+        budget.track(owner, "values", index, value)
+
+    retained_bytes = sum(
+        _exhaustive_representative_entry_size(key, value)
+        for (_namespace, key), value in owner.entries.items()
+    )
+    assert len(owner.entries) == 9
+    assert retained_bytes <= configured_bytes
+    assert retained_bytes >= 2_304
+
+
+def test_stratum_models_all_entries_from_rolling_samples() -> None:
+    state = run_context_lru._StratumState(
+        entry_count=4,
+        shallow_total=400,
+        samples=deque([(100, 1_000)], maxlen=8),
+    )
+
+    assert state.modeled_bytes() == 4_000
+
+
+def test_stratum_keeps_only_eight_recent_samples() -> None:
+    state = run_context_lru._StratumState()
+    for deep in range(1_000, 2_000, 100):
+        state.samples.append((100, deep))
+
+    assert list(state.samples) == [
+        (100, 1_200),
+        (100, 1_300),
+        (100, 1_400),
+        (100, 1_500),
+        (100, 1_600),
+        (100, 1_700),
+        (100, 1_800),
+        (100, 1_900),
+    ]
+
+
+def test_stratum_calibrates_first_and_each_256th_admission() -> None:
+    state = run_context_lru._StratumState()
+
+    decisions = []
+    for _ in range(512):
+        decisions.append(state.should_calibrate_next())
+        state.admission_count += 1
+
+    assert [index + 1 for index, decision in enumerate(decisions) if decision] == [
+        1,
+        256,
+        512,
+    ]
+
+
+def test_track_calibrates_only_first_and_each_256th_stratum_admission() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    deep_calls = 0
+
+    def estimate(key: object, value: object, *, stop_after: int | None) -> int:
+        nonlocal deep_calls
+        deep_calls += 1
+        return 1_024
+
+    with mock.patch.object(run_context_lru, "estimate_cache_entry_size", estimate):
+        for index in range(512):
+            value = [index]
+            owner.store("values", index, value)
+            budget.track(owner, "values", index, value)
+
+    assert deep_calls == 3
+    assert len(owner.entries) == 512
+    assert budget.estimated_bytes > 0
+
+
+@pytest.mark.parametrize("seed_count", [0, 255])
+def test_concurrent_same_stratum_admissions_publish_one_due_calibration(
+    seed_count: int,
+) -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        return_value=1_024,
+    ):
+        for index in range(seed_count):
+            value = [index]
+            owner.store("values", index, value)
+            budget.track(owner, "values", index, value)
+
+    first_key = seed_count
+    second_key = seed_count + 1
+    values = {first_key: [first_key], second_key: [second_key]}
+    estimator_started = {first_key: Event(), second_key: Event()}
+    allow_estimators = Event()
+    worker_errors: list[BaseException] = []
+
+    def blocking_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        typed_key = cast(int, key)
+        estimator_started[typed_key].set()
+        assert allow_estimators.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        return 1_024
+
+    def track_entry(key: int) -> None:
+        try:
+            budget.track(owner, "values", key, values[key])
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    for key, value in values.items():
+        owner.store("values", key, value)
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        blocking_estimator,
+    ):
+        workers = [Thread(target=track_entry, args=(key,)) for key in values]
+        for worker in workers:
+            worker.start()
+        try:
+            assert all(
+                started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+                for started in estimator_started.values()
+            )
+        finally:
+            allow_estimators.set()
+            for worker in workers:
+                worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert all(not worker.is_alive() for worker in workers)
+    if worker_errors:
+        raise worker_errors[0]
+    state = next(iter(budget._strata.values()))
+    expected_sample_count = 1 if seed_count == 0 else 2
+    assert len(state.samples) == expected_sample_count
+    assert state.admission_count == seed_count + 2
+    assert len(owner.entries) == seed_count + 2
+
+
+def test_atomic_admission_never_calibrates() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    owner.store("values", "key", "value")
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=AssertionError("atomic admission calibrated"),
+    ):
+        budget.track(owner, "values", "key", "value")
+
+    assert owner.entries == {("values", "key"): "value"}
+    assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
+
+
+def test_ordinary_calibrated_admission_publishes_without_attempt_token() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        return_value=1_024,
+    ) as estimator:
+        for index in range(255):
+            value = [index]
+            owner.store("values", index, value)
+            budget.track(owner, "values", index, value)
+
+    assert estimator.call_count == 1
+    assert len(owner.entries) == 255
+    assert not budget._entry_attempt_generations
+
+
+def test_calibration_updates_aggregate_without_iterating_entries() -> None:
+    class DirectOnlyEntries(OrderedDict[object, object]):
+        def __iter__(self) -> Iterator[object]:
+            raise AssertionError("aggregate calibration iterated entries")  # noqa: TRY003
+
+        def values(self) -> object:
+            raise AssertionError("aggregate calibration read entry values")  # noqa: TRY003
+
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        return_value=1_024,
+    ):
+        for index in range(2):
+            value = [index]
+            owner.store("values", index, value)
+            budget.track(owner, "values", index, value)
+
+    stratum = run_context_lru._admission_signal("values", 0, [0]).stratum
+    assert stratum is not None
+    before = budget.estimated_bytes
+    original_entries = budget._entries
+    budget._entries = cast(OrderedDict, DirectOnlyEntries(budget._entries))
+
+    try:
+        with budget._lock:
+            budget._publish_calibration_locked(stratum, 100, 2_000)
+    finally:
+        budget._entries = original_entries
+
+    assert budget.estimated_bytes > before
+
+
+def test_replacement_changes_calibrated_stratum_accounting() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    small = [1]
+    large = [1, 2]
+    owner.store("values", "key", small)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=[1_024, 2_048],
+    ):
+        budget.track(owner, "values", "key", small)
+        owner.store("values", "key", large)
+        budget.track(owner, "values", "key", large)
+
+    entry = budget._entries[(id(owner), "values", "key")]
+    assert (
+        entry.stratum
+        == run_context_lru._admission_signal("values", "key", large).stratum
+    )
+    assert budget.estimated_bytes == 2_048
+
+
+def test_refresh_updates_shallow_signal_without_extra_calibration() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    initial = [1, 2, 3, 4, 5]
+    refreshed = [1, 2, 3, 4, 5, 6, 7, 8]
+    owner.store("values", "key", initial)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        return_value=1_024,
+    ) as estimator:
+        budget.track(owner, "values", "key", initial)
+        initial_shallow = budget._entries[(id(owner), "values", "key")].shallow_bytes
+        owner.store("values", "key", refreshed)
+        budget.refresh(owner, "values", "key", refreshed)
+
+    refreshed_entry = budget._entries[(id(owner), "values", "key")]
+    assert estimator.call_count == 1
+    assert refreshed_entry.shallow_bytes > initial_shallow
+    assert budget._strata[cast(tuple, refreshed_entry.stratum)].admission_count == 2
+
+
+def test_first_blocked_estimate_is_not_published_early() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    value = [1]
+    owner.store("values", "key", value)
+    estimator_started = Event()
+    allow_estimator = Event()
+
+    def blocking_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        estimator_started.set()
+        assert allow_estimator.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        return 1_024
+
+    with mock.patch.object(
+        run_context_lru, "estimate_cache_entry_size", blocking_estimator
+    ):
+        worker = Thread(target=budget.track, args=(owner, "values", "key", value))
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            assert (id(owner), "values", "key") not in budget._entries
+            assert budget.estimated_bytes == 0
+        finally:
+            allow_estimator.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+
+
+def test_zero_cap_rejects_without_blocked_estimate() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 0)
+    value = [1]
+    owner.store("values", "key", value)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        side_effect=AssertionError("zero cap calibrated"),
+    ):
+        budget.track(owner, "values", "key", value)
+
+    assert not owner.entries
+    assert budget.estimated_bytes == 0
+
+
+def test_calibrated_oversized_entry_is_not_retained() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 1_024)
+    value = [bytearray(2_048)]
+    owner.store("values", "key", value)
+
+    with mock.patch.object(
+        run_context_lru, "estimate_cache_entry_size", return_value=2_048
+    ):
+        budget.track(owner, "values", "key", value)
+
+    assert not owner.entries
+    assert not budget._entries
+    assert budget.estimated_bytes == 0
+
+
+def test_calibrated_estimator_exception_cleans_value_token_and_accounting() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    value = [1]
+    owner.store("values", "key", value)
+
+    with (
+        mock.patch.object(
+            run_context_lru,
+            "estimate_cache_entry_size",
+            side_effect=RuntimeError("estimation failed"),
+        ),
+        pytest.raises(RuntimeError, match="estimation failed"),
+    ):
+        budget.track(owner, "values", "key", value)
+
+    assert not owner.entries
+    assert not budget._entries
+    assert not budget._entry_attempt_generations
+    assert budget.estimated_bytes == 0
+
+
+def test_stale_blocked_estimate_cannot_replace_newer_same_key_sample() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    old = ["old"]
+    new = ["new"]
+    owner.store("values", "key", old)
+    estimator_started = Event()
+    allow_old = Event()
+
+    def delayed_estimator(key: object, value: object, *, stop_after: int | None) -> int:
+        if value is old:
+            estimator_started.set()
+            assert allow_old.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            return 2_048
+        assert value is new
+        return 1_024
+
+    with mock.patch.object(
+        run_context_lru, "estimate_cache_entry_size", delayed_estimator
+    ):
+        worker = Thread(target=budget.track, args=(owner, "values", "key", old))
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            owner.store("values", "key", new)
+            budget.track(owner, "values", "key", new)
+        finally:
+            allow_old.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+    assert owner.entries[("values", "key")] is new
+    entry = budget._entries[(id(owner), "values", "key")]
+    assert (
+        entry.shallow_bytes
+        == run_context_lru._admission_signal("values", "key", new).shallow_bytes
+    )
+    assert list(budget._strata[cast(tuple, entry.stratum)].samples) == [
+        (entry.shallow_bytes, 1_024)
+    ]
+
+
+@pytest.mark.parametrize("invalidation", ["weak_finalization", "owner_reuse"])
+def test_blocked_estimate_lifecycle_invalidation_prevents_calibration(
+    invalidation: str,
+) -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    value = ["value"]
+    owner.store("values", "key", value)
+    estimator_started = Event()
+    allow_estimator = Event()
+    worker_errors: list[BaseException] = []
+
+    def blocking_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        estimator_started.set()
+        assert allow_estimator.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        return 1_024
+
+    def track_entry() -> None:
+        try:
+            budget.track(owner, "values", "key", value)
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru, "estimate_cache_entry_size", blocking_estimator
+    ):
+        worker = Thread(target=track_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            owner_id = id(owner)
+            with budget._lock:
+                if invalidation == "weak_finalization":
+                    owner_reference = budget._owner_references[owner_id]
+                    budget._owner_finalizer(owner_id)(owner_reference)
+                else:
+                    replacement = CacheOwner()
+                    budget._owner_references[owner_id] = ref(replacement)
+                    budget._owner_reference_locked(owner)
+        finally:
+            allow_estimator.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert not budget._strata
+    assert not budget._entries
+    assert not budget._entry_attempt_generations
+
+
+def test_stale_configuration_sample_never_enters_new_generation_window() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    first_limit = 10_000
+    second_limit = 20_000
+    budget.register(owner, first_limit)
+    value = ["value"]
+    owner.store("values", "key", value)
+    estimator_started = Event()
+    allow_first_estimate = Event()
+    deep_results = iter((9_000, 1_024))
+
+    def changing_generation_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        result = next(deep_results)
+        if result == 9_000:
+            assert stop_after == first_limit
+            estimator_started.set()
+            assert allow_first_estimate.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        else:
+            assert stop_after == second_limit
+        return result
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        changing_generation_estimator,
+    ):
+        worker = Thread(target=budget.track, args=(owner, "values", "key", value))
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            with budget._lock:
+                budget._max_bytes = second_limit
+                budget._configuration_generation += 1
+        finally:
+            allow_first_estimate.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+    entry = budget._entries[(id(owner), "values", "key")]
+    assert list(budget._strata[cast(tuple, entry.stratum)].samples) == [
+        (entry.shallow_bytes, 1_024)
+    ]
+
+
+def test_setting_change_to_zero_invalidates_blocked_estimate_without_recalibration() -> (
+    None
+):
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000)
+    value = ["value"]
+    owner.store("values", "key", value)
+    estimator_started = Event()
+    allow_estimator = Event()
+    estimator_calls = 0
+    worker_errors: list[BaseException] = []
+
+    def blocking_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        nonlocal estimator_calls
+        estimator_calls += 1
+        if estimator_calls > 1:
+            raise AssertionError("zero-cap transition recalibrated")  # noqa: TRY003
+        estimator_started.set()
+        assert allow_estimator.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        return 1_024
+
+    def track_entry() -> None:
+        try:
+            budget.track(owner, "values", "key", value)
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru, "estimate_cache_entry_size", blocking_estimator
+    ):
+        worker = Thread(target=track_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            budget.register(owner, 0)
+        finally:
+            allow_estimator.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    assert estimator_calls == 1
+    assert not owner.entries
+    assert not budget._entry_attempt_generations
+    assert not budget._strata
 
 
 @pytest.mark.parametrize("configured", [None, 0, 1, 1024])
@@ -978,6 +1755,8 @@ def test_estimation_does_not_hold_coordinator_lock() -> None:
     worker_errors: list[BaseException] = []
     reader_errors: list[BaseException] = []
 
+    blocked_value = ["value"]
+
     def blocking_estimator(
         key: Hashable,
         value: object,
@@ -985,7 +1764,7 @@ def test_estimation_does_not_hold_coordinator_lock() -> None:
         stop_after: int | None,
     ) -> int:
         assert key == "blocked"
-        assert value == "value"
+        assert value is blocked_value
         assert stop_after == 10_000
         estimator_started.set()
         assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
@@ -993,7 +1772,7 @@ def test_estimation_does_not_hold_coordinator_lock() -> None:
 
     def track_entry() -> None:
         try:
-            budget.track(owner, "values", "blocked", "value")
+            budget.track(owner, "values", "blocked", blocked_value)
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1042,9 +1821,10 @@ def test_track_retries_estimation_after_limit_change() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     old_limit = 10_000
-    new_limit = MIN_TRACKED_ENTRY_BYTES
+    new_limit = MIN_TRACKED_ENTRY_BYTES * 2
     budget.register(owner, old_limit)
-    owner.store("values", "key", "value")
+    value = ["value"]
+    owner.store("values", "key", value)
 
     estimator_started = Event()
     allow_estimator_to_finish = Event()
@@ -1058,7 +1838,7 @@ def test_track_retries_estimation_after_limit_change() -> None:
         stop_after: int | None,
     ) -> int:
         assert key == "key"
-        assert value == "value"
+        assert value == ["value"]
         stop_after_values.append(stop_after)
         if len(stop_after_values) == 1:
             estimator_started.set()
@@ -1067,7 +1847,7 @@ def test_track_retries_estimation_after_limit_change() -> None:
 
     def track_entry() -> None:
         try:
-            budget.track(owner, "values", "key", "value")
+            budget.track(owner, "values", "key", value)
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1092,7 +1872,7 @@ def test_track_retries_estimation_after_limit_change() -> None:
     if worker_errors:
         raise worker_errors[0]
     assert stop_after_values == [old_limit, new_limit]
-    assert owner.entries[("values", "key")] == "value"
+    assert owner.entries[("values", "key")] == ["value"]
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
 
 
@@ -1100,7 +1880,8 @@ def test_track_abandons_admission_during_continuous_limit_changes() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     budget.register(owner, 10_000)
-    owner.store("values", "key", "value")
+    value = ["value"]
+    owner.store("values", "key", value)
     estimator_calls = 0
 
     def changing_configuration_estimator(
@@ -1111,7 +1892,7 @@ def test_track_abandons_admission_during_continuous_limit_changes() -> None:
     ) -> int:
         nonlocal estimator_calls
         assert key == "key"
-        assert value == "value"
+        assert value == ["value"]
         assert stop_after is not None
         estimator_calls += 1
         if estimator_calls <= 100:
@@ -1126,7 +1907,7 @@ def test_track_abandons_admission_during_continuous_limit_changes() -> None:
         "estimate_cache_entry_size",
         side_effect=changing_configuration_estimator,
     ):
-        budget.track(owner, "values", "key", "value")
+        budget.track(owner, "values", "key", value)
 
     assert estimator_calls == 4
     assert ("values", "key") not in owner.entries
@@ -1140,7 +1921,8 @@ def test_track_discards_current_entry_after_estimator_exception() -> None:
     budget.register(owner, 10_000)
     owner.store("values", "key", "old")
     budget.track(owner, "values", "key", "old")
-    owner.store("values", "key", "new")
+    new_value = ["new"]
+    owner.store("values", "key", new_value)
     tracked_key = (id(owner), "values", "key")
 
     with (
@@ -1151,7 +1933,7 @@ def test_track_discards_current_entry_after_estimator_exception() -> None:
         ),
         pytest.raises(RuntimeError, match="estimation failed"),
     ):
-        budget.track(owner, "values", "key", "new")
+        budget.track(owner, "values", "key", new_value)
 
     assert ("values", "key") not in owner.entries
     assert tracked_key not in budget._entries
@@ -1163,7 +1945,8 @@ def test_failed_track_does_not_evict_newer_same_key_replacement() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     budget.register(owner, 10_000)
-    owner.store("values", "key", "old")
+    old_value = ["old"]
+    owner.store("values", "key", old_value)
 
     estimator_started = Event()
     allow_estimator_to_fail = Event()
@@ -1177,16 +1960,15 @@ def test_failed_track_does_not_evict_newer_same_key_replacement() -> None:
     ) -> int:
         assert key == "key"
         assert stop_after == 10_000
-        if value == "old":
+        if value is old_value:
             estimator_started.set()
             assert allow_estimator_to_fail.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             raise RuntimeError
-        assert value == "new"
-        return MIN_TRACKED_ENTRY_BYTES
+        raise AssertionError("new atomic replacement was estimated")  # noqa: TRY003
 
     def track_old_entry() -> None:
         try:
-            budget.track(owner, "values", "key", "old")
+            budget.track(owner, "values", "key", old_value)
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1209,7 +1991,7 @@ def test_failed_track_does_not_evict_newer_same_key_replacement() -> None:
     assert len(worker_errors) == 1
     assert isinstance(worker_errors[0], RuntimeError)
     assert owner.entries[("values", "key")] == "new"
-    assert budget._entries[(id(owner), "values", "key")].size == (
+    assert budget._entries[(id(owner), "values", "key")].exact_bytes == (
         MIN_TRACKED_ENTRY_BYTES
     )
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
@@ -1222,7 +2004,8 @@ def test_track_does_not_reintroduce_accounting_after_owner_mutation(
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     budget.register(owner, 10_000)
-    owner.store("values", "key", "value")
+    value = ["value"]
+    owner.store("values", "key", value)
 
     estimator_started = Event()
     allow_estimator_to_finish = Event()
@@ -1235,7 +2018,7 @@ def test_track_does_not_reintroduce_accounting_after_owner_mutation(
         stop_after: int | None,
     ) -> int:
         assert key == "key"
-        assert value == "value"
+        assert value == ["value"]
         assert stop_after == 10_000
         estimator_started.set()
         assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
@@ -1243,7 +2026,7 @@ def test_track_does_not_reintroduce_accounting_after_owner_mutation(
 
     def track_entry() -> None:
         try:
-            budget.track(owner, "values", "key", "value")
+            budget.track(owner, "values", "key", value)
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1276,7 +2059,8 @@ def test_track_keeps_latest_same_key_replacement_accounting() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     budget.register(owner, 10_000)
-    owner.store("values", "key", "old")
+    old_value = ["old"]
+    owner.store("values", "key", old_value)
 
     estimator_started = Event()
     allow_estimator_to_finish = Event()
@@ -1290,16 +2074,15 @@ def test_track_keeps_latest_same_key_replacement_accounting() -> None:
     ) -> int:
         assert key == "key"
         assert stop_after == 10_000
-        if value == "old":
+        if value is old_value:
             estimator_started.set()
             assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             return MIN_TRACKED_ENTRY_BYTES * 2
-        assert value == "new"
-        return MIN_TRACKED_ENTRY_BYTES
+        raise AssertionError("new atomic replacement was estimated")  # noqa: TRY003
 
     def track_old_entry() -> None:
         try:
-            budget.track(owner, "values", "key", "old")
+            budget.track(owner, "values", "key", old_value)
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1323,7 +2106,10 @@ def test_track_keeps_latest_same_key_replacement_accounting() -> None:
     if worker_errors:
         raise worker_errors[0]
     assert owner.entries[("values", "key")] == "new"
-    assert budget._entries[(id(owner), "values", "key")].size == MIN_TRACKED_ENTRY_BYTES
+    assert (
+        budget._entries[(id(owner), "values", "key")].exact_bytes
+        == MIN_TRACKED_ENTRY_BYTES
+    )
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
 
 
@@ -1331,7 +2117,8 @@ def test_track_admits_distinct_entry_after_other_entry_is_tracked() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     budget.register(owner, 10_000)
-    owner.store("values", "a", "A")
+    a_value = ["A"]
+    owner.store("values", "a", a_value)
 
     estimator_started = Event()
     allow_estimator_to_finish = Event()
@@ -1345,17 +2132,16 @@ def test_track_admits_distinct_entry_after_other_entry_is_tracked() -> None:
     ) -> int:
         assert stop_after == 10_000
         if key == "a":
-            assert value == "A"
+            assert value is a_value
             estimator_started.set()
             assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
         else:
-            assert key == "b"
-            assert value == "B"
+            raise AssertionError("atomic entry was estimated")  # noqa: TRY003
         return MIN_TRACKED_ENTRY_BYTES
 
     def track_a() -> None:
         try:
-            budget.track(owner, "values", "a", "A")
+            budget.track(owner, "values", "a", a_value)
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1378,7 +2164,7 @@ def test_track_admits_distinct_entry_after_other_entry_is_tracked() -> None:
     assert not worker.is_alive()
     if worker_errors:
         raise worker_errors[0]
-    assert owner.entries == {("values", "a"): "A", ("values", "b"): "B"}
+    assert owner.entries == {("values", "a"): a_value, ("values", "b"): "B"}
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES * 2
 
 
@@ -1386,7 +2172,8 @@ def test_track_rejects_pre_clear_attempt_after_owner_lifecycle_restarts() -> Non
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     budget.register(owner, 10_000)
-    owner.store("values", "key", "old")
+    old_value = ["old"]
+    owner.store("values", "key", old_value)
 
     estimator_started = Event()
     allow_estimator_to_finish = Event()
@@ -1400,16 +2187,15 @@ def test_track_rejects_pre_clear_attempt_after_owner_lifecycle_restarts() -> Non
     ) -> int:
         assert key == "key"
         assert stop_after == 10_000
-        if value == "old":
+        if value is old_value:
             estimator_started.set()
             assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
             return MIN_TRACKED_ENTRY_BYTES * 2
-        assert value == "new"
-        return MIN_TRACKED_ENTRY_BYTES
+        raise AssertionError("new atomic entry was estimated")  # noqa: TRY003
 
     def track_old_entry() -> None:
         try:
-            budget.track(owner, "values", "key", "old")
+            budget.track(owner, "values", "key", old_value)
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1436,18 +2222,27 @@ def test_track_rejects_pre_clear_attempt_after_owner_lifecycle_restarts() -> Non
     if worker_errors:
         raise worker_errors[0]
     assert owner.entries[("values", "key")] == "new"
-    assert budget._entries[(id(owner), "values", "key")].size == MIN_TRACKED_ENTRY_BYTES
+    assert (
+        budget._entries[(id(owner), "values", "key")].exact_bytes
+        == MIN_TRACKED_ENTRY_BYTES
+    )
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
 
 
 def test_track_does_not_admit_entry_evicted_while_estimation_is_blocked() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
-    entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(owner, entry_size * 2)
-    for key, value in (("a", "A"), ("b", "B")):
-        owner.store("values", key, value)
-        budget.track(owner, "values", key, value)
+    initial_limit = 1_000_000
+    budget.register(owner, initial_limit)
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        return_value=MIN_TRACKED_ENTRY_BYTES,
+    ):
+        for index in range(255):
+            value = [index]
+            owner.store("values", index, value)
+            budget.track(owner, "values", index, value)
 
     estimator_started = Event()
     allow_estimator_to_finish = Event()
@@ -1461,18 +2256,18 @@ def test_track_does_not_admit_entry_evicted_while_estimation_is_blocked() -> Non
         stop_after: int | None,
     ) -> int:
         nonlocal estimator_calls
-        assert key == "a"
-        assert value == "A"
-        assert stop_after in {entry_size, entry_size * 2}
+        assert key == 0
+        assert value == [0]
+        assert stop_after == initial_limit
         estimator_calls += 1
         if estimator_calls == 1:
             estimator_started.set()
             assert allow_estimator_to_finish.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
-        return entry_size
+        return MIN_TRACKED_ENTRY_BYTES
 
     def refresh_entry() -> None:
         try:
-            budget.refresh(owner, "values", "a", "A")
+            budget.refresh(owner, "values", 0, [0])
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1485,7 +2280,7 @@ def test_track_does_not_admit_entry_evicted_while_estimation_is_blocked() -> Non
         worker.start()
         try:
             assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
-            budget.register(owner, entry_size)
+            budget.register(owner, MIN_TRACKED_ENTRY_BYTES * 2)
             allow_estimator_to_finish.set()
         finally:
             allow_estimator_to_finish.set()
@@ -1494,9 +2289,9 @@ def test_track_does_not_admit_entry_evicted_while_estimation_is_blocked() -> Non
     assert not worker.is_alive()
     if worker_errors:
         raise worker_errors[0]
-    assert ("values", "a") not in owner.entries
-    assert (id(owner), "values", "a") not in budget._entries
-    assert budget.estimated_bytes == entry_size
+    assert ("values", 0) not in owner.entries
+    assert (id(owner), "values", 0) not in budget._entries
+    assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
 
 
 def test_register_only_advances_configuration_generation_for_limit_changes() -> None:
@@ -1514,7 +2309,7 @@ def test_register_only_advances_configuration_generation_for_limit_changes() -> 
     assert budget._configuration_generation == 2
 
 
-def test_disabling_budget_releases_attempt_tokens_for_removed_entries() -> None:
+def test_successful_admissions_do_not_leave_attempt_tokens() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
 
@@ -1523,7 +2318,7 @@ def test_disabling_budget_releases_attempt_tokens_for_removed_entries() -> None:
         owner.store("values", key, "value")
         budget.track(owner, "values", key, "value")
         tracked_key = (id(owner), "values", key)
-        assert tracked_key in budget._entry_attempt_generations
+        assert tracked_key not in budget._entry_attempt_generations
 
         budget.register(owner, None)
         owner._evict_run_cache_entry("values", key)
@@ -1537,7 +2332,8 @@ def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     budget.register(owner, 10_000)
-    owner.store("values", "key", "value")
+    value = ["value"]
+    owner.store("values", "key", value)
 
     estimator_started = Event()
     allow_estimator_to_finish = Event()
@@ -1552,7 +2348,7 @@ def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
     ) -> int:
         nonlocal estimator_calls
         assert key == "key"
-        assert value == "value"
+        assert value == ["value"]
         assert stop_after == 10_000
         estimator_calls += 1
         invocation = estimator_calls
@@ -1564,7 +2360,7 @@ def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
 
     def track_entry() -> None:
         try:
-            budget.track(owner, "values", "key", "value")
+            budget.track(owner, "values", "key", value)
         except BaseException as error:  # noqa: BLE001
             worker_errors.append(error)
 
@@ -1589,7 +2385,8 @@ def test_disabling_budget_rejects_pre_disable_estimate_after_reenable() -> None:
     if worker_errors:
         raise worker_errors[0]
     assert estimator_calls == 2
-    assert budget._entries[(id(owner), "values", "key")].size == MIN_TRACKED_ENTRY_BYTES
+    entry = budget._entries[(id(owner), "values", "key")]
+    assert entry.stratum is not None
     assert budget.estimated_bytes == MIN_TRACKED_ENTRY_BYTES
 
 
@@ -1598,8 +2395,8 @@ def test_budget_evicts_oldest_entry_across_owners() -> None:
     first = CacheOwner()
     second = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(first, entry_size * 2)
-    budget.register(second, entry_size * 2)
+    budget.register(first, entry_size * 3)
+    budget.register(second, entry_size * 3)
 
     first.store("values", "a", "A")
     budget.track(first, "values", "a", "A")
@@ -1617,7 +2414,7 @@ def test_budget_touch_refreshes_recency() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(owner, entry_size * 2)
+    budget.register(owner, entry_size * 3)
     for key, value in (("a", "A"), ("b", "B")):
         owner.store("values", key, value)
         budget.track(owner, "values", key, value)
@@ -1634,7 +2431,7 @@ def test_budget_touch_many_preserves_latest_access_order() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(owner, entry_size * 3)
+    budget.register(owner, entry_size * 4)
     for key, value in (("a", "A"), ("b", "B"), ("c", "C")):
         owner.store("values", key, value)
         budget.track(owner, "values", key, value)
@@ -1723,7 +2520,7 @@ def test_budget_refreshes_mru_after_eviction() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(owner, entry_size)
+    budget.register(owner, entry_size * 2)
     for key, value in (("a", "A"), ("b", "B")):
         owner.store("values", key, value)
         budget.track(owner, "values", key, value)
@@ -1801,9 +2598,12 @@ def test_budget_stale_owner_finalizer_preserves_replacement_mru() -> None:
         owner=replacement_reference,
         namespace="values",
         key="replacement",
-        size=entry_size,
+        exact_bytes=entry_size,
+        stratum=None,
+        shallow_bytes=0,
     )
     budget._mru_key = tracked_key
+    budget._exact_total_bytes = entry_size
     budget._total_bytes = entry_size
 
     budget._owner_finalizer(owner_id)(stale_reference)
@@ -1819,7 +2619,7 @@ def test_budget_refreshes_mru_after_oversized_rejection() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(owner, entry_size)
+    budget.register(owner, entry_size * 2)
     owner.store("values", "a", "A")
     budget.track(owner, "values", "a", "A")
     owner.store("values", "oversized", b"x" * 1024)
@@ -1923,7 +2723,7 @@ def test_budget_rebuilds_live_owners_when_limit_changes() -> None:
     budget.track(first, "values", "a", "A")
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
 
-    budget.register(second, entry_size)
+    budget.register(second, entry_size * 2)
     second.store("values", "b", "B")
     budget.track(second, "values", "b", "B")
 
@@ -1939,7 +2739,7 @@ def test_budget_rebuild_eviction_does_not_mutate_live_owner_iteration() -> None:
         owner.store("values", key, value)
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
 
-    budget.register(owner, entry_size * 2)
+    budget.register(owner, entry_size * 3)
 
     assert ("values", "a") not in owner.entries
     assert ("values", "b") in owner.entries
@@ -1951,13 +2751,13 @@ def test_budget_lowering_finite_limit_preserves_single_owner_lru_order() -> None
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(owner, entry_size * 3)
+    budget.register(owner, entry_size * 4)
     for key, value in (("a", "A"), ("b", "B"), ("c", "C")):
         owner.store("values", key, value)
         budget.track(owner, "values", key, value)
 
     budget.touch(owner, "values", "a")
-    budget.register(owner, entry_size * 2)
+    budget.register(owner, entry_size * 3)
 
     assert ("values", "a") in owner.entries
     assert ("values", "b") not in owner.entries
@@ -1969,8 +2769,8 @@ def test_budget_lowering_finite_limit_preserves_cross_owner_lru_order() -> None:
     first = CacheOwner()
     second = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(first, entry_size * 3)
-    budget.register(second, entry_size * 3)
+    budget.register(first, entry_size * 4)
+    budget.register(second, entry_size * 4)
     first.store("values", "a", "A")
     budget.track(first, "values", "a", "A")
     for key, value in (("b", "B"), ("c", "C")):
@@ -1979,7 +2779,7 @@ def test_budget_lowering_finite_limit_preserves_cross_owner_lru_order() -> None:
 
     budget.touch(first, "values", "a")
     budget._owners = OrderedOwnerRegistry((first, second))
-    budget.register(second, entry_size * 2)
+    budget.register(second, entry_size * 3)
 
     assert ("values", "a") in first.entries
     assert ("values", "b") not in second.entries
@@ -1990,12 +2790,12 @@ def test_budget_new_empty_owner_enforces_lower_finite_limit() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(owner, entry_size * 3)
+    budget.register(owner, entry_size * 4)
     for key, value in (("a", "A"), ("b", "B"), ("c", "C")):
         owner.store("values", key, value)
         budget.track(owner, "values", key, value)
 
-    budget.register(CacheOwner(), entry_size * 2)
+    budget.register(CacheOwner(), entry_size * 3)
 
     assert ("values", "a") not in owner.entries
     assert ("values", "b") in owner.entries
@@ -2017,8 +2817,11 @@ def test_budget_stale_dead_owner_cleanup_preserves_replacement_accounting() -> N
         owner=replacement_reference,
         namespace="values",
         key="replacement",
-        size=entry_size,
+        exact_bytes=entry_size,
+        stratum=None,
+        shallow_bytes=0,
     )
+    budget._exact_total_bytes = entry_size
     budget._total_bytes = entry_size
 
     budget._owner_finalizer(owner_id)(stale_reference)
@@ -2030,13 +2833,13 @@ def test_budget_stale_dead_owner_cleanup_preserves_replacement_accounting() -> N
 def test_budget_reentrant_eviction_honors_raised_limit() -> None:
     budget = ProcessRunContextCacheBudget()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    owner = LimitRaisingCacheOwner(budget, entry_size * 2)
-    budget.register(owner, entry_size * 3)
+    owner = LimitRaisingCacheOwner(budget, entry_size * 3)
+    budget.register(owner, entry_size * 4)
     for key, value in (("a", "A"), ("b", "B"), ("c", "C")):
         owner.store("values", key, value)
         budget.track(owner, "values", key, value)
 
-    budget.register(owner, entry_size)
+    budget.register(owner, entry_size * 2)
 
     assert ("values", "a") not in owner.entries
     assert ("values", "b") in owner.entries
@@ -2049,13 +2852,13 @@ def test_budget_registers_prepopulated_owner_when_finite_limit_changes() -> None
     first = CacheOwner()
     second = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(first, entry_size * 3)
+    budget.register(first, entry_size * 4)
     first.store("values", "a", "A")
     budget.track(first, "values", "a", "A")
     for key, value in (("b", "B"), ("c", "C")):
         second.store("values", key, value)
 
-    budget.register(second, entry_size * 2)
+    budget.register(second, entry_size * 3)
 
     assert ("values", "a") not in first.entries
     assert ("values", "b") in second.entries
@@ -2068,13 +2871,13 @@ def test_budget_registers_prepopulated_owner_when_finite_limit_is_unchanged() ->
     first = CacheOwner()
     second = CacheOwner()
     entry_size = estimate_cache_entry_size("a", "A", stop_after=None)
-    budget.register(first, entry_size * 2)
+    budget.register(first, entry_size * 3)
     first.store("values", "a", "A")
     budget.track(first, "values", "a", "A")
     for key, value in (("b", "B"), ("c", "C")):
         second.store("values", key, value)
 
-    budget.register(second, entry_size * 2)
+    budget.register(second, entry_size * 3)
 
     assert ("values", "a") not in first.entries
     assert ("values", "b") in second.entries

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -170,10 +170,17 @@ def test_estimate_cache_entry_size_handles_mutually_cyclic_sampled_sequences(
     second: list[object] = [None] * 200
     first[-1] = second
     second[-1] = first
+    visited: list[object] = []
 
-    size = estimate_cache_entry_size("cycle", first, stop_after=stop_after)
+    with mock.patch.object(
+        run_context_lru,
+        "_calibration_visit_observer",
+        visited.append,
+    ):
+        size = estimate_cache_entry_size("cycle", first, stop_after=stop_after)
 
     assert MIN_TRACKED_ENTRY_BYTES <= size
+    assert len(visited) < run_context_lru.RUN_CONTEXT_CALIBRATION_CANDIDATE_LIMIT
     if stop_after is not None:
         assert size <= stop_after
 
@@ -237,6 +244,121 @@ def test_estimate_cache_entry_size_stops_after_atomic_value_exceeds_budget() -> 
 
     assert size == 2
     getsizeof.assert_called_once_with(value)
+
+
+# Mutation caught: calling application sizing or length hooks during admission.
+def test_admission_signal_does_not_execute_application_hooks() -> None:
+    class Value:
+        __slots__ = ("payload",)
+
+        def __init__(self) -> None:
+            self.payload = bytearray(8_192)
+
+        def __sizeof__(self) -> int:
+            raise AssertionError("application __sizeof__ must not execute")  # noqa: TRY003
+
+        def __len__(self) -> int:
+            raise AssertionError("application __len__ must not execute")  # noqa: TRY003
+
+    signal = run_context_lru._admission_signal("values", "key", Value())
+
+    assert signal.exact_bytes is None
+    assert signal.stratum == ("values", "slots", 1)
+    assert 1 <= signal.shallow_bytes < 8_192
+
+
+# Mutation caught: bucketing distinct native container sizes together.
+def test_admission_signal_uses_exact_builtin_length_bucket() -> None:
+    short = run_context_lru._admission_signal("values", "key", [None] * 65)
+    long = run_context_lru._admission_signal("values", "key", [None] * 129)
+
+    assert short.stratum == ("values", "list", 128)
+    assert long.stratum == ("values", "list", 256)
+
+
+# Mutation caught: routing atomic entries through calibrated storage strata.
+def test_admission_signal_keeps_atomic_entry_exact() -> None:
+    signal = run_context_lru._admission_signal("values", "key", b"payload")
+
+    assert signal.stratum is None
+    assert signal.exact_bytes == max(
+        MIN_TRACKED_ENTRY_BYTES,
+        sys.getsizeof("key") + sys.getsizeof(b"payload"),
+    )
+
+
+# Mutation caught: treating hostile builtin subclasses as their native bases.
+@pytest.mark.parametrize("container_type", [dict, list, str])
+def test_admission_signal_does_not_execute_hostile_builtin_subclass_hooks(
+    container_type: type[object],
+) -> None:
+    class HostileContainer(container_type):  # type: ignore[misc, valid-type]
+        def __len__(self) -> int:
+            raise AssertionError("application __len__ must not execute")  # noqa: TRY003
+
+        def __sizeof__(self) -> int:
+            raise AssertionError("application __sizeof__ must not execute")  # noqa: TRY003
+
+        def __eq__(self, other: object) -> bool:
+            raise AssertionError("application equality must not execute")  # noqa: TRY003
+
+        @property
+        def __class__(self) -> type[object]:
+            raise AssertionError("application metadata must not execute")  # noqa: TRY003
+
+    if container_type is dict:
+        value = HostileContainer({"payload": bytearray(64)})
+    elif container_type is list:
+        value = HostileContainer([bytearray(64)])
+    else:
+        value = HostileContainer("payload")
+
+    signal = run_context_lru._admission_signal("values", "key", value)
+
+    assert signal.exact_bytes is None
+    assert signal.stratum is not None
+    assert signal.stratum[1] not in {"dict", "list", "shallow_leaf"}
+    assert signal.shallow_bytes >= 1
+
+
+# Mutation caught: reading instance dictionary values instead of native storage metadata.
+def test_admission_signal_buckets_genuine_instance_dict_without_reading_values() -> (
+    None
+):
+    class Value:
+        pass
+
+    one_attribute = Value()
+    one_attribute.first = object()
+    three_attributes = Value()
+    three_attributes.first = object()
+    three_attributes.second = object()
+    three_attributes.third = object()
+
+    one_signal = run_context_lru._admission_signal("values", "key", one_attribute)
+    three_signal = run_context_lru._admission_signal("values", "key", three_attributes)
+
+    assert one_signal.stratum == ("values", "instance_dict", 1)
+    assert three_signal.stratum == ("values", "instance_dict", 4)
+
+
+# Mutation caught: invoking an object's overridable __sizeof__ during estimation.
+def test_estimator_does_not_execute_application_sizing_hook() -> None:
+    class Value:
+        __slots__ = ("payload",)
+
+        def __init__(self) -> None:
+            self.payload = bytearray(1_024)
+
+        def __sizeof__(self) -> int:
+            return 1
+
+    value = Value()
+    size = estimate_cache_entry_size("key", value, stop_after=None)
+
+    assert size == (
+        object.__sizeof__(value) + sys.getsizeof("key") + sys.getsizeof(value.payload)
+    )
 
 
 def test_estimate_cache_entry_size_counts_shared_object_once_per_entry() -> None:
@@ -303,6 +425,38 @@ def test_estimate_cache_entry_size_samples_large_uniform_mapping_with_margin() -
     )
 
     estimated = estimate_cache_entry_size(key, value, stop_after=None)
+
+    assert exact <= estimated <= math.ceil(exact * 1.06)
+
+
+# Mutation caught: allowing nested sampled candidates to grow without a global bound.
+def test_estimator_bounds_nested_container_candidate_visits() -> None:
+    value: object = bytearray(64)
+    for _ in range(40):
+        value = [value for _ in range(129)]
+    visited: list[object] = []
+
+    with mock.patch.object(
+        run_context_lru,
+        "_calibration_visit_observer",
+        visited.append,
+    ):
+        size = estimate_cache_entry_size("key", value, stop_after=10**400)
+
+    assert MIN_TRACKED_ENTRY_BYTES <= size <= 10**400
+    assert len(visited) <= run_context_lru.RUN_CONTEXT_CALIBRATION_CANDIDATE_LIMIT
+
+
+# Mutation caught: using floor projection that underestimates uniform samples.
+def test_estimator_fixed_point_projection_is_within_uniform_margin() -> None:
+    value = [bytearray(64) for _ in range(2_000)]
+    exact = (
+        sys.getsizeof("key")
+        + sys.getsizeof(value)
+        + sum(sys.getsizeof(item) for item in value)
+    )
+
+    estimated = estimate_cache_entry_size("key", value, stop_after=None)
 
     assert exact <= estimated <= math.ceil(exact * 1.06)
 

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -1297,6 +1297,10 @@ def test_concurrent_due_samples_preserve_seeded_window_and_count_both_entries() 
     configuration_generation = budget._configuration_generation
     owners = {1: first_owner, 2: second_owner}
     values = {key: [key] for key in owners}
+    signals = {
+        key: run_context_lru._admission_signal("values", key, value)
+        for key, value in values.items()
+    }
     estimator_started = {key: Event() for key in owners}
     allow_estimators = Event()
     worker_errors: list[BaseException] = []
@@ -1337,10 +1341,17 @@ def test_concurrent_due_samples_preserve_seeded_window_and_count_both_entries() 
     if worker_errors:
         raise worker_errors[0]
     assert budget._strata == {SEEDED_DUE_STRATUM: state}
-    assert list(state.samples) == [*SEEDED_CALIBRATION_WINDOW[1:], (92, 2_000)]
+    sample_shallow_bytes = {signal.shallow_bytes for signal in signals.values()}
+    assert len(sample_shallow_bytes) == 1
+    assert list(state.samples) == [
+        *SEEDED_CALIBRATION_WINDOW[1:],
+        (sample_shallow_bytes.pop(), 2_000),
+    ]
     assert state.admission_count == 257
     assert state.entry_count == 3
-    assert state.shallow_total == 284
+    assert state.shallow_total == 100 + sum(
+        signal.shallow_bytes for signal in signals.values()
+    )
     assert set(budget._entries) == {
         peer_key,
         (id(first_owner), "values", 1),
@@ -1348,7 +1359,7 @@ def test_concurrent_due_samples_preserve_seeded_window_and_count_both_entries() 
     }
     assert not budget._entry_attempt_generations
     assert budget._configuration_generation == configuration_generation
-    assert budget.estimated_bytes == 3_261
+    assert budget.estimated_bytes == state.modeled_bytes()
 
 
 def test_stale_blocked_estimate_cannot_replace_newer_same_key_sample() -> None:
@@ -3325,6 +3336,96 @@ def test_recency_mode_disables_after_weak_owner_removal_lowers_usage() -> None:
     assert removed_reference() is None
     assert budget.is_recency_enabled is False
     assert survivor.mode_updates[-1][:2] == (True, False)
+
+
+def test_touch_many_flushes_reentrant_finalizer_mode_publication() -> None:
+    budget = ProcessRunContextCacheBudget()
+
+    class LockCheckingOwner(ModeRecordingCacheOwner):
+        def _set_run_cache_modes(
+            self,
+            budget_enabled: bool,
+            recency_enabled: bool,
+            generation: int,
+        ) -> None:
+            assert not budget._lock._is_owned()  # type: ignore[attr-defined]
+            super()._set_run_cache_modes(
+                budget_enabled,
+                recency_enabled,
+                generation,
+            )
+
+    survivor = LockCheckingOwner()
+    removed = CacheOwner()
+    budget.register(survivor, 10_000)
+    budget.register(removed, 10_000)
+    _track_exact_bytes(budget, survivor, "survivor", 1_000)
+    _track_exact_bytes(budget, removed, "removed", 7_000)
+    assert budget.is_recency_enabled is True
+    removed_reference = budget._owner_references[id(removed)]
+
+    class FinalizingKey:
+        def __init__(self) -> None:
+            self.finalized = False
+
+        def __hash__(self) -> int:
+            if not self.finalized:
+                self.finalized = True
+                budget._owner_finalizer(id(removed))(removed_reference)
+            return hash("survivor")
+
+        def __eq__(self, other: object) -> bool:
+            return other == "survivor"
+
+    budget.touch_many(survivor, (("values", FinalizingKey()),))
+
+    assert budget.is_recency_enabled is False
+    assert survivor.mode_updates[-1][:2] == (True, False)
+
+
+def test_touch_many_rejects_stale_recency_generation_after_aba() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = ModeRecordingCacheOwner()
+    budget.register(owner, 10_000)
+    _track_exact_bytes(budget, owner, "first", 4_000)
+    _track_exact_bytes(budget, owner, "second", 4_000)
+    stale_generation = owner.mode_generation
+    assert budget.is_recency_enabled is True
+
+    budget.register(owner, 20_000)
+    assert budget.is_recency_enabled is False
+    budget.register(owner, 10_000)
+    assert budget.is_recency_enabled is True
+    assert owner.mode_generation > stale_generation
+
+    budget.touch_many(
+        owner,
+        (("values", "first"),),
+        mode_generation=stale_generation,
+    )
+
+    assert tuple(entry[2] for entry in budget._entries) == ("first", "second")
+
+
+def test_touch_many_rejects_current_generation_when_recency_is_disabled() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = ModeRecordingCacheOwner()
+    budget.register(owner, 10_000)
+    _track_exact_bytes(budget, owner, "first", 4_000)
+    _track_exact_bytes(budget, owner, "second", 4_000)
+    assert budget.is_recency_enabled is True
+
+    budget.register(owner, 20_000)
+    assert budget.is_recency_enabled is False
+    disabled_generation = owner.mode_generation
+
+    budget.touch_many(
+        owner,
+        (("values", "first"),),
+        mode_generation=disabled_generation,
+    )
+
+    assert tuple(entry[2] for entry in budget._entries) == ("first", "second")
 
 
 def test_recency_reentrant_callback_keeps_newest_generation() -> None:

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -35,6 +35,15 @@ class CacheOwner:
     def _set_run_cache_budget_enabled(self, enabled: bool) -> None:
         self.budget_enabled = enabled
 
+    def _set_run_cache_modes(
+        self,
+        budget_enabled: bool,
+        recency_enabled: bool,
+        generation: int,
+    ) -> None:
+        del recency_enabled, generation
+        self.budget_enabled = budget_enabled
+
     def store(
         self,
         namespace: RunCacheNamespace,
@@ -157,6 +166,44 @@ class RaisingLock:
         traceback: object,
     ) -> None:
         return None
+
+
+class ModeRecordingCacheOwner(CacheOwner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.mode_updates: list[tuple[bool, bool, int]] = []
+        self.mode_generation = -1
+
+    def _set_run_cache_modes(
+        self,
+        budget_enabled: bool,
+        recency_enabled: bool,
+        generation: int,
+    ) -> None:
+        if generation < self.mode_generation:
+            return
+        self.mode_generation = generation
+        self.budget_enabled = budget_enabled
+        self.mode_updates.append((budget_enabled, recency_enabled, generation))
+
+
+def _track_exact_bytes(
+    budget: ProcessRunContextCacheBudget,
+    owner: CacheOwner,
+    key: str,
+    exact_bytes: int,
+) -> None:
+    owner.store("values", key, key)
+    with mock.patch.object(
+        run_context_lru,
+        "_admission_signal",
+        return_value=run_context_lru._AdmissionSignal(
+            stratum=None,
+            shallow_bytes=0,
+            exact_bytes=exact_bytes,
+        ),
+    ):
+        budget.track(owner, "values", key, key)
 
 
 class CountingHashKey:
@@ -2940,6 +2987,152 @@ def test_budget_notifies_live_owners_when_enabled_mode_changes() -> None:
 
     assert not first.budget_enabled
     assert not second.budget_enabled
+
+
+def test_recency_enables_at_80_percent_and_disables_below_70_percent() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = ModeRecordingCacheOwner()
+    budget.register(owner, 10_000)
+
+    _track_exact_bytes(budget, owner, "below-enable", 7_999)
+    assert budget.is_recency_enabled is False
+    _track_exact_bytes(budget, owner, "at-enable", 1)
+    assert budget.is_recency_enabled is True
+
+    budget.remove(owner, "values", "at-enable")
+    assert budget.is_recency_enabled is True
+    budget.remove(owner, "values", "below-enable")
+    assert budget.is_recency_enabled is False
+    assert [update[:2] for update in owner.mode_updates] == [
+        (True, False),
+        (True, True),
+        (True, False),
+    ]
+
+
+def test_recency_mode_handles_disabled_zero_and_cap_transitions() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = ModeRecordingCacheOwner()
+
+    budget.register(owner, None)
+    assert owner.mode_updates[-1][:2] == (False, False)
+    budget.register(owner, 0)
+    assert owner.mode_updates[-1][:2] == (True, False)
+    budget.register(owner, 10_000)
+    _track_exact_bytes(budget, owner, "entry", 4_200)
+
+    budget.register(owner, 5_250)
+    assert budget.is_recency_enabled is True
+    budget.register(owner, 6_000)
+    assert budget.is_recency_enabled is True
+    budget.register(owner, 6_001)
+    assert budget.is_recency_enabled is False
+
+
+def test_recency_mode_does_not_publish_duplicate_mode_tuple() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = ModeRecordingCacheOwner()
+    budget.register(owner, 10_000)
+    first_update = owner.mode_updates[-1]
+
+    _track_exact_bytes(budget, owner, "entry", 1_000)
+    budget.register(owner, 10_001)
+
+    assert owner.mode_updates == [first_update]
+
+
+def test_recency_mode_disables_after_weak_owner_removal_lowers_usage() -> None:
+    import gc
+
+    budget = ProcessRunContextCacheBudget()
+    survivor = ModeRecordingCacheOwner()
+    removed = ModeRecordingCacheOwner()
+    budget.register(survivor, 10_000)
+    budget.register(removed, 10_000)
+    _track_exact_bytes(budget, removed, "large", 8_000)
+    assert budget.is_recency_enabled is True
+
+    removed_reference = ref(removed)
+    del removed
+    gc.collect()
+
+    assert removed_reference() is None
+    assert budget.is_recency_enabled is False
+    assert survivor.mode_updates[-1][:2] == (True, False)
+
+
+def test_recency_reentrant_callback_keeps_newest_generation() -> None:
+    budget = ProcessRunContextCacheBudget()
+
+    class ReentrantOwner(ModeRecordingCacheOwner):
+        def _set_run_cache_modes(
+            self,
+            budget_enabled: bool,
+            recency_enabled: bool,
+            generation: int,
+        ) -> None:
+            if recency_enabled:
+                budget.register(self, 20_000)
+            super()._set_run_cache_modes(
+                budget_enabled,
+                recency_enabled,
+                generation,
+            )
+
+    owner = ReentrantOwner()
+    budget.register(owner, 10_000)
+    _track_exact_bytes(budget, owner, "entry", 8_000)
+
+    assert budget.is_recency_enabled is False
+    assert owner.mode_updates[-1][0:2] == (True, False)
+    assert owner.mode_updates[-1][2] > owner.mode_updates[-2][2]
+
+
+def test_recency_callback_is_deferred_past_reentrant_outer_lock() -> None:
+    budget = ProcessRunContextCacheBudget()
+
+    class TrackingLock:
+        def __init__(self, wrapped: object) -> None:
+            self.wrapped = wrapped
+            self.depth = 0
+
+        def __enter__(self) -> None:
+            self.wrapped.__enter__()  # type: ignore[attr-defined]
+            self.depth += 1
+
+        def __exit__(self, *args: object) -> None:
+            self.depth -= 1
+            self.wrapped.__exit__(*args)  # type: ignore[attr-defined]
+
+        def _is_owned(self) -> bool:
+            return self.depth > 0
+
+    tracking_lock = TrackingLock(budget._lock)
+    budget._lock = tracking_lock  # type: ignore[assignment]
+
+    class LockCheckingOwner(LimitRaisingCacheOwner):
+        def _set_run_cache_modes(
+            self,
+            budget_enabled: bool,
+            recency_enabled: bool,
+            generation: int,
+        ) -> None:
+            assert tracking_lock.depth == 0
+            super()._set_run_cache_modes(
+                budget_enabled,
+                recency_enabled,
+                generation,
+            )
+
+    owner = LockCheckingOwner(budget, 2_000)
+    budget.register(owner, 640)
+    _track_exact_bytes(budget, owner, "first", 256)
+    _track_exact_bytes(budget, owner, "second", 256)
+    assert budget.is_recency_enabled is True
+
+    _track_exact_bytes(budget, owner, "third", 256)
+
+    assert budget.is_recency_enabled is False
 
 
 def test_budget_refreshes_mru_after_eviction() -> None:

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict, deque
 from collections.abc import Hashable, Iterable, Iterator
+from datetime import date, timedelta
 from threading import Event, Thread
 from unittest import mock
 import math
@@ -54,6 +55,57 @@ class CacheOwner:
         key: Hashable,
     ) -> None:
         self.entries.pop((namespace, key), None)
+
+
+SEEDED_DUE_STRATUM = cast(run_context_lru.StratumKey, ("values", "list", 1))
+SEEDED_CALIBRATION_WINDOW = ((100, 1_000),) * 8
+
+
+def _seed_due_stratum_with_peer(
+    budget: ProcessRunContextCacheBudget,
+    peer_owner: CacheOwner,
+    pending_owner: CacheOwner,
+) -> tuple[run_context_lru._StratumState, tuple[int, RunCacheNamespace, Hashable]]:
+    budget.register(peer_owner, 100_000)
+    budget.register(pending_owner, 100_000)
+    state = run_context_lru._StratumState(
+        admission_count=255,
+        samples=deque(SEEDED_CALIBRATION_WINDOW, maxlen=8),
+    )
+    budget._strata[SEEDED_DUE_STRATUM] = state
+    peer_key = (id(peer_owner), "values", "peer")
+    peer_owner.store("values", "peer", ["peer"])
+    with budget._lock:
+        budget._add_entry_accounting_locked(
+            peer_key,
+            _TrackedEntry(
+                owner=budget._owner_reference_locked(peer_owner),
+                namespace="values",
+                key="peer",
+                exact_bytes=0,
+                stratum=SEEDED_DUE_STRATUM,
+                shallow_bytes=100,
+            ),
+        )
+        budget._mru_key = peer_key
+    assert budget.estimated_bytes == 1_000
+    return state, peer_key
+
+
+def _assert_seeded_due_stratum_unchanged(
+    budget: ProcessRunContextCacheBudget,
+    peer_owner: CacheOwner,
+    state: run_context_lru._StratumState,
+    peer_key: tuple[int, RunCacheNamespace, Hashable],
+) -> None:
+    assert budget._strata == {SEEDED_DUE_STRATUM: state}
+    assert list(state.samples) == list(SEEDED_CALIBRATION_WINDOW)
+    assert state.admission_count == 255
+    assert state.entry_count == 1
+    assert state.shallow_total == 100
+    assert set(budget._entries) == {peer_key}
+    assert peer_owner.entries == {("values", "peer"): ["peer"]}
+    assert budget.estimated_bytes == 1_000
 
 
 class LimitRaisingCacheOwner(CacheOwner):
@@ -244,14 +296,27 @@ def _representative_slotted_managers() -> list[tuple[Hashable, object]]:
 
 def _representative_metric_series() -> list[tuple[Hashable, object]]:
     entries = []
+    first_day = date(2024, 1, 1)
     for index in range(512):
         records = (
             RepresentativeMetric(index, "actual", index / 10),
             RepresentativeMetric(index + 1, "forecast", index / 8),
         )
-        series = {day: records[day % 2] for day in range(120)}
+        series = {
+            first_day + timedelta(days=offset): records[offset % 2]
+            for offset in range(120)
+        }
         entries.append((index, series))
     return entries
+
+
+def test_representative_metric_series_uses_120_distinct_dates() -> None:
+    entries = _representative_metric_series()
+
+    for _key, series in entries:
+        metric_series = cast(dict[object, object], series)
+        assert len(metric_series) == 120
+        assert all(type(day) is date for day in metric_series)
 
 
 def _representative_shared_aggregate() -> list[tuple[Hashable, object]]:
@@ -351,6 +416,87 @@ def test_representative_pressure_retains_between_ninety_and_one_hundred_percent(
     assert len(owner.entries) == 9
     assert retained_bytes <= configured_bytes
     assert retained_bytes >= 2_304
+
+
+@pytest.mark.parametrize(
+    ("configured_bytes", "expected_target"),
+    [(1, 0), (19, 18), (20, 19), (101, 95), (1_000, 950)],
+)
+def test_eviction_target_uses_floor_of_ninety_five_percent(
+    configured_bytes: int,
+    expected_target: int,
+) -> None:
+    assert run_context_lru._eviction_target(configured_bytes) == expected_target
+
+
+@pytest.mark.parametrize(
+    ("first_charge", "expected_keys"),
+    [(694, {"first", "second"}), (695, {"second"})],
+)
+def test_reserve_eviction_keeps_equality_and_evicts_one_byte_above_target(
+    first_charge: int,
+    expected_keys: set[str],
+) -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 1_000)
+    owner_reference = ref(owner)
+    entries = (("first", first_charge), ("second", 256))
+
+    with budget._lock:
+        for key, exact_bytes in entries:
+            owner.store("values", key, key)
+            budget._add_entry_accounting_locked(
+                (id(owner), "values", key),
+                _TrackedEntry(
+                    owner=owner_reference,
+                    namespace="values",
+                    key=key,
+                    exact_bytes=exact_bytes,
+                    stratum=None,
+                    shallow_bytes=0,
+                ),
+            )
+            budget._mru_key = (id(owner), "values", key)
+        budget._evict_excess_locked()
+
+    assert {key for _namespace, key in owner.entries} == expected_keys
+    assert budget.estimated_bytes == sum(
+        exact_bytes for key, exact_bytes in entries if key in expected_keys
+    )
+
+
+@pytest.mark.parametrize(
+    ("estimated_bytes", "expected_reason"),
+    [
+        (960, "run cache entry evicted by process-wide LRU budget"),
+        (1_001, "run cache entry skipped because it exceeds the process budget"),
+    ],
+)
+def test_complete_cap_oversized_rejection_is_distinct_from_reserve_eviction(
+    estimated_bytes: int,
+    expected_reason: str,
+) -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 1_000)
+    value = [bytearray(64)]
+    owner.store("values", "key", value)
+
+    with (
+        mock.patch.object(
+            run_context_lru,
+            "estimate_cache_entry_size",
+            return_value=estimated_bytes,
+        ),
+        mock.patch.object(run_context_lru.logger, "debug") as debug,
+    ):
+        budget.track(owner, "values", "key", value)
+
+    assert not owner.entries
+    assert not budget._entries
+    assert budget.estimated_bytes == 0
+    assert debug.call_args.args == (expected_reason,)
 
 
 def test_stratum_models_all_entries_from_rolling_samples() -> None:
@@ -695,6 +841,225 @@ def test_calibrated_estimator_exception_cleans_value_token_and_accounting() -> N
     assert not budget._entries
     assert not budget._entry_attempt_generations
     assert budget.estimated_bytes == 0
+
+
+def test_due_estimator_failure_preserves_seeded_stratum_and_peer() -> None:
+    budget = ProcessRunContextCacheBudget()
+    peer_owner = CacheOwner()
+    pending_owner = CacheOwner()
+    state, peer_key = _seed_due_stratum_with_peer(budget, peer_owner, pending_owner)
+    lifecycle_generation = budget._owner_lifecycle_generations.get(id(pending_owner))
+    configuration_generation = budget._configuration_generation
+    value = ["pending"]
+    pending_owner.store("values", "pending", value)
+    active_lifecycle_generations: list[int] = []
+
+    def failing_estimator(key: object, value: object, *, stop_after: int | None) -> int:
+        active_lifecycle_generations.append(
+            budget._owner_lifecycle_generations[id(pending_owner)]
+        )
+        raise RuntimeError("estimation failed")  # noqa: TRY003
+
+    with (
+        mock.patch.object(
+            run_context_lru,
+            "estimate_cache_entry_size",
+            side_effect=failing_estimator,
+        ),
+        pytest.raises(RuntimeError, match="estimation failed"),
+    ):
+        budget.track(pending_owner, "values", "pending", value)
+
+    _assert_seeded_due_stratum_unchanged(budget, peer_owner, state, peer_key)
+    assert ("values", "pending") not in pending_owner.entries
+    assert not budget._entry_attempt_generations
+    assert budget._configuration_generation == configuration_generation
+    assert active_lifecycle_generations == [
+        budget._owner_lifecycle_generations[id(pending_owner)]
+    ]
+    assert active_lifecycle_generations[0] != (lifecycle_generation or 0)
+
+
+def test_due_sample_configuration_retry_failure_preserves_seeded_stratum() -> None:
+    budget = ProcessRunContextCacheBudget()
+    peer_owner = CacheOwner()
+    pending_owner = CacheOwner()
+    state, peer_key = _seed_due_stratum_with_peer(budget, peer_owner, pending_owner)
+    first_generation = budget._configuration_generation
+    value = ["pending"]
+    pending_owner.store("values", "pending", value)
+    estimator_started = Event()
+    allow_first_estimator = Event()
+    stop_after_values: list[int | None] = []
+    lifecycle_generations: list[int] = []
+    worker_errors: list[BaseException] = []
+
+    def changing_configuration_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        stop_after_values.append(stop_after)
+        lifecycle_generations.append(
+            budget._owner_lifecycle_generations[id(pending_owner)]
+        )
+        if len(stop_after_values) == 1:
+            estimator_started.set()
+            assert allow_first_estimator.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            return 9_000
+        raise RuntimeError("new-generation estimation failed")  # noqa: TRY003
+
+    def track_entry() -> None:
+        try:
+            budget.track(pending_owner, "values", "pending", value)
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        changing_configuration_estimator,
+    ):
+        worker = Thread(target=track_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            with budget._lock:
+                budget._max_bytes = 200_000
+                budget._configuration_generation += 1
+        finally:
+            allow_first_estimator.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+    assert len(worker_errors) == 1
+    assert isinstance(worker_errors[0], RuntimeError)
+    _assert_seeded_due_stratum_unchanged(budget, peer_owner, state, peer_key)
+    assert stop_after_values == [100_000, 200_000]
+    assert lifecycle_generations == [lifecycle_generations[0]] * 2
+    assert budget._configuration_generation == first_generation + 1
+    assert not budget._entry_attempt_generations
+
+
+@pytest.mark.parametrize("invalidation", ["weak_finalization", "owner_reuse"])
+def test_due_lifecycle_invalidation_preserves_seeded_stratum_and_peer(
+    invalidation: str,
+) -> None:
+    budget = ProcessRunContextCacheBudget()
+    peer_owner = CacheOwner()
+    pending_owner = CacheOwner()
+    state, peer_key = _seed_due_stratum_with_peer(budget, peer_owner, pending_owner)
+    configuration_generation = budget._configuration_generation
+    value = ["pending"]
+    pending_owner.store("values", "pending", value)
+    estimator_started = Event()
+    allow_estimator = Event()
+    worker_errors: list[BaseException] = []
+
+    def blocking_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        estimator_started.set()
+        assert allow_estimator.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        return 2_000
+
+    def track_entry() -> None:
+        try:
+            budget.track(pending_owner, "values", "pending", value)
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru, "estimate_cache_entry_size", blocking_estimator
+    ):
+        worker = Thread(target=track_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            pending_owner_id = id(pending_owner)
+            lifecycle_generation = budget._owner_lifecycle_generations[pending_owner_id]
+            with budget._lock:
+                if invalidation == "weak_finalization":
+                    owner_reference = budget._owner_references[pending_owner_id]
+                    budget._owner_finalizer(pending_owner_id)(owner_reference)
+                else:
+                    replacement = CacheOwner()
+                    budget._owner_references[pending_owner_id] = ref(replacement)
+                    budget._owner_reference_locked(pending_owner)
+        finally:
+            allow_estimator.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    _assert_seeded_due_stratum_unchanged(budget, peer_owner, state, peer_key)
+    assert not budget._entry_attempt_generations
+    assert budget._configuration_generation == configuration_generation
+    assert lifecycle_generation > 0
+    assert id(pending_owner) not in budget._owner_lifecycle_generations
+
+
+def test_concurrent_due_samples_preserve_seeded_window_and_count_both_entries() -> None:
+    budget = ProcessRunContextCacheBudget()
+    peer_owner = CacheOwner()
+    first_owner = CacheOwner()
+    state, peer_key = _seed_due_stratum_with_peer(budget, peer_owner, first_owner)
+    second_owner = CacheOwner()
+    budget.register(second_owner, 100_000)
+    configuration_generation = budget._configuration_generation
+    owners = {1: first_owner, 2: second_owner}
+    values = {key: [key] for key in owners}
+    estimator_started = {key: Event() for key in owners}
+    allow_estimators = Event()
+    worker_errors: list[BaseException] = []
+
+    def blocking_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        typed_key = cast(int, key)
+        estimator_started[typed_key].set()
+        assert allow_estimators.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        return 2_000
+
+    def track_entry(key: int) -> None:
+        try:
+            budget.track(owners[key], "values", key, values[key])
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    for key, owner in owners.items():
+        owner.store("values", key, values[key])
+    with mock.patch.object(
+        run_context_lru, "estimate_cache_entry_size", blocking_estimator
+    ):
+        workers = [Thread(target=track_entry, args=(key,)) for key in owners]
+        for worker in workers:
+            worker.start()
+        try:
+            assert all(
+                started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+                for started in estimator_started.values()
+            )
+        finally:
+            allow_estimators.set()
+            for worker in workers:
+                worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert all(not worker.is_alive() for worker in workers)
+    if worker_errors:
+        raise worker_errors[0]
+    assert budget._strata == {SEEDED_DUE_STRATUM: state}
+    assert list(state.samples) == [*SEEDED_CALIBRATION_WINDOW[1:], (92, 2_000)]
+    assert state.admission_count == 257
+    assert state.entry_count == 3
+    assert state.shallow_total == 284
+    assert set(budget._entries) == {
+        peer_key,
+        (id(first_owner), "values", 1),
+        (id(second_owner), "values", 2),
+    }
+    assert not budget._entry_attempt_generations
+    assert budget._configuration_generation == configuration_generation
+    assert budget.estimated_bytes == 3_261
 
 
 def test_stale_blocked_estimate_cannot_replace_newer_same_key_sample() -> None:
@@ -2053,6 +2418,67 @@ def test_track_does_not_reintroduce_accounting_after_owner_mutation(
     if worker_errors:
         raise worker_errors[0]
     assert budget.estimated_bytes == 0
+
+
+@pytest.mark.parametrize("mutation", ["remove", "clear_context"])
+def test_due_sample_mutation_preserves_seeded_stratum_and_peer(
+    mutation: str,
+) -> None:
+    budget = ProcessRunContextCacheBudget()
+    peer_owner = CacheOwner()
+    pending_owner = CacheOwner()
+    state, peer_key = _seed_due_stratum_with_peer(budget, peer_owner, pending_owner)
+    configuration_generation = budget._configuration_generation
+    value = ["pending"]
+    pending_owner.store("values", "pending", value)
+    estimator_started = Event()
+    allow_estimator = Event()
+    worker_errors: list[BaseException] = []
+
+    def blocking_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        estimator_started.set()
+        assert allow_estimator.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        return 2_000
+
+    def track_entry() -> None:
+        try:
+            budget.track(pending_owner, "values", "pending", value)
+        except BaseException as error:  # noqa: BLE001
+            worker_errors.append(error)
+
+    with mock.patch.object(
+        run_context_lru, "estimate_cache_entry_size", blocking_estimator
+    ):
+        worker = Thread(target=track_entry)
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            lifecycle_generation = budget._owner_lifecycle_generations[
+                id(pending_owner)
+            ]
+            if mutation == "remove":
+                pending_owner._evict_run_cache_entry("values", "pending")
+                budget.remove(pending_owner, "values", "pending")
+            else:
+                budget.clear_context(pending_owner)
+        finally:
+            allow_estimator.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+    _assert_seeded_due_stratum_unchanged(budget, peer_owner, state, peer_key)
+    assert not budget._entry_attempt_generations
+    assert budget._configuration_generation == configuration_generation
+    if mutation == "remove":
+        assert budget._owner_lifecycle_generations[id(pending_owner)] == (
+            lifecycle_generation
+        )
+    else:
+        assert id(pending_owner) not in budget._owner_lifecycle_generations
 
 
 def test_track_keeps_latest_same_key_replacement_accounting() -> None:

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -5,8 +5,8 @@ from threading import Event, Thread
 from unittest import mock
 import math
 import sys
-from types import ModuleType
-from typing import Callable, cast
+from types import FrameType, ModuleType
+from typing import Callable, Never, cast
 from weakref import ref
 
 import pytest
@@ -554,6 +554,248 @@ def test_stratum_models_all_entries_from_rolling_samples() -> None:
     )
 
     assert state.modeled_bytes() == 4_000
+
+
+def test_ordinary_admission_does_not_iterate_calibration_samples() -> None:
+    class IterationForbiddenDeque(deque[tuple[int, int]]):
+        def __iter__(self) -> Never:
+            raise AssertionError(  # noqa: TRY003
+                "ordinary admission iterated calibration samples"
+            )
+
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    first_value = [1]
+    owner.store("values", "first", first_value)
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        return_value=1_024,
+    ):
+        budget.track(owner, "values", "first", first_value)
+
+    state = next(iter(budget._strata.values()))
+    samples = tuple(state.samples)
+    state.samples = IterationForbiddenDeque(samples, maxlen=8)
+    second_value = [2]
+    owner.store("values", "second", second_value)
+
+    budget.track(owner, "values", "second", second_value)
+
+    assert owner.entries[("values", "second")] is second_value
+    assert budget.estimated_bytes > 0
+    state.samples = deque(samples, maxlen=8)
+    budget.clear_context(owner)
+
+
+def test_empty_stratum_retains_only_calibration_metadata() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    value = [bytearray(96)]
+    owner.store("values", "key", value)
+    budget.track(owner, "values", "key", value)
+    tracked = budget._entries[(id(owner), "values", "key")]
+    assert tracked.stratum is not None
+    sample = tuple(budget._strata[tracked.stratum].samples)
+
+    budget.clear_context(owner)
+
+    assert not budget._entries
+    assert not budget._strata
+    assert budget.estimated_bytes == 0
+    retained = budget._calibration_history[tracked.stratum]
+    assert retained.samples == sample
+    assert retained.admission_count == 1
+
+
+def test_repeated_context_reuses_retained_calibration_without_deep_sample() -> None:
+    budget = ProcessRunContextCacheBudget()
+    first_owner = CacheOwner()
+    budget.register(first_owner, 10_000_000)
+    first_value = [bytearray(96)]
+    first_owner.store("values", "first", first_value)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        return_value=1_024,
+    ) as estimator:
+        budget.track(first_owner, "values", "first", first_value)
+        budget.clear_context(first_owner)
+        second_owner = CacheOwner()
+        budget.register(second_owner, 10_000_000)
+        second_value = [bytearray(96)]
+        second_owner.store("values", "second", second_value)
+        budget.track(second_owner, "values", "second", second_value)
+
+    assert estimator.call_count == 1
+    assert budget.estimated_bytes > 0
+
+
+def test_materially_different_retained_stratum_still_calibrates() -> None:
+    budget = ProcessRunContextCacheBudget()
+    first_owner = CacheOwner()
+    budget.register(first_owner, 10_000_000)
+    first_value = [1]
+    first_owner.store("values", "first", first_value)
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        return_value=1_024,
+    ) as estimator:
+        budget.track(first_owner, "values", "first", first_value)
+        budget.clear_context(first_owner)
+        second_owner = CacheOwner()
+        budget.register(second_owner, 10_000_000)
+        second_value = [1, 2, 3]
+        second_owner.store("values", "second", second_value)
+        budget.track(second_owner, "values", "second", second_value)
+
+    assert estimator.call_count == 2
+
+
+def test_calibration_history_is_bounded_and_evicts_oldest_deterministically() -> None:
+    budget = ProcessRunContextCacheBudget()
+    limit = run_context_lru.RUN_CONTEXT_CALIBRATION_HISTORY_LIMIT
+    strata = [
+        cast(run_context_lru.StratumKey, ("values", "opaque", index))
+        for index in range(limit + 1)
+    ]
+    with budget._lock:
+        for index, stratum in enumerate(strata):
+            budget._retain_calibration_locked(
+                stratum,
+                run_context_lru._StratumState(
+                    admission_count=index + 1,
+                    samples=deque([(100, 1_000)], maxlen=8),
+                ),
+            )
+
+    assert list(budget._calibration_history) == strata[1:]
+
+
+def test_failed_due_sample_does_not_corrupt_retained_calibration() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    stratum = cast(run_context_lru.StratumKey, ("values", "list", 1))
+    with budget._lock:
+        budget._retain_calibration_locked(
+            stratum,
+            run_context_lru._StratumState(
+                admission_count=255,
+                samples=deque([(100, 1_000)], maxlen=8),
+            ),
+        )
+    value = [1]
+    owner.store("values", "key", value)
+
+    with (
+        mock.patch.object(
+            run_context_lru,
+            "estimate_cache_entry_size",
+            side_effect=RuntimeError("estimation failed"),
+        ),
+        pytest.raises(RuntimeError, match="estimation failed"),
+    ):
+        budget.track(owner, "values", "key", value)
+
+    assert not budget._strata
+    retained = budget._calibration_history[stratum]
+    assert retained.admission_count == 255
+    assert retained.samples == ((100, 1_000),)
+
+
+def test_lifecycle_invalidated_due_sample_does_not_corrupt_retained_calibration() -> (
+    None
+):
+    budget = ProcessRunContextCacheBudget()
+    owner = CacheOwner()
+    budget.register(owner, 10_000_000)
+    stratum = cast(run_context_lru.StratumKey, ("values", "list", 1))
+    with budget._lock:
+        budget._retain_calibration_locked(
+            stratum,
+            run_context_lru._StratumState(
+                admission_count=255,
+                samples=deque([(100, 1_000)], maxlen=8),
+            ),
+        )
+    value = [1]
+    owner.store("values", "key", value)
+    estimator_started = Event()
+    allow_estimator = Event()
+
+    def blocking_estimator(
+        key: object, value: object, *, stop_after: int | None
+    ) -> int:
+        estimator_started.set()
+        assert allow_estimator.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+        return 2_000
+
+    with mock.patch.object(
+        run_context_lru,
+        "estimate_cache_entry_size",
+        blocking_estimator,
+    ):
+        worker = Thread(target=budget.track, args=(owner, "values", "key", value))
+        worker.start()
+        try:
+            assert estimator_started.wait(timeout=HANDOFF_TIMEOUT_SECONDS)
+            budget.clear_context(owner)
+        finally:
+            allow_estimator.set()
+            worker.join(timeout=HANDOFF_TIMEOUT_SECONDS)
+
+    assert not worker.is_alive()
+    assert not budget._strata
+    retained = budget._calibration_history[stratum]
+    assert retained.admission_count == 255
+    assert retained.samples == ((100, 1_000),)
+
+
+def test_configuration_change_discards_retained_calibration() -> None:
+    budget = ProcessRunContextCacheBudget()
+    first_owner = CacheOwner()
+    budget.register(first_owner, 10_000_000)
+    value = [1]
+    first_owner.store("values", "key", value)
+    budget.track(first_owner, "values", "key", value)
+    budget.clear_context(first_owner)
+    assert budget._calibration_history
+
+    second_owner = CacheOwner()
+    budget.register(second_owner, 20_000_000)
+
+    assert not budget._calibration_history
+
+
+def test_reused_calibration_keeps_representative_aggregate_within_five_percent() -> (
+    None
+):
+    budget = ProcessRunContextCacheBudget()
+    calibration_owner = CacheOwner()
+    budget.register(calibration_owner, 1_000_000_000)
+    calibration_value = [bytearray(96)]
+    calibration_owner.store("values", "calibration", calibration_value)
+    budget.track(calibration_owner, "values", "calibration", calibration_value)
+    budget.clear_context(calibration_owner)
+
+    owner = CacheOwner()
+    budget.register(owner, 1_000_000_000)
+    entries = [(index, [bytearray(96)]) for index in range(64)]
+    for key, value in entries:
+        owner.store("values", key, value)
+        budget.track(owner, "values", key, value)
+
+    exact_total = sum(
+        _exhaustive_representative_entry_size(key, value) for key, value in entries
+    )
+    assert math.ceil(exact_total * 0.95) <= budget.estimated_bytes
+    assert budget.estimated_bytes <= math.ceil(exact_total * 1.05)
 
 
 def test_stratum_keeps_only_eight_recent_samples() -> None:
@@ -1634,6 +1876,30 @@ def test_estimator_bounds_nested_container_candidate_visits() -> None:
 
     assert MIN_TRACKED_ENTRY_BYTES <= size <= 10**400
     assert len(visited) <= run_context_lru.RUN_CONTEXT_CALIBRATION_CANDIDATE_LIMIT
+
+
+def test_estimator_exact_type_classification_adds_no_generators_per_candidate() -> None:
+    generator_calls = 0
+    value = list(range(64))
+
+    def profile(frame: FrameType, event: str, arg: object) -> None:
+        del arg
+        nonlocal generator_calls
+        if (
+            event == "call"
+            and frame.f_code.co_name == "<genexpr>"
+            and frame.f_code.co_filename == run_context_lru.__file__
+        ):
+            generator_calls += 1
+
+    previous_profile = sys.getprofile()
+    sys.setprofile(profile)
+    try:
+        estimate_cache_entry_size("key", value, stop_after=None)
+    finally:
+        sys.setprofile(previous_profile)
+
+    assert generator_calls <= len(value) + 1
 
 
 # Mutation caught: using floor projection that underestimates uniform samples.

--- a/tests/unit/test_run_context_lru.py
+++ b/tests/unit/test_run_context_lru.py
@@ -3135,6 +3135,177 @@ def test_recency_callback_is_deferred_past_reentrant_outer_lock() -> None:
     assert budget.is_recency_enabled is False
 
 
+def test_unchanged_mode_admission_enters_coordinator_lock_once() -> None:
+    budget = ProcessRunContextCacheBudget()
+    owner = ModeRecordingCacheOwner()
+    budget.register(owner, 10_000)
+
+    class CountingLock:
+        def __init__(self, wrapped: object) -> None:
+            self.wrapped = wrapped
+            self.enter_count = 0
+
+        def __enter__(self) -> None:
+            self.enter_count += 1
+            self.wrapped.__enter__()  # type: ignore[attr-defined]
+
+        def __exit__(self, *args: object) -> None:
+            self.wrapped.__exit__(*args)  # type: ignore[attr-defined]
+
+        def _is_owned(self) -> bool:
+            return bool(self.wrapped._is_owned())  # type: ignore[attr-defined]
+
+    counting_lock = CountingLock(budget._lock)
+    budget._lock = counting_lock  # type: ignore[assignment]
+
+    _track_exact_bytes(budget, owner, "entry", 1_000)
+
+    assert counting_lock.enter_count == 1
+    assert owner.mode_updates == [(True, False, 1)]
+
+
+def test_track_eviction_exception_reconciles_recency_below_70_percent() -> None:
+    budget = ProcessRunContextCacheBudget()
+
+    class RaisingEvictionOwner(ModeRecordingCacheOwner):
+        def _evict_run_cache_entry(
+            self,
+            namespace: RunCacheNamespace,
+            key: Hashable,
+        ) -> None:
+            super()._evict_run_cache_entry(namespace, key)
+            raise RuntimeError("eviction failed")  # noqa: TRY003
+
+    raising = RaisingEvictionOwner()
+    survivor = ModeRecordingCacheOwner()
+    budget.register(raising, 1_000)
+    budget.register(survivor, 1_000)
+    _track_exact_bytes(budget, raising, "large", 500)
+    _track_exact_bytes(budget, survivor, "warm", 300)
+    assert budget.is_recency_enabled is True
+
+    with pytest.raises(RuntimeError, match="eviction failed"):
+        _track_exact_bytes(budget, survivor, "new", 300)
+
+    assert budget.estimated_bytes == 600
+    assert budget.is_recency_enabled is False
+    assert survivor.mode_updates[-1][:2] == (True, False)
+
+
+def test_eviction_exception_precedes_mode_callback_exception() -> None:
+    budget = ProcessRunContextCacheBudget()
+
+    class DoublyRaisingOwner(ModeRecordingCacheOwner):
+        raise_on_disabled_mode = False
+
+        def _evict_run_cache_entry(
+            self,
+            namespace: RunCacheNamespace,
+            key: Hashable,
+        ) -> None:
+            super()._evict_run_cache_entry(namespace, key)
+            raise RuntimeError("primary eviction failed")  # noqa: TRY003
+
+        def _set_run_cache_modes(
+            self,
+            budget_enabled: bool,
+            recency_enabled: bool,
+            generation: int,
+        ) -> None:
+            super()._set_run_cache_modes(
+                budget_enabled,
+                recency_enabled,
+                generation,
+            )
+            if self.raise_on_disabled_mode and not recency_enabled:
+                raise RuntimeError("secondary publication failed")  # noqa: TRY003
+
+    raising = DoublyRaisingOwner()
+    survivor = ModeRecordingCacheOwner()
+    budget.register(raising, 1_000)
+    budget.register(survivor, 1_000)
+    _track_exact_bytes(budget, raising, "large", 500)
+    _track_exact_bytes(budget, survivor, "warm", 300)
+    raising.raise_on_disabled_mode = True
+
+    with pytest.raises(RuntimeError, match="primary eviction failed") as captured:
+        _track_exact_bytes(budget, survivor, "new", 300)
+
+    assert any(
+        "secondary publication failed" in note
+        for note in getattr(captured.value, "__notes__", ())
+    )
+    assert survivor.mode_updates[-1][:2] == (True, False)
+
+
+def test_register_eviction_exception_reconciles_recency_below_70_percent() -> None:
+    budget = ProcessRunContextCacheBudget()
+
+    class RaisingEvictionOwner(ModeRecordingCacheOwner):
+        def _evict_run_cache_entry(
+            self,
+            namespace: RunCacheNamespace,
+            key: Hashable,
+        ) -> None:
+            super()._evict_run_cache_entry(namespace, key)
+            raise RuntimeError("cap eviction failed")  # noqa: TRY003
+
+    raising = RaisingEvictionOwner()
+    survivor = ModeRecordingCacheOwner()
+    budget.register(raising, 1_000)
+    budget.register(survivor, 1_000)
+    _track_exact_bytes(budget, raising, "large", 500)
+    _track_exact_bytes(budget, survivor, "warm", 300)
+    assert budget.is_recency_enabled is True
+
+    with pytest.raises(RuntimeError, match="cap eviction failed"):
+        budget.register(survivor, 700)
+
+    assert budget.estimated_bytes == 300
+    assert budget.is_recency_enabled is False
+    assert survivor.mode_updates[-1][:2] == (True, False)
+
+
+def test_rebuild_exception_publishes_enabled_mode_after_partial_eviction() -> None:
+    budget = ProcessRunContextCacheBudget()
+
+    class RaisingEvictionOwner(ModeRecordingCacheOwner):
+        def _evict_run_cache_entry(
+            self,
+            namespace: RunCacheNamespace,
+            key: Hashable,
+        ) -> None:
+            super()._evict_run_cache_entry(namespace, key)
+            raise RuntimeError("rebuild eviction failed")  # noqa: TRY003
+
+    raising = RaisingEvictionOwner()
+    survivor = ModeRecordingCacheOwner()
+    late = ModeRecordingCacheOwner()
+    budget.register(raising, None)
+    budget.register(survivor, None)
+    budget.register(late, None)
+    raising.store("values", "large", "large")
+    survivor.store("values", "warm", "warm")
+    late.store("values", "new", "new")
+    budget._owners = OrderedOwnerRegistry((raising, survivor, late))
+
+    signals = iter((500, 300, 300))
+
+    def admission_signal(*args: object) -> run_context_lru._AdmissionSignal:
+        del args
+        return run_context_lru._AdmissionSignal(None, 0, next(signals))
+
+    with (
+        mock.patch.object(run_context_lru, "_admission_signal", admission_signal),
+        pytest.raises(RuntimeError, match="rebuild eviction failed"),
+    ):
+        budget.register(late, 1_000)
+
+    assert budget.estimated_bytes == 600
+    assert budget.is_recency_enabled is False
+    assert survivor.mode_updates[-1][:2] == (True, False)
+
+
 def test_budget_refreshes_mru_after_eviction() -> None:
     budget = ProcessRunContextCacheBudget()
     owner = CacheOwner()


### PR DESCRIPTION
## Summary

The capped run-context path still performs deep sizing and global recency/accounting work far more often than needed. This PR replaces per-entry deep sizing with bounded aggregate calibration and disables read-recency work until the process is near its configured budget.

It is opened as a draft because the controlled Knowledge Hub shipment benchmark now passes three of four comparison gates, but direct-warm remains above the strict 1.10x target.

## Related issue

Follow-up to #451. No linked issue.

## What changed

- Added hostile-safe shallow admission signals and an integer-only bounded calibration estimator.
- Calibrated storage families from the first and sparse later samples instead of traversing every admitted object graph.
- Added aggregate accounting with a 5% modeled reserve and representative 5% accuracy fixtures.
- Retained bounded calibration metadata across empty contexts; no cached values, keys, owner references, or telemetry are retained.
- Disabled read-recency bookkeeping below 80% budget pressure and added 70% disable hysteresis.
- Preserved global eviction, zero-cap behavior, pending-publication pinning, lifecycle freshness, and concurrent same-key replacement guards.
- Added deterministic race, failure, lifecycle, accuracy, and bounded-work coverage.
- Made the standalone benchmark importable from a non-installed checkout.

## Validation

```text
PYTHONPATH=src python -m pytest tests/unit/test_run_context_lru.py tests/unit/test_calculation_run_context.py — 279 passed
ruff check [focused source/test/benchmark files] — passed
ruff format --check [focused source/test/benchmark files] — passed
mypy --strict src/general_manager/cache/run_context.py src/general_manager/cache/run_context_lru.py scripts/benchmark_run_context_cache_budget.py — passed
pre-commit hooks on both final Task 4 commits — passed
python scripts/benchmark_run_context_cache_budget.py — hits 0.99x capped/uncapped; scalar inserts 9.95x; container inserts 9.11x
```

Controlled Knowledge Hub Docker Compose block, three samples per version, PR versus v0.67.5:

```text
GraphQL cold  0.451429s / 0.496654s = 0.909x — pass
GraphQL warm  0.101258s / 0.100483s = 1.008x — pass
Direct cold   0.365430s / 0.395358s = 0.924x — pass
Direct warm   0.023643s / 0.017324s = 1.365x — does not meet 1.10x gate
```

GraphQL and direct response digests matched, and both cold runs executed 430 queries. The complete repository suite and rotated nine-sample Compose gate have not been run on this draft state.

## Documentation

Updated `docs/api/cache.md` and `docs/concepts/caching.md` to explain aggregate calibration, the 5% modeled reserve, pressure-only approximate LRU behavior, pending-publication pinning, accuracy limits, and that no telemetry is collected.

## Reviewer notes

- Calibration accuracy targets representative aggregates, not adversarial object graphs or process RSS.
- The retained process-wide calibration history is bounded to 256 storage families and contains only counters and shallow/deep sample pairs.
- Profiling the remaining direct-warm gap shows the workload peaks at only 4.03 MB (0.094% of the 4 GiB cap), while 1,327 admissions still enter detailed coordinator accounting. A future owner-local reservation design would be needed to meet the final 1.10x gate without relaxing accuracy or pressure behavior.
- No settings, telemetry, dependencies, migrations, public exports, or version numbers were added.
- Suggested review order: `run_context_lru.py`, `run_context.py`, focused tests, then public documentation.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [ ] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and `mypy --strict` pass.
- [x] User-facing documentation is updated where behavior changed.
