### PR TITLE
fix: preserve calculation list authorization subsets

### DIFF
--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -302,7 +302,7 @@ def apply_read_authorization(
             instance_check_reasons=(),
         )
 
-    filtered_queryset = queryset
+    filtered_queryset: Bucket[GeneralManagerT] | None = queryset
     if (
         not permission_plan.requires_instance_check
         and len(permission_plan.filters) == 1
@@ -321,7 +321,7 @@ def apply_read_authorization(
         return result
 
     if permission_plan.filters:
-        filtered_queryset = queryset.none()
+        filtered_queryset = None
         for permission_filter in permission_plan.filters:
             filter_dict = permission_filter.get("filter", {})
             exclude_dict = permission_filter.get("exclude", {})
@@ -329,7 +329,10 @@ def apply_read_authorization(
                 qs_perm = queryset
             else:
                 qs_perm = queryset.filter(**filter_dict).exclude(**exclude_dict)
-            filtered_queryset = filtered_queryset | qs_perm
+            filtered_queryset = (
+                qs_perm if filtered_queryset is None else filtered_queryset | qs_perm
+            )
+    assert filtered_queryset is not None
 
     result = filter_queryset_by_read_permission(
         filtered_queryset,
@@ -362,10 +365,9 @@ def filter_queryset_by_read_permission(
 
     When an instance gate is not required, or the manager has no Permission
     class, the original queryset is returned without eagerly computing counts.
-    Otherwise each candidate is checked with ``can_read_instance()``. Authorized
-    rows with an ``identification["id"]`` are rebuilt through an ``id__in``
-    filter; authorized rows without an id are unioned back as concrete manager
-    instances.
+    Otherwise each candidate is checked with ``can_read_instance()`` and the
+    originating bucket reconstructs the exact authorized instance subset using
+    its backend-native representation.
     """
     if not requires_instance_check:
         return ReadAuthorizationResult(
@@ -392,25 +394,15 @@ def filter_queryset_by_read_permission(
             instance_check_reasons=instance_check_reasons,
         )
 
-    authorized_ids: list[object] = []
     authorized_instances: list[GeneralManagerT] = []
     candidate_count = 0
     for instance in queryset:
         candidate_count += 1
         if PermissionClass(instance, info.context.user).can_read_instance():
-            identification = cast(Mapping[str, object], instance.identification)
-            instance_id = identification.get("id")
-            if instance_id is None:
-                authorized_instances.append(instance)
-            else:
-                authorized_ids.append(instance_id)
+            authorized_instances.append(instance)
 
-    authorized_queryset = (
-        queryset.filter(id__in=authorized_ids) if authorized_ids else queryset.none()
-    )
-    for instance in authorized_instances:
-        authorized_queryset = authorized_queryset | instance
-    authorized_count = len(authorized_ids) + len(authorized_instances)
+    authorized_queryset = queryset.with_instances(authorized_instances)
+    authorized_count = len(authorized_instances)
     return ReadAuthorizationResult(
         queryset=authorized_queryset,
         candidate_count=candidate_count,

--- a/src/general_manager/bucket/base_bucket.py
+++ b/src/general_manager/bucket/base_bucket.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from collections.abc import Hashable, Mapping
+from collections.abc import Hashable, Iterable, Mapping
 from typing import (
     Generator,
     TYPE_CHECKING,
@@ -437,3 +437,18 @@ class Bucket(ABC, Generic[GeneralManagerType]):
             "The 'none' method is not implemented in the base Bucket class. "
             "Subclasses should implement this method to return an empty bucket."
         )
+
+    def with_instances(
+        self,
+        instances: Iterable[GeneralManagerType],
+    ) -> Bucket[GeneralManagerType]:
+        """Return a bucket containing exactly the supplied manager instances.
+
+        Callers provide instances in source iteration order and implementations
+        retain that order. Backends may override this compatibility fallback to
+        avoid repeated unions or unsupported lookups.
+        """
+        subset = self.none()
+        for instance in instances:
+            subset = subset | instance
+        return subset

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -219,6 +219,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         self._excludes = parse_filters(self.exclude_definitions, possible_values)
 
         self._data: list[Combination] | None = None
+        self._allowed_identifications: list[Combination] | None = None
         self.sort_key = sort_key
         self.reverse = reverse
         self._effective_search_date = current_as_of_date()
@@ -251,6 +252,10 @@ class CalculationBucket(Bucket[GeneralManagerType]):
             reverse,
         )
         bucket._effective_search_date = self._effective_search_date
+        if self._allowed_identifications is not None:
+            bucket._allowed_identifications = [
+                dict(identification) for identification in self._allowed_identifications
+            ]
         return bucket
 
     def __eq__(self, other: object) -> bool:
@@ -292,6 +297,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
             ),
             {
                 "data": self._data,
+                "allowed_identifications": self._allowed_identifications,
                 "effective_search_date": self._effective_search_date,
             },
         )
@@ -307,6 +313,10 @@ class CalculationBucket(Bucket[GeneralManagerType]):
             None
         """
         self._data = cast(list[Combination] | None, state.get("data"))
+        self._allowed_identifications = cast(
+            list[Combination] | None,
+            state.get("allowed_identifications"),
+        )
         self._effective_search_date = cast(
             "datetime | None", state.get("effective_search_date")
         )
@@ -656,6 +666,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
             self._manager_class,
             freeze_bucket_index_value(self.filter_definitions),
             freeze_bucket_index_value(self.exclude_definitions),
+            freeze_bucket_index_value(self._allowed_identifications),
             self._normalized_sort_key(),
             self.reverse,
         )
@@ -738,6 +749,17 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                     sorted_filters["input_filters"],
                     sorted_filters["input_excludes"],
                 )
+                if self._allowed_identifications is not None:
+                    allowed_identification_keys = {
+                        freeze_bucket_index_value(identification)
+                        for identification in self._allowed_identifications
+                    }
+                    current_combinations = [
+                        manager.identification
+                        for manager in self._manager_combinations(current_combinations)
+                        if freeze_bucket_index_value(manager.identification)
+                        in allowed_identification_keys
+                    ]
                 sort_key = self._normalized_sort_key()
                 needs_manager_access = (
                     bool(sorted_filters["prop_filters"])
@@ -1222,6 +1244,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         own.exclude_definitions = {}
         own._filters = {}
         own._excludes = {}
+        own._allowed_identifications = []
         return own
 
     def with_instances(
@@ -1245,5 +1268,8 @@ class CalculationBucket(Bucket[GeneralManagerType]):
             sort_key=self.sort_key,
             reverse=self.reverse,
         )
+        subset._allowed_identifications = [
+            dict(identification) for identification in identifications
+        ]
         subset._data = identifications
         return subset

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -1223,3 +1223,27 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         own._filters = {}
         own._excludes = {}
         return own
+
+    def with_instances(
+        self,
+        instances: Iterable[GeneralManagerType],
+    ) -> CalculationBucket[GeneralManagerType]:
+        """Return a materialized subset using declared input identifications."""
+        self._ensure_as_of_compatible()
+        from general_manager.manager.general_manager import GeneralManager
+
+        identifications: list[Combination] = []
+        for instance in instances:
+            if instance.__class__ != self._manager_class:
+                raise IncompatibleBucketTypeError(self.__class__, type(instance))
+            if isinstance(instance, GeneralManager):
+                instance._ensure_as_of_compatible()
+            identifications.append(dict(instance.identification))
+        subset = self._derive(
+            filter_definitions=self.filter_definitions.copy(),
+            exclude_definitions=self.exclude_definitions.copy(),
+            sort_key=self.sort_key,
+            reverse=self.reverse,
+        )
+        subset._data = identifications
+        return subset

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -458,11 +458,22 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                 sorted_filters["input_excludes"],
                 snapshot_iterables=snapshot_iterables,
             )
-            if sorted_filters["prop_filters"] or sorted_filters["prop_excludes"]:
+            allowed_identification_keys = None
+            if self._allowed_identifications is not None:
+                allowed_identification_keys = {
+                    freeze_bucket_index_value(identification)
+                    for identification in self._allowed_identifications
+                }
+            if (
+                sorted_filters["prop_filters"]
+                or sorted_filters["prop_excludes"]
+                or allowed_identification_keys is not None
+            ):
                 preview_iterator = self._iter_prop_filtered_identifications(
                     preview_iterator,
                     sorted_filters["prop_filters"],
                     sorted_filters["prop_excludes"],
+                    allowed_identification_keys,
                 )
             preview = list(islice(preview_iterator, limit + 1))
 
@@ -1050,6 +1061,7 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         combinations: Iterable[Combination],
         prop_filters: ParsedFilters,
         prop_excludes: ParsedFilters,
+        allowed_identification_keys: set[Hashable] | None = None,
     ) -> Generator[Combination, None, None]:
         """
         Lazily apply property filters and yield manager identifications.
@@ -1060,6 +1072,12 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         """
         for combo in combinations:
             manager = self._manager_class(**combo)
+            if (
+                allowed_identification_keys is not None
+                and freeze_bucket_index_value(manager.identification)
+                not in allowed_identification_keys
+            ):
+                continue
             if self._filter_prop_combinations([manager], prop_filters, prop_excludes):
                 yield manager.identification
 

--- a/src/general_manager/bucket/calculation_bucket.py
+++ b/src/general_manager/bucket/calculation_bucket.py
@@ -370,12 +370,29 @@ class CalculationBucket(Bucket[GeneralManagerType]):
         }
 
         other._ensure_as_of_compatible()
-        return self._derive(
+        combined = self._derive(
             filter_definitions=combined_filters,
             exclude_definitions=combined_excludes,
             sort_key=None,
             reverse=False,
         )
+        if self._allowed_identifications is None:
+            if other._allowed_identifications is not None:
+                combined._allowed_identifications = [
+                    dict(identification)
+                    for identification in other._allowed_identifications
+                ]
+        elif other._allowed_identifications is not None:
+            other_allowed_keys = {
+                freeze_bucket_index_value(identification)
+                for identification in other._allowed_identifications
+            }
+            combined._allowed_identifications = [
+                dict(identification)
+                for identification in self._allowed_identifications
+                if freeze_bucket_index_value(identification) in other_allowed_keys
+            ]
+        return combined
 
     def __str__(self) -> str:
         """
@@ -749,17 +766,21 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                     sorted_filters["input_filters"],
                     sorted_filters["input_excludes"],
                 )
+                manager_combinations: list[GeneralManagerType] | None = None
                 if self._allowed_identifications is not None:
                     allowed_identification_keys = {
                         freeze_bucket_index_value(identification)
                         for identification in self._allowed_identifications
                     }
-                    current_combinations = [
-                        manager.identification
+                    manager_combinations = [
+                        manager
                         for manager in self._manager_combinations(current_combinations)
                         if freeze_bucket_index_value(manager.identification)
                         in allowed_identification_keys
                     ]
+                    current_combinations = self._manager_identifications(
+                        manager_combinations
+                    )
                 sort_key = self._normalized_sort_key()
                 needs_manager_access = (
                     bool(sorted_filters["prop_filters"])
@@ -768,9 +789,10 @@ class CalculationBucket(Bucket[GeneralManagerType]):
                 )
 
                 if needs_manager_access:
-                    manager_combinations = self._manager_combinations(
-                        current_combinations
-                    )
+                    if manager_combinations is None:
+                        manager_combinations = self._manager_combinations(
+                            current_combinations
+                        )
                     manager_combinations = self._filter_prop_combinations(
                         manager_combinations,
                         sorted_filters["prop_filters"],

--- a/src/general_manager/bucket/database_bucket.py
+++ b/src/general_manager/bucket/database_bucket.py
@@ -1,7 +1,7 @@
 """Database-backed bucket implementation for GeneralManager collections."""
 
 from __future__ import annotations
-from collections.abc import Callable, Hashable, Mapping
+from collections.abc import Callable, Hashable, Iterable, Mapping
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Generator, TypeVar, cast
 
@@ -1533,3 +1533,19 @@ class DatabaseBucket(Bucket[GeneralManagerType]):
         own._query_signature_cache = _QUERY_SIGNATURE_NOT_COMPUTED
         own._trusted_query_signature = None
         return own
+
+    def with_instances(
+        self,
+        instances: Iterable[GeneralManagerType],
+    ) -> DatabaseBucket[GeneralManagerType]:
+        """Return a source-ordered subset selected by manager primary keys."""
+        self._ensure_as_of_compatible()
+        ids: list[object] = []
+        for instance in instances:
+            if not isinstance(instance, GeneralManager) or (
+                instance.__class__ != self._manager_class
+            ):
+                raise DatabaseBucketTypeMismatchError(self.__class__, type(instance))
+            instance._ensure_as_of_compatible()
+            ids.append(instance.identification["id"])
+        return self.filter(id__in=ids) if ids else self.none()

--- a/src/general_manager/bucket/request_bucket.py
+++ b/src/general_manager/bucket/request_bucket.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator, Hashable, Mapping
+from collections.abc import Generator, Hashable, Iterable, Mapping
 from typing import TYPE_CHECKING, Protocol, cast
 
 from general_manager.bucket.base_bucket import Bucket, GeneralManagerType
@@ -451,6 +451,17 @@ class RequestBucket(Bucket[GeneralManagerType]):
     def none(self) -> "RequestBucket[GeneralManagerType]":
         """Return an empty materialized bucket preserving the operation name."""
         return self._from_items(tuple())
+
+    def with_instances(
+        self,
+        instances: Iterable[GeneralManagerType],
+    ) -> "RequestBucket[GeneralManagerType]":
+        """Return a materialized subset without re-executing the request plan."""
+        items = tuple(instances)
+        for instance in items:
+            if not isinstance(instance, self._manager_class):
+                raise RequestBucketTypeMismatchError(self.__class__, type(instance))
+        return self._from_items(items)
 
     @property
     def operation_name(self) -> str:

--- a/tests/integration/test_graphql_calculation_permissions.py
+++ b/tests/integration/test_graphql_calculation_permissions.py
@@ -1,0 +1,138 @@
+from datetime import date
+from typing import Literal, cast
+
+from django.contrib.auth import get_user_model
+from django.db.models import CharField
+from django.utils.crypto import get_random_string
+
+from general_manager.api.property import graph_ql_property
+from general_manager.interface import CalculationInterface, DatabaseInterface
+from general_manager.manager import GeneralManager, Input
+from general_manager.permission.base_permission import (
+    BasePermission,
+    PermissionConstraint,
+    ReadPermissionPlan,
+)
+from general_manager.utils.testing import GeneralManagerTransactionTestCase
+
+
+class TestGraphQLCalculationPermissions(GeneralManagerTransactionTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        class AuthorizationSubject(GeneralManager):
+            class Interface(DatabaseInterface):
+                name = CharField(max_length=100)
+
+        class ReportCalculation(GeneralManager):
+            class Interface(CalculationInterface):
+                subject = Input(
+                    AuthorizationSubject,
+                    possible_values=lambda: AuthorizationSubject.all(),
+                )
+                period = Input(
+                    date,
+                    possible_values=[date(2026, 1, 31), date(2026, 2, 28)],
+                    depends_on=["subject"],
+                )
+
+            class Permission(BasePermission):
+                def describe_operation_permissions(
+                    self,
+                    action: Literal["create", "read", "update", "delete"],
+                ) -> tuple[str, ...]:
+                    return ()
+
+                def check_operation_permission(
+                    self,
+                    action: Literal["create", "read", "update", "delete"],
+                ) -> bool:
+                    return True
+
+                def check_permission(
+                    self,
+                    action: Literal["create", "read", "update", "delete"],
+                    attribute: str,
+                ) -> bool:
+                    return True
+
+                def get_permission_filter(self) -> list[PermissionConstraint]:
+                    return [{"filter": {}, "exclude": {}}]
+
+                def get_read_permission_plan(self) -> ReadPermissionPlan:
+                    return ReadPermissionPlan(
+                        filters=[{"filter": {}, "exclude": {}}],
+                        requires_instance_check=True,
+                        instance_check_reasons=("unfilterable_read_rule",),
+                    )
+
+                def can_read_instance(self) -> bool:
+                    calculation = cast(ReportCalculation, self.instance)
+                    return calculation.period.month == 2
+
+            @graph_ql_property
+            def result(self) -> int:
+                return 1
+
+        cls.Subject = AuthorizationSubject
+        cls.Calculation = ReportCalculation
+        cls.general_manager_classes = [AuthorizationSubject, ReportCalculation]
+
+    def setUp(self) -> None:
+        super().setUp()
+        password = get_random_string(12)
+        self.user = get_user_model().objects.create_user(
+            username="calculation-permission-user",
+            password=password,
+        )
+        self.client.login(
+            username="calculation-permission-user",
+            password=password,
+        )
+        self.subject = self.Subject.Factory.create(name="Subject")
+
+    def test_list_returns_only_instance_authorized_calculations(self) -> None:
+        response = self.query(
+            """
+            query {
+                reportCalculationList(page: 1, pageSize: 10) {
+                    items { period result }
+                    pageInfo { totalCount }
+                }
+            }
+            """
+        )
+
+        self.assertResponseNoErrors(response)
+        self.assertEqual(
+            response.json()["data"]["reportCalculationList"],
+            {
+                "items": [{"period": "2026-02-28", "result": 1}],
+                "pageInfo": {"totalCount": 1},
+            },
+        )
+
+    def test_filtered_list_returns_only_instance_authorized_calculations(self) -> None:
+        response = self.query(
+            """
+            query($subjectId: ID!) {
+                reportCalculationList(
+                    page: 1,
+                    pageSize: 10,
+                    filter: {subject: {id: $subjectId}}
+                ) {
+                    items { period result }
+                    pageInfo { totalCount }
+                }
+            }
+            """,
+            variables={"subjectId": self.subject.id},
+        )
+
+        self.assertResponseNoErrors(response)
+        self.assertEqual(
+            response.json()["data"]["reportCalculationList"],
+            {
+                "items": [{"period": "2026-02-28", "result": 1}],
+                "pageInfo": {"totalCount": 1},
+            },
+        )

--- a/tests/unit/test_base_bucket.py
+++ b/tests/unit/test_base_bucket.py
@@ -154,6 +154,10 @@ class DummyBucket(Bucket[int]):
         """
         return DummyBucket(self._manager_class, self._data)
 
+    def none(self):
+        """Return an empty DummyBucket for base contract tests."""
+        return DummyBucket(self._manager_class)
+
     def get(self, **kwargs):
         # support lookup by 'value'
         """
@@ -296,6 +300,14 @@ class BucketTests(SimpleTestCase):
         copy = self.bucket.all()
         self.assertIsNot(copy, self.bucket)
         self.assertEqual(copy, self.bucket)
+
+    def test_with_instances_uses_empty_bucket_and_unions_items_in_order(self):
+        """Keep the default subset fallback available to existing subclasses."""
+        subset = self.bucket.with_instances([2, 3, 1])
+
+        self.assertIsInstance(subset, DummyBucket)
+        self.assertEqual(list(subset), [2, 3, 1])
+        self.assertEqual(list(self.bucket), [3, 1, 2])
 
     def test_get_no_kwargs(self):
         """

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -60,6 +60,23 @@ class DummyGeneralManager:
 DummyCalculationInterface._parent_class = DummyGeneralManager
 
 
+class InputIdentificationInterface(CalculationInterface):
+    input_fields: ClassVar[dict] = {
+        "field1": Input(str, possible_values=["first", "second"]),
+        "field2": Input(int, possible_values=[1, 2]),
+    }
+
+
+class InputIdentificationManager:
+    Interface = InputIdentificationInterface
+
+    def __init__(self, **kwargs):
+        self.identification = dict(kwargs)
+
+
+InputIdentificationInterface._parent_class = InputIdentificationManager
+
+
 class CountingIterable:
     def __init__(self, values):
         self.values = values
@@ -417,20 +434,6 @@ class TestCalculationBucket(TestCase):
         self, _mock_parse
     ) -> None:
         """Keep exact input identifications without reconstructing through filters."""
-
-        class InputIdentificationInterface(CalculationInterface):
-            input_fields: ClassVar[dict] = {
-                "field1": Input(str, possible_values=["first", "second"]),
-                "field2": Input(int, possible_values=[1, 2]),
-            }
-
-        class InputIdentificationManager:
-            Interface = InputIdentificationInterface
-
-            def __init__(self, **kwargs):
-                self.identification = dict(kwargs)
-
-        InputIdentificationInterface._parent_class = InputIdentificationManager
         snapshot = datetime(2022, 1, 1, tzinfo=UTC)
         with as_of(snapshot):
             source = CalculationBucket(
@@ -448,13 +451,30 @@ class TestCalculationBucket(TestCase):
 
             subset = source.with_instances(selected)
             empty = source.with_instances(())
+            restored = pickle.loads(pickle.dumps(subset))  # noqa: S301
+            filtered = restored.filter(field1__in=["first", "second"])
+            sorted_subset = restored.sort("field2")
+
+            expected_identifications = [
+                {"field1": "second", "field2": 2},
+                {"field1": "first", "field2": 1},
+            ]
 
             self.assertEqual(
                 [item.identification for item in subset],
-                [
-                    {"field1": "second", "field2": 2},
-                    {"field1": "first", "field2": 1},
-                ],
+                expected_identifications,
+            )
+            self.assertEqual(
+                restored._allowed_identifications, expected_identifications
+            )
+            self.assertIsNone(filtered._data)
+            self.assertEqual(
+                filtered._allowed_identifications, expected_identifications
+            )
+            self.assertIsNone(sorted_subset._data)
+            self.assertEqual(
+                sorted_subset._allowed_identifications,
+                expected_identifications,
             )
             self.assertIsNot(subset, source)
             self.assertIsInstance(empty, CalculationBucket)
@@ -1245,6 +1265,32 @@ class TestCalculationBucketAdditional(TestCase):
         self.assertIn("...", s)
         self.assertIsNone(bucket._data)
         self.assertLessEqual(values.yield_count, 6)
+
+    @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
+    def test_str_uncached_preview_honors_allowed_identifications(self, _mock_parse):
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "n": Input(type=int, possible_values=range(10)),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        DynInterface._parent_class = DynManager
+        source = CalculationBucket(DynManager)
+        restricted = source.with_instances([DynManager(n=7), DynManager(n=9)])
+        uncached = restricted.filter()
+
+        preview = str(uncached)
+
+        self.assertTrue(preview.startswith("CalculationBucket (2)["))
+        self.assertIn("DynManager(**{'n': 7})", preview)
+        self.assertIn("DynManager(**{'n': 9})", preview)
+        self.assertNotIn("DynManager(**{'n': 0})", preview)
+        self.assertIsNone(uncached._data)
 
     @patch("general_manager.bucket.calculation_bucket.parse_filters", return_value={})
     def test_str_preserves_static_iterator_possible_values(self, _mock_parse):

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -387,6 +387,59 @@ class TestCalculationBucket(TestCase):
         # Sliced bucket should have its own combinations
         self.assertEqual(sliced._data, [{"i": 1}, {"i": 2}])
 
+    def test_with_instances_materializes_non_id_identifications_in_order(
+        self, _mock_parse
+    ) -> None:
+        """Keep exact input identifications without reconstructing through filters."""
+
+        class InputIdentificationInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "field1": Input(str, possible_values=["first", "second"]),
+                "field2": Input(int, possible_values=[1, 2]),
+            }
+
+        class InputIdentificationManager:
+            Interface = InputIdentificationInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        InputIdentificationInterface._parent_class = InputIdentificationManager
+        snapshot = datetime(2022, 1, 1, tzinfo=UTC)
+        with as_of(snapshot):
+            source = CalculationBucket(
+                InputIdentificationManager,
+                {"field1": "source"},
+                {"field2": 0},
+                ("field1", "field2"),
+                True,
+            )
+            source._data = [{"field1": "cached", "field2": 99}]
+            selected = [
+                InputIdentificationManager(field1="second", field2=2),
+                InputIdentificationManager(field1="first", field2=1),
+            ]
+
+            subset = source.with_instances(selected)
+            empty = source.with_instances(())
+
+            self.assertEqual(
+                [item.identification for item in subset],
+                [
+                    {"field1": "second", "field2": 2},
+                    {"field1": "first", "field2": 1},
+                ],
+            )
+            self.assertIsNot(subset, source)
+            self.assertIsInstance(empty, CalculationBucket)
+            self.assertEqual(list(empty), [])
+            self.assertEqual(source.filter_definitions, {"field1": "source"})
+            self.assertEqual(source.exclude_definitions, {"field2": 0})
+            self.assertEqual(source.sort_key, ("field1", "field2"))
+            self.assertTrue(source.reverse)
+            self.assertEqual(source._data, [{"field1": "cached", "field2": 99}])
+            self.assertEqual(source._effective_search_date, snapshot)
+
     def test_sort_returns_new_bucket(self, _mock_parse):
         """
         Tests that the sort() method returns a new CalculationBucket with updated sort key and reverse flag, leaving the original bucket unchanged.

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -14,6 +14,7 @@ from general_manager.cache.run_context import current_calculation_run_context
 from general_manager.interface import CalculationInterface
 from general_manager.manager.input import DateRangeDomain, Input
 from general_manager.manager import GeneralManager
+from general_manager.utils.filter_parser import parse_filters
 from tests.utils.simple_manager_interface import SimpleBucket
 from typing import ClassVar
 
@@ -434,11 +435,12 @@ class TestCalculationBucket(TestCase):
         self, _mock_parse
     ) -> None:
         """Keep exact input identifications without reconstructing through filters."""
+        _mock_parse.side_effect = parse_filters
         snapshot = datetime(2022, 1, 1, tzinfo=UTC)
         with as_of(snapshot):
             source = CalculationBucket(
                 InputIdentificationManager,
-                {"field1": "source"},
+                {"field1__in": ["first", "second"]},
                 {"field2": 0},
                 ("field1", "field2"),
                 True,
@@ -452,7 +454,7 @@ class TestCalculationBucket(TestCase):
             subset = source.with_instances(selected)
             empty = source.with_instances(())
             restored = pickle.loads(pickle.dumps(subset))  # noqa: S301
-            filtered = restored.filter(field1__in=["first", "second"])
+            filtered = restored.filter(field1="first")
             sorted_subset = restored.sort("field2")
 
             expected_identifications = [
@@ -471,6 +473,10 @@ class TestCalculationBucket(TestCase):
             self.assertEqual(
                 filtered._allowed_identifications, expected_identifications
             )
+            self.assertEqual(
+                [manager.identification for manager in filtered],
+                [{"field1": "first", "field2": 1}],
+            )
             self.assertIsNone(sorted_subset._data)
             self.assertEqual(
                 sorted_subset._allowed_identifications,
@@ -479,7 +485,10 @@ class TestCalculationBucket(TestCase):
             self.assertIsNot(subset, source)
             self.assertIsInstance(empty, CalculationBucket)
             self.assertEqual(list(empty), [])
-            self.assertEqual(source.filter_definitions, {"field1": "source"})
+            self.assertEqual(
+                source.filter_definitions,
+                {"field1__in": ["first", "second"]},
+            )
             self.assertEqual(source.exclude_definitions, {"field2": 0})
             self.assertEqual(source.sort_key, ("field1", "field2"))
             self.assertTrue(source.reverse)

--- a/tests/unit/test_calculation_bucket.py
+++ b/tests/unit/test_calculation_bucket.py
@@ -293,6 +293,32 @@ class TestCalculationBucket(TestCase):
         self.assertEqual(combined.filter_definitions, {"f1": 1})
         self.assertEqual(combined.exclude_definitions, {"e1": 2})
 
+    def test_or_intersects_distinct_allowed_instance_subsets(self, _mock_parse):
+        """Combining exact subsets must not widen either authorization boundary."""
+
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "num": Input(type=int, possible_values=[1, 2, 3]),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                self.identification = dict(kwargs)
+
+        DynInterface._parent_class = DynManager
+        source = CalculationBucket(DynManager)
+        left = source.with_instances([DynManager(num=1), DynManager(num=2)])
+        right = source.with_instances([DynManager(num=2), DynManager(num=3)])
+
+        combined = left | right
+
+        self.assertEqual(
+            [manager.identification for manager in combined],
+            [{"num": 2}],
+        )
+
     def test_or_with_invalid(self, _mock_parse):
         """
         Tests that combining a CalculationBucket with an incompatible type or a bucket of a different manager class raises a TypeError.
@@ -793,6 +819,37 @@ class TestGenerateCombinations(TestCase):
             calls,
             [{"num": 1}, {"num": 2}, {"num": 3}],
         )
