### PR TITLE
docs: document static permission decisions

### DIFF
--- a/docs/api/permission.md
+++ b/docs/api/permission.md
@@ -33,11 +33,14 @@ messages.
 
 `_get_permission_filter(permission)` resolves a permission expression to optional
 `filter`/`exclude` mappings with object-valued lookup values. Superusers and
-registered permission filters that return `None` both produce empty filter and
-exclude mappings. `_get_permission_filter_info(permission)` returns the same
-constraint plus a boolean indicating whether the permission was representable as
-a prefilter; `None` from the registered filter means `False`. Unknown permission
-names raise `PermissionNotFoundError`.
+registered permission filters that return `None` or a `PermissionFilterDecision`
+both produce empty filter and exclude mappings for this low-level compatibility
+helper. Read-plan composition preserves static decisions so GraphQL list and
+search resolvers can short-circuit definitive allow/deny outcomes.
+`_get_permission_filter_info(permission)` returns the same constraint plus a
+boolean indicating whether the permission was representable as a prefilter;
+`None` and static decisions mean `False`. Unknown permission names raise
+`PermissionNotFoundError`.
 
 ::: general_manager.permission.manager_based_permission.AdditiveManagerPermission
 
@@ -110,6 +113,8 @@ needs an explicit before/after comparison. Unsupported payload types raise
 `permission_data must be either a dict or an instance of GeneralManager.`
 
 ## Registry and reusable checks
+
+::: general_manager.permission.permission_checks.PermissionFilterDecision
 
 ::: general_manager.permission.permission_checks.register_permission
 

--- a/docs/concepts/permission/manager_based_permission.md
+++ b/docs/concepts/permission/manager_based_permission.md
@@ -190,11 +190,36 @@ registry. Each registry entry stores the permission method and a callable
 returns `None`.
 
 Permission filters can return `{"filter": {...}}`, `{"exclude": {...}}`, both
-keys, or `None`. The GraphQL/list path applies Django constraints as
-`filter(...).exclude(...)`, combines those constraints with client filters, and
-still evaluates a final per-instance read check for rules that could not be
-fully represented as query filters. Search backends receive the `filter` side as
-the backend prefilter and rely on the final instance gate for `exclude` checks.
+keys, or `None`. A user/config-only rule may instead return
+`PermissionFilterDecision.ALLOW_ALL` or `PermissionFilterDecision.DENY_ALL`:
+
+```python
+from general_manager.permission import PermissionFilterDecision, register_permission
+
+
+def is_tenant_operator_filter(user, _config):
+    return (
+        PermissionFilterDecision.ALLOW_ALL
+        if getattr(user, "is_staff", False)
+        else PermissionFilterDecision.DENY_ALL
+    )
+
+
+@register_permission(
+    "isTenantOperator", permission_filter=is_tenant_operator_filter
+)
+def is_tenant_operator(_instance, user, _config):
+    return bool(getattr(user, "is_staff", False))
+```
+
+Use a static decision only when every row has the same outcome for that
+user/configuration. `ALLOW_ALL` and `DENY_ALL` are preserved while read plans
+compose `&` fragments as AND and permission-list entries as OR alternatives;
+`None` remains the correct result for a rule that needs a concrete instance.
+The GraphQL/list path applies mapping constraints as `filter(...).exclude(...)`
+and still evaluates a final per-instance read check for conditional rules that
+need it. Search backends receive the `filter` side as the backend prefilter and
+rely on the final instance gate for `exclude` checks.
 
 Permission expressions use simple string splitting: `&` joins sub-permissions and
 `:` separates the registry name from config values. There is no escape syntax,

