### PR TITLE
feat: add GraphQL output-only value types

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -8,6 +8,8 @@
 
 ::: general_manager.api.graphql.BigIntScalar
 
+::: general_manager.api.graphql_type.GraphQLType
+
 ::: general_manager.api.graphql_errors.PublicGraphQLError
 
 `PublicGraphQLError(message: str, *, code: str)` constructs a GraphQL error for
@@ -42,6 +44,26 @@ are not stable import paths. Some internal types may still appear in generated
 reference pages or type-checker-visible implementation annotations when they are
 part of generated GraphQL plumbing; that visibility does not make them public
 import targets.
+
+`GraphQLType` is the stable package-root export for output-only response values:
+
+```python
+from general_manager import GraphQLType
+```
+
+Its concrete subclasses are frozen dataclass-style values whose annotated
+fields become GraphQL output fields. Python required/optional annotations and
+the supported `list`, `tuple[T, ...]`, and `set` shapes determine GraphQL
+nullability. They may be used as direct, optional, or collection return values
+from `@graph_ql_property`, but they never generate queries, mutations,
+subscriptions, filters, capabilities, or input objects. Import declarations
+during startup so they are registered before schema construction.
+
+The manager owning the `@graph_ql_property` controls access to the returned
+value. A nested `GeneralManager` field keeps its manager-level read permission
+checks, while plain scalar fields and nested `GraphQLType` fields have no
+independent permission boundary. Applications should omit or pre-authorize
+sensitive values before returning an output value.
 
 ## Historical queries with `@asOf`
 

--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -55,12 +55,15 @@ Python annotations define nullability and collection element nullability:
 | `list[User \| None]` | `[UserType]!` |
 | `list[User] \| None` | `[UserType!]` |
 
-Supported values are built-in GraphQL scalar annotations, `Measurement`,
-registered `GeneralManager` classes, registered `GraphQLType` classes, and
-`list[T]`, `tuple[T, ...]`, or `set[T]` collections. Optional forms use
-`T | None`. Bare collections, fixed heterogeneous tuples, `Any`,
-`Annotated[...]`, unresolved references, and unions containing more than one
-non-null type are rejected during schema generation.
+For scalar fields, the strict allowlist is `str`, `bool`, `int`, `float`,
+`Decimal`, `datetime`, `date`, and subclasses of those types. Unknown
+scalar-like classes are rejected; output declarations do not use the legacy
+manager mapper's fallback to `String`. Other supported values are
+`Measurement`, registered `GeneralManager` classes, registered `GraphQLType`
+classes, and `list[T]`, `tuple[T, ...]`, or `set[T]` collections. Optional forms
+use `T | None`. Bare collections, every fixed-length tuple (including
+`tuple[int, int]`), `Any`, `Annotated[...]`, unresolved references, and unions
+containing more than one non-null type are rejected during schema generation.
 
 An output type can be returned by any `@graph_ql_property` using a direct,
 optional, or collection annotation:
@@ -84,6 +87,12 @@ or manager lifecycle behavior. The owning manager controls access to the
 property. Nested manager fields retain that manager's normal read resolvers
 and permissions; plain scalar and nested output fields have no independent
 permission check.
+
+Output declarations and generated output `ObjectType` classes use registries
+separate from manager declarations and generated manager types. Manager-only
+roots, filters, subscriptions, search, capabilities, and lifecycle tooling
+continue to consume the manager registries; an output declaration is never
+added to those manager operation paths.
 
 ### Relation annotation compatibility
 

--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -18,6 +18,73 @@ Single-valued manager relations are exposed as object fields. Relation fields
 whose Python-side name ends with `_list` are exposed as paginated list fields
 with filtering, grouping, sorting, and pagination arguments.
 
+## Output-only value types
+
+Use the package-root `GraphQLType` when a response needs a nested object shape
+but does not represent a manager with identity, lifecycle, or independent
+operations. Import the module that declares each output type during startup so
+the declaration is registered before the schema is built:
+
+```python
+from dataclasses import field
+
+from general_manager import GraphQLType
+from general_manager.measurement import Measurement
+
+
+class ProjectHour(GraphQLType):
+    user: list[User]
+    total_hours: Measurement
+    task: Task
+    notes: str | None = None
+    tags: list[str] = field(default_factory=list)
+```
+
+Concrete subclasses automatically behave as frozen dataclasses; an explicit
+`@dataclass` decorator is not needed. Dataclass defaults and
+`default_factory` are supported, and `ClassVar` declarations are not exposed
+as fields. The generated Graphene object is named `ProjectHourType`.
+
+Python annotations define nullability and collection element nullability:
+
+| Python annotation | GraphQL field |
+| --- | --- |
+| `str` | `String!` |
+| `str \| None` | `String` |
+| `list[User]` | `[UserType!]!` |
+| `list[User \| None]` | `[UserType]!` |
+| `list[User] \| None` | `[UserType!]` |
+
+Supported values are built-in GraphQL scalar annotations, `Measurement`,
+registered `GeneralManager` classes, registered `GraphQLType` classes, and
+`list[T]`, `tuple[T, ...]`, or `set[T]` collections. Optional forms use
+`T | None`. Bare collections, fixed heterogeneous tuples, `Any`,
+`Annotated[...]`, unresolved references, and unions containing more than one
+non-null type are rejected during schema generation.
+
+An output type can be returned by any `@graph_ql_property` using a direct,
+optional, or collection annotation:
+
+```python
+class ProjectHoursSummary(GeneralManager):
+    @graph_ql_property
+    def project_hours(self) -> list[ProjectHour]:
+        return [
+            ProjectHour(
+                user=[user],
+                total_hours=Measurement(8, "h"),
+                task=task,
+            )
+        ]
+```
+
+`GraphQLType` declarations add only schema object types. They do not create
+root queries, list queries, mutations, subscriptions, filters, capabilities,
+or manager lifecycle behavior. The owning manager controls access to the
+property. Nested manager fields retain that manager's normal read resolvers
+and permissions; plain scalar and nested output fields have no independent
+permission check.
+
 ### Relation annotation compatibility
 
 Before mapping a relation, schema generation resolves its annotation to one

--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -26,10 +26,13 @@ operations. Import the module that declares each output type during startup so
 the declaration is registered before the schema is built:
 
 ```python
+from __future__ import annotations
+
 from dataclasses import field
 
 from general_manager import GraphQLType
 from general_manager.measurement import Measurement
+from your_app.managers import Task, User  # application-specific registered managers
 
 
 class ProjectHour(GraphQLType):
@@ -39,6 +42,13 @@ class ProjectHour(GraphQLType):
     notes: str | None = None
     tags: list[str] = field(default_factory=list)
 ```
+
+`User` and `Task` in this illustrative import are application-defined
+`GeneralManager` subclasses registered by your application; replace the import
+with the module used by your project. The `user` and `task` values in the
+property example below are likewise supplied by application-specific
+calculation logic. The `GraphQLType` declaration describes their output shape;
+it does not look them up or inject them.
 
 Concrete subclasses automatically behave as frozen dataclasses; an explicit
 `@dataclass` decorator is not needed. Dataclass defaults and

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -46,15 +46,19 @@ instance is created. The declaration above becomes the GraphQL object
 capability field, or manager lifecycle. It is available only through a field
 that references it, such as `projectHours` in the example.
 
-The output mapper accepts built-in scalar annotations, `Measurement`, registered
+For scalar fields, the strict allowlist is `str`, `bool`, `int`, `float`,
+`Decimal`, `datetime`, `date`, and subclasses of those types. Unknown
+scalar-like classes are rejected and do not receive the legacy mapper's
+fallback to `String`. The other supported values are `Measurement`, registered
 managers, registered output types, and `list[T]`, `tuple[T, ...]`, or `set[T]`.
 Use `T | None` for nullable values. Required annotations become non-null
 GraphQL fields, while optional annotations become nullable fields; collection
-elements follow the same rule. Bare collections, heterogeneous tuples,
-`Any`, `Annotated[...]`, unresolved references, and multi-target unions are
-invalid output annotations and fail schema generation with a field-specific
-error. Output declarations themselves are output-only: input objects and
-automatic root operations are not generated.
+elements follow the same rule. Bare collections, every fixed-length tuple such
+as `tuple[int, int]`, `Any`, `Annotated[...]`, unresolved references, and
+multi-target unions are invalid output annotations and fail schema generation
+with a field-specific error. Only homogeneous variadic tuples written as
+`tuple[T, ...]` are supported. Output declarations themselves are output-only:
+input objects and automatic root operations are not generated.
 
 The `@graph_ql_property` on the owning manager remains the authorization
 boundary. A nested manager field still uses that manager's normal GraphQL

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -2,6 +2,66 @@
 
 Managers with an `Interface` are registered during GeneralManager startup and receive generated query, mutation, and subscription fields based on their interface capabilities.
 
+## Return output-only GraphQL types
+
+Use `GraphQLType` for a response value that needs a GraphQL object shape but
+does not need a manager identity, lifecycle, or root operation. Import the
+declaration at startup (normally from an application module imported during
+app initialization) so GeneralManager discovers it before building the
+schema. Concrete subclasses are automatically frozen dataclasses:
+
+```python
+from __future__ import annotations
+
+from dataclasses import field
+
+from general_manager import GeneralManager, GraphQLType, graph_ql_property
+from general_manager.measurement import Measurement
+
+
+class ProjectHour(GraphQLType):
+    user: list[User]
+    total_hours: Measurement
+    task: Task
+    notes: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+
+class ProjectHoursSummary(GeneralManager):
+    @graph_ql_property
+    def project_hours(self) -> list[ProjectHour]:
+        return [
+            ProjectHour(
+                user=[user],
+                total_hours=Measurement(8, "h"),
+                task=task,
+            )
+        ]
+```
+
+No explicit `@dataclass` decorator is required. Standard dataclass defaults
+and `field(default_factory=...)` work, and construction is frozen after the
+instance is created. The declaration above becomes the GraphQL object
+`ProjectHourType`; it does not create a query, mutation, subscription, filter,
+capability field, or manager lifecycle. It is available only through a field
+that references it, such as `projectHours` in the example.
+
+The output mapper accepts built-in scalar annotations, `Measurement`, registered
+managers, registered output types, and `list[T]`, `tuple[T, ...]`, or `set[T]`.
+Use `T | None` for nullable values. Required annotations become non-null
+GraphQL fields, while optional annotations become nullable fields; collection
+elements follow the same rule. Bare collections, heterogeneous tuples,
+`Any`, `Annotated[...]`, unresolved references, and multi-target unions are
+invalid output annotations and fail schema generation with a field-specific
+error. Output declarations themselves are output-only: input objects and
+automatic root operations are not generated.
+
+The `@graph_ql_property` on the owning manager remains the authorization
+boundary. A nested manager field still uses that manager's normal GraphQL
+read permissions. Plain scalar fields and nested `GraphQLType` fields do not
+receive an independent permission check, so omit or pre-authorize sensitive
+values in the owning property.
+
 ## Declare manager relations
 
 Annotate related fields with the manager class that should appear in generated

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -17,6 +17,7 @@ from dataclasses import field
 
 from general_manager import GeneralManager, GraphQLType, graph_ql_property
 from general_manager.measurement import Measurement
+from your_app.managers import Task, User  # application-specific registered managers
 
 
 class ProjectHour(GraphQLType):