+
+    def test_allowed_subset_reuses_managers_for_property_access(self, _mock_parse):
+        calls = []
+
+        class DynInterface(CalculationInterface):
+            input_fields: ClassVar[dict] = {
+                "num": Input(type=int, possible_values=[1, 2, 3]),
+            }
+
+        class DynManager:
+            Interface = DynInterface
+
+            def __init__(self, **kwargs):
+                calls.append(dict(kwargs))
+                self.identification = dict(kwargs)
+                self.num = kwargs["num"]
+
+            @property
+            def doubled(self):
+                return self.num * 2
+
+        DynInterface._parent_class = DynManager
+        source = CalculationBucket(DynManager)
+        subset = source.with_instances([DynManager(num=2), DynManager(num=3)])
+        subset = subset.sort("doubled")
+        calls.clear()
+
+        combinations = subset.generate_combinations()
+
+        self.assertEqual(combinations, [{"num": 2}, {"num": 3}])
+        self.assertEqual(calls, [{"num": 1}, {"num": 2}, {"num": 3}])
 
     def test_mixed_input_and_property_sort_key_uses_manager_sorting(self, _mock_parse):
         calls = []

--- a/tests/unit/test_database_bucket.py
+++ b/tests/unit/test_database_bucket.py
@@ -275,6 +275,17 @@ class DatabaseBucketTestCase(TestCase):
         self.assertEqual(len(self.bucket), 3)
         self.assertEqual(self.bucket.count(), 3)
 