--- a/docs/examples/permission_cookbook.md
+++ b/docs/examples/permission_cookbook.md
@@ -76,6 +76,44 @@ def permission_visible_invoice(instance, user, _config):
     )
 ```
 
+## Static user-only decisions
+
+When a rule depends only on the requesting user and its configuration, return a
+`PermissionFilterDecision` instead of making the list/search path inspect every
+row. This example lets staff users read every `Project` and denies the entire
+manager for other users:
+
+```python
+from general_manager.manager import GeneralManager
+from general_manager.permission import PermissionFilterDecision, register_permission
+from general_manager.permission.manager_based_permission import AdditiveManagerPermission
+
+
+def is_project_reviewer_filter(user, _config):
+    return (
+        PermissionFilterDecision.ALLOW_ALL
+        if getattr(user, "is_staff", False)
+        else PermissionFilterDecision.DENY_ALL
+    )
+
+
+@register_permission(
+    "isProjectReviewer", permission_filter=is_project_reviewer_filter
+)
+def is_project_reviewer(_instance, user, _config):
+    return bool(getattr(user, "is_staff", False))
+
+
+class Project(GeneralManager):
+    class Permission(AdditiveManagerPermission):
+        __read__ = ["isProjectReviewer"]
+```
+
+Static decisions must be correct for every row. Use `None` when the rule needs
+the concrete instance, and use a mapping when a queryset constraint can narrow
+the candidate rows but does not itself prove authorization. Read expressions
+joined with `&` are ANDed; entries in `__read__` remain OR alternatives.
+
 ## Guarding GraphQL mutations
 
 Mutation classes can reuse permission checks for fine-grained control. The example below assumes an `Invoice` manager backed by a Django model:

--- a/docs/howto/permission_walkthrough.md
+++ b/docs/howto/permission_walkthrough.md
@@ -74,9 +74,34 @@ Add `"belongsToCustomer:customer"` to `__read__` to produce filters automaticall
 
 `permission_filter` may return only a `filter` mapping, only an `exclude`
 mapping, both keys, or `None`. Return `None` when a rule depends on runtime
-state that cannot be expressed as queryset kwargs. GeneralManager still stores a
-callable filter in `permission_functions` for permissions registered without a
-custom filter; that default callable returns `None`.
+state that cannot be expressed as queryset kwargs. For a rule whose outcome is
+the same for every row, return a static decision instead:
+
+```python
+from general_manager.permission import PermissionFilterDecision
+
+
+def is_project_reviewer_filter(user, _config):
+    return (
+        PermissionFilterDecision.ALLOW_ALL
+        if getattr(user, "is_staff", False)
+        else PermissionFilterDecision.DENY_ALL
+    )
+
+
+@register_permission(
+    "isProjectReviewer", permission_filter=is_project_reviewer_filter
+)
+def is_project_reviewer(_instance, user, _config):
+    return bool(getattr(user, "is_staff", False))
+```
+
+Use `ALLOW_ALL` only when the user/configuration grants every possible row and
+`DENY_ALL` only when it grants none. GraphQL list and search resolvers use these
+decisions to avoid unnecessary prefilters and per-row checks; a deny-all search
+manager is skipped. GeneralManager still stores a callable filter in
+`permission_functions` for permissions registered without a custom filter; that
+default callable returns `None`.
 
 Permission strings are split on `&` and `:` without escaping. Keep registered
 names colon-free for ordinary rules, and expect empty config segments to be


### PR DESCRIPTION
## Summary

This documentation-only PR completes the four required documentation forms for the static permission-filter decision contract introduced in the reviewed rolling window.

## Reviewed commits

The review window was `2026-08-15T04:02:44Z` through `2026-08-16T04:02:44Z`. The reviewed commits reachable from `origin/main` were:

```text
d0d3c6c5a808c0881b6a5444ce675a59b08b2667  0.70.0
3471b724403c50482b6dde4091f772aec530d9db  fix: recognize empty permission constraints
398433232185c60adb8b541b6c2b2ceb20a53b05  fix: address static permission review feedback
422d0f14c9e865ba7e9edf05b40d4ae7b18afd37  test: tighten permission guide coverage
2a632e4314fd64e1611d82618e7a8541fcc4678f  docs: clarify conditional permission gates
9eaab09552a6f34736a44c5039b6d8d451d1a75e  docs: explain static read permission decisions
2beb765a19409162f698c2ba25f1f39b6046832b  fix: suppress static search authorization summaries
60602232e4f4476e82593d5aa11c0ae8a4becadb  feat: short-circuit static search permissions
e81931d4ec8d6fe9b1127e9d0ee4cc9fa4eae762  feat: short-circuit static list permissions
99dcbfb0ef461e7229c6c99693c89bcc0273f300  fix: preserve compound exclude authorization
85816d9a57cc1f8286082640328bf0cdb8a8e88d  feat: compose static read permission plans
4a75e414566d1285e7b6daa4e13a1b67c4805d7e  fix: bridge static permission filter decisions
63846654d462d973f3794954d358ca25899318b3  feat: add static permission filter decisions
```

## Affected public APIs and behavior

- `general_manager.permission.PermissionFilterDecision` is the new stable export with `ALLOW_ALL` and `DENY_ALL`.
- `register_permission(..., permission_filter=...)` now accepts static decisions in addition to mapping constraints and `None`.
- Read-plan composition treats `&` fragments as AND and `__read__` entries as OR alternatives; static allow/deny outcomes short-circuit GraphQL list/search authorization, while `None` retains conditional row-level checks.
- The GraphQL `ReadPermissionPlan.decision` adapter field is documented as internal/compatibility behavior rather than a stable application import.

## Documentation changed

- `docs/api/permission.md` — corrected the compatibility-helper notes and added the enum API entry.
- `docs/concepts/permission/manager_based_permission.md` — explained the static-decision model and composition with a code example.
- `docs/howto/permission_walkthrough.md` — added a task-oriented static-decision recipe and safety guidance.
- `docs/examples/permission_cookbook.md` — added a directly usable user-only static-decision recipe.

The reviewed tip already contains the related GraphQL security and search concept coverage in `docs/concepts/graphql/security.md` and `docs/concepts/search.md`; both pages are already in navigation, so no `mkdocs.yml` change was needed.

## Validation

- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py tests/integration/test_request_docs_examples.py -q` — 8 passed.
- Focused permission/GraphQL suites — 262 passed, 26 subtests.
- `python -m mkdocs build --strict --site-dir /tmp/general-manager-docs-review-20260816` — passed; only existing unnav-linked planning/ADR notices were reported.
- Embedded Python documentation examples — 22 blocks parsed with `ast`.
- File-scoped pre-commit hooks and commit hooks — passed; Ruff and mypy were skipped because no Python files changed.
- `git diff --check` — passed.

## Open PR overlap check

Open PRs #456, #450, #449, and #448 were inspected before editing and again before PR creation. None duplicates this static permission decision/export documentation scope.

## Limitations

This PR changes documentation only. The full test suite was not rerun because no application code changed.