### PR TITLE
fix: normalize grouped relation unions

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -293,14 +293,16 @@ Iteration yields keys from `manager_class.Interface.get_attributes()` first in
 that mapping's order, then `GraphQLProperty` values declared directly on the
 manager class in class-`__dict__` order; duplicate names are not filtered.
 
-`id`, empty buckets, and all-`None` inputs aggregate to `None`. Bucket and
-manager values are combined with `|`, lists are concatenated, dicts are merged
-with later values overwriting earlier keys, strings are de-duplicated in
-encounter order and joined by `", "`, booleans use `any()` before numeric
-handling, numeric and `Measurement` values are summed, and date/time values use
-`max()`. The aggregation branch is chosen from interface metadata or a concrete
-`GraphQLProperty` return annotation, not from every runtime value, so mixed
-runtime values follow the selected branch and may raise from that operation.
+`id`, empty buckets, and all-`None` inputs aggregate to `None`. Repeated manager
+values with the same class and identification collapse to that manager;
+distinct managers and bucket values are combined with `|`. Lists are
+concatenated, dicts are merged with later values overwriting earlier keys,
+strings are de-duplicated in encounter order and joined by `", "`, booleans use
+`any()` before numeric handling, numeric and `Measurement` values are summed,
+and date/time values use `max()`. The aggregation branch is chosen from
+interface metadata or a concrete `GraphQLProperty` return annotation, not from
+every runtime value, so mixed runtime values follow the selected branch and may
+raise from that operation.
 GraphQL property annotations use the first `typing.get_args()` entry when
 present, otherwise the annotation object itself; unsupported non-class
 annotations raise `MissingGroupAttributeError`. `hash(group)` recursively

--- a/src/general_manager/manager/general_manager.py
+++ b/src/general_manager/manager/general_manager.py
@@ -411,7 +411,7 @@ class GeneralManager(metaclass=GeneralManagerMeta):
         if isinstance(other, Bucket):
             return other | self
         elif isinstance(other, GeneralManager) and other.__class__ == self.__class__:
-            return self.filter(id__in=[self.__id, other.__id])
+            return self.filter(id__in=[self, other])
         else:
             raise UnsupportedUnionOperandError(type(other))
 

--- a/src/general_manager/manager/group_manager.py
+++ b/src/general_manager/manager/group_manager.py
@@ -189,11 +189,12 @@ class GroupManager(Generic[GeneralManagerType]):
 
         Returns:
             Aggregated value for `item`: group `"id"`, empty buckets, and
-            all-`None` values return `None`; bucket/manager values are unioned
-            with `|`; lists are concatenated; dicts are merged with later values
-            overwriting earlier keys; strings are deduplicated in encounter
-            order and joined by `", "`; booleans use `any()` before numeric
-            handling; numeric and `Measurement` values are summed;
+            all-`None` values return `None`; repeated identical manager values
+            collapse to that manager, while distinct managers and bucket values
+            are unioned with `|`; lists are concatenated; dicts are merged with
+            later values overwriting earlier keys; strings are deduplicated in
+            encounter order and joined by `", "`; booleans use `any()` before
+            numeric handling; numeric and `Measurement` values are summed;
             datetime/date/time values use `max()`. The aggregation branch is
             selected from interface metadata or a concrete `GraphQLProperty`
             return annotation, not from each runtime value, so mixed runtime
@@ -237,7 +238,21 @@ class GroupManager(Generic[GeneralManagerType]):
             return new_data
         total_data = [i for i in total_data if i is not None]
 
-        if issubclass(data_type, (Bucket, GeneralManager)):
+        if issubclass(data_type, GeneralManager):
+            first_manager = cast(GeneralManager, total_data[0])
+            if all(
+                value.__class__ == first_manager.__class__
+                and value.identification == first_manager.identification
+                for value in cast(list[GeneralManager], total_data)
+            ):
+                new_data = first_manager
+            else:
+                for value in total_data:
+                    if new_data is None:
+                        new_data = value
+                    else:
+                        new_data = value | new_data  # type: ignore[operator]
+        elif issubclass(data_type, Bucket):
             for value in total_data:
                 if new_data is None:
                     new_data = value

