### PR TITLE
docs: document async-safe subscription field permissions

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -153,6 +153,39 @@ targets continue. The [RemoteAPI websocket concept](../concepts/interfaces/remot
 explains the event model and the [end-to-end recipe](../examples/remote_manager_interface_end_to_end.md)
 shows the client/server setup.
 
+## Subscription field authorization
+
+Generated subscription payloads retain the existing GraphQL field names and
+arguments. For each selected normal, measurement, or stored-file field, the
+effective resolver contract is:
+
+- **Inputs:** the generated manager instance and GraphQL execution context; no
+  new client-visible arguments or stable Python export were added. Detail and
+  class-wide subscriptions retain their existing generated operation shapes;
+  measurement payload fields retain the optional `targetUnit: String` argument.
+- **Permission check:** `Permission(instance, info.context.user).check_permission(
+  "read", field_name)` runs before field value access. Managers without a
+  `Permission` class allow the field by default.
+- **Allowed result:** the existing scalar value, measurement payload, or
+  stored-file payload. Measurement conversion and stored-file formatting keep
+  their existing behavior.
+- **Denied result:** `null` for that nullable payload field only; sibling fields
+  and the subscription action remain available.
+- **Exceptions:** exceptions raised by the field permission checker propagate
+  through normal GraphQL subscription error handling. No new exception type or
+  error code is introduced.
+
+For subscription execution, the permission check runs in an async-safe worker;
+value access and formatting run in GraphQL's execution context after permission
+succeeds. Query and mutation field resolution remains synchronous. This
+behavior is compatible with the existing object-level class-subscription check,
+which runs before an identified event is yielded, and with aggregate `refresh`
+events, whose `item` remains `null`. The generated schema is unchanged; the
+async-safe field authorization behavior is available from GeneralManager 0.73.1.
+See the [subscription concept](../concepts/graphql/subscriptions.md#signals-and-channels),
+[how-to](../howto/expose_via_graphql.md#protect-subscription-payload-fields), and
+[cookbook recipe](../examples/graphql_queries.md#subscribe-to-fields-with-read-permissions).
+
 ## Relation annotation compatibility
 
 Generated GraphQL relation fields resolve annotations to one registered

--- a/docs/examples/graphql_queries.md
+++ b/docs/examples/graphql_queries.md
@@ -143,6 +143,53 @@ Identified class-wide events are checked against the subscribing user's read
 permission in an async-safe worker after commit; unreadable objects are omitted.
 Aggregate `refresh` events have `item: null` and do not disclose a row ID.
 
+## Subscribe to fields with read permissions
+
+Field-level read rules also apply to the fields selected inside a subscription
+payload. This manager keeps `internalNote` visible only to staff users while
+leaving the public `name` field readable for any authenticated user:
+
+```python
+from general_manager import GeneralManager
+from general_manager.permission import AdditiveManagerPermission, register_permission
+
+
+@register_permission("isStaff")
+def is_staff(_instance, user, _config):
+    return bool(getattr(user, "is_staff", False))
+
+
+class Project(GeneralManager):
+    name: str
+    internal_note: str
+
+    class Permission(AdditiveManagerPermission):
+        __read__ = ["isAuthenticated"]
+        internal_note = {"read": ["isStaff"]}
+```
+
+Subscribe with the generated field names:
+
+```graphql
+subscription ProjectChangesWithFieldRules {
+  onProjectClassChange {
+    action
+    item {
+      id
+      name
+      internalNote
+    }
+  }
+}
+```
+
+For an authenticated non-staff subscriber, `internalNote` resolves to `null`
+while `name` and the event action remain available. The same rule applies to
+normal, measurement, and stored-file payload fields. See the
+[GraphQL how-to](../howto/expose_via_graphql.md#protect-subscription-payload-fields)
+and [API reference](../api/graphql.md#subscription-field-authorization) for
+execution and exception details.
+
 ## Bound run-scoped cache memory
 
 For a worker that serves long-lived GraphQL requests, configure the optional

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -287,6 +287,44 @@ permission exception propagates through the subscription error path. Aggregate
 `refresh` events have no identification and yield `item = null` without this
 object-level check.
 
+## Protect subscription payload fields
+
+Each selected normal, measurement, and stored-file field in a generated detail or
+class-wide subscription applies the manager's usual field-level read permission.
+For class-wide subscriptions, this happens after an identified event passes its
+object-level check. Configure a field-specific rule on the manager's `Permission`
+class as you would for a query:
+
+```python
+from general_manager import GeneralManager
+from general_manager.permission import AdditiveManagerPermission, register_permission
+
+
+@register_permission("isStaff")
+def is_staff(_instance, user, _config):
+    return bool(getattr(user, "is_staff", False))
+
+
+class Project(GeneralManager):
+    name: str
+    internal_note: str
+
+    class Permission(AdditiveManagerPermission):
+        __read__ = ["isAuthenticated"]
+        internal_note = {"read": ["isStaff"]}
+```
+
+With a subscription such as the one in the
+[field-permission recipe](../examples/graphql_queries.md#subscribe-to-fields-with-read-permissions),
+an authenticated non-staff user receives `name` and `internalNote: null`.
+The denial is limited to that field; sibling fields and the event action still
+resolve. Permission evaluation for subscription fields runs in an async-safe
+worker, while value access, measurement conversion, and stored-file formatting
+remain in GraphQL's execution context. Query and mutation field resolution stays
+synchronous. See the [subscription concept](../concepts/graphql/subscriptions.md#signals-and-channels)
+and [GraphQL API reference](../api/graphql.md#subscription-field-authorization)
+for the full compatibility and error contract.
+
 ## Expose authorization hints
 
 Use GraphQL permission capabilities when frontend code needs business-oriented authorization hints, such as whether the current user can rename a project. These fields are advisory only; backend permissions still enforce all reads and writes.


### PR DESCRIPTION
## Summary

Document the GeneralManager 0.73.1 change that makes generated GraphQL subscription field authorization async-safe.

### Reviewed commits

The rolling window was 2026-08-17T04:01:41Z through 2026-08-18T04:01:41Z. Complete diffs were reviewed for:

- `377327cb9ba83b22d43ed42843f46cb335668790` — 0.73.1 release metadata
- `b35576e42a2c2ae3fb0b9d0978777b6a106440b5` — subscription field-permission documentation
- `bd1667a83495e024d8546ab09742379bb17641c4` — structured subscription field-permission coverage
- `91a12fe6748be8fb910fa1733a659f8fa0a978d3` — async-safe subscription field permissions
- `54e24ccb2501bc1ee18aa490dafc240fb03b2ab6` — lifecycle documentation corrections
- `7c9236d4b70875fc0b3fa271293f3f11e1891d1e` — static permission-decision documentation
- `4ce678d5d12270cb3b1439a1ebe82b401d01c117` — recent public API documentation
- `0b495bc855dc27a919b0a6e98bbafdfa6a630157` — exact bucket-subset documentation
- `0e41b6d3614b6b6e2f832f9b710fafba8f9467cf` — compound GraphQL sorting documentation

The release and documentation-only commits introduce no additional application API behavior. The affected public surface is generated GraphQL subscription payload authorization: normal, measurement, and stored-file fields evaluate read permissions in an async-safe worker; denied fields remain `null`; query and mutation resolution remains synchronous; and permission-check exceptions follow normal GraphQL error handling.

### Documentation changes

- `docs/howto/expose_via_graphql.md` — field-level subscription authorization how-to
- `docs/examples/graphql_queries.md` — directly usable permissioned subscription recipe
- `docs/api/graphql.md` — generated operation shapes, inputs, results, exceptions, and 0.73.1 compatibility notes

The concept form already exists in `docs/concepts/graphql/subscriptions.md` and is linked from all three updated pages.

### Validation

- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py tests/integration/test_request_docs_examples.py -q` — 8 passed
- `PYTHONPATH=src python -m pytest tests/unit/test_graphql_helpers.py tests/unit/test_graphql_subscriptions.py tests/unit/test_stored_file_resolvers.py -q` — 201 passed, 15 subtests
- Strict MkDocs build — passed with only existing unnav-linked planning/ADR notices
- File-scoped pre-commit hooks — passed
- `git diff --check` — passed

No Python application files were changed, so Ruff and mypy had no files to check. The full test suite was not rerun because this is documentation-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented field-level read authorization for GraphQL subscriptions.
  * Clarified that unauthorized nullable fields return `null` while permitted sibling fields remain available.
  * Added examples covering staff-only fields, measurements, stored files, object-level checks, and async-safe permission evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->