+    def test_with_instances_retains_source_queryset_order(self):
+        """Materialize only supplied managers while preserving source ordering."""
+        first, _, third = list(self.bucket)
+
+        subset = self.bucket.with_instances([first, third])
+
+        self.assertEqual(
+            [item.identification["id"] for item in subset],
+            [self.u1.id, self.u3.id],
+        )
+
     def test_live_bucket_created_before_as_of_rejects_before_evaluation(self):
         snapshot = datetime(2024, 1, 1, tzinfo=UTC)
 

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -845,6 +845,55 @@ class GraphQLHelperTests(SimpleTestCase):
         assert result.requires_instance_check is False
         logger_mock.info.assert_not_called()
 
+    def test_apply_read_authorization_uses_bucket_instance_subset(self) -> None:
+        class SelectivePermission(BasePermission):
+            def check_permission(self, *args, **kwargs) -> bool:
+                return True
+
+            def check_operation_permission(self, *args, **kwargs) -> bool:
+                return True
+
+            def describe_operation_permissions(
+                self, *args, **kwargs
+            ) -> tuple[str, ...]:
+                return ()
+
+            def can_read_instance(self) -> bool:
+                return self.instance.identification["id"] == 2
+
+        class SelectiveManager(GeneralManager):
+            Interface = _DummyInterface
+            Permission = SelectivePermission
+
+        class IdFilterUnsupportedBucket(SimpleBucket):
+            def filter(self, **kwargs):
+                raise AssertionError
+
+        queryset = IdFilterUnsupportedBucket(
+            SelectiveManager,
+            [SelectiveManager(id=1), SelectiveManager(id=2)],
+        )
+
+        with mock.patch(
+            "general_manager.api.graphql_resolvers.get_read_permission_filter",
+            return_value=ReadPermissionPlan(
+                filters=[],
+                requires_instance_check=True,
+                instance_check_reasons=("unfilterable_read_rule",),
+            ),
+        ):
+            result = apply_read_authorization(
+                queryset,
+                SelectiveManager,
+                _Info(),
+                source="list",
+            )
+
+        assert [item.identification["id"] for item in result.queryset] == [2]
+        assert result.candidate_count == 2
+        assert result.authorized_count == 1
+        assert result.denied_count == 1
+
     def test_apply_read_authorization_allow_all_skips_row_permission_objects(
         self,
     ) -> None:

