### PR TITLE
docs: document GraphQL output types

### DIFF
--- a/docs/api/graphql.md
+++ b/docs/api/graphql.md
@@ -65,6 +65,27 @@ checks, while plain scalar fields and nested `GraphQLType` fields have no
 independent permission boundary. Applications should omit or pre-authorize
 sensitive values before returning an output value.
 
+Concrete subclasses use the dataclass-generated constructor: each annotated
+field with `init=True` is a constructor parameter, defaults follow standard
+dataclass rules, and `ClassVar` fields are not constructor or GraphQL fields.
+Instances are frozen; assigning to a field raises `dataclasses.FrozenInstanceError`.
+Invalid annotations fail schema generation with a field-specific `TypeError`,
+and duplicate or colliding output declarations fail with `ValueError` before
+the live GraphQL registries are mutated. The output-type contract is available
+from GeneralManager 0.75.0. See the [concept](../concepts/graphql/schema_autogen.md#output-only-value-types),
+[how-to](../howto/expose_via_graphql.md#return-output-only-graphql-types), and
+[cookbook recipe](../examples/graphql_output_types.md) for directly usable
+examples.
+
+During schema assembly, `GraphQL.create_graphql_output_type(output_class: type[GraphQLType]) -> type[graphene.ObjectType]` generates and
+registers the Graphene object for one declaration. It returns the existing
+generated type when the same declaration is already registered. Invalid
+annotations raise `TypeError`; duplicate declarations and registry or schema
+name collisions raise `ValueError` before registry state is changed. This is
+bootstrap plumbing rather than the application-facing registration API: define
+`GraphQLType` subclasses and import their module before startup schema
+construction.
+
 ## Historical queries with `@asOf`
 
 The [Historical Context API reference](historical_context.md) contains the
@@ -527,7 +548,10 @@ live `GraphQL` registries. The generated Graphene classes, fields, and resolver
 objects stored inside those dictionaries are shared with the live registry.
 Use `GraphQL.reset_registry()` in tests before rebuilding a schema; it clears
 generated query, mutation, subscription, search, capability, and manager
-registries. Generated registry entries are Graphene classes, fields, and
+registries as well as the output-type registry. The
+`graphql_output_type_registry` snapshot field maps `GraphQLType` declaration
+names to generated Graphene output classes and remains separate from the
+manager registry. Generated registry entries are Graphene classes, fields, and
 callables, so treat them as opaque objects unless you are writing integration
 tests around schema assembly.
 

--- a/docs/concepts/graphql/schema_autogen.md
+++ b/docs/concepts/graphql/schema_autogen.md
@@ -104,6 +104,9 @@ roots, filters, subscriptions, search, capabilities, and lifecycle tooling
 continue to consume the manager registries; an output declaration is never
 added to those manager operation paths.
 
+For a complete declaration, property, startup, and query example, see the
+[typed output-object recipe](../../examples/graphql_output_types.md).
+
 ### Relation annotation compatibility
 
 Before mapping a relation, schema generation resolves its annotation to one

--- a/docs/examples/graphql_output_types.md
+++ b/docs/examples/graphql_output_types.md
@@ -1,0 +1,128 @@
+# Return Typed Output Objects Through GraphQL
+
+Use `GraphQLType` when a GraphQL response needs a nested object shape but the
+value does not need a manager identity, lifecycle, or independent operation.
+This recipe defines a frozen output value, returns it from a
+`@graph_ql_property`, and queries the generated nested object.
+
+## Define the output value
+
+Concrete `GraphQLType` subclasses become frozen dataclass-style values. Their
+annotated fields become GraphQL fields; `field(default_factory=...)` supplies a
+fresh default for each Python instance.
+
+```python title="myapp/graphql_types.py"
+from __future__ import annotations
+
+from dataclasses import field
+
+from general_manager import GraphQLType
+
+
+class ProjectHour(GraphQLType):
+    task_id: int
+    hours: float
+    note: str | None = None
+    tags: list[str] = field(default_factory=list)
+```
+
+The generated GraphQL object is `ProjectHourType`. Required annotations become
+non-null fields, `T | None` becomes nullable, and collection element
+nullability follows the element annotation. `GraphQLType` declarations do not
+create root queries, mutations, subscriptions, filters, or input objects.
+
+Import the declaration module during application startup, before GeneralManager
+builds the schema:
+
+```python title="myapp/apps.py"
+from django.apps import AppConfig
+
+
+class MyAppConfig(AppConfig):
+    name = "myapp"
+
+    def ready(self) -> None:
+        from . import graphql_types  # noqa: F401
+        from . import managers  # noqa: F401
+```
+
+## Return the value from a GraphQL property
+
+The output type is available only through a field that references it. A
+calculation manager is useful here because its generated detail field accepts
+the declared input and exposes the property result:
+
+```python title="myapp/managers.py"
+from __future__ import annotations
+
+from general_manager import GeneralManager, graph_ql_property
+from general_manager.interface import CalculationInterface
+from general_manager.manager import Input
+
+from .graphql_types import ProjectHour
+
+
+class ProjectHoursSummary(GeneralManager):
+    class Interface(CalculationInterface):
+        project_id = Input(int, possible_values=(42,))
+
+    @graph_ql_property(cache="none")
+    def hours(self) -> list[ProjectHour]:
+        return [
+            ProjectHour(
+                task_id=7,
+                hours=8.5,
+                note="Ready for review",
+                tags=["billable", "forecast"],
+            )
+        ]
+```
+
+The owning manager's property is the authorization boundary. Nested manager
+fields keep their manager-level read checks, but scalar and nested
+`GraphQLType` fields do not receive an independent permission check. Omit or
+pre-authorize sensitive values before constructing the output object.
+
+## Query the generated object
+
+The calculation manager's generated detail field uses camel-case GraphQL names.
+The output object can be selected like any other GraphQL object:
+
+```graphql
+query ProjectHours {
+  projectHoursSummary(projectId: 42) {
+    hours {
+      taskId
+      hours
+      note
+      tags
+    }
+  }
+}
+```
+
+The response has the nested shape declared by `ProjectHour`:
+
+```json
+{
+  "data": {
+    "projectHoursSummary": {
+      "hours": [
+        {
+          "taskId": 7,
+          "hours": 8.5,
+          "note": "Ready for review",
+          "tags": ["billable", "forecast"]
+        }
+      ]
+    }
+  }
+}
+```
+
+The output mapper accepts scalar annotations, `Measurement`, registered
+managers, registered output types, and `list[T]`, `tuple[T, ...]`, or `set[T]`.
+Bare collections, fixed-length tuples, `Any`, `Annotated[...]`, unresolved
+references, and unions with more than one non-null member fail schema
+generation with a field-specific error. The output-type contract is available
+from GeneralManager 0.75.0.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -6,6 +6,7 @@ The cookbook collects self-contained snippets that demonstrate how to solve doma
 <!-- - [Nested set bill of materials](nested_set_bom.md) -->
 - [Derivative aggregation](derivatives_groups.md)
 - [GraphQL query patterns](graphql_queries.md)
+- [Typed GraphQL output objects](graphql_output_types.md)
 - [Persisted item ordering through GraphQL](graphql_preferred_item_order.md)
 - [Historical snapshot queries](historical_queries.md)
 - [Bulk data-change notifications](bulk_data_change_notifications.md)

--- a/docs/howto/expose_via_graphql.md
+++ b/docs/howto/expose_via_graphql.md
@@ -73,6 +73,10 @@ read permissions. Plain scalar fields and nested `GraphQLType` fields do not
 receive an independent permission check, so omit or pre-authorize sensitive
 values in the owning property.
 
+The [typed output-object recipe](../examples/graphql_output_types.md) shows the
+same contract with a complete startup import, calculation property, and
+GraphQL query.
+
 ## Declare manager relations
 
 Annotate related fields with the manager class that should appear in generated

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,7 @@ nav:
       - examples/project_volume_curve.md
       - examples/derivatives_groups.md
       - examples/graphql_queries.md
+      - examples/graphql_output_types.md
       - examples/graphql_preferred_item_order.md
       - examples/historical_queries.md
       - examples/bulk_data_change_notifications.md


### PR DESCRIPTION
## Reviewed commits

The exact rolling window was `2026-08-21T04:02:13Z` through `2026-08-22T04:02:13Z`, using commits reachable from `origin/main` after fetching origin:

- `3b43f27f5fb940438095cfde6da68a6e6b83c7ab`
- `c01aeaf089d95e2558625a63633d86e6b088daf9`
- `fc0ff733b8aca1489327a40604a9cb551f098e89`
- `15ce9343d004c3a39c4901b47fd359f7309fe7aa`
- `101e1669180a89d043b5a8043c221c7628008daf`
- `23606e0faf6672568fd39055c0bd3e4c32ab130c`
- `e22961827818aa97f08185a899db8b838e48730a`
- `20c8c07e71715de2da5b5719aaa653123ae6b629`
- `ee65da700101c9ec18d4d44ba3ff9f666c7529c9`
- `e0e76f430202cfded525da3914f596d1726478fa`
- `eafdf70e4480349781376c0db46a2ae3a59c41a0`
- `94aa767a635812502913cb1e404d4705dd8c35e4`
- `4102e0b08f915754b8f2f1eb1a286532ba4c40ce`
- `4cc65bfa387efc0d2afa70056fc5f645f3b38a9c`
- `c29b048d6d1bbf6b16eef8f8d8d1629a6db34335`
- `36be371daa8c92d6962d2b848bdd9c3a8ed399a2`
- `a84b2026da8e63983c0682944c79be4e08d582c7`
- `64ea29ba282cc3e0be79ad267c9acb9f7a800e54`
- `b8e48b93f063899ace684fa29beeefcf1118970c`
- `16077c4b7e3ac779d4de1bbcce8f5cfec0143b69`
- `7e225182a489e95cff40864ffaa8bc7bfbf7e574`
- `530029bf8fdb4cd88ae0503549efd0c539b580a2`

## Affected public API

- Package-root `general_manager.GraphQLType`: frozen dataclass-style output declarations whose annotated fields become generated GraphQL output objects.
- The resulting strict annotation contract for scalar, optional, collection, measurement, manager, and nested output fields returned by `@graph_ql_property`.
- `GraphQLRegistry.graphql_output_type_registry` and the schema-assembly behavior that generates `<DeclarationName>Type` objects. The internal mapper/error classes remain implementation details and are not documented as stable imports.

## Documentation changes

- Added `docs/examples/graphql_output_types.md` with declaration, startup import, property, query, response, permission, and invalid-annotation examples.
- Updated `docs/examples/index.md` and `mkdocs.yml`.
- Linked the cookbook from `docs/concepts/graphql/schema_autogen.md` and `docs/howto/expose_via_graphql.md`.
- Expanded `docs/api/graphql.md` with constructor/immutability, exception, compatibility, schema-assembly, registry, and cross-link notes.

## Validation

- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py tests/integration/test_request_docs_examples.py -q` — 8 passed.
- `PYTHONPATH=src python -m pytest tests/unit/test_graphql_type.py tests/unit/test_graphql_output.py tests/unit/test_graph_ql.py tests/integration/test_graphql_output_types.py -q` — 210 passed, 46 subtests passed.
- `python -m mkdocs build --strict --site-dir /tmp/general-manager-docs-review-20260822-final` — passed; only existing unnav-linked planning/ADR notices were reported.
- File-scoped `pre-commit` — passed; Ruff/mypy correctly skipped because no Python files changed.
- Python documentation blocks parsed with `ast`; the cookbook construction/frozen-instance runtime check passed; `git diff --check` passed.

Full test suite was not rerun because this PR is documentation-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for defining and using typed GraphQL output objects, including constructors, defaults, immutability, validation, and nested responses.
  * Documented output-type generation, registration behavior, and registry reset handling.
  * Added a complete cookbook example and linked it from the GraphQL guides and examples index.
  * Included the new recipe in the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->