### PR TITLE
docs: consolidate recent public API documentation

### DIFF
--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -629,6 +629,44 @@ exits a temporary `CalculationRunContext`. Use it only in `with` statements:
 manager, not a decorator or generator context manager; `__enter__()` yields a
 `CalculationRunContext` and `__exit__()` returns `None`.
 
+::: general_manager.cache.data_change_context.DataChangeTransactionContext
+
+`DataChangeTransactionContext(database_alias, caller_in_atomic_block)` is the
+mutable transaction-local state shared by the outermost ORM data-change
+lifecycle signals. Its identity fields are the database alias and whether the
+caller already owned an atomic block. `changed_classes` is a deduplicated
+`set[str]`; `metadata` is a caller-owned `dict[str, object]`; and
+`phase_seconds` is an additive `dict[str, float]` of recorded lifecycle work.
+
+::: general_manager.cache.data_change_context.DataChangeTransactionScope
+
+`DataChangeTransactionScope(transaction, is_outermost)` is the context-manager
+entry view used by the data-change signal envelope. It is not needed by ordinary
+signal consumers; receivers receive the `transaction` value directly as
+`transaction_context`.
+
+::: general_manager.cache.data_change_context.current_data_change_transaction
+
+`current_data_change_transaction(database_alias)` returns the live
+`DataChangeTransactionContext` for that alias, or `None` when no framework-owned
+envelope is active. It does not search other aliases.
+
+::: general_manager.cache.data_change_context.register_data_change_class
+
+`register_data_change_class(class_name, database_alias)` adds the class name to
+the matching framework-owned context's `changed_classes` set and returns
+`True`. It returns `False` for a missing alias, a caller-owned outer
+transaction, or no active envelope. It only checks the requested alias and does
+not raise a package-specific exception.
+
+::: general_manager.cache.data_change_context.record_data_change_phase
+
+`record_data_change_phase(phase, duration_seconds, database_alias)` records a
+finite duration for one of the documented lifecycle phases and returns `None`.
+Negative finite durations are clamped to zero; non-finite durations and calls
+without a matching live context are ignored. The helper is intended for
+framework receivers and observability integrations.
+
 ::: general_manager.cache.signals.pre_data_change
 
 ::: general_manager.cache.signals.post_data_change

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -463,6 +463,27 @@ normalizes it to `2024-01-01`; `year_end` normalizes it to `2024-12-31`.
 
 ::: general_manager.bucket.base_bucket.Bucket
 