--- a/tests/unit/test_request_interface.py
+++ b/tests/unit/test_request_interface.py
@@ -252,6 +252,22 @@ class TestRequestInterface(SimpleTestCase):
 
         self.assertIsInstance(bucket, RequestBucket)
 
+    def test_with_instances_reuses_materialized_request_candidates(self) -> None:
+        """Build an exact materialized subset without another request execution."""
+        bucket = RemoteProject.filter(status="active")
+        first, second = tuple(bucket)
+        calls_after_materialization = len(RemoteProject.Interface.calls)
+
+        subset = bucket.with_instances([first, second])
+
+        self.assertEqual(
+            [item.identification for item in subset],
+            [first.identification, second.identification],
+        )
+        self.assertEqual(
+            len(RemoteProject.Interface.calls), calls_after_materialization
+        )
+
     def test_request_capabilities_alias_is_reexported_from_bundles_package(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- add a backend-neutral bucket contract for reconstructing an exact set of authorized manager instances
- preserve authorized calculation identifications across later GraphQL filters, excludes, sorting, pickling, and run-scoped bucket indexing
- delegate GraphQL row authorization to the originating bucket instead of assuming every backend accepts `id__in`
- add generated GraphQL list regression coverage for authenticated non-superusers, with and without user-supplied filters

## Root cause

The generic GraphQL read-authorization helper rebuilt authorized rows with `queryset.filter(id__in=...)`. `CalculationBucket` only accepts declared calculation inputs, so a calculation interface without an `id` input raised `UnknownInputFieldError("id")`. Its constraint-based union behavior also could not safely represent an arbitrary materialized authorization subset.

## Impact

Generated calculation list resolvers now return the exact authorized instances and correct pagination counts for instance-check permission plans. Database buckets retain a single native `id__in` query, while request and calculation buckets use their native materialized representations.

Closes #454

## Validation

- `python -m pytest` — 5,953 passed, 3 skipped
- `ruff check .`
- `ruff format --check .`
- `mypy src/general_manager`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating exact, ordered subsets of existing results.
  - Preserved filtering, sorting, historical context, and cached data when creating subsets.
  - Added validation for incompatible records and contexts.

- **Bug Fixes**
  - Improved row-level authorization so GraphQL results include only authorized records, including calculations.
  - Avoided unnecessary request re-execution when filtering authorized results.

- **Tests**
  - Added coverage for authorization filtering, ordering, subset creation, and preserved result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->