--- a/tests/integration/test_database_manager.py
+++ b/tests/integration/test_database_manager.py
@@ -2050,6 +2050,24 @@ class DatabaseIntegrationTest(GeneralManagerTransactionTestCase):
         self.assertEqual(groups_by_country["US"]._data.count(), 1)
         self.assertEqual(groups_by_country[None]._data.count(), 1)
 
+    def test_group_by_foreign_key_id_collapses_repeated_relation(self):
+        country = self.TestCountry.filter(code="US").get()
+        second_human = self.TestHuman.create(
+            creator_id=None,
+            name="Grace",
+            country=country,
+            ignore_permission=True,
+        )
+
+        group = (
+            self.TestHuman.filter(id__in=[self.test_human1.id, second_human.id])
+            .group_by("country_id")
+            .get()
+        )
+
+        self.assertIsInstance(group.country, self.TestCountry)
+        self.assertEqual(group.country, country)
+
     def test_group_by_one_to_one_relation(self):
         first_request = self.ChangeRequest.create(
             title="First",

--- a/tests/integration/test_graphql_query.py
+++ b/tests/integration/test_graphql_query.py
@@ -261,6 +261,27 @@ class TestGraphQLQueryPagination(GeneralManagerTransactionTestCase):
         items = response.json()["data"]["projectList"]["items"]
         self.assertEqual([item["name"] for item in items], ["Able", "Zed", "Beta"])
 
+    def test_grouped_query_resolves_relation_grouped_by_scalar_id(self):
+        commercials = self.commercials.Factory.create(name="Shared")
+        self.project.Factory.create(name="First", commercials=commercials)
+        self.project.Factory.create(name="Second", commercials=commercials)
+        query = """
+        query {
+          projectList(groupBy: ["commercials_id"]) {
+            items { commercials { id name } }
+          }
+        }
+        """
+
+        response = self.query(query)
+
+        self.assertResponseNoErrors(response)
+        items = response.json()["data"]["projectList"]["items"]
+        self.assertEqual(
+            items,
+            [{"commercials": {"id": commercials.id, "name": "Shared"}}],
+        )
+
     def test_grouped_compound_relation_sort_applies_pagination_after_sorting(self):
         self._create_projects_for_relation_sorting()
         query = """

--- a/tests/unit/test_general_manager.py
+++ b/tests/unit/test_general_manager.py
@@ -854,21 +854,16 @@ class GeneralManagerTestCase(TestCase):
             pickle.loads(payload)  # noqa: S301
 
     def test_or_operator(self):
-        # Test the __or__ operator
         """
-        Tests that the bitwise OR operator combines two GeneralManager instances by invoking
-        the filter method with their IDs and returns a list of manager instances with correct identifications.
+        Test that manager union normalizes manager identifications for id lookups.
         """
         manager1 = self.manager()
         manager2 = self.manager()
-        result = manager1 | manager2
         with patch.object(
-            self.manager, "filter", return_value=[manager1, manager2]
+            DummyInterface, "filter", return_value=[manager1, manager2]
         ) as mock_filter:
             result = manager1 | manager2
-            mock_filter.assert_called_once_with(
-                id__in=[{"id": "dummy_id"}, {"id": "dummy_id"}]
-            )
+            mock_filter.assert_called_once_with(id__in=["dummy_id", "dummy_id"])
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].identification, {"id": "dummy_id"})  # type: ignore
@@ -884,6 +879,26 @@ class GeneralManagerTestCase(TestCase):
             _ = manager | object()  # type: ignore[operator]
 
         self.assertIn("Unsupported type for union", str(context.exception))
+
+    def test_or_operator_preserves_composite_identification_mappings(self):
+        manager1 = self.manager()
+        manager2 = self.manager()
+        first_identification = {"country": "DE", "number": 1}
+        second_identification = {"country": "US", "number": 2}
+        manager1._GeneralManager__id = first_identification
+        manager2._GeneralManager__id = second_identification
+
+        with patch.object(DummyInterface, "filter", return_value=[]) as mock_filter:
+            result = manager1 | manager2
+
+        forwarded = mock_filter.call_args.kwargs["id__in"]
+        self.assertEqual(
+            forwarded,
+            [first_identification, second_identification],
+        )
+        self.assertIsNot(forwarded[0], first_identification)
+        self.assertIsNot(forwarded[1], second_identification)
+        self.assertEqual(result, [])
 
     def test_manager_core_errors_are_public_exports(self):
         from general_manager.manager import (

--- a/tests/unit/test_group_manager.py
+++ b/tests/unit/test_group_manager.py
@@ -3,6 +3,7 @@ from datetime import date
 from typing import ClassVar
 from django.test import TestCase
 from general_manager.api.property import GraphQLProperty
+from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.group_manager import (
     GroupManager,
 )
@@ -326,6 +327,35 @@ class GroupManagerCombineValueTests(TestCase):
         )
         result = gm.combine_value("field")
         self.assertEqual(result, Measurement(3, "m"))
+
+    def test_combine_distinct_managers_preserves_union_bucket(self):
+        class RelatedInterface:
+            def __init__(self, manager_id):
+                self.identification = {"id": manager_id}
+
+            @classmethod
+            def filter(cls, **kwargs):
+                return ListBucket(
+                    RelatedManager(manager_id)
+                    for manager_id in dict.fromkeys(kwargs["id__in"])
+                )
+
+        class RelatedManager(GeneralManager):
+            pass
+
+        RelatedManager.Interface = RelatedInterface
+        gm = self.helper_make_group_manager(
+            [RelatedManager(1), RelatedManager(2)],
+            RelatedManager,
+        )
+
+        result = gm.combine_value("field")
+
+        self.assertIsInstance(result, ListBucket)
+        self.assertEqual(
+            [manager.identification for manager in result],
+            [{"id": 2}, {"id": 1}],
+        )
 
     def test_iterate_group_manager(self):
         # Test that iterating over GroupManager yields correct items


### PR DESCRIPTION
## Summary

- normalize same-class manager unions through the existing filter lookup conversion
- collapse repeated identical singular manager values during grouped aggregation
- preserve existing union behavior for distinct managers and bucket values
- add scalar, composite, ORM, GraphQL, and non-database regression coverage
- document grouped singular-manager semantics

## Root cause

`GeneralManager.__or__()` passed complete identification mappings directly to an `id__in` lookup. For ordinary ID-backed managers this produced dictionary values such as `{"id": 1}`, which Django rejects for scalar ID fields. After normalizing the lookup, grouped repeated singular relations would still resolve to a one-row bucket, which does not match the declared singular relation type.

The fix routes manager operands through the existing lookup normalizer and returns the manager itself when every grouped manager value has the same class and identification.

## Impact

Grouping multiple records by a generated foreign-key scalar ID can now resolve the corresponding singular relation consistently for both Python and GraphQL consumers. Composite identifications and distinct-manager aggregation retain their prior behavior.

Closes #463

## Validation

- `python -m pytest -q` — 6018 passed, 3 skipped, 2009 subtests passed
- `ruff check` — passed
- `ruff format --check` — passed
- `mypy src/general_manager/manager/general_manager.py src/general_manager/manager/group_manager.py` — passed
- pre-commit hooks — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grouping to collapse repeated related records into a single entry when they share the same identity.
  * Preserved distinct related records and bucket values during combination and aggregation.
  * Improved union behavior for related records, including support for composite identifiers.
  * Ensured grouped database and GraphQL results retain the correct related record details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->