+`Bucket.with_instances(instances: Iterable[GeneralManagerType]) -> Bucket[GeneralManagerType]`
+returns a bucket containing exactly the supplied manager instances. `instances`
+must contain instances of the bucket's manager class; pass them in source
+iteration order when the existing ordering matters. An empty iterable returns
+an empty bucket. The base implementation starts from `none()` and unions the
+instances, while concrete backends keep their native representation:
+`DatabaseBucket` selects matching manager IDs in source-queryset order,
+`RequestBucket` materializes the items without re-executing its request plan,
+and `CalculationBucket` materializes the declared identifications while
+retaining its filter, exclude, sort, and historical context.
+
+The method returns the concrete bucket family and raises the backend's existing
+`TypeError` subclass for an instance from the wrong manager class. It raises
+`HistoricalContextConflictError` when the bucket or an instance is used in an
+incompatible historical context; a database bucket also requires each manager
+identification to contain an `id` key. This backend-neutral contract is
+available from GeneralManager 0.71.0 and is used by generated GraphQL
+row-authorization flows. See the [bucket concept](../concepts/models_entities.md#buckets),
+[authorization how-to](../howto/expose_via_graphql.md#preserve-an-exact-authorized-subset),
+and [permission recipe](../examples/permission_cookbook.md#preserve-an-authorized-bucket-subset).
+
 ::: general_manager.bucket.database_bucket.DatabaseBucket
 
 `DatabaseBucket` is the ORM-backed collection returned by database and

--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -142,8 +142,10 @@ discards only events registered after that savepoint; events registered before
 it remain queued and publish when the outer transaction commits. When no
 transaction is active, Django executes the `on_commit()` callback immediately.
 GraphQL class-wide ordinary events hydrate the changed object and apply
-`can_read_instance()` after commit; aggregate `refresh` events have no row
-identification and yield `item = null` without object-level hydration.
+`can_read_instance()` in an async-safe worker using the user captured when the
+subscription starts. Unreadable or missing objects are suppressed, while an
+unexpected permission exception propagates; aggregate `refresh` events have no
+row identification and yield `item = null` without object-level hydration.
 
 RemoteAPI delivery is best-effort after commit: a missing channel layer emits
 no message, and ordinary channel-layer failures are logged while other queued
@@ -404,15 +406,20 @@ truncation toward zero for those inputs.
 
 For pagination, treat the generated GraphQL `pageInfo` response field as the
 user-facing contract. `totalCount` is counted after permission filters, user
-filters, excludes, sorting, and grouping, but before page slicing. Supplying
+filters, excludes, grouping, and sorting, but before page slicing. Without
+`groupBy`, sorting applies to records; with `groupBy`, sorting applies to the
+grouped manager objects after grouping and before pagination. Supplying
 only one of `page` or `pageSize` defaults the missing value to page 1 or size 10
 for slicing. Falsey explicit values such as `page: 0` or `pageSize: 0` follow
 the same fallbacks for slicing; `currentPage` is `page || 1`. The reported
 `pageSize` is the original argument value, not the effective slicing default, so
 it can be `null` when only `page` is supplied and `0` when `pageSize: 0` is
 supplied. `totalPages` is `1` when the original `pageSize` is omitted or falsey.
+With a positive explicit `pageSize`, an empty result has `totalPages: 0`.
 Negative `page` or `pageSize` values raise a GraphQL `BAD_USER_INPUT` error
-before slicing. Do not import generated/internal Python pagination classes
+before slicing. An already-empty grouped result with pagination returns an empty
+`items` list and its normal page metadata; it does not raise the grouped-bucket
+empty-slice error. Do not import generated/internal Python pagination classes
 directly.
 
 ::: general_manager.api.mutation.graph_ql_mutation

--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -183,6 +183,46 @@ explains the model, the [task guide](../howto/expose_via_graphql.md#declare-mana
 shows declaration patterns, and the [cookbook recipe](../examples/graphql_queries.md#query-a-manager-relation)
 shows directly usable queries.
 
+## Compound list sorting
+
+Generated top-level list fields and generated relation-list fields expose the
+following arguments when the manager has at least one sortable field:
+
+```graphql
+sortBy: [<Manager>SortByOptions!]
+reverse: Boolean
+```
+
+Both arguments are nullable. `sortBy` may be omitted, `null`, or an empty list;
+all three forms skip sorting, even when `reverse: true`. GraphQL list coercion
+also accepts one inline enum value, so `sortBy: name` remains valid. A typed
+variable uses the list form, for example `$sort: [ProjectSortByOptions!]`.
+The generated field returns the manager's paginated page type with its normal
+`items` and `pageInfo` fields; these arguments only change item ordering.
+
+The generated enum includes root scalar interface fields, root
+`@graph_ql_property` values declared with `sortable=True`, and eligible direct
+manager relations. A direct manager relation contributes the relation field
+itself, which sorts by its identifier, plus one-hop scalar interface fields such
+as `commercials__name`. Collection relations, multi-hop paths, and computed
+GraphQL properties on the related manager are not exposed as options. The
+generated enum is schema output, not a stable Python import.
+
+Keys are applied in list order: the first key is primary and later keys break
+ties. `reverse: true` reverses the complete compound ordering. For database
+buckets, eligible relation paths use the declared relation metadata and remain
+compatible with custom `filter_lookup` prefixes. Request and in-memory buckets
+resolve the same paths as attributes; missing attributes or incomparable values
+raise through the existing bucket/resolver error path without a new
+sorting-specific public error code. Invalid enum values and null list elements
+are rejected by GraphQL input coercion before the resolver runs.
+
+This compound sorting contract is available from GeneralManager 0.73.0. The
+[sorting concept](../concepts/graphql/filters_pagination.md#sorting) explains
+the model and ordering semantics, the [generated-list how-to](../howto/expose_via_graphql.md#query-generated-lists)
+shows the setup, and the [cookbook query](../examples/graphql_queries.md#sort-by-a-compound-relation-key)
+provides a directly usable request.
+
 ## Manager-typed calculation input filters
 
 `GraphQL.create_graphql_interface(manager: type[GeneralManager])` generates a

--- a/docs/api/permission.md
+++ b/docs/api/permission.md
@@ -33,11 +33,14 @@ messages.
 
 `_get_permission_filter(permission)` resolves a permission expression to optional
 `filter`/`exclude` mappings with object-valued lookup values. Superusers and
-registered permission filters that return `None` both produce empty filter and
-exclude mappings. `_get_permission_filter_info(permission)` returns the same
-constraint plus a boolean indicating whether the permission was representable as
-a prefilter; `None` from the registered filter means `False`. Unknown permission
-names raise `PermissionNotFoundError`.
+registered permission filters that return `None` or a `PermissionFilterDecision`
+both produce empty filter and exclude mappings for this low-level compatibility
+helper. Read-plan composition preserves static decisions so GraphQL list and
+search resolvers can short-circuit definitive allow/deny outcomes.
+`_get_permission_filter_info(permission)` returns the same constraint plus a
+boolean indicating whether the permission was representable as a prefilter;
+`None` and static decisions mean `False`. Unknown permission names raise
+`PermissionNotFoundError`.
 
 ::: general_manager.permission.manager_based_permission.AdditiveManagerPermission
 
@@ -110,6 +113,8 @@ needs an explicit before/after comparison. Unsupported payload types raise
 `permission_data must be either a dict or an instance of GeneralManager.`
 
 ## Registry and reusable checks
+
+::: general_manager.permission.permission_checks.PermissionFilterDecision
 
 ::: general_manager.permission.permission_checks.register_permission
 

--- a/docs/concepts/graphql/filters_pagination.md
+++ b/docs/concepts/graphql/filters_pagination.md
@@ -77,8 +77,9 @@ same Python fallback for slicing. `currentPage` is reported as `page || 1`.
 slicing default, so it remains `null` when only `page` is supplied and remains
 `0` for `pageSize: 0`. `totalPages` is computed from a truthy original
 `pageSize`; when `pageSize` is omitted or falsey it is reported as `1`, including
-empty result sets. Negative `page` or `pageSize` values are rejected before
-slicing and surface as GraphQL `BAD_USER_INPUT` errors.
+empty result sets; with a positive explicit `pageSize`, an empty result has
+`totalPages: 0`. Negative `page` or `pageSize` values are rejected before slicing
+and surface as GraphQL `BAD_USER_INPUT` errors.
 
 ## Grouping
 
@@ -102,6 +103,11 @@ properties. Capability warmup is triggered for ungrouped pages only when
 capabilities. Invalid group keys propagate the bucket's validation error through
 GraphQL execution.
 
+If filtering produces no groups, a paginated grouped query returns an empty
+`items` list with the normal page metadata instead of raising the grouped-bucket
+empty-slice error. Negative `page` or `pageSize` values are still rejected before
+this empty-result shortcut.
+
 ## Sorting
 
 Use the generated `sortBy` enum with an ordered list of keys. GraphQL list
@@ -117,6 +123,9 @@ fields; invalid names trigger `ValidationError` with descriptive messages.
 Invalid GraphQL enum values and null list elements are rejected by Graphene
 before the resolver runs. When `sortBy` is omitted, `null`, or an empty list,
 sorting is skipped even if `reverse` is true.
+
+With `groupBy`, sorting runs on grouped manager objects after grouping; without
+`groupBy`, it runs on the individual records.
 
 Typed variables use a list declaration such as
 `$sort: [ProjectSortByOptions!]`; add an outer `!` only when the variable itself

--- a/docs/concepts/models_entities.md
+++ b/docs/concepts/models_entities.md
@@ -57,6 +57,18 @@ same bucket context while returning no rows.
 
 Most application code should depend on the shared bucket behavior returned by manager APIs. Reach for a concrete bucket type only when documenting source-specific behavior, testing evaluation semantics, or extending an interface.
 
+When an integration has already selected the exact manager instances it should
+return, use `bucket.with_instances(instances)` to reconstruct that subset
+without changing the originating bucket's meaning. Pass instances in source
+iteration order when order matters. `DatabaseBucket` rebuilds a source-ordered
+subset from manager IDs; `RequestBucket` and `CalculationBucket` materialize the
+supplied managers without re-executing their request or calculation plan. The
+instances must belong to the bucket's manager class and compatible historical
+context. Generated GraphQL list authorization uses this contract for its final
+per-instance check; custom adapters can use the same pattern. See the
+[exact-subset how-to](../howto/expose_via_graphql.md#preserve-an-exact-authorized-subset)
+and [permission cookbook recipe](../examples/permission_cookbook.md#preserve-an-authorized-bucket-subset).
+
 ### Grouped data
 
 Use `group_by()` to aggregate managers into `GroupedManager` instances. Grouped

--- a/docs/concepts/permission/manager_based_permission.md
+++ b/docs/concepts/permission/manager_based_permission.md
@@ -190,11 +190,36 @@ registry. Each registry entry stores the permission method and a callable
 returns `None`.
 
 Permission filters can return `{"filter": {...}}`, `{"exclude": {...}}`, both
-keys, or `None`. The GraphQL/list path applies Django constraints as
-`filter(...).exclude(...)`, combines those constraints with client filters, and
-still evaluates a final per-instance read check for rules that could not be
-fully represented as query filters. Search backends receive the `filter` side as
-the backend prefilter and rely on the final instance gate for `exclude` checks.
+keys, or `None`. A user/config-only rule may instead return
+`PermissionFilterDecision.ALLOW_ALL` or `PermissionFilterDecision.DENY_ALL`:
+
+```python
+from general_manager.permission import PermissionFilterDecision, register_permission
+
+
+def is_tenant_operator_filter(user, _config):
+    return (
+        PermissionFilterDecision.ALLOW_ALL
+        if getattr(user, "is_staff", False)
+        else PermissionFilterDecision.DENY_ALL
+    )
+
+
+@register_permission(
+    "isTenantOperator", permission_filter=is_tenant_operator_filter
+)
+def is_tenant_operator(_instance, user, _config):
+    return bool(getattr(user, "is_staff", False))
+```
+
+Use a static decision only when every row has the same outcome for that
+user/configuration. `ALLOW_ALL` and `DENY_ALL` are preserved while read plans
+compose `&` fragments as AND and permission-list entries as OR alternatives;
+`None` remains the correct result for a rule that needs a concrete instance.
+The GraphQL/list path applies mapping constraints as `filter(...).exclude(...)`
+and still evaluates a final per-instance read check for conditional rules that
+need it. Search backends receive the `filter` side as the backend prefilter and
+rely on the final instance gate for `exclude` checks.
 
 Permission expressions use simple string splitting: `&` joins sub-permissions and
 `:` separates the registry name from config values. There is no escape syntax,

--- a/docs/examples/bulk_data_change_notifications.md
+++ b/docs/examples/bulk_data_change_notifications.md
@@ -28,3 +28,32 @@ flushes queued targets even when the body raises, then re-raises the body
 exception. If both the body and notification flush fail, the context raises a
 `BaseExceptionGroup` containing both failures. Ordinary channel-layer send
 errors are logged while other queued targets continue flushing.
+
+To observe the surrounding ORM transaction lifecycle, register a started
+receiver and collect changed classes from the ordinary post-change signal:
+
+```python
+from general_manager.cache.data_change_context import register_data_change_class
+from general_manager.cache.signals import (
+    data_change_transaction_started,
+    post_data_change,
+)
+
+
+def started(sender, transaction_context, **kwargs):
+    transaction_context.metadata["batch"] = begin_coordination()
+
+
+def changed(sender, database_alias, **kwargs):
+    register_data_change_class(sender.__name__, database_alias)
+
+
+data_change_transaction_started.connect(started, weak=False)
+post_data_change.connect(changed, weak=False)
+```
+
+`data_change_transaction_finished` reports `committed` for GeneralManager's
+own block or savepoint and `rolled_back` for failures. When the caller owns an
+outer transaction, register durable completion work with
+`transaction.on_commit(using=database_alias)`; the lifecycle's `committed`
+outcome alone does not prove that outer transaction committed.

--- a/docs/examples/bulk_data_change_notifications.md
+++ b/docs/examples/bulk_data_change_notifications.md
@@ -33,6 +33,8 @@ To observe the surrounding ORM transaction lifecycle, register a started
 receiver and collect changed classes from the ordinary post-change signal:
 
 ```python
+from django.db import transaction
+
 from general_manager.cache.data_change_context import register_data_change_class
 from general_manager.cache.signals import (
     data_change_transaction_started,
@@ -40,8 +42,12 @@ from general_manager.cache.signals import (
 )
 
 
-def started(sender, transaction_context, **kwargs):
+def started(sender, transaction_context, database_alias, **kwargs):
     transaction_context.metadata["batch"] = begin_coordination()
+    transaction.on_commit(
+        lambda: finish_coordination(transaction_context.metadata["batch"]),
+        using=database_alias,
+    )
 
 
 def changed(sender, database_alias, **kwargs):
@@ -53,7 +59,14 @@ post_data_change.connect(changed, weak=False)
 ```
 
 `data_change_transaction_finished` reports `committed` for GeneralManager's
-own block or savepoint and `rolled_back` for failures. When the caller owns an
-outer transaction, register durable completion work with
-`transaction.on_commit(using=database_alias)`; the lifecycle's `committed`
-outcome alone does not prove that outer transaction committed.
+own block or savepoint and `rolled_back` for failures. Register durable
+completion work unconditionally with
+`transaction.on_commit(using=database_alias)`; it runs after GeneralManager's
+transaction commits or, when the caller owns an outer transaction, after that
+outer transaction commits.
+
+`register_data_change_class()` returns `False` for a caller-owned outer
+transaction and does not add the class to
+`transaction_context.changed_classes`. In that case, collect changed class
+names in caller-owned transaction state and consume that state from an
+`on_commit(using=database_alias)` callback registered on the outer transaction.

--- a/docs/examples/graphql_queries.md
+++ b/docs/examples/graphql_queries.md
@@ -18,6 +18,29 @@ query ProjectList($page: Int!, $pageSize: Int!) {
 }
 ```
 
+## Sort grouped pages
+
+`sortBy` orders grouped manager objects after `groupBy` and before pagination.
+This keeps descending group order stable across pages:
+
+```graphql
+query ProjectsByStatus {
+  projectList(
+    groupBy: ["status"]
+    sortBy: status
+    reverse: true
+    page: 1
+    pageSize: 10
+  ) {
+    items { status }
+    pageInfo { totalCount currentPage totalPages pageSize }
+  }
+}
+```
+
+If the filter produces no groups, the same query shape returns `items: []` and
+page metadata rather than an empty-group slicing error.
+
 ## Nested buckets
 
 ```graphql
@@ -104,6 +127,36 @@ list is a no-op. See the [sorting concept](../concepts/graphql/filters_paginatio
 the [generated-list how-to](../howto/expose_via_graphql.md#query-generated-lists),
 and the [GraphQL API reference](../api/graphql.md#compound-list-sorting) for
 the supported relation paths and error behavior.
+
+## Subscribe to committed class changes
+
+```graphql
+subscription ProjectChanges {
+  onProjectClassChange {
+    action
+    item { id name }
+  }
+}
+```
+
+Identified class-wide events are checked against the subscribing user's read
+permission in an async-safe worker after commit; unreadable objects are omitted.
+Aggregate `refresh` events have `item: null` and do not disclose a row ID.
+
+## Bound run-scoped cache memory
+
+For a worker that serves long-lived GraphQL requests, configure the optional
+process-local run-cache budget:
+
+```python
+GENERAL_MANAGER = {
+    "RUN_CONTEXT_CACHE_MAX_BYTES": 256 * 1024 * 1024,
+}
+```
+
+The value is an estimated-memory LRU budget shared by live run contexts in that
+worker. Omit it or use `None` for unlimited retention; pending dependency-cache
+publications remain pinned until their lifecycle completes.
 
 ## Filter a calculation by manager input
 

--- a/docs/examples/graphql_queries.md
+++ b/docs/examples/graphql_queries.md
@@ -70,6 +70,41 @@ contracts, see the [GraphQL concept guide](../concepts/graphql/schema_autogen.md
 the [task guide](../howto/expose_via_graphql.md#declare-manager-relations), and
 the [API reference](../api/graphql.md#relation-annotation-compatibility).
 
+## Sort by a compound relation key
+
+Generated list fields accept an ordered `sortBy` list. This request sorts
+projects by the related commercial name first, then by project name and unique
+project ID to make ties deterministic:
+
+```graphql
+query ProjectsByCommercialName($sort: [ProjectSortByOptions!]) {
+  projectList(sortBy: $sort, page: 1, pageSize: 20) {
+    items {
+      id
+      name
+      commercials { id name }
+    }
+    pageInfo {
+      totalCount
+      currentPage
+      totalPages
+      pageSize
+    }
+  }
+}
+```
+
+```json
+{"sort": ["commercials__name", "name", "id"]}
+```
+
+The enum values must be exposed by the generated `ProjectSortByOptions` type.
+GraphQL also accepts a single inline value such as `sortBy: name`; an empty
+list is a no-op. See the [sorting concept](../concepts/graphql/filters_pagination.md#sorting),
+the [generated-list how-to](../howto/expose_via_graphql.md#query-generated-lists),
+and the [GraphQL API reference](../api/graphql.md#compound-list-sorting) for
+the supported relation paths and error behavior.
+
 ## Filter a calculation by manager input
 
 For a calculation manager with `project = Input(Project)`, use the same nested

--- a/docs/examples/permission_cookbook.md
+++ b/docs/examples/permission_cookbook.md
@@ -76,6 +76,44 @@ def permission_visible_invoice(instance, user, _config):
     )
 ```
 
+## Static user-only decisions
+
+When a rule depends only on the requesting user and its configuration, return a
+`PermissionFilterDecision` instead of making the list/search path inspect every
+row. This example lets staff users read every `Project` and denies the entire
+manager for other users:
+
+```python
+from general_manager.manager import GeneralManager
+from general_manager.permission import PermissionFilterDecision, register_permission
+from general_manager.permission.manager_based_permission import AdditiveManagerPermission
+
+
+def is_project_reviewer_filter(user, _config):
+    return (
+        PermissionFilterDecision.ALLOW_ALL
+        if getattr(user, "is_staff", False)
+        else PermissionFilterDecision.DENY_ALL
+    )
+
+
+@register_permission(
+    "isProjectReviewer", permission_filter=is_project_reviewer_filter
+)
+def is_project_reviewer(_instance, user, _config):
+    return bool(getattr(user, "is_staff", False))
+
+
+class Project(GeneralManager):
+    class Permission(AdditiveManagerPermission):
+        __read__ = ["isProjectReviewer"]
+```
+
+Static decisions must be correct for every row. Use `None` when the rule needs
+the concrete instance, and use a mapping when a queryset constraint can narrow
+the candidate rows but does not itself prove authorization. Read expressions
+joined with `&` are ANDed; entries in `__read__` remain OR alternatives.
+
 ## Guarding GraphQL mutations
 
 Mutation classes can reuse permission checks for fine-grained control. The example below assumes an `Invoice` manager backed by a Django model:

--- a/docs/examples/permission_cookbook.md
+++ b/docs/examples/permission_cookbook.md
@@ -142,6 +142,39 @@ def reject_invoice(info, invoice: Invoice, reason: str) -> Invoice:
 - Raise `PermissionCheckError(request_user, [...])` from custom checks when a domain-specific denial should be converted into a GraphQL permission error.
 - Call `GeneralManager.update` instead of writing to model fields directly; it re-runs permission checks and records history comments when provided.
 
+## Preserve an authorized bucket subset
+
+If a custom integration has already evaluated a per-instance rule, reconstruct
+the result from the original bucket instead of issuing a second identifier
+lookup. This works for database, request-backed, and calculation buckets:
+
+```python
+from typing import Any
+
+from general_manager.bucket import Bucket
+from myapp.managers import Invoice
+
+
+def visible_invoices(
+    invoices: Bucket[Invoice],
+    request_user: Any,
+) -> Bucket[Invoice]:
+    is_finance = request_user.groups.filter(name="finance").exists()
+    allowed = [
+        invoice
+        for invoice in invoices
+        if invoice.status != "archived" or is_finance
+    ]
+    return invoices.with_instances(allowed)
+```
+
+`with_instances()` keeps exactly the selected managers and returns the same
+concrete bucket family. Supply selected managers in source order when the
+existing order matters. The generated GraphQL authorization flow uses the same
+contract after row-level checks. See the [bucket concept](../concepts/models_entities.md#buckets)
+and [GraphQL how-to](../howto/expose_via_graphql.md#preserve-an-exact-authorized-subset)
+for the backend behavior and a generic resolver helper.
+
 ## Testing shortcuts
 
 ```python

--- a/docs/howto/bulk_data_change_notifications.md
+++ b/docs/howto/bulk_data_change_notifications.md
@@ -93,11 +93,10 @@ from general_manager.cache.signals import (
 
 def on_transaction_started(sender, transaction_context, database_alias, **kwargs):
     transaction_context.metadata["consumer"] = begin_coordination()
-    if transaction_context.caller_in_atomic_block:
-        transaction.on_commit(
-            lambda: finish_coordination(transaction_context.metadata["consumer"]),
-            using=database_alias,
-        )
+    transaction.on_commit(
+        lambda: finish_coordination(transaction_context.metadata["consumer"]),
+        using=database_alias,
+    )
 
 
 def on_manager_changed(sender, database_alias, **kwargs):
@@ -109,12 +108,20 @@ post_data_change.connect(on_manager_changed, weak=False)
 ```
 
 `data_change_transaction_finished` reports `committed` when GeneralManager's
-own block or savepoint exits successfully and `rolled_back` otherwise. If the
-caller already owns the outer transaction, `committed` is not the durable
-commit; use `transaction.on_commit(using=database_alias)` as shown. Nested
-same-alias mutations share one lifecycle context, and
+own block or savepoint exits successfully and `rolled_back` otherwise. Register
+completion unconditionally with
+`transaction.on_commit(using=database_alias)` as shown so it follows either
+GeneralManager's commit or the caller-owned outer commit. Nested same-alias
+mutations share one lifecycle context, and
 `transaction_context.changed_classes` deduplicates the classes registered by
-the post-change receiver.
+the post-change receiver when GeneralManager owns the transaction.
+
+When the caller already owns the outer transaction,
+`register_data_change_class()` returns `False` without adding the class to
+`transaction_context.changed_classes`. Consumers that need outer-transaction
+aggregation must instead collect class names in caller-owned transaction state
+and consume them from an `on_commit(using=database_alias)` callback registered
+on that outer transaction.
 
 For the full callable signature and exception contract, see the
 [GraphQL API reference](../api/graphql.md#bulk-notification-context). The

--- a/docs/howto/bulk_data_change_notifications.md
+++ b/docs/howto/bulk_data_change_notifications.md
@@ -75,6 +75,47 @@ Nested notification contexts join the already-active outer batch instead of
 flushing independently. Outside the context, existing row-level notification
 delivery remains commit-bound and rollback-safe.
 
+## Observe the data-change lifecycle
+
+Use the lifecycle signals when an integration needs to coordinate work around
+the outermost ORM mutation, rather than around every nested `pre_data_change`
+or `post_data_change` callback:
+
+```python
+from django.db import transaction
+
+from general_manager.cache.data_change_context import register_data_change_class
+from general_manager.cache.signals import (
+    data_change_transaction_started,
+    post_data_change,
+)
+
+
+def on_transaction_started(sender, transaction_context, database_alias, **kwargs):
+    transaction_context.metadata["consumer"] = begin_coordination()
+    if transaction_context.caller_in_atomic_block:
+        transaction.on_commit(
+            lambda: finish_coordination(transaction_context.metadata["consumer"]),
+            using=database_alias,
+        )
+
+
+def on_manager_changed(sender, database_alias, **kwargs):
+    register_data_change_class(sender.__name__, database_alias)
+
+
+data_change_transaction_started.connect(on_transaction_started, weak=False)
+post_data_change.connect(on_manager_changed, weak=False)
+```
+
+`data_change_transaction_finished` reports `committed` when GeneralManager's
+own block or savepoint exits successfully and `rolled_back` otherwise. If the
+caller already owns the outer transaction, `committed` is not the durable
+commit; use `transaction.on_commit(using=database_alias)` as shown. Nested
+same-alias mutations share one lifecycle context, and
+`transaction_context.changed_classes` deduplicates the classes registered by
+the post-change receiver.
+
 For the full callable signature and exception contract, see the
 [GraphQL API reference](../api/graphql.md#bulk-notification-context). The
 [cookbook recipe](../examples/bulk_data_change_notifications.md) is a compact

--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -100,6 +100,27 @@ read-only after class definition. `GraphQLPropertyReturnAnnotationError`,
 from `general_manager.api`. `GraphQLProperty` itself remains an implementation
 descriptor unless it appears in the public API registry.
 
+### Bound long-lived run caches
+
+Run-scoped values are unlimited by default. For long-lived or concurrent
+requests, set a process-local estimated-memory budget shared by live
+`CalculationRunContext` instances:
+
+```python
+GENERAL_MANAGER = {
+    "RUN_CONTEXT_CACHE_MAX_BYTES": 256 * 1024 * 1024,
+}
+```
+
+`None` or an omitted setting keeps unlimited retention; `0` retains no
+eviction-safe entries; and a positive integer enables least-recently-used
+eviction across the worker's live run contexts. Negative integers, booleans,
+and other non-integer values raise `django.core.exceptions.ImproperlyConfigured`
+when a run context is created. Pending dependency-cache publications remain
+pinned until they are flushed or discarded. The estimate is taken at insertion
+time, so this setting is a cache-retention guardrail rather than a hard process
+RSS limit. Give each worker process its own capacity allowance.
+
 ## Step 3: Verify invalidation
 
 For dependency-aware properties, update a derivative that contributes to the summary. The dependency tracker captures the relationship and invalidates the cache entry automatically.

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -270,7 +270,20 @@ Invalid `sortBy` enum values are rejected by Graphene; invalid filter, grouping,
 or slicing values propagate the corresponding bucket or resolver error. When
 grouping is active, pagination slices grouped manager objects rather than the
 original ungrouped rows, and the GraphQL `items` field still uses the manager's
-generated item type.
+generated item type. If no rows match, a paginated grouped query returns an
+empty `items` list with `totalCount: 0`; negative `page` or `pageSize` values
+still raise the normal input error.
+
+## Class-wide subscription permission checks
+
+Class-wide subscriptions receive committed row-level events for any instance of
+the manager class. Before an identified event is yielded, GeneralManager
+rehydrates the manager and checks object-level read permission in an
+`asyncio.to_thread` worker using the user captured when the subscription starts.
+An unreadable or no-longer-existing object is suppressed, while an unexpected
+permission exception propagates through the subscription error path. Aggregate
+`refresh` events have no identification and yield `item = null` without this
+object-level check.
 
 ## Expose authorization hints
 

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -173,8 +173,10 @@ relation-list fields use the same list-valued sort contract.
 When a custom resolver has already evaluated each candidate manager against an
 instance-level policy, keep the originating bucket and reconstruct the result
 with `with_instances()`. This preserves the bucket's backend-specific
-representation and avoids replacing composite or calculation identifications
-with an `id__in` lookup:
+representation. Non-database buckets that retain full identification mappings,
+such as `CalculationBucket`, can preserve composite identifications without
+replacing them with an `id__in` lookup. `DatabaseBucket` is ID-based and reads
+each manager's `identification["id"]`:
 
 ```python
 from collections.abc import Callable

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -168,6 +168,43 @@ as `commercials__owner__name` are not exposed as sort options. Computed
 sortable properties on the root manager are eligible. Top-level and generated
 relation-list fields use the same list-valued sort contract.
 
+## Preserve an exact authorized subset
+
+When a custom resolver has already evaluated each candidate manager against an
+instance-level policy, keep the originating bucket and reconstruct the result
+with `with_instances()`. This preserves the bucket's backend-specific
+representation and avoids replacing composite or calculation identifications
+with an `id__in` lookup:
+
+```python
+from collections.abc import Callable
+from typing import TypeVar
+
+from general_manager.bucket import Bucket
+from general_manager.manager import GeneralManager
+
+
+ManagerT = TypeVar("ManagerT", bound=GeneralManager)
+
+
+def authorized_subset(
+    bucket: Bucket[ManagerT],
+    can_read: Callable[[ManagerT], bool],
+) -> Bucket[ManagerT]:
+    authorized = [manager for manager in bucket if can_read(manager)]
+    return bucket.with_instances(authorized)
+```
+
+The returned bucket contains exactly the managers that passed the policy. Pass
+the managers in the bucket's iteration order when the existing ordering must be
+retained. Database-backed buckets reconstruct a source-ordered ID subset;
+request-backed and calculation buckets materialize the supplied instances
+without re-running their remote request or calculation domain. Generated
+GraphQL list resolvers apply this contract automatically for row-level read
+authorization, so custom resolvers only need it when they own that policy step.
+See the [bucket concept](../concepts/models_entities.md#buckets) and the
+[permission cookbook version](../examples/permission_cookbook.md#preserve-an-authorized-bucket-subset).
+
 ```graphql
 query ActiveProjects($filters: ProjectFilterInput) {
   projectList(filter: $filters, sortBy: name, page: 1, pageSize: 20) {

--- a/docs/howto/permission_walkthrough.md
+++ b/docs/howto/permission_walkthrough.md
@@ -74,9 +74,34 @@ Add `"belongsToCustomer:customer"` to `__read__` to produce filters automaticall
 
 `permission_filter` may return only a `filter` mapping, only an `exclude`
 mapping, both keys, or `None`. Return `None` when a rule depends on runtime
-state that cannot be expressed as queryset kwargs. GeneralManager still stores a
-callable filter in `permission_functions` for permissions registered without a
-custom filter; that default callable returns `None`.
+state that cannot be expressed as queryset kwargs. For a rule whose outcome is
+the same for every row, return a static decision instead:
+
+```python
+from general_manager.permission import PermissionFilterDecision
+
+
+def is_project_reviewer_filter(user, _config):
+    return (
+        PermissionFilterDecision.ALLOW_ALL
+        if getattr(user, "is_staff", False)
+        else PermissionFilterDecision.DENY_ALL
+    )
+
+
+@register_permission(
+    "isProjectReviewer", permission_filter=is_project_reviewer_filter
+)
+def is_project_reviewer(_instance, user, _config):
+    return bool(getattr(user, "is_staff", False))
+```
+
+Use `ALLOW_ALL` only when the user/configuration grants every possible row and
+`DENY_ALL` only when it grants none. GraphQL list and search resolvers use these
+decisions to avoid unnecessary prefilters and per-row checks; a deny-all search
+manager is skipped. GeneralManager still stores a callable filter in
+`permission_functions` for permissions registered without a custom filter; that
+default callable returns `None`.
 
 Permission strings are split on `&` and `:` without escaping. Keep registered
 names colon-free for ordinary rules, and expect empty config segments to be


### PR DESCRIPTION
## Summary

Consolidates the three open documentation-only PRs into one reviewable change. This PR now includes the complete documentation from #449, #457, and the original #459.

## Documentation covered

- Run-context cache budgets, grouped GraphQL sorting/pagination, async-safe subscription permission checks, and data-change transaction lifecycle APIs.
- Static permission decisions, including `PermissionFilterDecision`, permission-plan composition, task guidance, and cookbook examples.
- Exact bucket subsets through `Bucket.with_instances(...)`, including backend semantics and authorization recipes.
- Compound GraphQL sorting, including list-valued `sortBy`, relation keys, examples, and API-reference coverage.

All affected concept, how-to, cookbook/example, and API-reference pages remain in the existing navigation.

## Consolidation

- Supersedes #449.
- Supersedes #457.
- Preserves the original #459 documentation.
- Shared GraphQL pages were reconciled so the older grouped-pagination material and newer compound-sorting material are both retained.

## Validation

- `python -m pytest tests/docs/test_public_api_docs_coverage.py tests/integration/test_request_docs_examples.py -q` — 8 passed.
- `python -m mkdocs build --strict --site-dir /tmp/general-manager-docs-consolidated` — passed; only the repository's existing unnav-linked page notices were reported.
- `git diff --check origin/main...HEAD` — passed.

## Limitations

This PR changes documentation only. The full application test suite was not rerun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API guidance for transaction lifecycle contexts, phase tracking, bucket reconstruction, and static permission decisions.
  * Documented GraphQL sorting, grouping-aware pagination, subscription authorization, and handling of missing or unauthorized records.
  * Added examples for data-change notifications, cache retention, GraphQL queries, and permission-based bucket filtering.
  * Clarified validation rules, transaction commit behavior, ordering semantics, permission outcomes, and empty-result handling across supported features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->