### PR TITLE
docs: document recent public API changes

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -488,6 +488,9 @@ and [permission recipe](../examples/permission_cookbook.md#preserve-an-authorize
 
 ## Projected reads
 
+The projected-read methods and their four validation exceptions are public from
+GeneralManager 0.74.0 onward.
+
 `Bucket.values(*fields: str) -> tuple[dict[str, object], ...]` returns a fully
 materialized tuple of ordinary dictionaries in bucket iteration order. The
 tuple-style and flat forms of `values_list()` are:
@@ -558,6 +561,14 @@ supplied bucket and does not rebuild a broader query or accept a `user`,
 `info`, permission object, or implicit authorization lookup. An authorized
 subset remains restricted, while an unrestricted bucket has the same
 authorization characteristics as iterating that bucket.
+
+::: general_manager.bucket.projection.EmptyProjectionFieldsError
+
+::: general_manager.bucket.projection.DuplicateProjectionFieldError
+
+::: general_manager.bucket.projection.UnknownProjectionFieldError
+
+::: general_manager.bucket.projection.FlatProjectionFieldCountError
 
 ::: general_manager.bucket.database_bucket.DatabaseBucket
 

--- a/docs/concepts/models_entities.md
+++ b/docs/concepts/models_entities.md
@@ -106,6 +106,13 @@ measurements. Group-by keys must be string attribute names exposed by the
 manager interface. Non-string keys raise `InvalidGroupByKeyTypeError`, and
 unknown keys raise `UnknownGroupByKeyError`.
 
+Manager-valued attributes use their manager class and identification mapping
+when they are aggregated. Repeated references to the same related manager
+collapse to one manager, while distinct related managers are combined with the
+normal bucket-union behavior. This keeps grouping by a foreign-key identifier
+from manufacturing duplicate related objects while preserving a bucket when a
+group contains more than one related manager.
+
 A `GroupBucket` is materialized from the source bucket at construction time.
 Each distinct tuple of group-by values becomes one group, emitted in
 `str(group_by_value)` order. Manager-valued group keys compare by manager class

--- a/docs/examples/graphql_queries.md
+++ b/docs/examples/graphql_queries.md
@@ -41,6 +41,27 @@ query ProjectsByStatus {
 If the filter produces no groups, the same query shape returns `items: []` and
 page metadata rather than an empty-group slicing error.
 
+## Group by a related manager identity
+
+Grouping by a scalar foreign-key identifier preserves the related manager in
+the aggregated result. Repeated rows pointing to the same related manager
+collapse to one object; distinct managers remain available through their union
+bucket:
+
+```graphql
+query ProjectsByCommercial {
+  projectList(groupBy: ["commercials_id"]) {
+    items { commercials { id name } }
+  }
+}
+```
+
+The generated resolver applies the same bucket and `GroupManager` behavior as
+the Python API. See the [grouped-data concept](../concepts/models_entities.md#grouped-data),
+[GraphQL how-to](../howto/expose_via_graphql.md#query-generated-lists), and
+[core API reference](../api/core.md#general_manager.manager.group_manager.GroupManager)
+for the full grouping and error contract.
+
 ## Nested buckets
 
 ```graphql

--- a/docs/examples/project_volume_curve.md
+++ b/docs/examples/project_volume_curve.md
@@ -51,5 +51,6 @@ Use this pattern to power charts in dashboards or export data to CSV.
 `values_list()` materializes the grouped bucket in its existing order without
 constructing another list of manager objects. Use `values("date", "volume")`
 instead when a dictionary shape is more convenient for a serializer or CSV
-writer. Both forms keep the group values shallow and preserve the bucket's
-source and historical context.
+writer. Both forms use the bucket's source and historical context during
+evaluation, then return detached shallow snapshots; the resulting tuples or
+dictionaries do not retain that bucket metadata.

--- a/docs/examples/project_volume_curve.md
+++ b/docs/examples/project_volume_curve.md
@@ -26,17 +26,14 @@ class DerivativeVolume(GeneralManager):
 ```
 
 ```python
-def project_volume_curve(project: Project) -> list[tuple[date, Measurement]]:
+def project_volume_curve(project: Project) -> tuple[tuple[date, Measurement], ...]:
     grouped = (
         project.derivative_volume_list
         .filter(project=project)
         .group_by("date")
         .sort("date")
     )
-    return [
-        (group.date, group.volume)
-        for group in grouped
-    ]
+    return grouped.values_list("date", "volume")
 ```
 
 Result:
@@ -48,3 +45,11 @@ for entry_date, volume in curve:
 ```
 
 Use this pattern to power charts in dashboards or export data to CSV.
+
+## Project selected fields
+
+`values_list()` materializes the grouped bucket in its existing order without
+constructing another list of manager objects. Use `values("date", "volume")`
+instead when a dictionary shape is more convenient for a serializer or CSV
+writer. Both forms keep the group values shallow and preserve the bucket's
+source and historical context.

--- a/docs/howto/cache_dependent_calculation.md
+++ b/docs/howto/cache_dependent_calculation.md
@@ -393,6 +393,9 @@ partially optimize the other fields in a mixed request. The same fallback
 applies to relations and other fields whose public value requires manager
 access.
 
+For a complete grouped-data example that turns projected rows into an
+export-ready result, see the [volume-curve cookbook recipe](../examples/project_volume_curve.md#project-selected-fields).
+
 The stable public API is `Bucket.index_by(...)`, `Bucket.index_many(...)`, and
 the exported bucket-index exception classes. The lower-level
 `general_manager.bucket.indexing` helpers are importable support functions, not

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -255,6 +255,20 @@ while sorting by another exposed field uses that field's aggregated group value.
 `totalCount` is computed after permission filtering, user filters, excludes,
 grouping, and sorting, but before page slicing.
 
+Grouping by a scalar foreign-key identifier also normalizes the aggregated
+manager value. Rows that point to the same related manager collapse to one
+object; a group containing distinct related managers returns their union bucket.
+For example, this groups projects by the related commercial identity while
+returning the generated relation field:
+
+```graphql
+query ProjectsByCommercial {
+  projectList(groupBy: ["commercials_id"]) {
+    items { commercials { id name } }
+  }
+}
+```
+
 ```graphql
 query ProjectsByDescendingStatus {
   projectList(groupBy: ["status"], sortBy: status, reverse: true) {


### PR DESCRIPTION
## Summary

This draft documents the public API changes found on `origin/main` during the rolling window 2026-08-18T05:57:22Z through 2026-08-19T05:57:22Z.

## Reviewed commits

The 24 reviewed reachable commits were:

`6f931f2462f1020ff1bd8f43da5628813173a98a`, `e8c51fa8bda5a2fefb883b0a6f7aee9f79d055ff`, `2a152bf00e8e5a2fe95d8b3338399de0e503c551`, `c524c445ceb02c34233231213728be3ce37d1f51`, `830a29d2ee4d3fb75cdac2f6ddb2d429cc758b17`, `570c63aede342883fdd146a54b8f7f078824d7da`, `7d7a327c07ac71b1415568a3b7ed9724110bdcf0`, `a7b24837b524ef03d3ec07b9089e8e717c876bb5`, `32db932df608ea25cb809e1b51a0c0873f42381b`, `a19fb561bc2d47d499609104d927999498e259bc`, `0e6c81b5b618c95d03061513654f5ce44c643b8f`, `fe303f0e6d05e0eca62615a5079c31a1b01b43f1`, `130749d80d7d4b8b30f1bffb62ce3a348b78b601`, `14d38818b8b21cc0f3e99b85963c068fbf6be86b`, `5a91a6e05f61fe092cb869ae9105a7fc2d0801a0`, `487d3905f45b80829792d863cf5e77ae956f9b0f`, `16294a50cb0ca4c0984d2aa802d5b280e84816c1`, `9c3f9f042ae4dc559aa98c158daaf74bc9c63cca`, `b51e6e7af2af57a83b3b32522f0988f2d54f19e0`, `eadd987740265c720ef54629e4c90f59c9b5c1ec`, `5b3afa3edb60c733b0cda18a538c7a1252a925ed`, `c1967875c89fc21c454853e691fbcdc4fd462793`, `eb4462992565d9a1aa58bef6b0a1745203160069`, `e41f5baff821c9b73d8463c7c2bf5ec3603dffa1`.

## Affected public APIs

- `Bucket.values(*fields)` and `Bucket.values_list(*fields, flat=False)`, including `EmptyProjectionFieldsError`, `DuplicateProjectionFieldError`, `UnknownProjectionFieldError`, and `FlatProjectionFieldCountError`, published in 0.74.0.
- The backend-neutral bucket projection contract: validation order, native/portable fallback behavior, grouped projections, historical reads, run-scoped reuse, dependency replay, and authorization boundaries.
- `GeneralManager.__or__` and grouped manager aggregation: same-class manager unions now normalize copied identification values; repeated manager-valued aggregates collapse by class plus identification, while distinct managers remain a bucket union.
- Async-safe GraphQL subscription field authorization was reviewed from `6f931f2`; its concept, how-to, cookbook, and API-reference forms were already complete on `origin/main`, so this PR does not duplicate those pages.
- Release-only metadata commits and internal projection implementation/test commits introduced no additional stable public surface beyond the items above.

## Documentation changed

- `docs/api/core.md`
- `docs/concepts/models_entities.md`
- `docs/examples/graphql_queries.md`
- `docs/examples/project_volume_curve.md`
- `docs/howto/cache_dependent_calculation.md`
- `docs/howto/expose_via_graphql.md`

## Validation

- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py tests/integration/test_request_docs_examples.py -q` — 8 passed.
- Focused projection/grouped-relation tests — 54 passed.
- Strict MkDocs build — passed; only existing unnav-linked planning/ADR and git-revision notices remain.
- Parsed 18 Python and 19 GraphQL fenced documentation blocks.
- File-scoped pre-commit checks and `git diff --check` — passed.
- Full test suite was not rerun because this is documentation-only; Ruff and mypy had no Python files to check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented projected-read methods and related validation errors available in GeneralManager 0.74.0 and later.
  * Clarified grouping behavior for manager-valued attributes, including duplicate references and manager unions.
  * Added GraphQL examples for grouping by scalar foreign-key identifiers.
  * Updated the volume-curve example with immutable tuple results and serialization-friendly output formats.
  * Added a reference to the volume-curve cookbook recipe for grouped-data calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->