@@ -38,6 +39,12 @@ class ProjectHoursSummary(GeneralManager):
             )
         ]
 ```
+
+`User` and `Task` are application-defined `GeneralManager` subclasses in this
+illustrative example; replace the import with your registered manager module.
+The `user` and `task` values passed to `ProjectHour` must be produced by the
+owning property's application-specific calculation logic. `GraphQLType` only
+describes the nested response shape and does not fetch or inject those values.
 
 No explicit `@dataclass` decorator is required. Standard dataclass defaults
 and `field(default_factory=...)` work, and construction is frozen after the

--- a/src/general_manager/_types/general_manager.py
+++ b/src/general_manager/_types/general_manager.py
@@ -10,6 +10,7 @@ __all__ = [
     "FieldConfig",
     "GeneralManager",
     "GraphQL",
+    "GraphQLType",
     "IndexConfig",
     "Input",
     "ManagerBasedPermission",
@@ -45,6 +46,7 @@ from general_manager.interface.interfaces.existing_model import ExistingModelInt
 from general_manager.search.config import FieldConfig
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.api.graphql import GraphQL
+from general_manager.api.graphql_type import GraphQLType
 from general_manager.search.config import IndexConfig
 from general_manager.manager.input import Input
 from general_manager.permission.manager_based_permission import ManagerBasedPermission

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -476,7 +476,7 @@ class GraphQL:
             manager_registry=cls.manager_registry,
             output_class_registry=output_classes,
         )
-        fields: GraphQLFieldMap = {}
+        fields: dict[str, graphene.Field] = {}
         for declared_field in dataclasses.fields(output_class):
             mapped = map_graphql_output_annotation(
                 hints[declared_field.name],
@@ -489,20 +489,24 @@ class GraphQL:
                 measurement_type=MeasurementType,
                 scalar_mapper=cls._map_field_to_graphene_base_type,
             )
-            fields[declared_field.name] = mapped.field
-            fields[f"resolve_{declared_field.name}"] = create_output_field_resolver(
+            field = cast(graphene.Field, mapped.field)
+            field.resolver = create_output_field_resolver(
                 declared_field.name,
                 mapped.resolver_type,
             )
+            fields[declared_field.name] = field
 
         generated = type(
             generated_name,
             (graphene.ObjectType,),
-            {
-                "__graphql_output_declaration__": output_class,
-                **fields,
-            },
+            {"__graphql_output_declaration__": output_class},
         )
+        # Graphene reserves class attributes such as ``Meta`` and interprets
+        # ``resolve_<field>`` attributes as resolver methods.  Mounting fields
+        # directly in the generated options keeps the GraphQL field namespace
+        # independent from those class-level namespaces; each Field carries
+        # its resolver explicitly.
+        generated._meta.fields.update(fields)  # type: ignore[attr-defined]
         cls.graphql_output_type_registry[output_name] = generated
         return generated
 
@@ -523,6 +527,15 @@ class GraphQL:
                 return name
             name = getattr(value, "name", None)
             return name if isinstance(name, str) else getattr(value, "__name__", None)
+
+        for framework_type in (MeasurementType, PageInfo, StoredFile, StoredImage):
+            framework_name = _type_name(framework_type)
+            if framework_name == generated_name:
+                raise GraphQLOutputTypeError.registry_collision(
+                    generated_name,
+                    "framework GraphQL type",
+                    framework_name,
+                )
 
         registry_sources: tuple[
             tuple[str, Mapping[str, object], frozenset[str], bool], ...

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -13,6 +13,7 @@ from typing import (
     AsyncIterator,
     Callable,
     ClassVar,
+    ForwardRef,
     Generator,
     Iterable,
     Mapping,
@@ -176,6 +177,26 @@ GraphQLMutationMap = dict[str, type[graphene.Mutation]]
 _SUBSCRIPTION_CLEANUP_FAILURE_MESSAGE = "subscription cleanup failed"
 _SUBSCRIPTION_ROLLBACK_FAILURE_MESSAGE = "subscription setup and rollback failed"
 _SUBSCRIPTION_STREAM_CLEANUP_FAILURE_MESSAGE = "subscription stream and cleanup failed"
+
+
+def _contains_graphql_output_type(
+    annotation: object,
+    output_classes: Mapping[str, type[GraphQLType]],
+) -> bool:
+    """Return whether an annotation contains a registered GraphQL output class."""
+    if isinstance(annotation, ForwardRef):
+        annotation = annotation.__forward_arg__
+    if isinstance(annotation, str):
+        name = annotation.strip()
+        if len(name) >= 2 and name[0] == name[-1] and name[0] in {"'", '"'}:
+            name = name[1:-1].strip()
+        return name in output_classes
+    if safe_issubclass(annotation, GraphQLType):
+        return True
+    return any(
+        _contains_graphql_output_type(argument, output_classes)
+        for argument in get_args(annotation)
+    )
 
 
 class GraphQLOutputTypeError(ValueError):
@@ -790,12 +811,37 @@ class GraphQL:
                     resolved_field_type,
                 )
 
+        output_classes = {
+            output_class.__name__: output_class
+            for output_class in get_registered_graphql_types()
+        }
+
         # handle GraphQLProperty attributes
         for (
             attr_name,
             attr_value,
         ) in generalManagerClass.Interface.get_graph_ql_properties().items():
             raw_hint = attr_value.graphql_type_hint
+
+            if _contains_graphql_output_type(raw_hint, output_classes):
+                mapped = map_graphql_output_annotation(
+                    raw_hint,
+                    owner_name=generalManagerClass.__name__,
+                    field_name=attr_name,
+                    manager_registry=cls.manager_registry,
+                    manager_type_registry=cls.graphql_type_registry,
+                    output_class_registry=output_classes,
+                    output_type_registry=cls.graphql_output_type_registry,
+                    measurement_type=MeasurementType,
+                    scalar_mapper=cls._map_field_to_graphene_base_type,
+                )
+                fields[attr_name] = mapped.field
+                fields[f"resolve_{attr_name}"] = cls._create_resolver(
+                    attr_name,
+                    cast(type, mapped.resolver_type),
+                )
+                continue
+
             origin = get_origin(raw_hint)
             type_args = [t for t in get_args(raw_hint) if t is not type(None)]
 

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -18,6 +18,8 @@ from typing import (
     Generator,
     Iterable,
     Mapping,
+    Annotated,
+    Literal,
     TYPE_CHECKING,
     SupportsIndex,
     SupportsInt,
@@ -192,6 +194,12 @@ def _contains_graphql_output_type(
         if len(name) >= 2 and name[0] == name[-1] and name[0] in {"'", '"'}:
             name = name[1:-1].strip()
         return name in output_classes
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        args = get_args(annotation)
+        return bool(args) and _contains_graphql_output_type(args[0], output_classes)
+    if origin is Literal:
+        return False
     if safe_issubclass(annotation, GraphQLType):
         return True
     return any(

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import Counter
 from contextlib import asynccontextmanager
 from copy import deepcopy
 import dataclasses
@@ -449,11 +450,11 @@ class GraphQL:
         """
         declarations = get_registered_graphql_types()
         declaration_names = [declaration.__name__ for declaration in declarations]
-        duplicate_names = {
-            name for name in declaration_names if declaration_names.count(name) > 1
-        }
+        duplicate_names = sorted(
+            name for name, count in Counter(declaration_names).items() if count > 1
+        )
         if duplicate_names:
-            duplicate_name = sorted(duplicate_names)[0]
+            duplicate_name = duplicate_names[0]
             raise GraphQLOutputTypeError.duplicate_declaration(duplicate_name)
 
         output_classes = dict(zip(declaration_names, declarations, strict=True))

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -503,25 +503,45 @@ class GraphQL:
             name = getattr(value, "name", None)
             return name if isinstance(name, str) else getattr(value, "__name__", None)
 
-        registry_sources: tuple[tuple[str, Mapping[str, object]], ...] = (
-            ("manager", cls.manager_registry),
-            ("manager GraphQL type", cls.graphql_type_registry),
-            ("output GraphQL type", cls.graphql_output_type_registry),
-            ("page GraphQL type", cls._page_type_registry),
+        registry_sources: tuple[
+            tuple[str, Mapping[str, object], frozenset[str], bool], ...
+        ] = (
+            ("manager", cls.manager_registry, frozenset((output_name,)), False),
+            (
+                "manager GraphQL type",
+                cls.graphql_type_registry,
+                frozenset((output_name,)),
+                True,
+            ),
+            (
+                "output GraphQL type",
+                cls.graphql_output_type_registry,
+                frozenset(),
+                True,
+            ),
+            (
+                "page GraphQL type",
+                cls._page_type_registry,
+                frozenset((generated_name,)),
+                True,
+            ),
             (
                 "subscription payload GraphQL type",
                 cls._subscription_payload_registry,
+                frozenset(),
+                True,
             ),
             (
                 "capability GraphQL type",
                 cls.graphql_capability_type_registry,
+                frozenset((generated_name,)),
+                True,
             ),
         )
-        for source_name, registry in registry_sources:
+        for source_name, registry, schema_keys, check_type_name in registry_sources:
             for registered_name, registered_type in registry.items():
-                if (
-                    registered_name in {output_name, generated_name}
-                    or _type_name(registered_type) == generated_name
+                if registered_name in schema_keys or (
+                    check_type_name and _type_name(registered_type) == generated_name
                 ):
                     raise GraphQLOutputTypeError.registry_collision(
                         generated_name,

--- a/src/general_manager/api/graphql.py
+++ b/src/general_manager/api/graphql.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from copy import deepcopy
+import dataclasses
 import re
 from time import perf_counter
 from types import UnionType
@@ -90,6 +91,11 @@ from general_manager.api.graphql_mutations import (
     generate_update_mutation_class as _generate_update_mutation_class_fn,
     generate_delete_mutation_class as _generate_delete_mutation_class_fn,
 )
+from general_manager.api.graphql_output import (
+    create_output_field_resolver,
+    map_graphql_output_annotation,
+    resolve_output_type_hints,
+)
 from general_manager.api.graphql_resolvers import (
     GraphQLSortInput,
     parse_input as _parse_input_fn,
@@ -119,6 +125,10 @@ from general_manager.api.graphql_search import (
     normalize_filter_input as _normalize_filter_input_fn,
 )
 from general_manager.api.notification_batching import _queue_notification
+from general_manager.api.graphql_type import (
+    GraphQLType,
+    get_registered_graphql_types,
+)
 from general_manager.api.graphql_subscriptions import (
     get_channel_layer_safe as _get_channel_layer_fn,
     group_name as _group_name_fn,
@@ -166,6 +176,43 @@ GraphQLMutationMap = dict[str, type[graphene.Mutation]]
 _SUBSCRIPTION_CLEANUP_FAILURE_MESSAGE = "subscription cleanup failed"
 _SUBSCRIPTION_ROLLBACK_FAILURE_MESSAGE = "subscription setup and rollback failed"
 _SUBSCRIPTION_STREAM_CLEANUP_FAILURE_MESSAGE = "subscription stream and cleanup failed"
+
+
+class GraphQLOutputTypeError(ValueError):
+    """Raised when an output declaration cannot be registered safely."""
+
+    @classmethod
+    def duplicate_declaration(cls, name: str) -> GraphQLOutputTypeError:
+        return cls(
+            f"Duplicate GraphQL output declaration name '{name}' is not allowed."
+        )
+
+    @classmethod
+    def already_registered(cls, generated_name: str) -> GraphQLOutputTypeError:
+        return cls(f"GraphQL output type '{generated_name}' is already registered.")
+
+    @classmethod
+    def registry_collision(
+        cls,
+        generated_name: str,
+        source_name: str,
+        registered_name: str,
+    ) -> GraphQLOutputTypeError:
+        return cls(
+            f"GraphQL output type '{generated_name}' collides with the "
+            f"registered {source_name} '{registered_name}'."
+        )
+
+    @classmethod
+    def schema_collision(
+        cls,
+        generated_name: str,
+        registered_name: str,
+    ) -> GraphQLOutputTypeError:
+        return cls(
+            f"GraphQL output type '{generated_name}' collides with the "
+            f"existing schema type '{registered_name}'."
+        )
 
 
 async def _cleanup_subscription_resources(
@@ -272,6 +319,7 @@ class GraphQL:
     _page_type_registry: ClassVar[dict[str, type[graphene.ObjectType]]] = {}
     _subscription_payload_registry: ClassVar[dict[str, type[graphene.ObjectType]]] = {}
     graphql_type_registry: ClassVar[dict[str, type[graphene.ObjectType]]] = {}
+    graphql_output_type_registry: ClassVar[dict[str, type[graphene.ObjectType]]] = {}
     graphql_filter_type_registry: ClassVar[
         dict[str, type[graphene.InputObjectType]]
     ] = {}
@@ -319,6 +367,7 @@ class GraphQL:
         cls._page_type_registry = {}
         cls._subscription_payload_registry = {}
         cls.graphql_type_registry = {}
+        cls.graphql_output_type_registry = {}
         cls.graphql_filter_type_registry = {}
         cls.graphql_capability_type_registry = {}
         cls.manager_registry = {}
@@ -356,12 +405,143 @@ class GraphQL:
             page_type_registry=dict(cls._page_type_registry),
             subscription_payload_registry=dict(cls._subscription_payload_registry),
             graphql_type_registry=dict(cls.graphql_type_registry),
+            graphql_output_type_registry=dict(cls.graphql_output_type_registry),
             graphql_filter_type_registry=dict(cls.graphql_filter_type_registry),
             graphql_capability_type_registry=dict(cls.graphql_capability_type_registry),
             manager_registry=dict(cls.manager_registry),
             search_union=cls._search_union,
             search_result_type=cls._search_result_type,
         )
+
+    @classmethod
+    def create_graphql_output_type(
+        cls,
+        output_class: type[GraphQLType],
+    ) -> type[graphene.ObjectType]:
+        """Generate and register a Graphene type for an output declaration.
+
+        Output declarations are value objects only: generating one never adds
+        query, mutation, or subscription fields and never registers a manager.
+        The declaration registry is process-wide, while generated types belong
+        to the current GraphQL registry lifecycle and are therefore reset by
+        :meth:`reset_registry`.
+        """
+        declarations = get_registered_graphql_types()
+        declaration_names = [declaration.__name__ for declaration in declarations]
+        duplicate_names = {
+            name for name in declaration_names if declaration_names.count(name) > 1
+        }
+        if duplicate_names:
+            duplicate_name = sorted(duplicate_names)[0]
+            raise GraphQLOutputTypeError.duplicate_declaration(duplicate_name)
+
+        output_classes = dict(zip(declaration_names, declarations, strict=True))
+        output_name = output_class.__name__
+        generated_name = f"{output_name}Type"
+        existing = cls.graphql_output_type_registry.get(output_name)
+        if existing is not None:
+            source = getattr(existing, "__graphql_output_declaration__", None)
+            if source is output_class:
+                return existing
+            raise GraphQLOutputTypeError.already_registered(generated_name)
+
+        cls._validate_graphql_output_type_name(
+            output_name=output_name,
+            generated_name=generated_name,
+        )
+
+        hints = resolve_output_type_hints(
+            output_class,
+            manager_registry=cls.manager_registry,
+            output_class_registry=output_classes,
+        )
+        fields: GraphQLFieldMap = {}
+        for declared_field in dataclasses.fields(output_class):
+            mapped = map_graphql_output_annotation(
+                hints[declared_field.name],
+                owner_name=output_name,
+                field_name=declared_field.name,
+                manager_registry=cls.manager_registry,
+                manager_type_registry=cls.graphql_type_registry,
+                output_class_registry=output_classes,
+                output_type_registry=cls.graphql_output_type_registry,
+                measurement_type=MeasurementType,
+                scalar_mapper=cls._map_field_to_graphene_base_type,
+            )
+            fields[declared_field.name] = mapped.field
+            fields[f"resolve_{declared_field.name}"] = create_output_field_resolver(
+                declared_field.name,
+                mapped.resolver_type,
+            )
+
+        generated = type(
+            generated_name,
+            (graphene.ObjectType,),
+            {
+                "__graphql_output_declaration__": output_class,
+                **fields,
+            },
+        )
+        cls.graphql_output_type_registry[output_name] = generated
+        return generated
+
+    @classmethod
+    def _validate_graphql_output_type_name(
+        cls,
+        *,
+        output_name: str,
+        generated_name: str,
+    ) -> None:
+        """Reject known GraphQL type-name collisions before registry mutation."""
+
+        def _type_name(value: object) -> str | None:
+            name = getattr(value, "_meta", None)
+            if name is not None:
+                name = getattr(name, "name", None)
+            if isinstance(name, str):
+                return name
+            name = getattr(value, "name", None)
+            return name if isinstance(name, str) else getattr(value, "__name__", None)
+
+        registry_sources: tuple[tuple[str, Mapping[str, object]], ...] = (
+            ("manager", cls.manager_registry),
+            ("manager GraphQL type", cls.graphql_type_registry),
+            ("output GraphQL type", cls.graphql_output_type_registry),
+            ("page GraphQL type", cls._page_type_registry),
+            (
+                "subscription payload GraphQL type",
+                cls._subscription_payload_registry,
+            ),
+            (
+                "capability GraphQL type",
+                cls.graphql_capability_type_registry,
+            ),
+        )
+        for source_name, registry in registry_sources:
+            for registered_name, registered_type in registry.items():
+                if (
+                    registered_name in {output_name, generated_name}
+                    or _type_name(registered_type) == generated_name
+                ):
+                    raise GraphQLOutputTypeError.registry_collision(
+                        generated_name,
+                        source_name,
+                        registered_name,
+                    )
+
+        schema = cls._schema
+        graphql_schema = getattr(schema, "graphql_schema", None)
+        type_map = getattr(graphql_schema, "type_map", None)
+        if isinstance(type_map, Mapping):
+            for registered_name, registered_type in type_map.items():
+                if (
+                    registered_name == generated_name
+                    or _type_name(registered_type) == generated_name
+                ):
+                    raise GraphQLOutputTypeError.schema_collision(
+                        generated_name,
+                        registered_name,
+                    )
 
     @staticmethod
     def _group_name(

--- a/src/general_manager/api/graphql_output.py
+++ b/src/general_manager/api/graphql_output.py
@@ -427,25 +427,59 @@ def resolve_output_type_hints(
     }
     localns.setdefault(owner_name, owner)
     try:
-        return get_type_hints(owner, globalns=globalns, localns=localns)
-    except (AttributeError, KeyError, NameError, TypeError, ValueError) as error:
-        missing = getattr(error, "name", None) or str(error)
-        raise _annotation_error(owner_name, "annotations", missing) from error
+        return get_type_hints(
+            owner,
+            globalns=globalns,
+            localns=localns,
+            include_extras=True,
+        )
+    except (AttributeError, KeyError, NameError, TypeError, ValueError):
+        raw_annotations: dict[str, object] = {}
+        if isinstance(owner, type):
+            for base in reversed(owner.__mro__):
+                raw_annotations.update(getattr(base, "__annotations__", {}))
+        else:
+            raw_annotations.update(getattr(owner, "__annotations__", {}))
+        if not raw_annotations:
+            raise _annotation_error(owner_name, "annotations", owner) from None
+
+        resolved: dict[str, object] = {}
+        for field_name, annotation in raw_annotations.items():
+            holder = type(
+                "_GraphQLOutputAnnotation",
+                (),
+                {"__annotations__": {"value": annotation}},
+            )
+            try:
+                resolved[field_name] = get_type_hints(
+                    holder,
+                    globalns=globalns,
+                    localns=localns,
+                    include_extras=True,
+                )["value"]
+            except (
+                AttributeError,
+                KeyError,
+                NameError,
+                TypeError,
+                ValueError,
+            ) as error:
+                raise _annotation_error(owner_name, field_name, annotation) from error
+        return resolved
 
 
 def _resolve_output_measurement(
     value: object,
     target_unit: str | None,
 ) -> object:
-    if isinstance(value, (list, tuple, set)):
-        converted = [
-            measurement_to_graphql_payload(item, target_unit) for item in value
-        ]
-        if isinstance(value, tuple):
-            return tuple(converted)
-        if isinstance(value, set):
-            return converted
-        return converted
+    if value is None or isinstance(value, Measurement):
+        return measurement_to_graphql_payload(value, target_unit)
+    if isinstance(value, list):
+        return [_resolve_output_measurement(item, target_unit) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_resolve_output_measurement(item, target_unit) for item in value)
+    if isinstance(value, set):
+        return [_resolve_output_measurement(item, target_unit) for item in value]
     return measurement_to_graphql_payload(value, target_unit)
 
 

--- a/src/general_manager/api/graphql_output.py
+++ b/src/general_manager/api/graphql_output.py
@@ -1,0 +1,477 @@
+"""Strict annotation mapping and resolvers for GraphQL output values."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from datetime import date, datetime
+from decimal import Decimal
+import sys
+from types import UnionType
+from typing import Any, ForwardRef, Union, get_args, get_origin, get_type_hints
+
+import graphene
+
+from general_manager.api.graphql_resolvers import measurement_to_graphql_payload
+from general_manager.api.graphql_type import GraphQLType
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.measurement.measurement import Measurement
+from general_manager.utils.type_checks import safe_issubclass
+
+
+@dataclass(frozen=True, slots=True)
+class MappedGraphQLOutput:
+    """Graphene field metadata and the Python value type for its resolver."""
+
+    field: object
+    resolver_type: object
+
+
+class GraphQLOutputAnnotationError(TypeError):
+    """Raised when an output declaration uses an unsupported annotation shape."""
+
+    def __init__(self, owner_name: str, field_name: str, annotation: object) -> None:
+        self.owner_name = owner_name
+        self.field_name = field_name
+        self.annotation = annotation
+        super().__init__(
+            f"Unsupported GraphQL field type for "
+            f"{owner_name}.{field_name}: {annotation!r}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _MappedAnnotation:
+    """Internal Graphene type metadata before a field wrapper is mounted."""
+
+    graphene_type: object
+    resolver_type: object
+    nullable: bool
+    contains_measurement: bool
+
+
+def _annotation_error(
+    owner_name: str,
+    field_name: str,
+    annotation: object,
+) -> GraphQLOutputAnnotationError:
+    return GraphQLOutputAnnotationError(owner_name, field_name, annotation)
+
+
+def _is_union(annotation: object) -> bool:
+    origin = get_origin(annotation)
+    return origin in (Union, UnionType)
+
+
+def _unwrap_optional_annotation(
+    annotation: object,
+    *,
+    owner_name: str,
+    field_name: str,
+) -> tuple[bool, object]:
+    """Return nullable status and the sole non-``None`` union member."""
+    if _is_union(annotation):
+        members = get_args(annotation)
+        if len(members) == 2 and type(None) in members:
+            concrete = next(member for member in members if member is not type(None))
+            return True, concrete
+        raise _annotation_error(owner_name, field_name, annotation)
+    if annotation is None or annotation is type(None):
+        raise _annotation_error(owner_name, field_name, annotation)
+    return False, annotation
+
+
+def _registry_name_for_class(
+    annotation: object,
+    registry: Mapping[str, type[object]],
+) -> str | None:
+    """Find the live registry key for a declared class without copying it."""
+    if not isinstance(annotation, type):
+        return None
+    class_name = annotation.__name__
+    if registry.get(class_name) is annotation:
+        return class_name
+    for name, registered in registry.items():
+        if registered is annotation:
+            return name
+    return None
+
+
+def _resolve_registered_name(
+    annotation: object,
+    *,
+    owner_name: str,
+    field_name: str,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    output_class_registry: Mapping[str, type[GraphQLType]],
+) -> object:
+    """Resolve a simple forward-reference name through the live registries."""
+    if isinstance(annotation, ForwardRef):
+        annotation = annotation.__forward_arg__
+    if not isinstance(annotation, str):
+        return annotation
+
+    name = annotation.strip()
+    if len(name) >= 2 and name[0] == name[-1] and name[0] in {"'", '"'}:
+        name = name[1:-1].strip()
+    manager_type = manager_registry.get(name)
+    output_type = output_class_registry.get(name)
+    if manager_type is not None and output_type is not None:
+        raise _annotation_error(owner_name, field_name, annotation)
+    if manager_type is not None:
+        return manager_type
+    if output_type is not None:
+        return output_type
+    return annotation
+
+
+def _lazy_registry_type(
+    registry: Mapping[str, type[graphene.ObjectType]],
+    name: str,
+) -> Callable[[], type[graphene.ObjectType]]:
+    """Return a Graphene thunk that reads a generated registry at resolution time."""
+    return lambda: registry[name]
+
+
+def _map_collection_annotation(
+    annotation: object,
+    *,
+    owner_name: str,
+    field_name: str,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    manager_type_registry: Mapping[str, type[graphene.ObjectType]],
+    output_class_registry: Mapping[str, type[GraphQLType]],
+    output_type_registry: Mapping[str, type[graphene.ObjectType]],
+    measurement_type: type[graphene.ObjectType],
+    scalar_mapper: Callable[[type], type],
+) -> _MappedAnnotation:
+    origin = get_origin(annotation)
+    if origin not in (list, tuple, set):
+        raise _annotation_error(owner_name, field_name, annotation)
+
+    args = get_args(annotation)
+    if origin is tuple:
+        if len(args) != 2 or args[1] is not Ellipsis:
+            raise _annotation_error(owner_name, field_name, annotation)
+        element_annotation = args[0]
+    else:
+        if len(args) != 1:
+            raise _annotation_error(owner_name, field_name, annotation)
+        element_annotation = args[0]
+
+    element = _map_annotation(
+        element_annotation,
+        owner_name=owner_name,
+        field_name=field_name,
+        manager_registry=manager_registry,
+        manager_type_registry=manager_type_registry,
+        output_class_registry=output_class_registry,
+        output_type_registry=output_type_registry,
+        measurement_type=measurement_type,
+        scalar_mapper=scalar_mapper,
+    )
+    element_type = element.graphene_type
+    if not element.nullable:
+        element_type = graphene.NonNull(element_type)
+    return _MappedAnnotation(
+        graphene.List(element_type),
+        element.resolver_type,
+        nullable=False,
+        contains_measurement=element.contains_measurement,
+    )
+
+
+def _map_non_optional_value(
+    annotation: object,
+    *,
+    owner_name: str,
+    field_name: str,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    manager_type_registry: Mapping[str, type[graphene.ObjectType]],
+    output_class_registry: Mapping[str, type[GraphQLType]],
+    output_type_registry: Mapping[str, type[graphene.ObjectType]],
+    measurement_type: type[graphene.ObjectType],
+    scalar_mapper: Callable[[type], type],
+) -> _MappedAnnotation:
+    annotation = _resolve_registered_name(
+        annotation,
+        owner_name=owner_name,
+        field_name=field_name,
+        manager_registry=manager_registry,
+        output_class_registry=output_class_registry,
+    )
+    if annotation is Any:
+        raise _annotation_error(owner_name, field_name, annotation)
+
+    if annotation in (list, tuple, set):
+        raise _annotation_error(owner_name, field_name, annotation)
+
+    origin = get_origin(annotation)
+    if origin is not None:
+        if _is_union(annotation):
+            raise _annotation_error(owner_name, field_name, annotation)
+        return _map_collection_annotation(
+            annotation,
+            owner_name=owner_name,
+            field_name=field_name,
+            manager_registry=manager_registry,
+            manager_type_registry=manager_type_registry,
+            output_class_registry=output_class_registry,
+            output_type_registry=output_type_registry,
+            measurement_type=measurement_type,
+            scalar_mapper=scalar_mapper,
+        )
+
+    if safe_issubclass(annotation, GraphQLType):
+        output_name = _registry_name_for_class(annotation, output_class_registry)
+        if output_name is None:
+            raise _annotation_error(owner_name, field_name, annotation)
+        return _MappedAnnotation(
+            _lazy_registry_type(output_type_registry, output_name),
+            annotation,
+            nullable=False,
+            contains_measurement=False,
+        )
+
+    if safe_issubclass(annotation, GeneralManager):
+        manager_name = _registry_name_for_class(annotation, manager_registry)
+        if manager_name is None:
+            raise _annotation_error(owner_name, field_name, annotation)
+        return _MappedAnnotation(
+            _lazy_registry_type(manager_type_registry, manager_name),
+            annotation,
+            nullable=False,
+            contains_measurement=False,
+        )
+
+    if safe_issubclass(annotation, Measurement):
+        return _MappedAnnotation(
+            measurement_type,
+            annotation,
+            nullable=False,
+            contains_measurement=True,
+        )
+
+    if not isinstance(annotation, type):
+        raise _annotation_error(owner_name, field_name, annotation)
+
+    # Keep this allowlist explicit.  The legacy mapper intentionally falls back
+    # to String for unknown classes, which is unsafe for output declarations.
+    if safe_issubclass(annotation, bool):
+        scalar_type = scalar_mapper(annotation)
+    elif safe_issubclass(annotation, str):
+        scalar_type = scalar_mapper(annotation)
+    elif safe_issubclass(annotation, int):
+        scalar_type = scalar_mapper(annotation)
+    elif safe_issubclass(annotation, (float, Decimal)):
+        scalar_type = scalar_mapper(annotation)
+    elif safe_issubclass(annotation, datetime):
+        scalar_type = scalar_mapper(annotation)
+    elif safe_issubclass(annotation, date):
+        scalar_type = scalar_mapper(annotation)
+    else:
+        raise _annotation_error(owner_name, field_name, annotation)
+    return _MappedAnnotation(
+        scalar_type,
+        annotation,
+        nullable=False,
+        contains_measurement=False,
+    )
+
+
+def _map_annotation(
+    annotation: object,
+    *,
+    owner_name: str,
+    field_name: str,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    manager_type_registry: Mapping[str, type[graphene.ObjectType]],
+    output_class_registry: Mapping[str, type[GraphQLType]],
+    output_type_registry: Mapping[str, type[graphene.ObjectType]],
+    measurement_type: type[graphene.ObjectType],
+    scalar_mapper: Callable[[type], type],
+) -> _MappedAnnotation:
+    nullable, concrete = _unwrap_optional_annotation(
+        annotation,
+        owner_name=owner_name,
+        field_name=field_name,
+    )
+    mapped = _map_non_optional_value(
+        concrete,
+        owner_name=owner_name,
+        field_name=field_name,
+        manager_registry=manager_registry,
+        manager_type_registry=manager_type_registry,
+        output_class_registry=output_class_registry,
+        output_type_registry=output_type_registry,
+        measurement_type=measurement_type,
+        scalar_mapper=scalar_mapper,
+    )
+    return replace(mapped, nullable=nullable)
+
+
+def _map_non_optional_annotation(
+    annotation: object,
+    *,
+    owner_name: str,
+    field_name: str,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    manager_type_registry: Mapping[str, type[graphene.ObjectType]],
+    output_class_registry: Mapping[str, type[GraphQLType]],
+    output_type_registry: Mapping[str, type[graphene.ObjectType]],
+    measurement_type: type[graphene.ObjectType],
+    scalar_mapper: Callable[[type], type],
+) -> MappedGraphQLOutput:
+    """Map one non-optional annotation to a required Graphene field."""
+    mapped = _map_non_optional_value(
+        annotation,
+        owner_name=owner_name,
+        field_name=field_name,
+        manager_registry=manager_registry,
+        manager_type_registry=manager_type_registry,
+        output_class_registry=output_class_registry,
+        output_type_registry=output_type_registry,
+        measurement_type=measurement_type,
+        scalar_mapper=scalar_mapper,
+    )
+    field_kwargs: dict[str, object] = {}
+    if mapped.contains_measurement:
+        field_kwargs["target_unit"] = graphene.String()
+    return MappedGraphQLOutput(
+        graphene.Field(mapped.graphene_type, required=True, **field_kwargs),
+        mapped.resolver_type,
+    )
+
+
+def _set_output_nullability(
+    mapped: MappedGraphQLOutput,
+    *,
+    nullable: bool,
+) -> MappedGraphQLOutput:
+    """Apply the outer field's nullability while preserving field arguments."""
+    if not nullable:
+        return mapped
+    field = mapped.field
+    if not isinstance(field, graphene.Field):
+        return mapped
+    field_type = field.type
+    if isinstance(field_type, graphene.NonNull):
+        field_type = field_type.of_type
+    return replace(
+        mapped,
+        field=graphene.Field(
+            field_type,
+            args=field.args,
+            resolver=field.resolver,
+            deprecation_reason=field.deprecation_reason,
+            name=field.name,
+            description=field.description,
+            required=False,
+            default_value=field.default_value,
+        ),
+    )
+
+
+def map_graphql_output_annotation(
+    annotation: object,
+    *,
+    owner_name: str,
+    field_name: str,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    manager_type_registry: Mapping[str, type[graphene.ObjectType]],
+    output_class_registry: Mapping[str, type[GraphQLType]],
+    output_type_registry: Mapping[str, type[graphene.ObjectType]],
+    measurement_type: type[graphene.ObjectType],
+    scalar_mapper: Callable[[type], type],
+) -> MappedGraphQLOutput:
+    """Map a strict GraphQL output annotation to a mounted Graphene field."""
+    nullable, concrete_type = _unwrap_optional_annotation(
+        annotation,
+        owner_name=owner_name,
+        field_name=field_name,
+    )
+    try:
+        mapped = _map_non_optional_annotation(
+            concrete_type,
+            owner_name=owner_name,
+            field_name=field_name,
+            manager_registry=manager_registry,
+            manager_type_registry=manager_type_registry,
+            output_class_registry=output_class_registry,
+            output_type_registry=output_type_registry,
+            measurement_type=measurement_type,
+            scalar_mapper=scalar_mapper,
+        )
+    except GraphQLOutputAnnotationError as error:
+        # Preserve the annotation written on the owning field in diagnostics,
+        # even when an invalid collection element was the first failure.
+        if error.annotation is not annotation:
+            raise _annotation_error(owner_name, field_name, annotation) from error
+        raise
+    return _set_output_nullability(mapped, nullable=nullable)
+
+
+def resolve_output_type_hints(
+    owner: type[object] | Callable[..., object],
+    *,
+    manager_registry: Mapping[str, type[GeneralManager]],
+    output_class_registry: Mapping[str, type[GraphQLType]],
+) -> dict[str, object]:
+    """Resolve output annotations using the live manager/output declarations."""
+    owner_name = getattr(owner, "__name__", type(owner).__name__)
+    module = sys.modules.get(getattr(owner, "__module__", ""))
+    globalns = vars(module) if module is not None else {}
+    localns: dict[str, object] = {
+        **manager_registry,
+        **output_class_registry,
+    }
+    localns.setdefault(owner_name, owner)
+    try:
+        return get_type_hints(owner, globalns=globalns, localns=localns)
+    except (AttributeError, KeyError, NameError, TypeError, ValueError) as error:
+        missing = getattr(error, "name", None) or str(error)
+        raise _annotation_error(owner_name, "annotations", missing) from error
+
+
+def _resolve_output_measurement(
+    value: object,
+    target_unit: str | None,
+) -> object:
+    if isinstance(value, (list, tuple, set)):
+        converted = [
+            measurement_to_graphql_payload(item, target_unit) for item in value
+        ]
+        if isinstance(value, tuple):
+            return tuple(converted)
+        if isinstance(value, set):
+            return converted
+        return converted
+    return measurement_to_graphql_payload(value, target_unit)
+
+
+def create_output_field_resolver(
+    field_name: str,
+    resolver_type: object | None = None,
+) -> Callable[..., object]:
+    """Build a resolver for a field on a materialized GraphQL output value.
+
+    Unlike manager resolvers this function never checks permissions or
+    historical context.  Measurement values share the manager conversion
+    helper so ``target_unit`` behaves identically in both resolver paths.
+    """
+
+    def resolver(
+        parent: object,
+        info: object | None = None,
+        target_unit: str | None = None,
+        **kwargs: object,
+    ) -> object:
+        del info, kwargs
+        value = getattr(parent, field_name)
+        if safe_issubclass(resolver_type, Measurement) or isinstance(
+            value, Measurement
+        ):
+            return _resolve_output_measurement(value, target_unit)
+        return value
+
+    return resolver

--- a/src/general_manager/api/graphql_output.py
+++ b/src/general_manager/api/graphql_output.py
@@ -356,7 +356,10 @@ def _set_output_nullability(
         return mapped
     field_type = field.type
     if isinstance(field_type, graphene.NonNull):
-        field_type = field_type.of_type
+        # ``of_type`` resolves Graphene thunks immediately.  Output types are
+        # generated after manager interfaces, so keep a lazy output registry
+        # lookup unresolved until the schema is assembled.
+        field_type = field_type._of_type
     return replace(
         mapped,
         field=graphene.Field(

--- a/src/general_manager/api/graphql_output.py
+++ b/src/general_manager/api/graphql_output.py
@@ -321,8 +321,9 @@ def _map_non_optional_annotation(
     output_type_registry: Mapping[str, type[graphene.ObjectType]],
     measurement_type: type[graphene.ObjectType],
     scalar_mapper: Callable[[type], type],
+    required: bool,
 ) -> MappedGraphQLOutput:
-    """Map one non-optional annotation to a required Graphene field."""
+    """Map one non-optional annotation to a Graphene field."""
     mapped = _map_non_optional_value(
         annotation,
         owner_name=owner_name,
@@ -338,40 +339,8 @@ def _map_non_optional_annotation(
     if mapped.contains_measurement:
         field_kwargs["target_unit"] = graphene.String()
     return MappedGraphQLOutput(
-        graphene.Field(mapped.graphene_type, required=True, **field_kwargs),
+        graphene.Field(mapped.graphene_type, required=required, **field_kwargs),
         mapped.resolver_type,
-    )
-
-
-def _set_output_nullability(
-    mapped: MappedGraphQLOutput,
-    *,
-    nullable: bool,
-) -> MappedGraphQLOutput:
-    """Apply the outer field's nullability while preserving field arguments."""
-    if not nullable:
-        return mapped
-    field = mapped.field
-    if not isinstance(field, graphene.Field):
-        return mapped
-    field_type = field.type
-    if isinstance(field_type, graphene.NonNull):
-        # ``of_type`` resolves Graphene thunks immediately.  Output types are
-        # generated after manager interfaces, so keep a lazy output registry
-        # lookup unresolved until the schema is assembled.
-        field_type = field_type._of_type
-    return replace(
-        mapped,
-        field=graphene.Field(
-            field_type,
-            args=field.args,
-            resolver=field.resolver,
-            deprecation_reason=field.deprecation_reason,
-            name=field.name,
-            description=field.description,
-            required=False,
-            default_value=field.default_value,
-        ),
     )
 
 
@@ -404,6 +373,7 @@ def map_graphql_output_annotation(
             output_type_registry=output_type_registry,
             measurement_type=measurement_type,
             scalar_mapper=scalar_mapper,
+            required=not nullable,
         )
     except GraphQLOutputAnnotationError as error:
         # Preserve the annotation written on the owning field in diagnostics,
@@ -411,7 +381,7 @@ def map_graphql_output_annotation(
         if error.annotation is not annotation:
             raise _annotation_error(owner_name, field_name, annotation) from error
         raise
-    return _set_output_nullability(mapped, nullable=nullable)
+    return mapped
 
 
 def resolve_output_type_hints(

--- a/src/general_manager/api/graphql_resolvers.py
+++ b/src/general_manager/api/graphql_resolvers.py
@@ -792,6 +792,28 @@ def can_read_instance(
 # ---------------------------------------------------------------------------
 
 
+def measurement_to_graphql_payload(
+    value: object,
+    target_unit: str | None = None,
+) -> dict[str, object] | None:
+    """Convert a measurement value to the payload consumed by ``MeasurementType``.
+
+    This helper deliberately performs no manager permission or historical-context
+    checks.  Those checks belong to the resolver that owns the value; output
+    dataclasses are already materialized values and must not be treated as
+    managers.  ``target_unit`` is applied before the magnitude/unit payload is
+    built so manager and output resolvers share one conversion implementation.
+    """
+    if not isinstance(value, Measurement):
+        return None
+    if target_unit:
+        value = value.to(target_unit)
+    return {
+        "value": value.quantity.magnitude,
+        "unit": value.unit,
+    }
+
+
 def create_measurement_resolver(field_name: str) -> Resolver:
     """
     Return a resolver for a :class:`~general_manager.measurement.Measurement` field.
@@ -810,15 +832,10 @@ def create_measurement_resolver(field_name: str) -> Resolver:
         _ensure_as_of_compatible(self)
 
         def resolve_measurement() -> dict[str, object] | None:
-            result = getattr(self, field_name)
-            if not isinstance(result, Measurement):
-                return None
-            if target_unit:
-                result = result.to(target_unit)
-            return {
-                "value": result.quantity.magnitude,
-                "unit": result.unit,
-            }
+            return measurement_to_graphql_payload(
+                getattr(self, field_name),
+                target_unit,
+            )
 
         return resolve_with_read_permission(
             self,

--- a/src/general_manager/api/graphql_type.py
+++ b/src/general_manager/api/graphql_type.py
@@ -40,5 +40,8 @@ def get_registered_graphql_types() -> tuple[type[GraphQLType], ...]:
 def _restore_registered_graphql_types(
     types: tuple[type[GraphQLType], ...],
 ) -> None:
-    """Restore the declaration registry to a previously captured snapshot."""
+    """Restore a declaration registry snapshot for test/integration cleanup.
+
+    This is test infrastructure, not a public registry-reset API.
+    """
     GraphQLTypeMeta._registered_types[:] = types

--- a/src/general_manager/api/graphql_type.py
+++ b/src/general_manager/api/graphql_type.py
@@ -1,0 +1,44 @@
+"""Frozen value declarations for GraphQL output objects."""
+
+from __future__ import annotations
+
+from dataclasses import Field, dataclass, field
+from typing import ClassVar, cast, dataclass_transform
+
+
+@dataclass_transform(field_specifiers=(Field, field), frozen_default=True)
+class GraphQLTypeMeta(type):
+    """Create and register frozen dataclass-based GraphQL output declarations."""
+
+    _registered_types: ClassVar[list[type[GraphQLType]]] = []
+
+    def __new__(
+        mcls: type[GraphQLTypeMeta],
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, object],
+    ) -> type[GraphQLType]:
+        created = cast(
+            "type[GraphQLType]",
+            type.__new__(mcls, name, bases, namespace),
+        )
+        if bases:
+            created = dataclass(frozen=True)(created)
+            mcls._registered_types.append(created)
+        return created
+
+
+class GraphQLType(metaclass=GraphQLTypeMeta):
+    """Frozen annotated value exposed only as a GraphQL output object."""
+
+
+def get_registered_graphql_types() -> tuple[type[GraphQLType], ...]:
+    """Return the declared GraphQL output types in creation order."""
+    return tuple(GraphQLTypeMeta._registered_types)
+
+
+def _restore_registered_graphql_types(
+    types: tuple[type[GraphQLType], ...],
+) -> None:
+    """Restore the declaration registry to a previously captured snapshot."""
+    GraphQLTypeMeta._registered_types[:] = types

--- a/src/general_manager/api/registry.py
+++ b/src/general_manager/api/registry.py
@@ -64,6 +64,9 @@ class GraphQLRegistry:
     graphql_type_registry: dict[str, type[graphene.ObjectType]] = field(
         default_factory=dict
     )
+    graphql_output_type_registry: dict[str, type[graphene.ObjectType]] = field(
+        default_factory=dict
+    )
     graphql_filter_type_registry: dict[str, type[graphene.InputObjectType]] = field(
         default_factory=dict
     )

--- a/src/general_manager/bootstrap.py
+++ b/src/general_manager/bootstrap.py
@@ -44,6 +44,7 @@ from graphql import (
 from general_manager.api.graphql_as_of import build_as_of_directive
 from general_manager.api.graphql_view import GeneralManagerGraphQLView
 from general_manager.api.graphql import GraphQL
+from general_manager.api.graphql_type import get_registered_graphql_types
 from general_manager.api.remote_api import add_remote_api_urls
 from general_manager.api.remote_invalidation import ensure_remote_invalidation_route
 from general_manager.conf import get_setting
@@ -558,6 +559,9 @@ def handle_graph_ql(
         GraphQL.create_graphql_interface(general_manager_class)
         GraphQL.create_graphql_mutation(general_manager_class)
 
+    for output_class in get_registered_graphql_types():
+        GraphQL.create_graphql_output_type(output_class)
+
     GraphQL.register_file_upload_mutation()
     GraphQL.register_search_query()
     GraphQL.register_current_user_capabilities()
@@ -587,7 +591,10 @@ def handle_graph_ql(
 
     schema_kwargs: dict[str, object] = {
         "query": GraphQL._query_class,
-        "types": (graphene.DateTime,),
+        "types": (
+            graphene.DateTime,
+            *GraphQL.graphql_output_type_registry.values(),
+        ),
     }
     if GraphQL._mutation_class is not None:
         schema_kwargs["mutation"] = GraphQL._mutation_class

--- a/src/general_manager/public_api_registry.py
+++ b/src/general_manager/public_api_registry.py
@@ -14,6 +14,7 @@ LazyExportMap = Mapping[str, str | tuple[str, str]]
 
 GENERAL_MANAGER_EXPORTS: LazyExportMap = {
     "GraphQL": ("general_manager.api.graphql", "GraphQL"),
+    "GraphQLType": ("general_manager.api.graphql_type", "GraphQLType"),
     "graph_ql_property": ("general_manager.api.property", "graph_ql_property"),
     "graph_ql_mutation": ("general_manager.api.mutation", "graph_ql_mutation"),
     "GeneralManager": ("general_manager.manager.general_manager", "GeneralManager"),

--- a/tests/integration/test_graphql_output_types.py
+++ b/tests/integration/test_graphql_output_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import ClassVar, Literal
 from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
@@ -19,6 +20,13 @@ from general_manager.interface import CalculationInterface
 from general_manager.manager.general_manager import GeneralManager
 from general_manager.manager.input import Input
 from general_manager.measurement.measurement import Measurement
+from general_manager.permission.base_permission import (
+    BasePermission,
+    ReadPermissionPlan,
+)
+
+
+_PRE_MODULE_DECLARATIONS = get_registered_graphql_types()
 
 
 class IntegrationProjectHour(GraphQLType):
@@ -30,6 +38,95 @@ class IntegrationProjectHour(GraphQLType):
 class IntegrationProjectDetails(GraphQLType):
     hour: IntegrationProjectHour
     label: str
+
+
+class PermissionedRelatedManager(GeneralManager):
+    class Permission(BasePermission):
+        checks: ClassVar[list[str]] = []
+
+        def check_permission(
+            self,
+            action: Literal["create", "read", "update", "delete"],
+            attribute: str,
+        ) -> bool:
+            del action
+            type(self).checks.append(attribute)
+            return attribute == "allowed"
+
+        def check_operation_permission(
+            self,
+            action: Literal["create", "read", "update", "delete"],
+        ) -> bool:
+            del action
+            return True
+
+        def describe_operation_permissions(
+            self,
+            action: Literal["create", "read", "update", "delete"],
+        ) -> tuple[str, ...]:
+            del action
+            return ()
+
+        def get_read_permission_plan(self) -> ReadPermissionPlan:
+            return ReadPermissionPlan(filters=[], requires_instance_check=False)
+
+    class Interface(CalculationInterface):
+        related_id = Input(int)
+
+    @graph_ql_property(cache="none")
+    def allowed(self) -> str:
+        return "visible"
+
+    @graph_ql_property(cache="none")
+    def denied(self) -> str:
+        return "hidden"
+
+
+class IntegrationPermissionDetails(GraphQLType):
+    label: str
+    related: PermissionedRelatedManager
+
+
+class PermissionedProjectSummary(GeneralManager):
+    class Permission(BasePermission):
+        checks: ClassVar[list[str]] = []
+        allow_details: ClassVar[bool] = True
+
+        def check_permission(
+            self,
+            action: Literal["create", "read", "update", "delete"],
+            attribute: str,
+        ) -> bool:
+            del action
+            type(self).checks.append(attribute)
+            return attribute != "details" or type(self).allow_details
+
+        def check_operation_permission(
+            self,
+            action: Literal["create", "read", "update", "delete"],
+        ) -> bool:
+            del action
+            return True
+
+        def describe_operation_permissions(
+            self,
+            action: Literal["create", "read", "update", "delete"],
+        ) -> tuple[str, ...]:
+            del action
+            return ()
+
+        def get_read_permission_plan(self) -> ReadPermissionPlan:
+            return ReadPermissionPlan(filters=[], requires_instance_check=False)
+
+    class Interface(CalculationInterface):
+        project_id = Input(int)
+
+    @graph_ql_property(cache="none")
+    def details(self) -> IntegrationPermissionDetails | None:
+        return IntegrationPermissionDetails(
+            label="permissioned",
+            related=PermissionedRelatedManager(related_id=7),
+        )
 
 
 class ProjectSummary(GeneralManager):
@@ -62,6 +159,9 @@ class ProjectSummary(GeneralManager):
         )
 
 
+_restore_registered_graphql_types(_PRE_MODULE_DECLARATIONS)
+
+
 def _restore_graphql_registry(snapshot: object) -> None:
     GraphQL._query_class = snapshot.query_class  # type: ignore[attr-defined]
     GraphQL._mutation_class = snapshot.mutation_class  # type: ignore[attr-defined]
@@ -89,14 +189,35 @@ def _restore_graphql_registry(snapshot: object) -> None:
     GraphQL._search_result_type = snapshot.search_result_type  # type: ignore[attr-defined]
 
 
+def _restore_and_assert_registries(
+    graphql_snapshot: object,
+    declaration_snapshot: tuple[type[GraphQLType], ...],
+) -> None:
+    _restore_graphql_registry(graphql_snapshot)
+    _restore_registered_graphql_types(declaration_snapshot)
+    assert GraphQL.get_registry_snapshot() == graphql_snapshot
+    assert get_registered_graphql_types() == declaration_snapshot
+
+
+def _activate_declarations(
+    *required: type[GraphQLType],
+) -> None:
+    _restore_registered_graphql_types((*_PRE_MODULE_DECLARATIONS, *required))
+
+
 class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
     def setUp(self) -> None:
         super().setUp()
         graphql_registry = GraphQL.get_registry_snapshot()
-        declaration_registry = get_registered_graphql_types()
-        self.addCleanup(_restore_graphql_registry, graphql_registry)
-        self.addCleanup(_restore_registered_graphql_types, declaration_registry)
+        self.addCleanup(
+            _restore_and_assert_registries,
+            graphql_registry,
+            _PRE_MODULE_DECLARATIONS,
+        )
         GraphQL.reset_registry()
+        _restore_registered_graphql_types(_PRE_MODULE_DECLARATIONS)
+        self.assertEqual(get_registered_graphql_types(), _PRE_MODULE_DECLARATIONS)
+        _activate_declarations(IntegrationProjectHour, IntegrationProjectDetails)
 
         with (
             patch.object(GraphQL, "register_file_upload_mutation"),
@@ -151,8 +272,127 @@ class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
 
         query_fields = self.schema.graphql_schema.query_type.fields
         self.assertIn("projectSummary", query_fields)
-        self.assertNotIn("projectHour", query_fields)
-        self.assertNotIn("projectHourList", query_fields)
+        self.assertNotIn("integrationProjectHour", query_fields)
+        self.assertNotIn("integrationProjectHourList", query_fields)
+        self.assertNotIn("integrationProjectDetails", query_fields)
+        self.assertNotIn("integrationProjectDetailsList", query_fields)
         self.assertIsNotNone(
             self.schema.graphql_schema.get_type("IntegrationProjectHourType")
+        )
+
+
+class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        graphql_registry = GraphQL.get_registry_snapshot()
+        self.addCleanup(
+            _restore_and_assert_registries,
+            graphql_registry,
+            _PRE_MODULE_DECLARATIONS,
+        )
+        GraphQL.reset_registry()
+        _restore_registered_graphql_types(_PRE_MODULE_DECLARATIONS)
+        self.assertEqual(get_registered_graphql_types(), _PRE_MODULE_DECLARATIONS)
+        _activate_declarations(IntegrationPermissionDetails)
+        PermissionedRelatedManager.Permission.checks.clear()
+        PermissionedProjectSummary.Permission.checks.clear()
+        PermissionedProjectSummary.Permission.allow_details = True
+
+        with (
+            patch.object(GraphQL, "register_file_upload_mutation"),
+            patch.object(GraphQL, "register_search_query"),
+            patch("general_manager.uploads.urls.add_file_upload_urls"),
+            patch("general_manager.bootstrap.add_graphql_url"),
+        ):
+            handle_graph_ql([PermissionedRelatedManager, PermissionedProjectSummary])
+
+        schema = GraphQL.get_schema()
+        self.assertIsNotNone(schema)
+        self.schema = schema
+
+    def _execute(self, query: str):
+        return self.schema.execute(
+            query,
+            context_value=SimpleNamespace(user=AnonymousUser()),
+        )
+
+    def test_nested_manager_permissions_and_owner_property_permissions_are_preserved(
+        self,
+    ) -> None:
+        ordinary = self._execute(
+            """
+            query {
+                permissionedProjectSummary(projectId: 3) {
+                    details { label }
+                }
+            }
+            """
+        )
+
+        self.assertIsNone(ordinary.errors)
+        self.assertEqual(
+            ordinary.data,
+            {"permissionedProjectSummary": {"details": {"label": "permissioned"}}},
+        )
+        self.assertEqual(PermissionedProjectSummary.Permission.checks, ["details"])
+        self.assertEqual(PermissionedRelatedManager.Permission.checks, [])
+
+        nested = self._execute(
+            """
+            query {
+                permissionedProjectSummary(projectId: 3) {
+                    details { label related { allowed denied } }
+                }
+            }
+            """
+        )
+
+        self.assertIsNone(nested.errors)
+        self.assertEqual(
+            nested.data,
+            {
+                "permissionedProjectSummary": {
+                    "details": {
+                        "label": "permissioned",
+                        "related": {"allowed": "visible", "denied": None},
+                    }
+                }
+            },
+        )
+        self.assertEqual(
+            PermissionedProjectSummary.Permission.checks,
+            ["details", "details"],
+        )
+        self.assertEqual(
+            PermissionedRelatedManager.Permission.checks,
+            ["allowed", "denied"],
+        )
+
+        query_fields = self.schema.graphql_schema.query_type.fields
+        self.assertNotIn("integrationPermissionDetails", query_fields)
+        self.assertNotIn("integrationPermissionDetailsList", query_fields)
+
+        PermissionedProjectSummary.Permission.allow_details = False
+        denied = self._execute(
+            """
+            query {
+                permissionedProjectSummary(projectId: 3) {
+                    details { label related { allowed } }
+                }
+            }
+            """
+        )
+
+        self.assertIsNone(denied.errors)
+        self.assertEqual(
+            denied.data,
+            {"permissionedProjectSummary": {"details": None}},
+        )
+        self.assertEqual(
+            PermissionedProjectSummary.Permission.checks,
+            ["details", "details", "details"],
+        )
+        self.assertEqual(
+            PermissionedRelatedManager.Permission.checks,
+            ["allowed", "denied"],
         )

--- a/tests/integration/test_graphql_output_types.py
+++ b/tests/integration/test_graphql_output_types.py
@@ -162,6 +162,10 @@ class ProjectSummary(GeneralManager):
 _restore_registered_graphql_types(_PRE_MODULE_DECLARATIONS)
 
 
+class PostBaselineSentinel(GraphQLType):
+    marker: str
+
+
 def _restore_graphql_registry(snapshot: object) -> None:
     GraphQL._query_class = snapshot.query_class  # type: ignore[attr-defined]
     GraphQL._mutation_class = snapshot.mutation_class  # type: ignore[attr-defined]
@@ -200,24 +204,54 @@ def _restore_and_assert_registries(
 
 
 def _activate_declarations(
+    declaration_snapshot: tuple[type[GraphQLType], ...],
     *required: type[GraphQLType],
 ) -> None:
-    _restore_registered_graphql_types((*_PRE_MODULE_DECLARATIONS, *required))
+    _restore_registered_graphql_types(
+        declaration_snapshot
+        + tuple(
+            declaration
+            for declaration in required
+            if declaration not in declaration_snapshot
+        )
+    )
+
+
+def _assert_late_declaration_survives_cleanup(
+    declaration_snapshot: tuple[type[GraphQLType], ...],
+    integration_declarations: tuple[type[GraphQLType], ...],
+) -> None:
+    declarations = get_registered_graphql_types()
+    assert declarations == declaration_snapshot
+    assert PostBaselineSentinel in declarations
+    assert all(
+        declaration not in declarations for declaration in integration_declarations
+    )
 
 
 class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
     def setUp(self) -> None:
         super().setUp()
         graphql_registry = GraphQL.get_registry_snapshot()
+        declaration_registry = get_registered_graphql_types()
+        self.addCleanup(
+            _assert_late_declaration_survives_cleanup,
+            declaration_registry,
+            (IntegrationProjectHour, IntegrationProjectDetails),
+        )
         self.addCleanup(
             _restore_and_assert_registries,
             graphql_registry,
-            _PRE_MODULE_DECLARATIONS,
+            declaration_registry,
         )
         GraphQL.reset_registry()
-        _restore_registered_graphql_types(_PRE_MODULE_DECLARATIONS)
-        self.assertEqual(get_registered_graphql_types(), _PRE_MODULE_DECLARATIONS)
-        _activate_declarations(IntegrationProjectHour, IntegrationProjectDetails)
+        _restore_registered_graphql_types(declaration_registry)
+        self.assertEqual(get_registered_graphql_types(), declaration_registry)
+        _activate_declarations(
+            declaration_registry,
+            IntegrationProjectHour,
+            IntegrationProjectDetails,
+        )
 
         with (
             patch.object(GraphQL, "register_file_upload_mutation"),
@@ -280,20 +314,32 @@ class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
             self.schema.graphql_schema.get_type("IntegrationProjectHourType")
         )
 
+    def test_late_declaration_survives_setup_and_cleanup(self) -> None:
+        declarations = get_registered_graphql_types()
+        self.assertIn(PostBaselineSentinel, declarations)
+        self.assertIn(IntegrationProjectHour, declarations)
+        self.assertIn(IntegrationProjectDetails, declarations)
+
 
 class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
     def setUp(self) -> None:
         super().setUp()
         graphql_registry = GraphQL.get_registry_snapshot()
+        declaration_registry = get_registered_graphql_types()
+        self.addCleanup(
+            _assert_late_declaration_survives_cleanup,
+            declaration_registry,
+            (IntegrationPermissionDetails,),
+        )
         self.addCleanup(
             _restore_and_assert_registries,
             graphql_registry,
-            _PRE_MODULE_DECLARATIONS,
+            declaration_registry,
         )
         GraphQL.reset_registry()
-        _restore_registered_graphql_types(_PRE_MODULE_DECLARATIONS)
-        self.assertEqual(get_registered_graphql_types(), _PRE_MODULE_DECLARATIONS)
-        _activate_declarations(IntegrationPermissionDetails)
+        _restore_registered_graphql_types(declaration_registry)
+        self.assertEqual(get_registered_graphql_types(), declaration_registry)
+        _activate_declarations(declaration_registry, IntegrationPermissionDetails)
         PermissionedRelatedManager.Permission.checks.clear()
         PermissionedProjectSummary.Permission.checks.clear()
         PermissionedProjectSummary.Permission.allow_details = True

--- a/tests/integration/test_graphql_output_types.py
+++ b/tests/integration/test_graphql_output_types.py
@@ -2,19 +2,25 @@ from __future__ import annotations
 
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import ClassVar, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
 from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import SimpleTestCase
+from graphql import ExecutionResult
 
-from general_manager.api.graphql import GraphQL
+from general_manager.api.graphql import GraphQL, GraphQLMutationMap
+from general_manager.api.registry import GraphQLRegistry
 from general_manager.api.graphql_type import (
     GraphQLType,
     _restore_registered_graphql_types,
     get_registered_graphql_types,
 )
-from general_manager.api.property import _TYPE_HINT_UNRESOLVED, graph_ql_property
+from general_manager.api.property import (
+    GraphQLProperty,
+    _TYPE_HINT_UNRESOLVED,
+    graph_ql_property,
+)
 from general_manager.bootstrap import handle_graph_ql
 from general_manager.interface import CalculationInterface
 from general_manager.manager.general_manager import GeneralManager
@@ -24,6 +30,21 @@ from general_manager.permission.base_permission import (
     BasePermission,
     ReadPermissionPlan,
 )
+
+if TYPE_CHECKING:
+
+    class IntegrationProjectHour(GraphQLType):
+        task_id: int
+        total_hours: Measurement
+        users: list[str]
+
+    class IntegrationProjectDetails(GraphQLType):
+        hour: IntegrationProjectHour
+        label: str
+
+    class IntegrationPermissionDetails(GraphQLType):
+        label: str
+        related: PermissionedRelatedManager
 
 
 class PermissionedRelatedManager(GeneralManager):
@@ -103,8 +124,11 @@ class PermissionedProjectSummary(GeneralManager):
         project_id = Input(int)
 
     @graph_ql_property(cache="none")
-    def details(self) -> "IntegrationPermissionDetails | None":  # noqa: F821
-        details_type = globals()["IntegrationPermissionDetails"]
+    def details(self) -> "IntegrationPermissionDetails | None":
+        details_type = cast(
+            type[IntegrationPermissionDetails],
+            globals()["IntegrationPermissionDetails"],
+        )
         return details_type(
             label="permissioned",
             related=PermissionedRelatedManager(related_id=7),
@@ -116,8 +140,11 @@ class ProjectSummary(GeneralManager):
         project_id = Input(int)
 
     @graph_ql_property(cache="none")
-    def hours(self) -> "list[IntegrationProjectHour]":  # noqa: F821
-        project_hour_type = globals()["IntegrationProjectHour"]
+    def hours(self) -> "list[IntegrationProjectHour]":
+        project_hour_type = cast(
+            type[IntegrationProjectHour],
+            globals()["IntegrationProjectHour"],
+        )
         return [
             project_hour_type(
                 task_id=3,
@@ -127,53 +154,75 @@ class ProjectSummary(GeneralManager):
         ]
 
     @graph_ql_property(cache="none")
-    def optional_hour(self) -> "IntegrationProjectHour | None":  # noqa: F821
+    def optional_hour(self) -> "IntegrationProjectHour | None":
         return None
 
     @graph_ql_property(cache="none")
     def optional_hours(
         self,
-    ) -> "list[IntegrationProjectHour | None]":  # noqa: F821
+    ) -> "list[IntegrationProjectHour | None]":
         return [None, self.hours[0]]
 
     @graph_ql_property(cache="none")
-    def details(self) -> "IntegrationProjectDetails":  # noqa: F821
-        details_type = globals()["IntegrationProjectDetails"]
+    def details(self) -> "IntegrationProjectDetails":
+        details_type = cast(
+            type[IntegrationProjectDetails],
+            globals()["IntegrationProjectDetails"],
+        )
         return details_type(
             hour=self.hours[0],
             label="summary",
         )
 
 
-def _restore_graphql_registry(snapshot: object) -> None:
-    GraphQL._query_class = snapshot.query_class  # type: ignore[attr-defined]
-    GraphQL._mutation_class = snapshot.mutation_class  # type: ignore[attr-defined]
-    GraphQL._subscription_class = snapshot.subscription_class  # type: ignore[attr-defined]
-    GraphQL._schema = snapshot.schema  # type: ignore[attr-defined]
-    GraphQL._mutations = snapshot.mutations  # type: ignore[attr-defined]
-    GraphQL._query_fields = snapshot.query_fields  # type: ignore[attr-defined]
-    GraphQL._subscription_fields = snapshot.subscription_fields  # type: ignore[attr-defined]
-    GraphQL._page_type_registry = snapshot.page_type_registry  # type: ignore[attr-defined]
-    GraphQL._subscription_payload_registry = (  # type: ignore[attr-defined]
-        snapshot.subscription_payload_registry  # type: ignore[attr-defined]
+GraphQLPropertyHintSnapshot = tuple[tuple[GraphQLProperty, object], ...]
+
+
+def _snapshot_graphql_property_hints(
+    manager_classes: tuple[type[GeneralManager], ...],
+) -> GraphQLPropertyHintSnapshot:
+    return tuple(
+        (property_value, property_value._graphql_type_hint)
+        for manager_class in manager_classes
+        for property_value in manager_class.Interface.get_graph_ql_properties().values()
     )
-    GraphQL.graphql_type_registry = snapshot.graphql_type_registry  # type: ignore[attr-defined]
-    GraphQL.graphql_output_type_registry = (  # type: ignore[attr-defined]
-        snapshot.graphql_output_type_registry  # type: ignore[attr-defined]
-    )
-    GraphQL.graphql_filter_type_registry = (  # type: ignore[attr-defined]
-        snapshot.graphql_filter_type_registry  # type: ignore[attr-defined]
-    )
-    GraphQL.graphql_capability_type_registry = (  # type: ignore[attr-defined]
-        snapshot.graphql_capability_type_registry  # type: ignore[attr-defined]
-    )
-    GraphQL.manager_registry = snapshot.manager_registry  # type: ignore[attr-defined]
-    GraphQL._search_union = snapshot.search_union  # type: ignore[attr-defined]
-    GraphQL._search_result_type = snapshot.search_result_type  # type: ignore[attr-defined]
+
+
+def _assert_graphql_property_hints(
+    snapshot: GraphQLPropertyHintSnapshot,
+) -> None:
+    for property_value, expected_hint in snapshot:
+        assert property_value._graphql_type_hint is expected_hint
+
+
+def _restore_graphql_property_hints(
+    snapshot: GraphQLPropertyHintSnapshot,
+) -> None:
+    for property_value, expected_hint in snapshot:
+        property_value._graphql_type_hint = expected_hint
+
+
+def _restore_graphql_registry(snapshot: GraphQLRegistry) -> None:
+    GraphQL._query_class = snapshot.query_class
+    GraphQL._mutation_class = snapshot.mutation_class
+    GraphQL._subscription_class = snapshot.subscription_class
+    GraphQL._schema = snapshot.schema
+    GraphQL._mutations = cast(GraphQLMutationMap, snapshot.mutations)
+    GraphQL._query_fields = snapshot.query_fields
+    GraphQL._subscription_fields = snapshot.subscription_fields
+    GraphQL._page_type_registry = snapshot.page_type_registry
+    GraphQL._subscription_payload_registry = snapshot.subscription_payload_registry
+    GraphQL.graphql_type_registry = snapshot.graphql_type_registry
+    GraphQL.graphql_output_type_registry = snapshot.graphql_output_type_registry
+    GraphQL.graphql_filter_type_registry = snapshot.graphql_filter_type_registry
+    GraphQL.graphql_capability_type_registry = snapshot.graphql_capability_type_registry
+    GraphQL.manager_registry = snapshot.manager_registry
+    GraphQL._search_union = snapshot.search_union
+    GraphQL._search_result_type = snapshot.search_result_type
 
 
 def _restore_and_assert_registries(
-    graphql_snapshot: object,
+    graphql_snapshot: GraphQLRegistry,
     declaration_snapshot: tuple[type[GraphQLType], ...],
 ) -> None:
     _restore_graphql_registry(graphql_snapshot)
@@ -208,6 +257,8 @@ def _activate_declarations(
 
 
 class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
+    _expected_property_hints: GraphQLPropertyHintSnapshot | None = None
+
     def setUp(self) -> None:
         super().setUp()
         graphql_registry = GraphQL.get_registry_snapshot()
@@ -224,6 +275,16 @@ class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
         self.addCleanup(_restore_module_bindings, previous_bindings)
         GraphQL.reset_registry()
 
+        property_hints = _snapshot_graphql_property_hints(
+            (ProjectSummary, PermissionedProjectSummary)
+        )
+        if self.__class__._expected_property_hints is not None:
+            _assert_graphql_property_hints(self.__class__._expected_property_hints)
+        self.__class__._expected_property_hints = property_hints
+        self.addCleanup(_restore_graphql_property_hints, property_hints)
+
+        # Keep declarations test-local to avoid module-import registry leaks;
+        # temporary module globals let postponed string hints resolve.
         project_hour = type(
             "IntegrationProjectHour",
             (GraphQLType,),
@@ -259,11 +320,8 @@ class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
             get_registered_graphql_types()[-2:],
             (project_hour, project_details),
         )
-        for manager_class in (ProjectSummary, PermissionedProjectSummary):
-            for (
-                property_value
-            ) in manager_class.Interface.get_graph_ql_properties().values():
-                property_value._graphql_type_hint = _TYPE_HINT_UNRESOLVED
+        for property_value, _ in property_hints:
+            property_value._graphql_type_hint = _TYPE_HINT_UNRESOLVED
         _activate_declarations(
             declaration_registry,
             project_hour,
@@ -280,6 +338,7 @@ class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
 
         schema = GraphQL.get_schema()
         self.assertIsNotNone(schema)
+        assert schema is not None
         self.schema = schema
 
     def test_graphql_properties_expose_output_objects_without_root_operations(
@@ -347,6 +406,9 @@ class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
 
 
 class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
+    _expected_property_hints: GraphQLPropertyHintSnapshot | None = None
+    _expected_allow_details: bool | None = None
+
     def setUp(self) -> None:
         super().setUp()
         graphql_registry = GraphQL.get_registry_snapshot()
@@ -362,6 +424,28 @@ class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
             {"IntegrationPermissionDetails": previous_binding},
         )
         GraphQL.reset_registry()
+
+        property_hints = _snapshot_graphql_property_hints((PermissionedProjectSummary,))
+        if self.__class__._expected_property_hints is not None:
+            _assert_graphql_property_hints(self.__class__._expected_property_hints)
+        self.__class__._expected_property_hints = property_hints
+        self.addCleanup(_restore_graphql_property_hints, property_hints)
+        previous_allow_details = PermissionedProjectSummary.Permission.allow_details
+        if self.__class__._expected_allow_details is not None:
+            self.assertEqual(
+                PermissionedProjectSummary.Permission.allow_details,
+                self.__class__._expected_allow_details,
+            )
+        self.__class__._expected_allow_details = previous_allow_details
+        self.addCleanup(
+            setattr,
+            PermissionedProjectSummary.Permission,
+            "allow_details",
+            previous_allow_details,
+        )
+
+        # Keep declarations test-local to avoid module-import registry leaks;
+        # temporary module globals let postponed string hints resolve.
         permission_details = type(
             "IntegrationPermissionDetails",
             (GraphQLType,),
@@ -376,9 +460,7 @@ class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
         globals()["IntegrationPermissionDetails"] = permission_details
         self.permission_details = permission_details
         self.assertIs(get_registered_graphql_types()[-1], permission_details)
-        for (
-            property_value
-        ) in PermissionedProjectSummary.Interface.get_graph_ql_properties().values():
+        for property_value, _ in property_hints:
             property_value._graphql_type_hint = _TYPE_HINT_UNRESOLVED
         _activate_declarations(declaration_registry, permission_details)
         PermissionedRelatedManager.Permission.checks.clear()
@@ -395,13 +477,20 @@ class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
 
         schema = GraphQL.get_schema()
         self.assertIsNotNone(schema)
+        assert schema is not None
         self.schema = schema
 
-    def _execute(self, query: str):
-        return self.schema.execute(
-            query,
-            context_value=SimpleNamespace(user=AnonymousUser()),
+    def _execute(self, query: str) -> ExecutionResult:
+        return cast(
+            ExecutionResult,
+            self.schema.execute(
+                query,
+                context_value=SimpleNamespace(user=AnonymousUser()),
+            ),
         )
+
+    def test_setup_restores_shared_state_for_the_next_schema_build(self) -> None:
+        self.assertTrue(PermissionedProjectSummary.Permission.allow_details)
 
     def test_nested_manager_permissions_and_owner_property_permissions_are_preserved(
         self,
@@ -455,11 +544,12 @@ class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
             ["allowed", "denied"],
         )
 
+        PermissionedProjectSummary.Permission.allow_details = False
+
         query_fields = self.schema.graphql_schema.query_type.fields
         self.assertNotIn("integrationPermissionDetails", query_fields)
         self.assertNotIn("integrationPermissionDetailsList", query_fields)
 
-        PermissionedProjectSummary.Permission.allow_details = False
         denied = self._execute(
             """
             query {

--- a/tests/integration/test_graphql_output_types.py
+++ b/tests/integration/test_graphql_output_types.py
@@ -14,7 +14,7 @@ from general_manager.api.graphql_type import (
     _restore_registered_graphql_types,
     get_registered_graphql_types,
 )
-from general_manager.api.property import graph_ql_property
+from general_manager.api.property import _TYPE_HINT_UNRESOLVED, graph_ql_property
 from general_manager.bootstrap import handle_graph_ql
 from general_manager.interface import CalculationInterface
 from general_manager.manager.general_manager import GeneralManager
@@ -24,20 +24,6 @@ from general_manager.permission.base_permission import (
     BasePermission,
     ReadPermissionPlan,
 )
-
-
-_PRE_MODULE_DECLARATIONS = get_registered_graphql_types()
-
-
-class IntegrationProjectHour(GraphQLType):
-    task_id: int
-    total_hours: Measurement
-    users: list[str]
-
-
-class IntegrationProjectDetails(GraphQLType):
-    hour: IntegrationProjectHour
-    label: str
 
 
 class PermissionedRelatedManager(GeneralManager):
@@ -82,11 +68,6 @@ class PermissionedRelatedManager(GeneralManager):
         return "hidden"
 
 
-class IntegrationPermissionDetails(GraphQLType):
-    label: str
-    related: PermissionedRelatedManager
-
-
 class PermissionedProjectSummary(GeneralManager):
     class Permission(BasePermission):
         checks: ClassVar[list[str]] = []
@@ -122,8 +103,9 @@ class PermissionedProjectSummary(GeneralManager):
         project_id = Input(int)
 
     @graph_ql_property(cache="none")
-    def details(self) -> IntegrationPermissionDetails | None:
-        return IntegrationPermissionDetails(
+    def details(self) -> "IntegrationPermissionDetails | None":  # noqa: F821
+        details_type = globals()["IntegrationPermissionDetails"]
+        return details_type(
             label="permissioned",
             related=PermissionedRelatedManager(related_id=7),
         )
@@ -134,9 +116,10 @@ class ProjectSummary(GeneralManager):
         project_id = Input(int)
 
     @graph_ql_property(cache="none")
-    def hours(self) -> list[IntegrationProjectHour]:
+    def hours(self) -> "list[IntegrationProjectHour]":  # noqa: F821
+        project_hour_type = globals()["IntegrationProjectHour"]
         return [
-            IntegrationProjectHour(
+            project_hour_type(
                 task_id=3,
                 total_hours=Measurement(Decimal("8.5"), "h"),
                 users=["Ng", "Smith"],
@@ -144,26 +127,22 @@ class ProjectSummary(GeneralManager):
         ]
 
     @graph_ql_property(cache="none")
-    def optional_hour(self) -> IntegrationProjectHour | None:
+    def optional_hour(self) -> "IntegrationProjectHour | None":  # noqa: F821
         return None
 
     @graph_ql_property(cache="none")
-    def optional_hours(self) -> list[IntegrationProjectHour | None]:
+    def optional_hours(
+        self,
+    ) -> "list[IntegrationProjectHour | None]":  # noqa: F821
         return [None, self.hours[0]]
 
     @graph_ql_property(cache="none")
-    def details(self) -> IntegrationProjectDetails:
-        return IntegrationProjectDetails(
+    def details(self) -> "IntegrationProjectDetails":  # noqa: F821
+        details_type = globals()["IntegrationProjectDetails"]
+        return details_type(
             hour=self.hours[0],
             label="summary",
         )
-
-
-_restore_registered_graphql_types(_PRE_MODULE_DECLARATIONS)
-
-
-class PostBaselineSentinel(GraphQLType):
-    marker: str
 
 
 def _restore_graphql_registry(snapshot: object) -> None:
@@ -203,6 +182,17 @@ def _restore_and_assert_registries(
     assert get_registered_graphql_types() == declaration_snapshot
 
 
+def _restore_module_bindings(bindings: dict[str, object]) -> None:
+    for name, previous in bindings.items():
+        if previous is _MISSING:
+            globals().pop(name, None)
+        else:
+            globals()[name] = previous
+
+
+_MISSING = object()
+
+
 def _activate_declarations(
     declaration_snapshot: tuple[type[GraphQLType], ...],
     *required: type[GraphQLType],
@@ -217,40 +207,67 @@ def _activate_declarations(
     )
 
 
-def _assert_late_declaration_survives_cleanup(
-    declaration_snapshot: tuple[type[GraphQLType], ...],
-    integration_declarations: tuple[type[GraphQLType], ...],
-) -> None:
-    declarations = get_registered_graphql_types()
-    assert declarations == declaration_snapshot
-    assert PostBaselineSentinel in declarations
-    assert all(
-        declaration not in declarations for declaration in integration_declarations
-    )
-
-
 class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
     def setUp(self) -> None:
         super().setUp()
         graphql_registry = GraphQL.get_registry_snapshot()
         declaration_registry = get_registered_graphql_types()
         self.addCleanup(
-            _assert_late_declaration_survives_cleanup,
-            declaration_registry,
-            (IntegrationProjectHour, IntegrationProjectDetails),
-        )
-        self.addCleanup(
             _restore_and_assert_registries,
             graphql_registry,
             declaration_registry,
         )
+        binding_names = ("IntegrationProjectHour", "IntegrationProjectDetails")
+        previous_bindings = {
+            name: globals().get(name, _MISSING) for name in binding_names
+        }
+        self.addCleanup(_restore_module_bindings, previous_bindings)
         GraphQL.reset_registry()
-        _restore_registered_graphql_types(declaration_registry)
-        self.assertEqual(get_registered_graphql_types(), declaration_registry)
+
+        project_hour = type(
+            "IntegrationProjectHour",
+            (GraphQLType,),
+            {
+                "__module__": __name__,
+                "__annotations__": {
+                    "task_id": int,
+                    "total_hours": Measurement,
+                    "users": list[str],
+                },
+            },
+        )
+        project_details = type(
+            "IntegrationProjectDetails",
+            (GraphQLType,),
+            {
+                "__module__": __name__,
+                "__annotations__": {
+                    "hour": project_hour,
+                    "label": str,
+                },
+            },
+        )
+        globals().update(
+            {
+                "IntegrationProjectHour": project_hour,
+                "IntegrationProjectDetails": project_details,
+            }
+        )
+        self.project_hour = project_hour
+        self.project_details = project_details
+        self.assertEqual(
+            get_registered_graphql_types()[-2:],
+            (project_hour, project_details),
+        )
+        for manager_class in (ProjectSummary, PermissionedProjectSummary):
+            for (
+                property_value
+            ) in manager_class.Interface.get_graph_ql_properties().values():
+                property_value._graphql_type_hint = _TYPE_HINT_UNRESOLVED
         _activate_declarations(
             declaration_registry,
-            IntegrationProjectHour,
-            IntegrationProjectDetails,
+            project_hour,
+            project_details,
         )
 
         with (
@@ -315,10 +332,18 @@ class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
         )
 
     def test_late_declaration_survives_setup_and_cleanup(self) -> None:
+        sentinel = type(
+            "PostBaselineSentinel",
+            (GraphQLType,),
+            {
+                "__module__": __name__,
+                "__annotations__": {"marker": str},
+            },
+        )
         declarations = get_registered_graphql_types()
-        self.assertIn(PostBaselineSentinel, declarations)
-        self.assertIn(IntegrationProjectHour, declarations)
-        self.assertIn(IntegrationProjectDetails, declarations)
+        self.assertIn(sentinel, declarations)
+        self.assertIn(self.project_hour, declarations)
+        self.assertIn(self.project_details, declarations)
 
 
 class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
@@ -327,19 +352,35 @@ class PermissionedGraphQLOutputIntegrationTests(SimpleTestCase):
         graphql_registry = GraphQL.get_registry_snapshot()
         declaration_registry = get_registered_graphql_types()
         self.addCleanup(
-            _assert_late_declaration_survives_cleanup,
-            declaration_registry,
-            (IntegrationPermissionDetails,),
-        )
-        self.addCleanup(
             _restore_and_assert_registries,
             graphql_registry,
             declaration_registry,
         )
+        previous_binding = globals().get("IntegrationPermissionDetails", _MISSING)
+        self.addCleanup(
+            _restore_module_bindings,
+            {"IntegrationPermissionDetails": previous_binding},
+        )
         GraphQL.reset_registry()
-        _restore_registered_graphql_types(declaration_registry)
-        self.assertEqual(get_registered_graphql_types(), declaration_registry)
-        _activate_declarations(declaration_registry, IntegrationPermissionDetails)
+        permission_details = type(
+            "IntegrationPermissionDetails",
+            (GraphQLType,),
+            {
+                "__module__": __name__,
+                "__annotations__": {
+                    "label": str,
+                    "related": PermissionedRelatedManager,
+                },
+            },
+        )
+        globals()["IntegrationPermissionDetails"] = permission_details
+        self.permission_details = permission_details
+        self.assertIs(get_registered_graphql_types()[-1], permission_details)
+        for (
+            property_value
+        ) in PermissionedProjectSummary.Interface.get_graph_ql_properties().values():
+            property_value._graphql_type_hint = _TYPE_HINT_UNRESOLVED
+        _activate_declarations(declaration_registry, permission_details)
         PermissionedRelatedManager.Permission.checks.clear()
         PermissionedProjectSummary.Permission.checks.clear()
         PermissionedProjectSummary.Permission.allow_details = True

--- a/tests/integration/test_graphql_output_types.py
+++ b/tests/integration/test_graphql_output_types.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import SimpleTestCase
+
+from general_manager.api.graphql import GraphQL
+from general_manager.api.graphql_type import (
+    GraphQLType,
+    _restore_registered_graphql_types,
+    get_registered_graphql_types,
+)
+from general_manager.api.property import graph_ql_property
+from general_manager.bootstrap import handle_graph_ql
+from general_manager.interface import CalculationInterface
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.input import Input
+from general_manager.measurement.measurement import Measurement
+
+
+class IntegrationProjectHour(GraphQLType):
+    task_id: int
+    total_hours: Measurement
+    users: list[str]
+
+
+class IntegrationProjectDetails(GraphQLType):
+    hour: IntegrationProjectHour
+    label: str
+
+
+class ProjectSummary(GeneralManager):
+    class Interface(CalculationInterface):
+        project_id = Input(int)
+
+    @graph_ql_property(cache="none")
+    def hours(self) -> list[IntegrationProjectHour]:
+        return [
+            IntegrationProjectHour(
+                task_id=3,
+                total_hours=Measurement(Decimal("8.5"), "h"),
+                users=["Ng", "Smith"],
+            )
+        ]
+
+    @graph_ql_property(cache="none")
+    def optional_hour(self) -> IntegrationProjectHour | None:
+        return None
+
+    @graph_ql_property(cache="none")
+    def optional_hours(self) -> list[IntegrationProjectHour | None]:
+        return [None, self.hours[0]]
+
+    @graph_ql_property(cache="none")
+    def details(self) -> IntegrationProjectDetails:
+        return IntegrationProjectDetails(
+            hour=self.hours[0],
+            label="summary",
+        )
+
+
+def _restore_graphql_registry(snapshot: object) -> None:
+    GraphQL._query_class = snapshot.query_class  # type: ignore[attr-defined]
+    GraphQL._mutation_class = snapshot.mutation_class  # type: ignore[attr-defined]
+    GraphQL._subscription_class = snapshot.subscription_class  # type: ignore[attr-defined]
+    GraphQL._schema = snapshot.schema  # type: ignore[attr-defined]
+    GraphQL._mutations = snapshot.mutations  # type: ignore[attr-defined]
+    GraphQL._query_fields = snapshot.query_fields  # type: ignore[attr-defined]
+    GraphQL._subscription_fields = snapshot.subscription_fields  # type: ignore[attr-defined]
+    GraphQL._page_type_registry = snapshot.page_type_registry  # type: ignore[attr-defined]
+    GraphQL._subscription_payload_registry = (  # type: ignore[attr-defined]
+        snapshot.subscription_payload_registry  # type: ignore[attr-defined]
+    )
+    GraphQL.graphql_type_registry = snapshot.graphql_type_registry  # type: ignore[attr-defined]
+    GraphQL.graphql_output_type_registry = (  # type: ignore[attr-defined]
+        snapshot.graphql_output_type_registry  # type: ignore[attr-defined]
+    )
+    GraphQL.graphql_filter_type_registry = (  # type: ignore[attr-defined]
+        snapshot.graphql_filter_type_registry  # type: ignore[attr-defined]
+    )
+    GraphQL.graphql_capability_type_registry = (  # type: ignore[attr-defined]
+        snapshot.graphql_capability_type_registry  # type: ignore[attr-defined]
+    )
+    GraphQL.manager_registry = snapshot.manager_registry  # type: ignore[attr-defined]
+    GraphQL._search_union = snapshot.search_union  # type: ignore[attr-defined]
+    GraphQL._search_result_type = snapshot.search_result_type  # type: ignore[attr-defined]
+
+
+class GraphQLOutputPropertyIntegrationTests(SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        graphql_registry = GraphQL.get_registry_snapshot()
+        declaration_registry = get_registered_graphql_types()
+        self.addCleanup(_restore_graphql_registry, graphql_registry)
+        self.addCleanup(_restore_registered_graphql_types, declaration_registry)
+        GraphQL.reset_registry()
+
+        with (
+            patch.object(GraphQL, "register_file_upload_mutation"),
+            patch.object(GraphQL, "register_search_query"),
+            patch("general_manager.uploads.urls.add_file_upload_urls"),
+            patch("general_manager.bootstrap.add_graphql_url"),
+        ):
+            handle_graph_ql([ProjectSummary])
+
+        schema = GraphQL.get_schema()
+        self.assertIsNotNone(schema)
+        self.schema = schema
+
+    def test_graphql_properties_expose_output_objects_without_root_operations(
+        self,
+    ) -> None:
+        response = self.schema.execute(
+            """
+            query {
+                projectSummary(projectId: 3) {
+                    hours { taskId totalHours { value unit } users }
+                    optionalHour { taskId }
+                    optionalHours { taskId }
+                    details { label hour { taskId } }
+                }
+            }
+            """,
+            context_value=SimpleNamespace(user=AnonymousUser()),
+        )
+
+        self.assertIsNone(response.errors)
+        self.assertEqual(
+            response.data,
+            {
+                "projectSummary": {
+                    "hours": [
+                        {
+                            "taskId": 3,
+                            "totalHours": {"value": 8.5, "unit": "hour"},
+                            "users": ["Ng", "Smith"],
+                        }
+                    ],
+                    "optionalHour": None,
+                    "optionalHours": [None, {"taskId": 3}],
+                    "details": {
+                        "label": "summary",
+                        "hour": {"taskId": 3},
+                    },
+                }
+            },
+        )
+
+        query_fields = self.schema.graphql_schema.query_type.fields
+        self.assertIn("projectSummary", query_fields)
+        self.assertNotIn("projectHour", query_fields)
+        self.assertNotIn("projectHourList", query_fields)
+        self.assertIsNotNone(
+            self.schema.graphql_schema.get_type("IntegrationProjectHourType")
+        )

--- a/tests/snapshots/public_api_exports.json
+++ b/tests/snapshots/public_api_exports.json
@@ -28,6 +28,10 @@
       "general_manager.api.graphql",
       "GraphQL"
     ],
+    "GraphQLType": [
+      "general_manager.api.graphql_type",
+      "GraphQLType"
+    ],
     "IndexConfig": [
       "general_manager.search.config",
       "IndexConfig"

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -1925,6 +1925,124 @@ class GraphQLTests(TestCase):
 
         self.assertEqual(GraphQL.get_registry_snapshot(), before)
 
+    def test_successful_output_generation_preserves_all_non_output_state(self) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class StableOutput(GraphQLType):
+            value: str
+
+        declaration_before = get_registered_graphql_types()
+
+        class ExistingQuery(graphene.ObjectType):
+            ping = graphene.String()
+
+        class ExistingMutation(graphene.ObjectType):
+            pass
+
+        class ExistingSubscription(graphene.ObjectType):
+            pass
+
+        class ExistingManagerType(graphene.ObjectType):
+            name = graphene.String()
+
+        class ExistingOutputType(graphene.ObjectType):
+            value = graphene.String()
+
+        class ExistingFilterType(graphene.InputObjectType):
+            value = graphene.String()
+
+        class ExistingCapabilityType(graphene.ObjectType):
+            enabled = graphene.Boolean()
+
+        existing_union = type(
+            "ExistingSearchUnion",
+            (graphene.Union,),
+            {"Meta": type("Meta", (), {"types": (ExistingManagerType,)})},
+        )
+        existing_schema = graphene.Schema(query=ExistingQuery)
+
+        GraphQL._query_class = ExistingQuery
+        GraphQL._mutation_class = ExistingMutation
+        GraphQL._subscription_class = ExistingSubscription
+        GraphQL._mutations = {"existingMutation": ExistingMutation}
+        GraphQL._query_fields = {"existingQuery": graphene.String()}
+        GraphQL._subscription_fields = {"existingSubscription": graphene.String()}
+        GraphQL._page_type_registry = {"ExistingManagerPage": ExistingManagerType}
+        GraphQL._subscription_payload_registry = {
+            "ExistingManagerSubscription": ExistingManagerType
+        }
+        GraphQL.graphql_type_registry = {"ExistingManager": ExistingManagerType}
+        GraphQL.graphql_output_type_registry = {"ExistingOutput": ExistingOutputType}
+        GraphQL.graphql_filter_type_registry = {"ExistingManager": ExistingFilterType}
+        GraphQL.graphql_capability_type_registry = {
+            "ExistingManager": ExistingCapabilityType
+        }
+        GraphQL.manager_registry = {"ExistingManager": GeneralManager}
+        GraphQL._search_union = existing_union
+        GraphQL._search_result_type = ExistingManagerType
+        GraphQL._schema = existing_schema
+
+        live_registry_refs = {
+            registry_name: getattr(GraphQL, registry_name)
+            for registry_name in (
+                "_mutations",
+                "_query_fields",
+                "_subscription_fields",
+                "_page_type_registry",
+                "_subscription_payload_registry",
+                "graphql_type_registry",
+                "graphql_filter_type_registry",
+                "graphql_capability_type_registry",
+                "manager_registry",
+                "graphql_output_type_registry",
+            )
+        }
+        before = GraphQL.get_registry_snapshot()
+        generated = GraphQL.create_graphql_output_type(StableOutput)
+        after = GraphQL.get_registry_snapshot()
+
+        self.assertEqual(get_registered_graphql_types(), declaration_before)
+        self.assertIs(after.query_class, before.query_class)
+        self.assertIs(after.mutation_class, before.mutation_class)
+        self.assertIs(after.subscription_class, before.subscription_class)
+        self.assertIs(after.schema, before.schema)
+        self.assertIs(after.search_union, before.search_union)
+        self.assertIs(after.search_result_type, before.search_result_type)
+        for registry_name in (
+            "mutations",
+            "query_fields",
+            "subscription_fields",
+            "page_type_registry",
+            "subscription_payload_registry",
+            "graphql_type_registry",
+            "graphql_filter_type_registry",
+            "graphql_capability_type_registry",
+            "manager_registry",
+        ):
+            self.assertEqual(
+                getattr(after, registry_name),
+                getattr(before, registry_name),
+                registry_name,
+            )
+        for registry_name, registry in live_registry_refs.items():
+            self.assertIs(getattr(GraphQL, registry_name), registry, registry_name)
+
+        expected_outputs = dict(before.graphql_output_type_registry)
+        expected_outputs["StableOutput"] = generated
+        self.assertIs(
+            GraphQL.graphql_output_type_registry,
+            live_registry_refs["graphql_output_type_registry"],
+        )
+        self.assertEqual(after.graphql_output_type_registry, expected_outputs)
+        self.assertIs(
+            after.graphql_output_type_registry["ExistingOutput"],
+            ExistingOutputType,
+        )
+
     def test_mutually_referring_output_types_generate_and_resolve(self) -> None:
         declarations = get_registered_graphql_types()
         registry_snapshot = GraphQL.get_registry_snapshot()

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -58,6 +58,8 @@ from general_manager.as_of import (
 )
 from general_manager.bucket.base_bucket import Bucket
 from general_manager.measurement.measurement import Measurement
+
+FrameworkMeasurement = Measurement
 from general_manager.manager.general_manager import GeneralManager, GeneralManagerMeta
 from general_manager.manager.input import Input
 from general_manager.api.property import (
@@ -1634,6 +1636,53 @@ class GraphQLTests(TestCase):
         assert GraphQL.create_graphql_output_type(ProjectHour) is generated
         assert GraphQL.graphql_output_type_registry == {"ProjectHour": generated}
 
+    def test_output_fields_can_use_graphene_reserved_and_resolver_like_names(
+        self,
+    ) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class ReservedOutput(GraphQLType):
+            amount: Measurement
+            resolve_amount: str
+            Meta: str
+
+        generated = GraphQL.create_graphql_output_type(ReservedOutput)
+        value = ReservedOutput(
+            amount=Measurement(2, "hour"),
+            resolve_amount="resolver-shaped field",
+            Meta="reserved field",
+        )
+
+        class Query(graphene.ObjectType):
+            value = graphene.Field(generated)
+
+            @staticmethod
+            def resolve_value(_root: object, _info: object) -> ReservedOutput:
+                return value
+
+        schema = graphene.Schema(query=Query, types=(generated,))
+        response = schema.execute(
+            """
+            { value { amount { value unit } resolveAmount Meta } }
+            """
+        )
+
+        self.assertIsNone(response.errors)
+        self.assertEqual(
+            response.data,
+            {
+                "value": {
+                    "amount": {"value": 2, "unit": "hour"},
+                    "resolveAmount": "resolver-shaped field",
+                    "Meta": "reserved field",
+                }
+            },
+        )
+
     def test_reset_registry_clears_generated_outputs_not_declarations(self) -> None:
         declarations = get_registered_graphql_types()
         registry_snapshot = GraphQL.get_registry_snapshot()
@@ -1740,6 +1789,36 @@ class GraphQLTests(TestCase):
 
         self.assertEqual(GraphQL.graphql_output_type_registry, before)
 
+    def test_output_type_rejects_framework_measurement_type_collision_without_mutation(
+        self,
+    ) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class Measurement(GraphQLType):
+            value: int
+
+        framework_measurement_field = GraphQL._map_field_to_graphene_read(
+            FrameworkMeasurement,
+            "measurement",
+        )
+        self.assertIs(framework_measurement_field.type, MeasurementType)
+        framework_type = type(
+            "FrameworkMeasurementOwnerType",
+            (graphene.ObjectType,),
+            {"measurement": framework_measurement_field},
+        )
+        GraphQL.graphql_type_registry["FrameworkMeasurementOwner"] = framework_type
+        before = GraphQL.get_registry_snapshot()
+
+        with self.assertRaisesRegex(ValueError, "MeasurementType"):
+            GraphQL.create_graphql_output_type(Measurement)
+
+        self.assertEqual(GraphQL.get_registry_snapshot(), before)
+
     def test_auxiliary_key_matching_output_name_without_schema_collision_is_allowed(
         self,
     ) -> None:
@@ -1809,6 +1888,110 @@ class GraphQLTests(TestCase):
 
         self.assertIs(GraphQL.graphql_output_type_registry, before)
         self.assertEqual(GraphQL.graphql_output_type_registry, {"Existing": sentinel})
+
+    def test_output_type_mapping_failure_preserves_every_graphql_registry(self) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class InvalidOutput(GraphQLType):
+            value: object
+
+        object_type = type("RegistryObjectType", (graphene.ObjectType,), {})
+        input_type = type("RegistryInputType", (graphene.InputObjectType,), {})
+        union_type = type(
+            "RegistryUnion",
+            (graphene.Union,),
+            {"Meta": type("Meta", (), {"types": (object_type,)})},
+        )
+        GraphQL._mutations["mutation"] = object_type
+        GraphQL._query_fields["query"] = graphene.String()
+        GraphQL._subscription_fields["subscription"] = graphene.String()
+        GraphQL._page_type_registry["page"] = object_type
+        GraphQL._subscription_payload_registry["subscription"] = object_type
+        GraphQL.graphql_type_registry["manager"] = object_type
+        GraphQL.graphql_output_type_registry["output"] = object_type
+        GraphQL.graphql_filter_type_registry["filter"] = input_type
+        GraphQL.graphql_capability_type_registry["capability"] = object_type
+        GraphQL.manager_registry["manager"] = GeneralManager
+        GraphQL._search_union = union_type
+        GraphQL._search_result_type = object_type
+        before = GraphQL.get_registry_snapshot()
+
+        with self.assertRaises(GraphQLOutputAnnotationError):
+            GraphQL.create_graphql_output_type(InvalidOutput)
+
+        self.assertEqual(GraphQL.get_registry_snapshot(), before)
+
+    def test_mutually_referring_output_types_generate_and_resolve(self) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        Left = type(
+            "MutualLeft",
+            (GraphQLType,),
+            {
+                "__module__": __name__,
+                "__annotations__": {
+                    "right": "MutualRight | None",
+                    "label": str,
+                },
+            },
+        )
+        Right = type(
+            "MutualRight",
+            (GraphQLType,),
+            {
+                "__module__": __name__,
+                "__annotations__": {
+                    "left": "MutualLeft | None",
+                    "label": str,
+                },
+            },
+        )
+
+        left_type = GraphQL.create_graphql_output_type(Left)
+        right_type = GraphQL.create_graphql_output_type(Right)
+
+        class Query(graphene.ObjectType):
+            left = graphene.Field(left_type)
+
+            @staticmethod
+            def resolve_left(_root: object, _info: object) -> object:
+                return Left(
+                    right=Right(
+                        left=Left(right=None, label="leaf"),
+                        label="right",
+                    ),
+                    label="root",
+                )
+
+        schema = graphene.Schema(query=Query, types=(left_type, right_type))
+        response = schema.execute(
+            "{ left { label right { label left { label right { label } } } } }"
+        )
+
+        self.assertIsNone(response.errors)
+        self.assertEqual(
+            response.data,
+            {
+                "left": {
+                    "label": "root",
+                    "right": {
+                        "label": "right",
+                        "left": {
+                            "label": "leaf",
+                            "right": None,
+                        },
+                    },
+                }
+            },
+        )
 
     def test_sort_options_include_direct_manager_and_related_scalars(self) -> None:
         related_computed = SimpleNamespace(sortable=True, graphql_type_hint=str)

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -2,6 +2,7 @@
 
 import json
 import asyncio
+from dataclasses import field as dataclass_field
 import subprocess
 import sys
 import unittest
@@ -32,6 +33,7 @@ from general_manager.api.graphql_type import (
     _restore_registered_graphql_types,
     get_registered_graphql_types,
 )
+from general_manager.api.graphql_output import GraphQLOutputAnnotationError
 from general_manager.api.graphql_mutations import (
     _graphql_mutation_field_name,
     _normalize_mutation_kwargs_for_manager,
@@ -1691,6 +1693,121 @@ class GraphQLTests(TestCase):
             GraphQL.create_graphql_output_type(SharedName)
 
         self.assertEqual(GraphQL.graphql_output_type_registry, before)
+
+    def test_output_type_rejects_true_known_schema_collisions_without_mutation(
+        self,
+    ) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class Collision(GraphQLType):
+            task_id: int
+
+        colliding_type = type("CollisionType", (graphene.ObjectType,), {})
+        sources = (
+            ("graphql_output_type_registry", "output-key"),
+            ("_page_type_registry", "page-key"),
+            ("_subscription_payload_registry", "subscription-key"),
+            ("graphql_capability_type_registry", "capability-key"),
+        )
+
+        for registry_name, registered_name in sources:
+            with self.subTest(registry_name=registry_name):
+                GraphQL.reset_registry()
+                registry = getattr(GraphQL, registry_name)
+                registry[registered_name] = colliding_type
+                before = dict(GraphQL.graphql_output_type_registry)
+
+                with self.assertRaises(ValueError):
+                    GraphQL.create_graphql_output_type(Collision)
+
+                self.assertEqual(GraphQL.graphql_output_type_registry, before)
+
+        GraphQL.reset_registry()
+        GraphQL._schema = SimpleNamespace(
+            graphql_schema=SimpleNamespace(
+                type_map={"schema-key": SimpleNamespace(name="CollisionType")}
+            )
+        )
+        before = dict(GraphQL.graphql_output_type_registry)
+
+        with self.assertRaises(ValueError):
+            GraphQL.create_graphql_output_type(Collision)
+
+        self.assertEqual(GraphQL.graphql_output_type_registry, before)
+
+    def test_auxiliary_key_matching_output_name_without_schema_collision_is_allowed(
+        self,
+    ) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class Collision(GraphQLType):
+            task_id: int
+
+        unrelated_type = type("UnrelatedPageType", (graphene.ObjectType,), {})
+        for registry_name in (
+            "_page_type_registry",
+            "_subscription_payload_registry",
+            "graphql_capability_type_registry",
+        ):
+            with self.subTest(registry_name=registry_name):
+                GraphQL.reset_registry()
+                registry = getattr(GraphQL, registry_name)
+                registry["Collision"] = unrelated_type
+
+                generated = GraphQL.create_graphql_output_type(Collision)
+
+                self.assertIs(
+                    GraphQL.graphql_output_type_registry["Collision"], generated
+                )
+
+    def test_output_type_mounts_inherited_and_derived_dataclass_fields(self) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class ProjectHour(GraphQLType):
+            task_id: int
+            users: list[str]
+
+        class DetailedProjectHour(ProjectHour):
+            label: str = dataclass_field(init=False, default="hours")
+
+        generated = GraphQL.create_graphql_output_type(DetailedProjectHour)
+
+        self.assertEqual(
+            set(generated._meta.fields),
+            {"task_id", "users", "label"},
+        )
+
+    def test_output_type_mapping_failure_preserves_prepopulated_registry(self) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class InvalidOutput(GraphQLType):
+            value: object
+
+        sentinel = type("ExistingOutputType", (graphene.ObjectType,), {})
+        GraphQL.graphql_output_type_registry["Existing"] = sentinel
+        before = GraphQL.graphql_output_type_registry
+
+        with self.assertRaises(GraphQLOutputAnnotationError):
+            GraphQL.create_graphql_output_type(InvalidOutput)
+
+        self.assertIs(GraphQL.graphql_output_type_registry, before)
+        self.assertEqual(GraphQL.graphql_output_type_registry, {"Existing": sentinel})
 
     def test_sort_options_include_direct_manager_and_related_scalars(self) -> None:
         related_computed = SimpleNamespace(sortable=True, graphql_type_hint=str)

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -27,6 +27,11 @@ from general_manager.api.graphql import (
     GraphQL,
     get_read_permission_filter,
 )
+from general_manager.api.graphql_type import (
+    GraphQLType,
+    _restore_registered_graphql_types,
+    get_registered_graphql_types,
+)
 from general_manager.api.graphql_mutations import (
     _graphql_mutation_field_name,
     _normalize_mutation_kwargs_for_manager,
@@ -77,6 +82,43 @@ from graphql import (
 )
 from graphql.language import StringValueNode
 from graphql.validation import ASTValidationRule
+
+
+def _restore_graphql_registry(snapshot: object) -> None:
+    GraphQL._query_class = snapshot.query_class  # type: ignore[attr-defined]
+    GraphQL._mutation_class = snapshot.mutation_class  # type: ignore[attr-defined]
+    GraphQL._subscription_class = snapshot.subscription_class  # type: ignore[attr-defined]
+    GraphQL._schema = snapshot.schema  # type: ignore[attr-defined]
+    GraphQL._mutations = snapshot.mutations  # type: ignore[attr-defined]
+    GraphQL._query_fields = snapshot.query_fields  # type: ignore[attr-defined]
+    GraphQL._subscription_fields = snapshot.subscription_fields  # type: ignore[attr-defined]
+    GraphQL._page_type_registry = snapshot.page_type_registry  # type: ignore[attr-defined]
+    GraphQL._subscription_payload_registry = (  # type: ignore[attr-defined]
+        snapshot.subscription_payload_registry  # type: ignore[attr-defined]
+    )
+    GraphQL.graphql_type_registry = snapshot.graphql_type_registry  # type: ignore[attr-defined]
+    GraphQL.graphql_output_type_registry = (  # type: ignore[attr-defined]
+        snapshot.graphql_output_type_registry  # type: ignore[attr-defined]
+    )
+    GraphQL.graphql_filter_type_registry = (  # type: ignore[attr-defined]
+        snapshot.graphql_filter_type_registry  # type: ignore[attr-defined]
+    )
+    GraphQL.graphql_capability_type_registry = (  # type: ignore[attr-defined]
+        snapshot.graphql_capability_type_registry  # type: ignore[attr-defined]
+    )
+    GraphQL.manager_registry = snapshot.manager_registry  # type: ignore[attr-defined]
+    GraphQL._search_union = snapshot.search_union  # type: ignore[attr-defined]
+    GraphQL._search_result_type = snapshot.search_result_type  # type: ignore[attr-defined]
+
+
+def _make_graphql_output_declaration(
+    name: str,
+) -> type[GraphQLType]:
+    return type(
+        name,
+        (GraphQLType,),
+        {"__module__": __name__, "__annotations__": {"task_id": int}},
+    )
 
 
 class GraphQLAsOfExecutionTests(unittest.TestCase):
@@ -1543,6 +1585,112 @@ class GraphQLTests(TestCase):
         self.general_manager_class.__name__ = "TestManager"
         self.info = MagicMock()
         self.info.context.user = AnonymousUser()
+
+    def test_create_graphql_output_type_has_no_operations(self) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class ProjectHour(GraphQLType):
+            task_id: int
+            users: list[str]
+
+        before = (
+            dict(GraphQL._query_fields),
+            dict(GraphQL._mutations),
+            dict(GraphQL._subscription_fields),
+        )
+        generated = GraphQL.create_graphql_output_type(ProjectHour)
+
+        assert generated.__name__ == "ProjectHourType"
+        assert set(generated._meta.fields) == {"task_id", "users"}
+        assert GraphQL.graphql_output_type_registry["ProjectHour"] is generated
+        assert "ProjectHour" not in GraphQL.manager_registry
+        assert before == (
+            GraphQL._query_fields,
+            GraphQL._mutations,
+            GraphQL._subscription_fields,
+        )
+
+    def test_create_graphql_output_type_is_idempotent_for_same_declaration(
+        self,
+    ) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class ProjectHour(GraphQLType):
+            task_id: int
+
+        generated = GraphQL.create_graphql_output_type(ProjectHour)
+
+        assert GraphQL.create_graphql_output_type(ProjectHour) is generated
+        assert GraphQL.graphql_output_type_registry == {"ProjectHour": generated}
+
+    def test_reset_registry_clears_generated_outputs_not_declarations(self) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class ProjectHour(GraphQLType):
+            task_id: int
+
+        GraphQL.create_graphql_output_type(ProjectHour)
+        GraphQL.reset_registry()
+
+        assert GraphQL.graphql_output_type_registry == {}
+        assert get_registered_graphql_types()[-1] is ProjectHour
+
+    def test_duplicate_output_declaration_names_fail_before_registry_mutation(
+        self,
+    ) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        FirstDuplicate = _make_graphql_output_declaration("DuplicateOutput")
+        _make_graphql_output_declaration("DuplicateOutput")
+        sentinel = type("SentinelType", (graphene.ObjectType,), {})
+        GraphQL.graphql_output_type_registry["Existing"] = sentinel
+        before = dict(GraphQL.graphql_output_type_registry)
+
+        with self.assertRaises(ValueError):
+            GraphQL.create_graphql_output_type(FirstDuplicate)
+
+        self.assertEqual(GraphQL.graphql_output_type_registry, before)
+
+    def test_output_type_rejects_manager_schema_name_collision_without_mutation(
+        self,
+    ) -> None:
+        declarations = get_registered_graphql_types()
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        GraphQL.reset_registry()
+
+        class SharedName(GraphQLType):
+            task_id: int
+
+        class SharedNameManager(GeneralManager):
+            pass
+
+        manager_type = type("SharedNameType", (graphene.ObjectType,), {})
+        GraphQL.manager_registry["SharedName"] = SharedNameManager
+        GraphQL.graphql_type_registry["SharedName"] = manager_type
+        before = dict(GraphQL.graphql_output_type_registry)
+
+        with self.assertRaises(ValueError):
+            GraphQL.create_graphql_output_type(SharedName)
+
+        self.assertEqual(GraphQL.graphql_output_type_registry, before)
 
     def test_sort_options_include_direct_manager_and_related_scalars(self) -> None:
         related_computed = SimpleNamespace(sortable=True, graphql_type_hint=str)

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -29,6 +29,7 @@ from general_manager.api.graphql import (
     GraphQL,
     get_read_permission_filter,
 )
+from general_manager.api.registry import GraphQLRegistry
 from general_manager.api.graphql_type import (
     GraphQLType,
     _restore_registered_graphql_types,
@@ -89,31 +90,23 @@ from graphql.language import StringValueNode
 from graphql.validation import ASTValidationRule
 
 
-def _restore_graphql_registry(snapshot: object) -> None:
-    GraphQL._query_class = snapshot.query_class  # type: ignore[attr-defined]
-    GraphQL._mutation_class = snapshot.mutation_class  # type: ignore[attr-defined]
-    GraphQL._subscription_class = snapshot.subscription_class  # type: ignore[attr-defined]
-    GraphQL._schema = snapshot.schema  # type: ignore[attr-defined]
-    GraphQL._mutations = snapshot.mutations  # type: ignore[attr-defined]
-    GraphQL._query_fields = snapshot.query_fields  # type: ignore[attr-defined]
-    GraphQL._subscription_fields = snapshot.subscription_fields  # type: ignore[attr-defined]
-    GraphQL._page_type_registry = snapshot.page_type_registry  # type: ignore[attr-defined]
-    GraphQL._subscription_payload_registry = (  # type: ignore[attr-defined]
-        snapshot.subscription_payload_registry  # type: ignore[attr-defined]
-    )
-    GraphQL.graphql_type_registry = snapshot.graphql_type_registry  # type: ignore[attr-defined]
-    GraphQL.graphql_output_type_registry = (  # type: ignore[attr-defined]
-        snapshot.graphql_output_type_registry  # type: ignore[attr-defined]
-    )
-    GraphQL.graphql_filter_type_registry = (  # type: ignore[attr-defined]
-        snapshot.graphql_filter_type_registry  # type: ignore[attr-defined]
-    )
-    GraphQL.graphql_capability_type_registry = (  # type: ignore[attr-defined]
-        snapshot.graphql_capability_type_registry  # type: ignore[attr-defined]
-    )
-    GraphQL.manager_registry = snapshot.manager_registry  # type: ignore[attr-defined]
-    GraphQL._search_union = snapshot.search_union  # type: ignore[attr-defined]
-    GraphQL._search_result_type = snapshot.search_result_type  # type: ignore[attr-defined]
+def _restore_graphql_registry(snapshot: GraphQLRegistry) -> None:
+    GraphQL._query_class = snapshot.query_class
+    GraphQL._mutation_class = snapshot.mutation_class
+    GraphQL._subscription_class = snapshot.subscription_class
+    GraphQL._schema = snapshot.schema
+    GraphQL._mutations = snapshot.mutations
+    GraphQL._query_fields = snapshot.query_fields
+    GraphQL._subscription_fields = snapshot.subscription_fields
+    GraphQL._page_type_registry = snapshot.page_type_registry
+    GraphQL._subscription_payload_registry = snapshot.subscription_payload_registry
+    GraphQL.graphql_type_registry = snapshot.graphql_type_registry
+    GraphQL.graphql_output_type_registry = snapshot.graphql_output_type_registry
+    GraphQL.graphql_filter_type_registry = snapshot.graphql_filter_type_registry
+    GraphQL.graphql_capability_type_registry = snapshot.graphql_capability_type_registry
+    GraphQL.manager_registry = snapshot.manager_registry
+    GraphQL._search_union = snapshot.search_union
+    GraphQL._search_result_type = snapshot.search_result_type
 
 
 def _make_graphql_output_declaration(

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -19,7 +19,7 @@ from django.test import RequestFactory
 from django.db.models import NOT_PROVIDED
 from unittest.mock import MagicMock, patch
 from django.contrib.auth.models import AnonymousUser
-from typing import Any, ClassVar, get_args
+from typing import Annotated, Any, ClassVar, Literal, get_args
 
 from general_manager import bootstrap as gm_bootstrap
 from general_manager.api.graphql import (
@@ -2629,6 +2629,9 @@ class GraphQLTests(TestCase):
         self.addCleanup(_restore_registered_graphql_types, declarations)
         GraphQL.reset_registry()
 
+        class ProjectHour(GraphQLType):
+            marker: str
+
         class RelatedManager(GeneralManager):
             pass
 
@@ -2661,6 +2664,14 @@ class GraphQLTests(TestCase):
             return []
 
         @graph_ql_property(cache="none")
+        def annotated_scalar(_instance) -> Annotated[str, ProjectHour]:
+            return "annotated"
+
+        @graph_ql_property(cache="none")
+        def literal_scalar(_instance) -> Literal["ProjectHour"]:
+            return "literal"
+
+        @graph_ql_property(cache="none")
         def unknown(_instance) -> object:
             return object()
 
@@ -2670,6 +2681,8 @@ class GraphQLTests(TestCase):
             "measurements": measurements,
             "related": related,
             "related_list": related_list,
+            "annotated_scalar": annotated_scalar,
+            "literal_scalar": literal_scalar,
             "unknown": unknown,
         }
 
@@ -2697,8 +2710,23 @@ class GraphQLTests(TestCase):
         ):
             GraphQL.create_graphql_interface(LegacyManager)
 
-        fields = GraphQL.graphql_type_registry["LegacyManager"]._meta.fields
+        LegacyManagerType = GraphQL.graphql_type_registry["LegacyManager"]
+        fields = LegacyManagerType._meta.fields
         self.assertIs(fields["scalar"].type, graphene.String)
+        self.assertIs(fields["annotated_scalar"].type, graphene.String)
+        self.assertIs(fields["literal_scalar"].type, graphene.String)
+        legacy_instance = SimpleNamespace(
+            annotated_scalar="annotated",
+            literal_scalar="literal",
+        )
+        self.assertEqual(
+            LegacyManagerType.resolve_annotated_scalar(legacy_instance, self.info),
+            "annotated",
+        )
+        self.assertEqual(
+            LegacyManagerType.resolve_literal_scalar(legacy_instance, self.info),
+            "literal",
+        )
         self.assertIs(fields["measurement"].type, MeasurementType)
         self.assertIsInstance(fields["measurements"].type, graphene.List)
         self.assertIs(fields["measurements"].type.of_type, MeasurementScalar)

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -2671,6 +2671,9 @@ class GraphQLTests(TestCase):
         def literal_scalar(_instance) -> Literal["ProjectHour"]:
             return "literal"
 
+        annotated_scalar._graphql_type_hint = Annotated[str, ProjectHour]
+        literal_scalar._graphql_type_hint = Literal["ProjectHour"]
+
         @graph_ql_property(cache="none")
         def unknown(_instance) -> object:
             return object()

--- a/tests/unit/test_graph_ql.py
+++ b/tests/unit/test_graph_ql.py
@@ -25,6 +25,7 @@ from general_manager import bootstrap as gm_bootstrap
 from general_manager.api.graphql import (
     BigIntScalar,
     MeasurementType,
+    MeasurementScalar,
     GraphQL,
     get_read_permission_filter,
 )
@@ -2327,6 +2328,91 @@ class GraphQLTests(TestCase):
             GraphQL.create_graphql_interface(TestManager)
             self.assertIn("TestManager", GraphQL.graphql_type_registry)
 
+    def test_legacy_graphql_property_shapes_remain_unchanged(self) -> None:
+        registry_snapshot = GraphQL.get_registry_snapshot()
+        declarations = get_registered_graphql_types()
+        self.addCleanup(_restore_graphql_registry, registry_snapshot)
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        GraphQL.reset_registry()
+
+        class RelatedManager(GeneralManager):
+            pass
+
+        RelatedType = type(
+            "RelatedManagerType",
+            (graphene.ObjectType,),
+            {"name": graphene.String()},
+        )
+        GraphQL.manager_registry["RelatedManager"] = RelatedManager
+        GraphQL.graphql_type_registry["RelatedManager"] = RelatedType
+
+        @graph_ql_property(cache="none")
+        def scalar(_instance) -> str:
+            return "value"
+
+        @graph_ql_property(cache="none")
+        def measurement(_instance) -> Measurement:
+            return Measurement(1, "m")
+
+        @graph_ql_property(cache="none")
+        def measurements(_instance) -> list[Measurement]:
+            return []
+
+        @graph_ql_property(cache="none")
+        def related(_instance) -> RelatedManager:
+            return RelatedManager()
+
+        @graph_ql_property(cache="none")
+        def related_list(_instance) -> list[RelatedManager]:
+            return []
+
+        @graph_ql_property(cache="none")
+        def unknown(_instance) -> object:
+            return object()
+
+        properties = {
+            "scalar": scalar,
+            "measurement": measurement,
+            "measurements": measurements,
+            "related": related,
+            "related_list": related_list,
+            "unknown": unknown,
+        }
+
+        class LegacyInterface(InterfaceBase):
+            input_fields: ClassVar[dict] = {}
+
+            @staticmethod
+            def get_attribute_types():
+                return {}
+
+            @classmethod
+            def get_graph_ql_properties(cls):
+                return properties
+
+        class LegacyManager:
+            Interface = LegacyInterface
+
+        with (
+            patch.object(GraphQL, "_add_queries_to_schema"),
+            patch.object(GraphQL, "_add_subscription_field"),
+            patch(
+                "general_manager.api.graphql.get_graphql_capabilities",
+                return_value=(),
+            ),
+        ):
+            GraphQL.create_graphql_interface(LegacyManager)
+
+        fields = GraphQL.graphql_type_registry["LegacyManager"]._meta.fields
+        self.assertIs(fields["scalar"].type, graphene.String)
+        self.assertIs(fields["measurement"].type, MeasurementType)
+        self.assertIsInstance(fields["measurements"].type, graphene.List)
+        self.assertIs(fields["measurements"].type.of_type, MeasurementScalar)
+        self.assertIs(fields["related"].type, RelatedType)
+        self.assertIsInstance(fields["related_list"].type, graphene.List)
+        self.assertIs(fields["related_list"].type.of_type, RelatedType)
+        self.assertIs(fields["unknown"].type, graphene.String)
+
     def test_list_resolver_with_invalid_filter_exclude(self):
         """
         Test that the list resolver returns the original queryset when filter or exclude arguments are invalid JSON.
@@ -2882,6 +2968,39 @@ class GraphQLDirectiveRegistrationTests(TestCase):
             patch("general_manager.bootstrap.add_graphql_url"),
         ):
             gm_bootstrap.handle_graph_ql([FirstManager, SecondManager])
+
+    def test_bootstrap_registers_output_types_without_root_operations(self) -> None:
+        declarations = get_registered_graphql_types()
+        self.addCleanup(_restore_registered_graphql_types, declarations)
+        GraphQL.reset_registry()
+
+        class BootstrapOutput(GraphQLType):
+            value: int
+
+        GraphQL._query_fields = {"ping": graphene.String()}
+        with (
+            patch.object(gm_bootstrap.GraphQL, "create_graphql_interface"),
+            patch.object(gm_bootstrap.GraphQL, "create_graphql_mutation"),
+            patch.object(gm_bootstrap.GraphQL, "register_file_upload_mutation"),
+            patch.object(gm_bootstrap.GraphQL, "register_search_query"),
+            patch.object(
+                gm_bootstrap.GraphQL,
+                "register_current_user_capabilities",
+            ),
+            patch("general_manager.uploads.urls.add_file_upload_urls"),
+            patch("general_manager.bootstrap.add_graphql_url"),
+        ):
+            gm_bootstrap.handle_graph_ql([])
+
+        generated = GraphQL.graphql_output_type_registry["BootstrapOutput"]
+        self.assertEqual(generated.__name__, "BootstrapOutputType")
+        self.assertIsNotNone(
+            GraphQL.get_schema().graphql_schema.get_type("BootstrapOutputType")
+        )
+        self.assertNotIn(
+            "bootstrapOutput",
+            GraphQL.get_schema().graphql_schema.query_type.fields,
+        )
 
     def test_build_schema_directives_uses_specified_directives_by_default(self) -> None:
         directives = gm_bootstrap._build_schema_directives()

--- a/tests/unit/test_graphql_helpers.py
+++ b/tests/unit/test_graphql_helpers.py
@@ -741,6 +741,7 @@ class GraphQLHelperTests(SimpleTestCase):
             "_page_type_registry": GraphQL._page_type_registry,
             "_subscription_payload_registry": GraphQL._subscription_payload_registry,
             "graphql_type_registry": GraphQL.graphql_type_registry,
+            "graphql_output_type_registry": GraphQL.graphql_output_type_registry,
             "graphql_filter_type_registry": GraphQL.graphql_filter_type_registry,
             "graphql_capability_type_registry": GraphQL.graphql_capability_type_registry,
             "manager_registry": GraphQL.manager_registry,
@@ -754,6 +755,7 @@ class GraphQLHelperTests(SimpleTestCase):
             GraphQL._page_type_registry = {"page": object_type}
             GraphQL._subscription_payload_registry = {"payload": object_type}
             GraphQL.graphql_type_registry = {"manager": object_type}
+            GraphQL.graphql_output_type_registry = {"output": object_type}
             GraphQL.graphql_filter_type_registry = {"filter": input_type}
             GraphQL.graphql_capability_type_registry = {"capability": object_type}
             GraphQL.manager_registry = {"manager": _DummyManager}
@@ -772,6 +774,10 @@ class GraphQLHelperTests(SimpleTestCase):
                     GraphQL._subscription_payload_registry,
                 ),
                 (snapshot.graphql_type_registry, GraphQL.graphql_type_registry),
+                (
+                    snapshot.graphql_output_type_registry,
+                    GraphQL.graphql_output_type_registry,
+                ),
                 (
                     snapshot.graphql_filter_type_registry,
                     GraphQL.graphql_filter_type_registry,
@@ -798,6 +804,9 @@ class GraphQLHelperTests(SimpleTestCase):
                 "_subscription_payload_registry"
             ]
             GraphQL.graphql_type_registry = original_values["graphql_type_registry"]
+            GraphQL.graphql_output_type_registry = original_values[
+                "graphql_output_type_registry"
+            ]
             GraphQL.graphql_filter_type_registry = original_values[
                 "graphql_filter_type_registry"
             ]

--- a/tests/unit/test_graphql_output.py
+++ b/tests/unit/test_graphql_output.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Annotated, Any
+
+import graphene
+import pytest
+
+from general_manager.api.graphql import GraphQL, MeasurementType
+from general_manager.api.graphql_output import (
+    GraphQLOutputAnnotationError,
+    create_output_field_resolver,
+    map_graphql_output_annotation,
+    resolve_output_type_hints,
+)
+from general_manager.api.graphql_type import (
+    GraphQLType,
+    _restore_registered_graphql_types,
+    get_registered_graphql_types,
+)
+from general_manager.manager.general_manager import GeneralManager
+from general_manager.measurement.measurement import Measurement
+
+
+class User(GeneralManager):
+    pass
+
+
+class UserType(graphene.ObjectType):
+    name = graphene.String()
+
+
+class Summary(GraphQLType):
+    title: str
+
+
+class SummaryType(graphene.ObjectType):
+    title = graphene.String()
+
+
+@pytest.fixture(autouse=True)
+def restore_graphql_type_registry() -> None:
+    snapshot = get_registered_graphql_types()
+    yield
+    _restore_registered_graphql_types(snapshot)
+
+
+def map_annotation(annotation: object):
+    return map_graphql_output_annotation(
+        annotation,
+        owner_name="Envelope",
+        field_name="value",
+        manager_registry={"User": User},
+        manager_type_registry={"User": UserType},
+        output_class_registry={"Summary": Summary},
+        output_type_registry={"Summary": SummaryType},
+        measurement_type=MeasurementType,
+        scalar_mapper=GraphQL._map_field_to_graphene_base_type,
+    )
+
+
+def test_collection_preserves_both_nullability_levels() -> None:
+    required = map_annotation(list[User])
+    nullable_items = map_annotation(list[User | None])
+    nullable_list = map_annotation(list[User] | None)
+
+    assert isinstance(required.field.type, graphene.NonNull)
+    assert isinstance(required.field.type.of_type, graphene.List)
+    assert isinstance(required.field.type.of_type.of_type, graphene.NonNull)
+    assert isinstance(nullable_items.field.type, graphene.NonNull)
+    assert not isinstance(nullable_items.field.type.of_type.of_type, graphene.NonNull)
+    assert not isinstance(nullable_list.field.type, graphene.NonNull)
+
+
+@pytest.mark.parametrize(
+    ("annotation", "graphene_type"),
+    [
+        (str, graphene.String),
+        (bool, graphene.Boolean),
+        (int, graphene.Int),
+        (float, graphene.Float),
+        (Decimal, graphene.Float),
+        (datetime, graphene.DateTime),
+        (date, graphene.Date),
+    ],
+)
+def test_supported_scalar_subclasses_use_their_graphene_scalar(
+    annotation: type,
+    graphene_type: type,
+) -> None:
+    mapped = map_annotation(annotation)
+
+    assert isinstance(mapped.field.type, graphene.NonNull)
+    assert mapped.field.type.of_type is graphene_type
+    assert mapped.resolver_type is annotation
+
+
+def test_direct_manager_uses_live_generated_type_registry() -> None:
+    mapped = map_annotation(User)
+
+    assert isinstance(mapped.field.type, graphene.NonNull)
+    assert mapped.field.type.of_type is UserType
+    assert mapped.resolver_type is User
+
+
+def test_nested_output_type_uses_output_registry_and_value_resolver_type() -> None:
+    mapped = map_annotation(list[Summary | None])
+
+    assert mapped.resolver_type is Summary
+    assert isinstance(mapped.field.type, graphene.NonNull)
+    assert isinstance(mapped.field.type.of_type, graphene.List)
+    assert not isinstance(mapped.field.type.of_type.of_type, graphene.NonNull)
+    assert mapped.field.type.of_type.of_type is SummaryType
+
+
+@pytest.mark.parametrize("annotation", [tuple[User, ...], set[User]])
+def test_supported_collection_shapes_map_to_graphene_lists(annotation: object) -> None:
+    mapped = map_annotation(annotation)
+
+    assert isinstance(mapped.field.type, graphene.NonNull)
+    assert isinstance(mapped.field.type.of_type, graphene.List)
+    assert isinstance(mapped.field.type.of_type.of_type, graphene.NonNull)
+    assert mapped.field.type.of_type.of_type.of_type is UserType
+    assert mapped.resolver_type is User
+
+
+def test_measurement_maps_to_measurement_object_with_target_unit_argument() -> None:
+    mapped = map_annotation(Measurement)
+
+    assert isinstance(mapped.field.type, graphene.NonNull)
+    assert mapped.field.type.of_type is MeasurementType
+    assert "target_unit" in mapped.field.args
+    assert mapped.resolver_type is Measurement
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        list,
+        set,
+        tuple,
+        tuple[int, str],
+        list[Any],
+        list[Annotated[int, "metadata"]],
+        int | str,
+        int | str | None,
+        object,
+        Any,
+        Annotated[int, "metadata"],
+        dict,
+    ],
+)
+def test_unsupported_annotations_name_owner_field_and_annotation(
+    annotation: object,
+) -> None:
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        map_annotation(annotation)
+
+    message = str(error.value)
+    assert "Envelope.value" in message
+    assert repr(annotation) in message
+
+
+def test_registered_names_resolve_in_type_hints() -> None:
+    class Envelope:
+        value: "Summary"
+        users: list["User"]
+
+    hints = resolve_output_type_hints(
+        Envelope,
+        manager_registry={"User": User},
+        output_class_registry={"Summary": Summary},
+    )
+
+    assert hints == {"value": Summary, "users": list[User]}
+
+
+def test_unresolved_forward_reference_names_owner() -> None:
+    class Envelope:
+        value: "MissingSummary"  # noqa: F821
+
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        resolve_output_type_hints(
+            Envelope,
+            manager_registry={"User": User},
+            output_class_registry={"Summary": Summary},
+        )
+
+    assert "Envelope" in str(error.value)
+    assert "MissingSummary" in str(error.value)
+
+
+def test_output_measurement_resolver_converts_without_manager_access_checks() -> None:
+    parent = SimpleNamespace(
+        amount=Measurement(1000, "meter"),
+        _ensure_as_of_compatible=lambda: (_ for _ in ()).throw(
+            AssertionError("output values must not use manager as-of checks")
+        ),
+    )
+    resolver = create_output_field_resolver("amount", Measurement)
+
+    assert resolver(parent, None, target_unit="kilometer") == {
+        "value": 1,
+        "unit": "kilometer",
+    }
+
+
+def test_output_normal_resolver_reads_dataclass_value_without_info() -> None:
+    parent = SimpleNamespace(title="Summary")
+    resolver = create_output_field_resolver("title", str)
+
+    assert resolver(parent, None) == "Summary"

--- a/tests/unit/test_graphql_output.py
+++ b/tests/unit/test_graphql_output.py
@@ -475,20 +475,30 @@ def test_unresolved_callable_forward_reference_reports_owner_field() -> None:
     assert "MissingValue" in str(error.value)
 
 
-def test_empty_annotations_report_owner_and_annotations_field() -> None:
-    class EmptyCallable:
-        def __call__(self, *_args: object, **_kwargs: object) -> object:
-            return None
+def test_annotationless_callable_reports_error_when_hint_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def resolver():
+        return None
 
-    invalid_owner = EmptyCallable()
+    def fail_get_type_hints(
+        *_args: object,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        raise TypeError
+
+    monkeypatch.setattr(
+        "general_manager.api.graphql_output.get_type_hints",
+        fail_get_type_hints,
+    )
     with pytest.raises(GraphQLOutputAnnotationError) as error:
         resolve_output_type_hints(
-            invalid_owner,
+            resolver,
             manager_registry={"User": User},
             output_class_registry={"Summary": _CURRENT_SUMMARY},
         )
 
-    assert "EmptyCallable.annotations" in str(error.value)
+    assert "resolver.annotations" in str(error.value)
 
 
 def test_output_measurement_resolver_converts_without_manager_access_checks() -> None:

--- a/tests/unit/test_graphql_output.py
+++ b/tests/unit/test_graphql_output.py
@@ -32,10 +32,6 @@ class UserType(graphene.ObjectType):
     name = graphene.String()
 
 
-class Summary(GraphQLType):
-    title: str
-
-
 class SummaryType(graphene.ObjectType):
     title = graphene.String()
 
@@ -60,21 +56,41 @@ class CustomDate(date):
     pass
 
 
+_CURRENT_SUMMARY: type[GraphQLType] | None = None
+
+
 @pytest.fixture(autouse=True)
 def restore_graphql_type_registry() -> None:
+    global _CURRENT_SUMMARY
     snapshot = get_registered_graphql_types()
+    _CURRENT_SUMMARY = type(
+        "Summary",
+        (GraphQLType,),
+        {
+            "__module__": __name__,
+            "__annotations__": {"title": str},
+        },
+    )
     yield
+    _CURRENT_SUMMARY = None
     _restore_registered_graphql_types(snapshot)
 
 
+@pytest.fixture
+def summary_type() -> type[GraphQLType]:
+    assert _CURRENT_SUMMARY is not None
+    return _CURRENT_SUMMARY
+
+
 def map_annotation(annotation: object):
+    assert _CURRENT_SUMMARY is not None
     return map_graphql_output_annotation(
         annotation,
         owner_name="Envelope",
         field_name="value",
         manager_registry={"User": User},
         manager_type_registry={"User": UserType},
-        output_class_registry={"Summary": Summary},
+        output_class_registry={"Summary": _CURRENT_SUMMARY},
         output_type_registry={"Summary": SummaryType},
         measurement_type=MeasurementType,
         scalar_mapper=GraphQL._map_field_to_graphene_base_type,
@@ -130,10 +146,12 @@ def test_direct_manager_uses_live_generated_type_registry() -> None:
     assert mapped.resolver_type is User
 
 
-def test_nested_output_type_uses_output_registry_and_value_resolver_type() -> None:
-    mapped = map_annotation(list[Summary | None])
+def test_nested_output_type_uses_output_registry_and_value_resolver_type(
+    summary_type: type[GraphQLType],
+) -> None:
+    mapped = map_annotation(list[summary_type | None])
 
-    assert mapped.resolver_type is Summary
+    assert mapped.resolver_type is summary_type
     assert isinstance(mapped.field.type, graphene.NonNull)
     assert isinstance(mapped.field.type.of_type, graphene.List)
     assert not isinstance(mapped.field.type.of_type.of_type, graphene.NonNull)
@@ -195,7 +213,7 @@ def test_live_generated_type_thunk_reads_entry_added_and_replaced_after_mapping(
         field_name="value",
         manager_registry={"User": User},
         manager_type_registry=manager_type_registry,
-        output_class_registry={"Summary": Summary},
+        output_class_registry={"Summary": _CURRENT_SUMMARY},
         output_type_registry={"Summary": SummaryType},
         measurement_type=MeasurementType,
         scalar_mapper=GraphQL._map_field_to_graphene_base_type,
@@ -213,17 +231,17 @@ def test_live_generated_type_thunk_reads_entry_added_and_replaced_after_mapping(
     assert mapped.field.type.of_type is SecondUserType
 
 
-def test_nullable_output_type_defers_live_registry_thunk_until_schema_assembly() -> (
-    None
-):
+def test_nullable_output_type_defers_live_registry_thunk_until_schema_assembly(
+    summary_type: type[GraphQLType],
+) -> None:
     output_type_registry: dict[str, type[graphene.ObjectType]] = {}
     mapped = map_graphql_output_annotation(
-        Summary | None,
+        summary_type | None,
         owner_name="Envelope",
         field_name="summary",
         manager_registry={"User": User},
         manager_type_registry={"User": UserType},
-        output_class_registry={"Summary": Summary},
+        output_class_registry={"Summary": summary_type},
         output_type_registry=output_type_registry,
         measurement_type=MeasurementType,
         scalar_mapper=GraphQL._map_field_to_graphene_base_type,
@@ -292,28 +310,32 @@ def test_unsupported_annotations_name_owner_field_and_annotation(
     assert repr(annotation) in message
 
 
-def test_registered_names_resolve_in_type_hints() -> None:
+def test_registered_names_resolve_in_type_hints(
+    summary_type: type[GraphQLType],
+) -> None:
     class Envelope:
-        value: "Summary"
+        value: "Summary"  # noqa: F821
         users: list["User"]
 
     hints = resolve_output_type_hints(
         Envelope,
         manager_registry={"User": User},
-        output_class_registry={"Summary": Summary},
+        output_class_registry={"Summary": summary_type},
     )
 
-    assert hints == {"value": Summary, "users": list[User]}
+    assert hints == {"value": summary_type, "users": list[User]}
 
 
-def test_resolved_annotated_hint_reaches_mapper_and_is_rejected() -> None:
+def test_resolved_annotated_hint_reaches_mapper_and_is_rejected(
+    summary_type: type[GraphQLType],
+) -> None:
     class Envelope:
         value: Annotated[int, "metadata"]
 
     hints = resolve_output_type_hints(
         Envelope,
         manager_registry={"User": User},
-        output_class_registry={"Summary": Summary},
+        output_class_registry={"Summary": summary_type},
     )
 
     assert hints["value"] == Annotated[int, "metadata"]
@@ -324,7 +346,7 @@ def test_resolved_annotated_hint_reaches_mapper_and_is_rejected() -> None:
             field_name="value",
             manager_registry={"User": User},
             manager_type_registry={"User": UserType},
-            output_class_registry={"Summary": Summary},
+            output_class_registry={"Summary": summary_type},
             output_type_registry={"Summary": SummaryType},
             measurement_type=MeasurementType,
             scalar_mapper=GraphQL._map_field_to_graphene_base_type,
@@ -343,7 +365,7 @@ def test_unresolved_forward_reference_names_first_owner_field() -> None:
         resolve_output_type_hints(
             Envelope,
             manager_registry={"User": User},
-            output_class_registry={"Summary": Summary},
+            output_class_registry={"Summary": _CURRENT_SUMMARY},
         )
 
     assert "Envelope" in str(error.value)

--- a/tests/unit/test_graphql_output.py
+++ b/tests/unit/test_graphql_output.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable, ForwardRef, cast
 
 import graphene
 import pytest
@@ -144,6 +144,81 @@ def test_direct_manager_uses_live_generated_type_registry() -> None:
     assert isinstance(mapped.field.type, graphene.NonNull)
     assert mapped.field.type.of_type is UserType
     assert mapped.resolver_type is User
+
+
+def test_registered_manager_alias_uses_identity_lookup() -> None:
+    mapped = map_graphql_output_annotation(
+        User,
+        owner_name="Envelope",
+        field_name="value",
+        manager_registry={"Owner": User},
+        manager_type_registry={"Owner": UserType},
+        output_class_registry={"Summary": _CURRENT_SUMMARY},
+        output_type_registry={"Summary": SummaryType},
+        measurement_type=MeasurementType,
+        scalar_mapper=GraphQL._map_field_to_graphene_base_type,
+    )
+
+    assert mapped.field.type.of_type is UserType
+    assert mapped.resolver_type is User
+
+
+@pytest.mark.parametrize("annotation", [ForwardRef("User"), "'User'", '"User"'])
+def test_forward_reference_names_resolve_through_live_manager_registry(
+    annotation: object,
+) -> None:
+    mapped = map_annotation(annotation)
+
+    assert mapped.field.type.of_type is UserType
+    assert mapped.resolver_type is User
+
+
+def test_forward_reference_name_collision_is_rejected() -> None:
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        map_graphql_output_annotation(
+            "Shared",
+            owner_name="Envelope",
+            field_name="value",
+            manager_registry={"Shared": User},
+            manager_type_registry={"Shared": UserType},
+            output_class_registry={"Shared": _CURRENT_SUMMARY},
+            output_type_registry={"Shared": SummaryType},
+            measurement_type=MeasurementType,
+            scalar_mapper=GraphQL._map_field_to_graphene_base_type,
+        )
+
+    assert "Envelope.value" in str(error.value)
+    assert repr("Shared") in str(error.value)
+
+
+def test_unregistered_forward_reference_name_is_rejected() -> None:
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        map_annotation("MissingValue")
+
+    assert "Envelope.value" in str(error.value)
+    assert repr("MissingValue") in str(error.value)
+
+
+def test_unregistered_output_type_is_rejected() -> None:
+    class UnregisteredOutput(GraphQLType):
+        title: str
+
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        map_annotation(UnregisteredOutput)
+
+    assert "Envelope.value" in str(error.value)
+    assert repr(UnregisteredOutput) in str(error.value)
+
+
+def test_unregistered_manager_type_is_rejected() -> None:
+    class UnregisteredManager(GeneralManager):
+        pass
+
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        map_annotation(UnregisteredManager)
+
+    assert "Envelope.value" in str(error.value)
+    assert repr(UnregisteredManager) in str(error.value)
 
 
 def test_nested_output_type_uses_output_registry_and_value_resolver_type(
@@ -288,7 +363,10 @@ def test_measurement_maps_to_measurement_object_with_target_unit_argument() -> N
         list,
         set,
         tuple,
+        list[int, str],
         tuple[int, str],
+        None,
+        type(None),
         list[Any],
         list[Annotated[int, "metadata"]],
         int | str,
@@ -374,6 +452,33 @@ def test_unresolved_forward_reference_names_first_owner_field() -> None:
     assert "MissingOther" not in str(error.value)
 
 
+def test_unresolved_callable_forward_reference_reports_owner_field() -> None:
+    def resolver(value: "MissingValue") -> "Summary":  # noqa: F821
+        return value
+
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        resolve_output_type_hints(
+            resolver,
+            manager_registry={"User": User},
+            output_class_registry={"Summary": _CURRENT_SUMMARY},
+        )
+
+    assert "resolver.value" in str(error.value)
+    assert "MissingValue" in str(error.value)
+
+
+def test_empty_annotations_report_owner_and_annotations_field() -> None:
+    invalid_owner = cast(Callable[..., object], object())
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        resolve_output_type_hints(
+            invalid_owner,
+            manager_registry={"User": User},
+            output_class_registry={"Summary": _CURRENT_SUMMARY},
+        )
+
+    assert "object.annotations" in str(error.value)
+
+
 def test_output_measurement_resolver_converts_without_manager_access_checks() -> None:
     parent = SimpleNamespace(
         amount=Measurement(1000, "meter"),
@@ -408,3 +513,10 @@ def test_output_normal_resolver_reads_dataclass_value_without_info() -> None:
     resolver = create_output_field_resolver("title", str)
 
     assert resolver(parent, None) == "Summary"
+
+
+def test_output_measurement_resolver_returns_none_for_non_measurement_value() -> None:
+    parent = SimpleNamespace(amount={"value": 1, "unit": "meter"})
+    resolver = create_output_field_resolver("amount", Measurement)
+
+    assert resolver(parent, None) is None

--- a/tests/unit/test_graphql_output.py
+++ b/tests/unit/test_graphql_output.py
@@ -40,6 +40,26 @@ class SummaryType(graphene.ObjectType):
     title = graphene.String()
 
 
+class CustomString(str):
+    pass
+
+
+class CustomInteger(int):
+    pass
+
+
+class CustomDecimal(Decimal):
+    pass
+
+
+class CustomDateTime(datetime):
+    pass
+
+
+class CustomDate(date):
+    pass
+
+
 @pytest.fixture(autouse=True)
 def restore_graphql_type_registry() -> None:
     snapshot = get_registered_graphql_types()
@@ -78,12 +98,17 @@ def test_collection_preserves_both_nullability_levels() -> None:
     ("annotation", "graphene_type"),
     [
         (str, graphene.String),
+        (CustomString, graphene.String),
         (bool, graphene.Boolean),
         (int, graphene.Int),
+        (CustomInteger, graphene.Int),
         (float, graphene.Float),
         (Decimal, graphene.Float),
+        (CustomDecimal, graphene.Float),
         (datetime, graphene.DateTime),
+        (CustomDateTime, graphene.DateTime),
         (date, graphene.Date),
+        (CustomDate, graphene.Date),
     ],
 )
 def test_supported_scalar_subclasses_use_their_graphene_scalar(
@@ -124,6 +149,60 @@ def test_supported_collection_shapes_map_to_graphene_lists(annotation: object) -
     assert isinstance(mapped.field.type.of_type.of_type, graphene.NonNull)
     assert mapped.field.type.of_type.of_type.of_type is UserType
     assert mapped.resolver_type is User
+
+
+@pytest.mark.parametrize(
+    ("annotation", "nullable_container", "nullable_item"),
+    [
+        (set[User] | None, True, False),
+        (set[User | None], False, True),
+        (tuple[User, ...] | None, True, False),
+        (tuple[User | None, ...], False, True),
+    ],
+)
+def test_set_and_tuple_preserve_container_and_item_nullability(
+    annotation: object,
+    nullable_container: bool,
+    nullable_item: bool,
+) -> None:
+    mapped = map_annotation(annotation)
+
+    field_type = mapped.field.type
+    assert isinstance(field_type, graphene.NonNull) is not nullable_container
+    list_type = (
+        field_type.of_type if isinstance(field_type, graphene.NonNull) else field_type
+    )
+    assert isinstance(list_type, graphene.List)
+    item_type = list_type.of_type
+    assert isinstance(item_type, graphene.NonNull) is not nullable_item
+
+
+def test_live_generated_type_thunk_reads_entry_added_and_replaced_after_mapping() -> (
+    None
+):
+    manager_type_registry: dict[str, type[graphene.ObjectType]] = {}
+    mapped = map_graphql_output_annotation(
+        User,
+        owner_name="Envelope",
+        field_name="value",
+        manager_registry={"User": User},
+        manager_type_registry=manager_type_registry,
+        output_class_registry={"Summary": Summary},
+        output_type_registry={"Summary": SummaryType},
+        measurement_type=MeasurementType,
+        scalar_mapper=GraphQL._map_field_to_graphene_base_type,
+    )
+
+    class FirstUserType(graphene.ObjectType):
+        name = graphene.String()
+
+    class SecondUserType(graphene.ObjectType):
+        name = graphene.String()
+
+    manager_type_registry["User"] = FirstUserType
+    assert mapped.field.type.of_type is FirstUserType
+    manager_type_registry["User"] = SecondUserType
+    assert mapped.field.type.of_type is SecondUserType
 
 
 def test_measurement_maps_to_measurement_object_with_target_unit_argument() -> None:
@@ -177,9 +256,38 @@ def test_registered_names_resolve_in_type_hints() -> None:
     assert hints == {"value": Summary, "users": list[User]}
 
 
-def test_unresolved_forward_reference_names_owner() -> None:
+def test_resolved_annotated_hint_reaches_mapper_and_is_rejected() -> None:
     class Envelope:
-        value: "MissingSummary"  # noqa: F821
+        value: Annotated[int, "metadata"]
+
+    hints = resolve_output_type_hints(
+        Envelope,
+        manager_registry={"User": User},
+        output_class_registry={"Summary": Summary},
+    )
+
+    assert hints["value"] == Annotated[int, "metadata"]
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        map_graphql_output_annotation(
+            hints["value"],
+            owner_name="Envelope",
+            field_name="value",
+            manager_registry={"User": User},
+            manager_type_registry={"User": UserType},
+            output_class_registry={"Summary": Summary},
+            output_type_registry={"Summary": SummaryType},
+            measurement_type=MeasurementType,
+            scalar_mapper=GraphQL._map_field_to_graphene_base_type,
+        )
+
+    assert "Envelope.value" in str(error.value)
+    assert repr(hints["value"]) in str(error.value)
+
+
+def test_unresolved_forward_reference_names_first_owner_field() -> None:
+    class Envelope:
+        value: "MissingValue"  # noqa: F821
+        other: "MissingOther"  # noqa: F821
 
     with pytest.raises(GraphQLOutputAnnotationError) as error:
         resolve_output_type_hints(
@@ -189,7 +297,9 @@ def test_unresolved_forward_reference_names_owner() -> None:
         )
 
     assert "Envelope" in str(error.value)
-    assert "MissingSummary" in str(error.value)
+    assert "Envelope.value" in str(error.value)
+    assert "MissingValue" in str(error.value)
+    assert "MissingOther" not in str(error.value)
 
 
 def test_output_measurement_resolver_converts_without_manager_access_checks() -> None:
@@ -205,6 +315,20 @@ def test_output_measurement_resolver_converts_without_manager_access_checks() ->
         "value": 1,
         "unit": "kilometer",
     }
+
+
+def test_output_measurement_resolver_recursively_converts_nested_collections() -> None:
+    meter = Measurement(1000, "meter")
+    parent = SimpleNamespace(
+        amounts=[[meter, None], (Measurement(2000, "meter"),), {meter}],
+    )
+    resolver = create_output_field_resolver("amounts", Measurement)
+
+    assert resolver(parent, None, target_unit="kilometer") == [
+        [{"value": 1, "unit": "kilometer"}, None],
+        ({"value": 2, "unit": "kilometer"},),
+        [{"value": 1, "unit": "kilometer"}],
+    ]
 
 
 def test_output_normal_resolver_reads_dataclass_value_without_info() -> None:

--- a/tests/unit/test_graphql_output.py
+++ b/tests/unit/test_graphql_output.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from datetime import date, datetime
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import Annotated, Any, Callable, ForwardRef, cast
+from typing import Annotated, Any, ForwardRef
 
 import graphene
 import pytest
+from django.test import override_settings
 
 from general_manager.api.graphql import GraphQL, MeasurementType
 from general_manager.api.graphql_output import (
@@ -21,6 +22,7 @@ from general_manager.api.graphql_type import (
     get_registered_graphql_types,
 )
 from general_manager.manager.general_manager import GeneralManager
+from general_manager.manager.meta import GeneralManagerMeta
 from general_manager.measurement.measurement import Measurement
 
 
@@ -211,14 +213,20 @@ def test_unregistered_output_type_is_rejected() -> None:
 
 
 def test_unregistered_manager_type_is_rejected() -> None:
-    class UnregisteredManager(GeneralManager):
-        pass
+    pending_before = list(GeneralManagerMeta.pending_graphql_interfaces)
+    with override_settings(GENERAL_MANAGER={"AUTOCREATE_GRAPHQL": False}):
+
+        class UnregisteredManager(GeneralManager):
+            pass
+
+        assert GeneralManagerMeta.pending_graphql_interfaces == pending_before
 
     with pytest.raises(GraphQLOutputAnnotationError) as error:
         map_annotation(UnregisteredManager)
 
     assert "Envelope.value" in str(error.value)
     assert repr(UnregisteredManager) in str(error.value)
+    assert GeneralManagerMeta.pending_graphql_interfaces == pending_before
 
 
 def test_nested_output_type_uses_output_registry_and_value_resolver_type(
@@ -468,7 +476,11 @@ def test_unresolved_callable_forward_reference_reports_owner_field() -> None:
 
 
 def test_empty_annotations_report_owner_and_annotations_field() -> None:
-    invalid_owner = cast(Callable[..., object], object())
+    class EmptyCallable:
+        def __call__(self, *_args: object, **_kwargs: object) -> object:
+            return None
+
+    invalid_owner = EmptyCallable()
     with pytest.raises(GraphQLOutputAnnotationError) as error:
         resolve_output_type_hints(
             invalid_owner,
@@ -476,7 +488,7 @@ def test_empty_annotations_report_owner_and_annotations_field() -> None:
             output_class_registry={"Summary": _CURRENT_SUMMARY},
         )
 
-    assert "object.annotations" in str(error.value)
+    assert "EmptyCallable.annotations" in str(error.value)
 
 
 def test_output_measurement_resolver_converts_without_manager_access_checks() -> None:

--- a/tests/unit/test_graphql_output.py
+++ b/tests/unit/test_graphql_output.py
@@ -205,6 +205,48 @@ def test_live_generated_type_thunk_reads_entry_added_and_replaced_after_mapping(
     assert mapped.field.type.of_type is SecondUserType
 
 
+def test_nullable_output_type_defers_live_registry_thunk_until_schema_assembly() -> (
+    None
+):
+    output_type_registry: dict[str, type[graphene.ObjectType]] = {}
+    mapped = map_graphql_output_annotation(
+        Summary | None,
+        owner_name="Envelope",
+        field_name="summary",
+        manager_registry={"User": User},
+        manager_type_registry={"User": UserType},
+        output_class_registry={"Summary": Summary},
+        output_type_registry=output_type_registry,
+        measurement_type=MeasurementType,
+        scalar_mapper=GraphQL._map_field_to_graphene_base_type,
+    )
+
+    assert mapped.field is not None
+
+    GeneratedSummaryType = type(
+        "SummaryType",
+        (graphene.ObjectType,),
+        {"title": graphene.String()},
+    )
+    output_type_registry["Summary"] = GeneratedSummaryType
+
+    assert not isinstance(mapped.field.type, graphene.NonNull)
+
+    class Query(graphene.ObjectType):
+        summary = mapped.field
+
+        @staticmethod
+        def resolve_summary(_root: object, _info: object) -> SimpleNamespace:
+            return SimpleNamespace(title="ready")
+
+    schema = graphene.Schema(query=Query)
+    response = schema.execute("{ summary { title } }")
+
+    assert response.errors is None
+    assert response.data == {"summary": {"title": "ready"}}
+    assert schema.graphql_schema.get_type("SummaryType") is not None
+
+
 def test_measurement_maps_to_measurement_object_with_target_unit_argument() -> None:
     mapped = map_annotation(Measurement)
 

--- a/tests/unit/test_graphql_output.py
+++ b/tests/unit/test_graphql_output.py
@@ -177,6 +177,14 @@ def test_set_and_tuple_preserve_container_and_item_nullability(
     assert isinstance(item_type, graphene.NonNull) is not nullable_item
 
 
+def test_fixed_length_homogeneous_tuple_is_rejected() -> None:
+    with pytest.raises(GraphQLOutputAnnotationError) as error:
+        map_annotation(tuple[int, int])
+
+    assert "Envelope.value" in str(error.value)
+    assert repr(tuple[int, int]) in str(error.value)
+
+
 def test_live_generated_type_thunk_reads_entry_added_and_replaced_after_mapping() -> (
     None
 ):

--- a/tests/unit/test_graphql_subscriptions.py
+++ b/tests/unit/test_graphql_subscriptions.py
@@ -2577,6 +2577,9 @@ class GraphQLAddSubscriptionFieldTests(unittest.TestCase):
             self._snapshot.subscription_payload_registry
         )
         GraphQL.graphql_type_registry = self._snapshot.graphql_type_registry
+        GraphQL.graphql_output_type_registry = (
+            self._snapshot.graphql_output_type_registry
+        )
         GraphQL.graphql_filter_type_registry = (
             self._snapshot.graphql_filter_type_registry
         )

--- a/tests/unit/test_graphql_type.py
+++ b/tests/unit/test_graphql_type.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import FrozenInstanceError, field, fields
 from typing import ClassVar
 
@@ -13,7 +14,7 @@ from general_manager.api.graphql_type import (
 
 
 @pytest.fixture(autouse=True)
-def restore_graphql_type_registry() -> None:
+def restore_graphql_type_registry() -> Iterator[None]:
     snapshot = get_registered_graphql_types()
     yield
     _restore_registered_graphql_types(snapshot)

--- a/tests/unit/test_graphql_type.py
+++ b/tests/unit/test_graphql_type.py
@@ -20,6 +20,8 @@ def restore_graphql_type_registry() -> None:
 
 
 def test_graphql_type_is_frozen_and_uses_dataclass_fields() -> None:
+    baseline = get_registered_graphql_types()
+
     class ProjectHour(GraphQLType):
         task_id: int
         users: list[str] = field(default_factory=list)
@@ -28,9 +30,42 @@ def test_graphql_type_is_frozen_and_uses_dataclass_fields() -> None:
     value = ProjectHour(task_id=7)
     assert value.users == []
     assert [item.name for item in fields(ProjectHour)] == ["task_id", "users"]
-    assert get_registered_graphql_types() == (ProjectHour,)
+    assert get_registered_graphql_types() == (*baseline, ProjectHour)
     with pytest.raises(FrozenInstanceError):
         value.task_id = 8  # type: ignore[misc]
+
+
+def test_graphql_type_supports_inheritance_and_init_false_fields() -> None:
+    baseline = get_registered_graphql_types()
+
+    class ProjectHour(GraphQLType):
+        task_id: int
+        users: list[str] = field(init=False, default_factory=list)
+
+    class DetailedProjectHour(ProjectHour):
+        label: str = "hours"
+
+    value = DetailedProjectHour(task_id=7)
+    sibling = DetailedProjectHour(task_id=8)
+
+    assert value.task_id == 7
+    assert value.users == []
+    assert value.label == "hours"
+    assert value.users is not sibling.users
+    assert [item.name for item in fields(DetailedProjectHour)] == [
+        "task_id",
+        "users",
+        "label",
+    ]
+    assert get_registered_graphql_types() == (
+        *baseline,
+        ProjectHour,
+        DetailedProjectHour,
+    )
+    with pytest.raises(FrozenInstanceError):
+        value.task_id = 8  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        value.users = ["alice"]  # type: ignore[misc]
 
 
 def test_graphql_type_construction_matches_dataclass_defaults() -> None:

--- a/tests/unit/test_graphql_type.py
+++ b/tests/unit/test_graphql_type.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, field, fields
+from typing import ClassVar
+
+import pytest
+
+from general_manager.api.graphql_type import (
+    GraphQLType,
+    _restore_registered_graphql_types,
+    get_registered_graphql_types,
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_graphql_type_registry() -> None:
+    snapshot = get_registered_graphql_types()
+    yield
+    _restore_registered_graphql_types(snapshot)
+
+
+def test_graphql_type_is_frozen_and_uses_dataclass_fields() -> None:
+    class ProjectHour(GraphQLType):
+        task_id: int
+        users: list[str] = field(default_factory=list)
+        label: ClassVar[str] = "hours"
+
+    value = ProjectHour(task_id=7)
+    assert value.users == []
+    assert [item.name for item in fields(ProjectHour)] == ["task_id", "users"]
+    assert get_registered_graphql_types() == (ProjectHour,)
+    with pytest.raises(FrozenInstanceError):
+        value.task_id = 8  # type: ignore[misc]
+
+
+def test_graphql_type_construction_matches_dataclass_defaults() -> None:
+    class ProjectHour(GraphQLType):
+        task_id: int
+        label: str = "hours"
+        users: list[str] = field(default_factory=list)
+
+    positional = ProjectHour(7)
+    keyword = ProjectHour(task_id=8, label="days", users=["alice"])
+    another = ProjectHour(9)
+
+    assert positional == ProjectHour(task_id=7, label="hours", users=[])
+    assert positional.task_id == 7
+    assert positional.label == "hours"
+    assert positional.users == []
+    assert keyword == ProjectHour(8, "days", ["alice"])
+    assert another.users == []
+    assert positional.users is not another.users
+
+    with pytest.raises(TypeError):
+        ProjectHour()  # type: ignore[call-arg]

--- a/tests/unit/test_public_api_init_modules.py
+++ b/tests/unit/test_public_api_init_modules.py
@@ -127,3 +127,11 @@ def test_invalid_error_template_error_is_exported_from_rule() -> None:
         is implementation_module.InvalidErrorTemplateError
     )
     assert "InvalidErrorTemplateError" in public_module.__all__
+
+
+def test_graphql_type_is_a_package_root_export() -> None:
+    public_module = import_module("general_manager")
+    implementation_module = import_module("general_manager.api.graphql_type")
+
+    assert "GraphQLType" in public_module.__all__
+    assert public_module.GraphQLType is implementation_module.GraphQLType


### PR DESCRIPTION
## Summary

Add output-only GraphQL value types that can be returned from `@graph_ql_property` methods without registering a manager or generating root operations.

## Related issue

No related issue was specified.

## What changed

- Add frozen dataclass-style `GraphQLType` declarations with Python annotation-driven nullability.
- Generate Graphene output object types without queries, mutations, subscriptions, filters, capabilities, search, or lifecycle registrations.
- Support documented scalar, optional, collection, manager, measurement, forward-reference, and mutually recursive output mappings.
- Preserve owning property authorization and nested manager field permissions.
- Publish `GraphQLType` from the package root and document the public contract.
- Add collision detection, registry isolation, bootstrap integration, and regression coverage.

## Validation

```text
python -m pytest [focused changed modules] -q — 655 passed, 61 subtests passed
python -m pytest — 6170 passed, 3 skipped, 1 pre-existing warning
ruff format --check [15 changed Python files] — passed
ruff check [15 changed Python files] — passed
mypy src/general_manager — 281 source files passed
pre-commit run --all-files — all hooks passed
python -m pytest tests/unit/test_public_api_init_modules.py tests/unit/test_generate_public_api_types.py tests/docs/test_public_api_docs_coverage.py -q — 315 passed
git diff --check — passed
```

## Documentation

Updated the GraphQL API, schema-generation concept guide, and exposure how-to with construction, annotation/nullability, supported and rejected shapes, permission behavior, registry separation, and output-only examples.

## Reviewer notes

- Existing manager-backed GraphQL properties keep their legacy mapping unless their annotation contains a `GraphQLType`.
- Output declarations are startup-registered but never become root operations.
- Nested managers retain their existing field-level permission behavior.
- The repository-wide public API generator has a pre-existing reproducibility mismatch in 13 helper files; this feature's explicit export snapshot and public API tests pass, and those unrelated rewrites are not included.
- The local Superpowers spec/plan and SDD reports are ignored and are not part of this PR.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and `python -m pytest` passes.
- [x] `ruff check`, `ruff format --check`, and strict project `mypy` configuration pass.
- [x] User-facing documentation is updated where behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GraphQLType` for reusable, output-only GraphQL object types.
  * Added support for nested, optional, collection, scalar, manager, and measurement fields.
  * Output types are automatically discovered and included during schema setup.
  * Added package-root access to `GraphQLType`.

* **Bug Fixes**
  * Preserved permission enforcement for nested managers and protected properties.
  * Improved measurement conversion in GraphQL responses.

* **Documentation**
  * Added guidance for defining, validating, registering, and authorizing GraphQL output types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->