### PR TITLE
fix: make subscription field permissions async-safe

### DIFF
--- a/docs/concepts/graphql/subscriptions.md
+++ b/docs/concepts/graphql/subscriptions.md
@@ -160,7 +160,12 @@ task errors still propagate from the await.
 
 - Subscriptions require Django Channels. If `get_channel_layer()` returns `None`, the resolver raises a descriptive GraphQL error explaining that `CHANNEL_LAYERS` must be configured.
 - Managers are automatically decorated with `@data_change` and emit `pre_data_change` and `post_data_change` signals. GraphQL receives `post_data_change` immediately, but deep-copies the event identification and schedules websocket publication with `transaction.on_commit()` using the changed manager's database alias. For ordinary events created inside a transaction, both the instance channel group (`gm_subscriptions.<Manager>.<digest>`) and class channel group (`gm_subscriptions.<Manager>.__class__`) receive the event only after the outermost commit. Events registered in a rolled-back transaction or savepoint disappear without publication.
-- For ordinary identified row-level class events, subscriptions hydrate the changed manager and call `can_read_instance()` together in an async-safe worker using the user captured when the subscription starts, before yielding the event. In particular, a newly created object is visible to hydration only after it is committed, eliminating the pre-commit create race while preserving object-level permission checks. Aggregate batch `refresh` events have no identification, yield `item = null`, and are exempt from object-level permission hydration and checking.
+- For ordinary identified row-level class events, subscriptions hydrate the changed manager and call `can_read_instance()` together in an async-safe worker using the user captured when the subscription starts, before yielding the event. In particular, a newly created object is visible to hydration only after it is committed, eliminating the pre-commit create race while preserving object-level permission checks. This event-level object authorization is separate from later field-level authorization for the selected payload. Aggregate batch `refresh` events have no identification, yield `item = null`, and are exempt from object-level permission hydration and checking.
+- Selected normal, measurement, and stored-file payload fields also evaluate
+  their field-level read permissions in an async-safe worker. Attribute-specific
+  permission denials retain the existing GraphQL behavior and resolve only that
+  field to `null`; value access and formatting remain in GraphQL's execution
+  context after authorization succeeds.
 
 ### Bulk notification refreshes
 

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -103,6 +103,7 @@ from general_manager.api.graphql_resolvers import (
     create_normal_resolver as _create_normal_resolver_fn,
     create_list_resolver as _create_list_resolver_fn,
     create_resolver as _create_resolver_fn,
+    resolve_with_read_permission as _resolve_with_read_permission_fn,
 )
 from general_manager.api.graphql_relations import resolve_general_manager_type
 from general_manager.api.graphql_search import (
@@ -570,17 +571,16 @@ class GraphQL:
                     _field_name: str = field_name,
                     _manager_name: str = generalManagerClass.__name__,
                 ) -> object:
-                    if not cls._check_read_permission(
+                    return cls._resolve_with_read_permission(
                         manager_instance,
                         info,
                         _field_name,
-                    ):
-                        return None
-                    return create_stored_file_value(
-                        manager_instance,
-                        info,
-                        field_name=_field_name,
-                        manager_name=_manager_name,
+                        lambda: create_stored_file_value(
+                            manager_instance,
+                            info,
+                            field_name=_field_name,
+                            manager_name=_manager_name,
+                        ),
                     )
 
                 fields[resolver_name] = resolve_stored_file
@@ -1145,6 +1145,20 @@ class GraphQL:
     ) -> bool:
         """Check read permission for *field_name*. See ``graphql_resolvers.check_read_permission``."""
         return _check_read_permission_fn(instance, info, field_name)
+
+    @staticmethod
+    def _resolve_with_read_permission(
+        instance: GeneralManager,
+        info: GraphQLResolveInfo,
+        field_name: str,
+        value_factory: Callable[[], object],
+    ) -> object:
+        return _resolve_with_read_permission_fn(
+            instance,
+            info,
+            field_name,
+            value_factory,
+        )
 
     @staticmethod
     def _create_list_resolver(

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -10,12 +10,22 @@ stable public import path.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Generic, TYPE_CHECKING, TypeAlias, TypeVar, TypedDict, cast
+from typing import (
+    Awaitable,
+    Generic,
+    TYPE_CHECKING,
+    TypeAlias,
+    TypeVar,
+    TypedDict,
+    cast,
+)
 
 import graphene
+from graphql import OperationType
 from graphql.language.ast import FieldNode, FragmentSpreadNode, InlineFragmentNode
 
 from general_manager.logging import get_logger
@@ -48,6 +58,7 @@ if TYPE_CHECKING:
     )
 
 GeneralManagerT = TypeVar("GeneralManagerT", bound=GeneralManager)
+ResolverValueT = TypeVar("ResolverValueT")
 GraphQLFilterInput = Mapping[str, object] | str | None
 GraphQLFilterMapping = dict[str, object]
 GraphQLSortInput: TypeAlias = (
@@ -686,6 +697,24 @@ def apply_grouping(
 # ---------------------------------------------------------------------------
 
 
+def check_read_permission_for_user(
+    instance: GeneralManager,
+    user: object,
+    field_name: str,
+) -> bool:
+    """
+    Return ``True`` if *user* may read *field_name* on *instance*.
+
+    When the manager defines a Permission class, this calls
+    ``Permission(instance, user).check_permission("read", field_name)``.
+    Managers without a Permission class default to allowing the field read.
+    """
+    PermissionClass: type[BasePermission] | None = getattr(instance, "Permission", None)
+    if PermissionClass:
+        return PermissionClass(instance, user).check_permission("read", field_name)
+    return True
+
+
 def check_read_permission(
     instance: GeneralManager,
     info: GraphQLResolveInfo,
@@ -698,12 +727,39 @@ def check_read_permission(
     ``Permission(instance, user).check_permission("read", field_name)``.
     Managers without a Permission class default to allowing the field read.
     """
-    PermissionClass: type[BasePermission] | None = getattr(instance, "Permission", None)
-    if PermissionClass:
-        return PermissionClass(instance, info.context.user).check_permission(
-            "read", field_name
+    return check_read_permission_for_user(instance, info.context.user, field_name)
+
+
+def resolve_with_read_permission(
+    instance: GeneralManager,
+    info: GraphQLResolveInfo,
+    field_name: str,
+    value_factory: Callable[[], ResolverValueT],
+) -> ResolverValueT | None | Awaitable[ResolverValueT | None]:
+    """Resolve a field after checking read permission.
+
+    Only subscription permission evaluation is offloaded to a worker thread;
+    query and mutation resolution remains synchronous.
+    """
+    user = info.context.user
+    operation = getattr(getattr(info, "operation", None), "operation", None)
+    if operation is not OperationType.SUBSCRIPTION:
+        if not check_read_permission_for_user(instance, user, field_name):
+            return None
+        return value_factory()
+
+    async def resolve_subscription_value() -> ResolverValueT | None:
+        allowed = await asyncio.to_thread(
+            check_read_permission_for_user,
+            instance,
+            user,
+            field_name,
         )
-    return True
+        if not allowed:
+            return None
+        return value_factory()
+
+    return resolve_subscription_value()
 
 
 def can_read_instance_for_user(
@@ -777,9 +833,12 @@ def create_normal_resolver(field_name: str) -> Resolver:
 
     def resolver(self: GeneralManager, info: GraphQLResolveInfo) -> object:
         _ensure_as_of_compatible(self)
-        if not check_read_permission(self, info, field_name):
-            return None
-        return getattr(self, field_name)
+        return resolve_with_read_permission(
+            self,
+            info,
+            field_name,
+            lambda: getattr(self, field_name),
+        )
 
     return resolver
 

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -806,19 +806,26 @@ def create_measurement_resolver(field_name: str) -> Resolver:
         self: GeneralManager,
         info: GraphQLResolveInfo,
         target_unit: str | None = None,
-    ) -> dict[str, object] | None:
+    ) -> object:
         _ensure_as_of_compatible(self)
-        if not check_read_permission(self, info, field_name):
-            return None
-        result = getattr(self, field_name)
-        if not isinstance(result, Measurement):
-            return None
-        if target_unit:
-            result = result.to(target_unit)
-        return {
-            "value": result.quantity.magnitude,
-            "unit": result.unit,
-        }
+
+        def resolve_measurement() -> dict[str, object] | None:
+            result = getattr(self, field_name)
+            if not isinstance(result, Measurement):
+                return None
+            if target_unit:
+                result = result.to(target_unit)
+            return {
+                "value": result.quantity.magnitude,
+                "unit": result.unit,
+            }
+
+        return resolve_with_read_permission(
+            self,
+            info,
+            field_name,
+            resolve_measurement,
+        )
 
     return resolver
 

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from types import MappingProxyType
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 import graphene  # type: ignore[import]
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.test import SimpleTestCase
-from graphql import GraphQLError
+from graphql import GraphQLError, OperationType
 from graphql import parse
 from graphql.language.ast import (
     FragmentDefinitionNode,
@@ -191,6 +193,13 @@ def _selection_info(query: str) -> object:
     )()
 
 
+def _resolver_info(operation: OperationType) -> object:
+    return SimpleNamespace(
+        context=SimpleNamespace(user=object()),
+        operation=SimpleNamespace(operation=operation),
+    )
+
+
 class GraphQLHelperTests(SimpleTestCase):
     def test_normal_resolver_validates_parent_before_permission(self) -> None:
         parent = mock.Mock()
@@ -199,13 +208,47 @@ class GraphQLHelperTests(SimpleTestCase):
 
         with (
             mock.patch(
-                "general_manager.api.graphql_resolvers.check_read_permission"
+                "general_manager.api.graphql_resolvers.resolve_with_read_permission"
             ) as permission,
             pytest.raises(RuntimeError, match="stale parent"),
         ):
             resolver(parent, _Info())
 
         permission.assert_not_called()
+
+    def test_normal_subscription_resolver_runs_permission_in_worker(self) -> None:
+        parent = SimpleNamespace(
+            name="Visible",
+            _ensure_as_of_compatible=lambda: None,
+        )
+        resolver = create_normal_resolver("name")
+
+        def permission(*_args: object) -> bool:
+            with pytest.raises(RuntimeError, match="no running event loop"):
+                asyncio.get_running_loop()
+            return True
+
+        async def resolve() -> object:
+            value = resolver(parent, _resolver_info(OperationType.SUBSCRIPTION))
+            return await value
+
+        with mock.patch(
+            "general_manager.api.graphql_resolvers.check_read_permission_for_user",
+            side_effect=permission,
+        ):
+            assert asyncio.run(resolve()) == "Visible"
+
+    def test_normal_query_resolver_stays_sync_inside_running_loop(self) -> None:
+        parent = SimpleNamespace(
+            name="Visible",
+            _ensure_as_of_compatible=lambda: None,
+        )
+        resolver = create_normal_resolver("name")
+
+        async def resolve() -> object:
+            return resolver(parent, _resolver_info(OperationType.QUERY))
+
+        assert asyncio.run(resolve()) == "Visible"
 
     def test_list_resolver_validates_parent_before_base_getter(self) -> None:
         parent = mock.Mock()

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from types import MappingProxyType
 from types import SimpleNamespace
 from unittest import mock
@@ -61,8 +62,10 @@ from general_manager.api.graphql_resolvers import (
     selection_includes_path,
     UnsupportedExcludeNoneRelationFilterError,
     create_list_resolver,
+    create_measurement_resolver,
     create_normal_resolver,
 )
+from general_manager.measurement.measurement import Measurement
 from tests.utils.simple_manager_interface import BaseTestInterface, SimpleBucket
 
 
@@ -237,6 +240,29 @@ class GraphQLHelperTests(SimpleTestCase):
             side_effect=permission,
         ):
             assert asyncio.run(resolve()) == "Visible"
+
+    def test_measurement_subscription_resolver_runs_permission_in_worker(self) -> None:
+        parent = SimpleNamespace(
+            amount=Measurement(12, "EUR"),
+            _ensure_as_of_compatible=lambda: None,
+        )
+        resolver = create_measurement_resolver("amount")
+
+        def permission(*_args: object) -> bool:
+            with pytest.raises(RuntimeError, match="no running event loop"):
+                asyncio.get_running_loop()
+            return True
+
+        async def resolve() -> object:
+            value = resolver(parent, _resolver_info(OperationType.SUBSCRIPTION))
+            assert inspect.isawaitable(value)
+            return await value
+
+        with mock.patch(
+            "general_manager.api.graphql_resolvers.check_read_permission_for_user",
+            side_effect=permission,
+        ):
+            assert asyncio.run(resolve()) == {"value": 12, "unit": "EUR"}
 
     def test_normal_query_resolver_stays_sync_inside_running_loop(self) -> None:
         parent = SimpleNamespace(

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -25,6 +25,7 @@ from general_manager.api.graphql import GraphQL
 from general_manager.interface import DatabaseInterface
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.permission import AdditiveManagerPermission, object_capability
+from general_manager.permission.permission_checks import register_permission
 from general_manager.utils.testing import GeneralManagerTransactionTestCase
 from tests.utils.simple_manager_interface import BaseTestInterface
 
@@ -50,6 +51,17 @@ class _DummyManager:
 
 
 _DummyInterface._parent_class = _DummyManager
+
+
+@register_permission("subscriptionFieldOwnerExists")
+def _subscription_field_owner_exists(
+    instance: GeneralManager,
+    user: object,
+    _config: list[str],
+) -> bool:
+    user_id = getattr(user, "pk", None)
+    owner_exists = get_user_model().objects.filter(pk=user_id).exists()
+    return owner_exists and instance.name != "Field denied"
 
 
 def _exception_group_leaves(error: BaseException) -> list[BaseException]:
@@ -204,6 +216,98 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
         update = second_event.data["onEmployeeChange"]
         self.assertEqual(update["action"], "update")
         self.assertEqual(update["item"]["name"], "Bob")
+
+    def test_detail_subscription_resolves_orm_backed_field_permission(self) -> None:
+        employee = self.Employee.create(name="Field visible", creator_id=self.user.id)
+        schema = self._build_schema()
+        subscription = """
+            subscription ($id: ID!) {
+                onEmployeeChange(id: $id) { item { id name } action }
+            }
+        """
+
+        async def run_subscription() -> object:
+            with patch.object(
+                self.Employee.Permission,
+                "name",
+                {"read": ["subscriptionFieldOwnerExists"]},
+                create=True,
+            ):
+                generator = await schema.subscribe(
+                    subscription,
+                    variable_values={"id": employee.id},
+                    context_value=SimpleNamespace(user=self.user),
+                )
+                try:
+                    return await generator.__anext__()
+                finally:
+                    await generator.aclose()
+
+        with patch.dict(os.environ):
+            os.environ.pop("DJANGO_ALLOW_ASYNC_UNSAFE", None)
+            event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        self.assertEqual(
+            event.data["onEmployeeChange"]["item"]["name"], "Field visible"
+        )
+
+    def test_detail_subscription_keeps_attribute_denial_nullable(self) -> None:
+        employee = self.Employee.create(name="Field denied", creator_id=self.user.id)
+        schema = self._build_schema()
+        subscription = """
+            subscription ($id: ID!) {
+                onEmployeeChange(id: $id) { item { id name } action }
+            }
+        """
+
+        async def run_subscription() -> object:
+            with patch.object(
+                self.Employee.Permission,
+                "name",
+                {"read": ["subscriptionFieldOwnerExists"]},
+                create=True,
+            ):
+                generator = await schema.subscribe(
+                    subscription,
+                    variable_values={"id": employee.id},
+                    context_value=SimpleNamespace(user=self.user),
+                )
+                try:
+                    return await generator.__anext__()
+                finally:
+                    await generator.aclose()
+
+        with patch.dict(os.environ):
+            os.environ.pop("DJANGO_ALLOW_ASYNC_UNSAFE", None)
+            event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        item = event.data["onEmployeeChange"]["item"]
+        self.assertEqual(str(item["id"]), str(employee.id))
+        self.assertIsNone(item["name"])
+
+    def test_sync_query_keeps_concrete_orm_backed_field_value(self) -> None:
+        employee = self.Employee.create(name="Field visible", creator_id=self.user.id)
+        schema = self._build_schema()
+        with patch.object(
+            self.Employee.Permission,
+            "name",
+            {"read": ["subscriptionFieldOwnerExists"]},
+            create=True,
+        ):
+            result = schema.execute(
+                """
+                query ($id: ID!) {
+                    employee(id: $id) { id name }
+                }
+                """,
+                variable_values={"id": employee.id},
+                context_value=SimpleNamespace(user=self.user),
+            )
+
+        self.assertIsNone(result.errors)
+        self.assertEqual(result.data["employee"]["name"], "Field visible")
 
     def test_subscription_capabilities_are_recomputed_for_each_event(self) -> None:
         employee = self.Employee.create(name="Alice", creator_id=self.user.id)
@@ -1066,6 +1170,73 @@ class TestGraphQLDatabaseSubscriptions(GeneralManagerTransactionTestCase):
             self.assertCountEqual(discard_attempts, successfully_added)
 
         asyncio.run(run_subscription())
+
+    def test_class_subscription_resolves_orm_backed_field_permission(self) -> None:
+        schema = self._build_schema()
+        context = SimpleNamespace(user=self.user)
+        subscription = """
+            subscription {
+                onEmployeeClassChange {
+                    action
+                    item { id name }
+                }
+            }
+        """
+        channel_layer = GraphQL._get_channel_layer(strict=True)
+        original_group_add = channel_layer.group_add
+
+        async def run_subscription() -> object:
+            required_groups = {
+                GraphQL._class_group_name(self.Employee),
+                GraphQL._refresh_group_name(self.Employee),
+            }
+            registered_groups: set[str] = set()
+            registration_ready = asyncio.Event()
+
+            async def tracking_group_add(group: str, channel: str) -> None:
+                await original_group_add(group, channel)
+                registered_groups.add(group)
+                if required_groups <= registered_groups:
+                    registration_ready.set()
+
+            with (
+                patch.object(channel_layer, "group_add", new=tracking_group_add),
+                patch.object(
+                    self.Employee.Permission,
+                    "name",
+                    {"read": ["subscriptionFieldOwnerExists"]},
+                    create=True,
+                ),
+            ):
+                generator = await schema.subscribe(subscription, context_value=context)
+                if hasattr(generator, "errors"):
+                    raise AssertionError(generator.errors)
+                next_event = asyncio.create_task(generator.__anext__())
+                try:
+                    await asyncio.wait_for(registration_ready.wait(), timeout=1)
+                    await asyncio.to_thread(
+                        lambda: self.Employee.create(
+                            name="Field visible",
+                            creator_id=self.user.id,
+                        )
+                    )
+                    return await asyncio.wait_for(next_event, timeout=1)
+                finally:
+                    if not next_event.done():
+                        next_event.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await next_event
+                    await generator.aclose()
+
+        with patch.dict(os.environ):
+            os.environ.pop("DJANGO_ALLOW_ASYNC_UNSAFE", None)
+            event = asyncio.run(run_subscription())
+
+        self.assertIsNone(event.errors)
+        self.assertEqual(
+            event.data["onEmployeeClassChange"]["item"]["name"],
+            "Field visible",
+        )
 
     def test_class_subscription_suppresses_unreadable_events(self) -> None:
         schema = self._build_schema()

--- a/tests/unit/test_stored_file_resolvers.py
+++ b/tests/unit/test_stored_file_resolvers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from types import SimpleNamespace
 from typing import ClassVar
@@ -16,6 +17,7 @@ from django.db import models
 from django.db.models import NOT_PROVIDED
 from django.test import override_settings
 from django.utils import timezone
+from graphql import OperationType
 
 from general_manager.uploads.graphql_types import (
     StoredFile,
@@ -608,6 +610,63 @@ def test_generated_file_resolver_preserves_field_read_permission() -> None:
         info = SimpleNamespace(context=SimpleNamespace(user=object()))
 
         assert resolver(manager, info) is None
+    finally:
+        GraphQL.graphql_type_registry = old_types
+        GraphQL.manager_registry = old_managers
+        del ResolverGraphManager.Permission
+
+
+def test_generated_file_subscription_resolver_offloads_only_permission() -> None:
+    permission_threads: list[bool] = []
+    value_threads: list[bool] = []
+    sentinel = object()
+
+    class AllowPermission:
+        def __init__(self, instance: object, user: object) -> None:
+            del instance, user
+
+        def check_permission(self, action: str, field_name: str) -> bool:
+            assert (action, field_name) == ("read", "document")
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                permission_threads.append(False)
+            return True
+
+    def stored_value(*_args: object, **_kwargs: object) -> object:
+        asyncio.get_running_loop()
+        value_threads.append(True)
+        return sentinel
+
+    ResolverGraphManager.Permission = AllowPermission  # type: ignore[assignment]
+    old_types = dict(GraphQL.graphql_type_registry)
+    old_managers = dict(GraphQL.manager_registry)
+    try:
+        with (
+            patch.object(GraphQL, "_add_queries_to_schema"),
+            patch.object(GraphQL, "_add_subscription_field"),
+        ):
+            GraphQL.create_graphql_interface(ResolverGraphManager)
+        generated = GraphQL.graphql_type_registry[ResolverGraphManager.__name__]
+        resolver = generated.resolve_document
+        manager = ResolverGraphManager._from_trusted_orm_instance(
+            ResolverRecord(id=7, document="documents/allowed.txt")
+        )
+        info = SimpleNamespace(
+            context=SimpleNamespace(user=object()),
+            operation=SimpleNamespace(operation=OperationType.SUBSCRIPTION),
+        )
+
+        async def resolve() -> object:
+            with patch(
+                "general_manager.api.graphql.create_stored_file_value",
+                side_effect=stored_value,
+            ):
+                return await resolver(manager, info)
+
+        assert asyncio.run(resolve()) is sentinel
+        assert permission_threads == [False]
+        assert value_threads == [True]
     finally:
         GraphQL.graphql_type_registry = old_types
         GraphQL.manager_registry = old_managers


### PR DESCRIPTION
## Summary

- run subscription payload field permission construction and evaluation in an async-safe worker
- preserve synchronous query and mutation resolution, attribute-specific overrides, and nullable denial behavior
- apply the shared boundary to normal, measurement, and stored-file fields and document the guarantee

## Root cause

Issue #442 moved class-event hydration and object-level authorization off the event loop, but GraphQL later materialized selected `item` fields through synchronous resolvers. ORM-backed field permissions therefore raised `SynchronousOnlyOperation` during subscription payload resolution.

The new operation-aware helper returns concrete values for queries and mutations. For subscriptions, it offloads only permission construction and evaluation with `asyncio.to_thread()`; getters, measurement conversion, and stored-file construction remain in GraphQL's execution context.

## Impact

Authorized subscription fields now resolve successfully when their permissions query the ORM. Attribute-specific denials continue to resolve only the protected field to `null`, without adding a GraphQL error. Public GraphQL schema shapes and database schemas are unchanged.

Closes #460.

## Validation

- `python -m pytest -q` — 6014 passed, 3 skipped, 2009 subtests passed
- focused GraphQL regression set — 211 passed, 15 subtests passed
- `ruff check` — passed
- `ruff format --check` — passed
- `mypy src/general_manager/api/graphql_resolvers.py src/general_manager/api/graphql.py` — passed
- task-level and whole-branch reviews found no critical or important issues

The full suite retains one pre-existing Django model re-registration warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL subscription field handling so read permissions are checked safely without blocking event processing.
  * Denied nullable fields now resolve to `null` while permitted fields continue to return their values normally.
  * Applied consistent permission behavior across regular fields, measurements, and stored files.
  * Preserved existing event-level authorization and aggregate refresh behavior.

* **Documentation**
  * Updated subscription guidance to explain field-level permissions and denial behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->