### PR TITLE
feat: lazily hydrate development search

### DIFF
--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -515,9 +515,9 @@ The backend registry functions `configure_search_backend`, `configure_search_bac
 For local development, the built-in DevSearch backend stores documents in
 memory and supports basic term matching with per-field boosts. It is a
 disposable per-process projection, does **not** provide typo tolerance, and
-should not be used in production. When Django `DEBUG=True`,
-`SEARCH_AUTO_REINDEX=True`, and the selected backend is DevSearch, each index
-is populated from configured managers by its first search in that process.
+should not be used in production. When `SEARCH_AUTO_REINDEX=True` and the
+selected backend is DevSearch, each index is populated from configured managers
+by its first search in that process.
 Hydration is tracked per index and guarded against concurrent or nested first
 searches. A hydration error reaches the caller and leaves that index retryable
 on a later search. Directly constructed DevSearch instances remain inert unless

--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -520,8 +520,9 @@ selected backend is DevSearch, each index is populated from configured managers
 by its first search in that process.
 Hydration is tracked per index and guarded against concurrent or nested first
 searches. A hydration error reaches the caller and leaves that index retryable
-on a later search. Directly constructed DevSearch instances remain inert unless
-their caller passes `auto_reindex=True`.
+on a later search. Directly constructed DevSearch instances remain inert until
+their caller passes `auto_reindex=True` to the constructor or calls
+`configure_auto_reindex(True)` on the instance.
 
 After an index hydrates, the existing synchronous search invalidation path
 keeps that same process's projection current with normal upserts and deletes.

--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -513,8 +513,21 @@ The backend registry functions `configure_search_backend`, `configure_search_bac
 ### DevSearch backend (service-free)
 
 For local development, the built-in DevSearch backend stores documents in
-memory and supports basic term matching with per-field boosts. It does **not**
-provide typo tolerance and should not be used in production.
+memory and supports basic term matching with per-field boosts. It is a
+disposable per-process projection, does **not** provide typo tolerance, and
+should not be used in production. When Django `DEBUG=True`,
+`SEARCH_AUTO_REINDEX=True`, and the selected backend is DevSearch, each index
+is populated from configured managers by its first search in that process.
+Hydration is tracked per index and guarded against concurrent or nested first
+searches. A hydration error reaches the caller and leaves that index retryable
+on a later search. Directly constructed DevSearch instances remain inert unless
+their caller passes `auto_reindex=True`.
+
+After an index hydrates, the existing synchronous search invalidation path
+keeps that same process's projection current with normal upserts and deletes.
+Writes, asynchronous invalidation, or `search_index --reindex` work performed
+in another process cannot update a running DevSearch backend. Restart the
+serving process so its next search builds a fresh projection.
 Structured filters use AND within one mapping and OR across a sequence of
 mappings. For `exact` and `in` checks against list/tuple/set document fields,
 collection filter values match on intersection; scalar `in` filter values do
@@ -530,8 +543,9 @@ strings on whitespace. It does not stem, parse phrases, or perform fuzzy matchin
 tokens are built from every top-level `SearchDocument.data` value: `None`
 produces no tokens, strings split on whitespace, lists/tuples/sets are processed
 recursively, and all other values become `str(value).lower().split()`. Dict
-values are not traversed and are tokenized from their string representation. A
-token matches when it equals or prefixes an indexed field token. Empty queries
+values are not traversed and are tokenized from their string representation.
+Every distinct query term must equal or prefix an indexed field token for a
+document to match; different terms may match different fields. Empty queries
 match every document that passes type and structured filters. The operation
 order is type filtering, structured filtering, query scoring/matching, sorting,
 and pagination. Structured filter keys target `SearchDocument.data` field names
@@ -555,8 +569,8 @@ before pagination, slices as `results[offset:offset + limit]` with negative
 values intentionally following Python slice behavior, stores document and
 settings objects by reference, returns hit data from the stored
 `SearchDocument.data` mapping, and keeps state only in the current process with
-no persistence or synchronization for concurrent reads/writes. Mutating returned
-DevSearch hit data can mutate the stored document payload.
+no persistence or cross-process synchronization for ordinary reads/writes.
+Mutating returned DevSearch hit data can mutate the stored document payload.
 DevSearch raises `NotImplementedError` for `filter_expression`; other
 operational failures are not normalized and may surface as ordinary Python
 exceptions.

--- a/docs/howto/search.md
+++ b/docs/howto/search.md
@@ -49,11 +49,12 @@ GENERAL_MANAGER = {
 }
 ```
 
-When the selected backend is `DevSearchBackend`, the first search for each
-index in that serving process lazily rebuilds that index from configured
-managers. If that rebuild fails, the search raises the source error and the
-next search retries it. Subsequent synchronous manager lifecycle updates in the
-same process upsert or delete the relevant documents normally.
+When the selected backend is `DevSearchBackend` and
+`SEARCH_AUTO_REINDEX=True`, the first search for each index in that serving
+process lazily rebuilds that index from configured managers. If that rebuild
+fails, the search raises the source error and the next search retries it.
+Subsequent synchronous manager lifecycle updates in the same process upsert or
+delete the relevant documents normally.
 
 DevSearch is process-local. Running `python manage.py search_index --reindex`
 in another process cannot fill the in-memory backend of an already running

--- a/docs/howto/search.md
+++ b/docs/howto/search.md
@@ -34,6 +34,30 @@ the backend is implemented and available in your environment.
 dotted import path, or the mapping form shown above. Leave it unset to use the
 in-memory `DevSearchBackend` fallback in local development.
 
+### Use lazy DevSearch hydration in development
+
+For a local development server, enable the disposable DevSearch projection with
+both `DEBUG=True` and `SEARCH_AUTO_REINDEX=True`:
+
+```python
+GENERAL_MANAGER = {
+    **GENERAL_MANAGER,
+    "SEARCH_AUTO_REINDEX": True,
+}
+```
+
+When the selected backend is `DevSearchBackend`, the first search for each
+index in that serving process lazily rebuilds that index from configured
+managers. If that rebuild fails, the search raises the source error and the
+next search retries it. Subsequent synchronous manager lifecycle updates in the
+same process upsert or delete the relevant documents normally.
+
+DevSearch is process-local. Running `python manage.py search_index --reindex`
+in another process cannot fill the in-memory backend of an already running
+server; restart that server so its next search hydrates its own projection.
+Directly constructed `DevSearchBackend` instances stay inert unless constructed
+with `auto_reindex=True`.
+
 ## Step 2: Add SearchConfig to a manager
 
 Define searchable, filterable, and sortable fields:
@@ -138,6 +162,9 @@ index setup, manager discovery, and reindexing errors propagate so CI or deploy
 scripts fail visibly.
 
 If you add or remove fields, filters, or sorts later, re-run with `--reindex`.
+For DevSearch, run this command in the same process only when manually managing
+that process's in-memory projection; a separate command process cannot populate
+a running server's DevSearch backend.
 
 ## Step 4: Query via GraphQL
 

--- a/docs/howto/search.md
+++ b/docs/howto/search.md
@@ -58,8 +58,9 @@ same process upsert or delete the relevant documents normally.
 DevSearch is process-local. Running `python manage.py search_index --reindex`
 in another process cannot fill the in-memory backend of an already running
 server; restart that server so its next search hydrates its own projection.
-Directly constructed `DevSearchBackend` instances stay inert unless constructed
-with `auto_reindex=True`.
+Directly constructed `DevSearchBackend` instances stay inert until constructed
+with `auto_reindex=True` or enabled later with
+`backend.configure_auto_reindex(True)`.
 
 ## Step 2: Add SearchConfig to a manager
 

--- a/docs/howto/search.md
+++ b/docs/howto/search.md
@@ -37,7 +37,7 @@ in-memory `DevSearchBackend` fallback in local development.
 ### Use lazy DevSearch hydration in development
 
 For a local development server, enable the disposable DevSearch projection with
-both `DEBUG=True` and `SEARCH_AUTO_REINDEX=True`:
+`SEARCH_AUTO_REINDEX=True`:
 
 ```python
 GENERAL_MANAGER = {

--- a/docs/howto/search.md
+++ b/docs/howto/search.md
@@ -36,12 +36,15 @@ in-memory `DevSearchBackend` fallback in local development.
 
 ### Use lazy DevSearch hydration in development
 
-For a local development server, enable the disposable DevSearch projection with
-`SEARCH_AUTO_REINDEX=True`:
+For a local development server, replace the Meilisearch configuration above
+with this complete disposable DevSearch configuration:
 
 ```python
 GENERAL_MANAGER = {
-    **GENERAL_MANAGER,
+    "SEARCH_BACKEND": {
+        "class": "general_manager.search.backends.dev.DevSearchBackend",
+        "options": {},
+    },
     "SEARCH_AUTO_REINDEX": True,
 }
 ```

--- a/docs/superpowers/plans/2026-08-22-dev-search-lifecycle.md
+++ b/docs/superpowers/plans/2026-08-22-dev-search-lifecycle.md
@@ -284,7 +284,6 @@ def _ensure_hydrated(self, index_name: str) -> None:
         self._hydrating_indexes.add(index_name)
         try:
             self._reindex_configured_managers(index_name)
-        else:
             self._hydrated_indexes.add(index_name)
         finally:
             self._hydrating_indexes.discard(index_name)

--- a/docs/superpowers/plans/2026-08-22-dev-search-lifecycle.md
+++ b/docs/superpowers/plans/2026-08-22-dev-search-lifecycle.md
@@ -1,0 +1,470 @@
+# DevSearch Lifecycle and All-Term Matching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the process-local DevSearch backend hydrate itself from configured managers on first use in development and require every distinct query term to match.
+
+**Architecture:** Keep DevSearch as a disposable in-memory projection. First implement all-term eligibility inside its existing scorer, then add opt-in, per-index lazy hydration using `SearchIndexer.reindex_manager_index()` and enable it through the existing `SEARCH_AUTO_REINDEX` plus `DEBUG` settings path.
+
+**Tech Stack:** Python 3.12+, Django, pytest/pytest-django, standard-library threading.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-dev-search-lifecycle-design.md`
+
+## Global Constraints
+
+- `DevSearchBackend` remains process-local and uses no persistent runtime files.
+- Add no models, migrations, dependencies, or cross-process coordination.
+- External backend lifecycle and query behavior remain unchanged.
+- Automatic hydration requires both `SEARCH_AUTO_REINDEX` and Django `DEBUG`.
+- Directly constructed DevSearch instances remain isolated unless explicitly opted in.
+- Hydration failures propagate and remain retryable.
+- Existing synchronous invalidation remains the only post-hydration maintenance mechanism.
+- Follow strict TDD: add each behavioral test and observe its expected failure before production changes.
+
+---
+
+### Task 1: Require Every Distinct Query Term
+
+**Files:**
+- Modify: `src/general_manager/search/backends/dev.py:225-309`
+- Test: `tests/unit/test_search_dev_backend.py`
+
+**Interfaces:**
+- Consumes: `DevSearchBackend.search()` and its existing `_tokenize_query()` / `_score_document()` helpers.
+- Produces: `_tokenize_query(query: str) -> list[str]` returning distinct lowercase terms in first-seen order; `_score_document(...) -> float` returning zero unless every term matches at least one document field.
+
+- [ ] **Step 1: Add failing all-term and cross-field tests**
+
+Extend the existing fixture with focused assertions equivalent to:
+
+```python
+def test_search_requires_every_distinct_query_term(self) -> None:
+    result = self.backend.search("global", "Alpha missing")
+    assert result.total == 0
+
+
+def test_search_allows_query_terms_to_match_different_fields(self) -> None:
+    result = self.backend.search("global", "Alpha public")
+    assert [hit.id for hit in result.hits] == ["Project:1"]
+
+
+def test_repeated_query_terms_do_not_inflate_score(self) -> None:
+    single = self.backend.search("global", "Alpha")
+    repeated = self.backend.search("global", "Alpha Alpha")
+    assert repeated.hits[0].score == single.hits[0].score
+```
+
+The production mutation caught by these tests is restoring the current
+any-positive-score eligibility or preserving duplicate query tokens.
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest \
+  tests/unit/test_search_dev_backend.py::DevSearchBackendTests::test_search_requires_every_distinct_query_term \
+  tests/unit/test_search_dev_backend.py::DevSearchBackendTests::test_search_allows_query_terms_to_match_different_fields \
+  tests/unit/test_search_dev_backend.py::DevSearchBackendTests::test_repeated_query_terms_do_not_inflate_score -q
+```
+
+Expected: the first test fails because `Project:1` is returned, and the duplicate-score test fails because the score is doubled; the cross-field test documents intended behavior and may already pass.
+
+- [ ] **Step 3: Implement distinct-token all-term scoring**
+
+Change tokenization to preserve first-seen order while deduplicating:
+
+```python
+@staticmethod
+def _tokenize_query(query: str) -> list[str]:
+    return list(dict.fromkeys(query.lower().split()))
+```
+
+Score one query term at a time. Accumulate every matching field boost for that
+term, but reject the document immediately when a term matches no field:
+
+```python
+score = 0.0
+for token in tokens:
+    token_score = 0.0
+    for field_name, field_tokens in token_index.items():
+        if token in field_tokens or any(
+            field_token.startswith(token) for field_token in field_tokens
+        ):
+            token_score += document.field_boosts.get(field_name, 1.0)
+    if token_score <= 0:
+        return 0.0
+    score += token_score
+```
+
+Retain the existing empty-query and `index_boost` behavior. Update the method
+docstrings to say that all distinct query tokens are required.
+
+- [ ] **Step 4: Run focused and neighboring tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/unit/test_search_dev_backend.py tests/unit/test_search_auto_reindex.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run Ruff on the task files**
+
+Run:
+
+```bash
+ruff check src/general_manager/search/backends/dev.py tests/unit/test_search_dev_backend.py
+ruff format --check src/general_manager/search/backends/dev.py tests/unit/test_search_dev_backend.py
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add src/general_manager/search/backends/dev.py tests/unit/test_search_dev_backend.py
+git commit -m "fix: require all dev search query terms"
+```
+
+---
+
+### Task 2: Lazily Hydrate DevSearch Per Process and Index
+
+**Files:**
+- Modify: `src/general_manager/search/backends/dev.py`
+- Modify: `src/general_manager/search/backend_registry.py`
+- Modify: `tests/unit/test_search_backend_registry.py`
+- Replace: `tests/unit/test_search_auto_reindex.py`
+- Modify: `docs/howto/search.md`
+- Modify: `docs/concepts/search.md`
+
+**Interfaces:**
+- Consumes: `SearchIndexer(backend).reindex_manager_index(manager_class, index_name)`, `iter_index_configs(index_name)`, Django settings, and Task 1 all-term scoring.
+- Produces: `DevSearchBackend(*, auto_reindex: bool = False)`, `DevSearchBackend.configure_auto_reindex(enabled: bool) -> None`, private per-index hydration before `search()`, and `_dev_auto_reindex_enabled(django_settings: object) -> bool` in the backend registry.
+
+- [ ] **Step 1: Add failing real-behavior tests for lazy hydration**
+
+Replace the removal-only auto-reindex coverage with tests that exercise a
+DevSearch subclass whose hydration source writes a real document into itself:
+
+```python
+class RecordingHydrationBackend(DevSearchBackend):
+    def __init__(self, *, fail_once: bool = False) -> None:
+        super().__init__(auto_reindex=True)
+        self.hydrated_indexes: list[str] = []
+        self.fail_once = fail_once
+
+    def _reindex_configured_managers(self, index_name: str) -> None:
+        self.hydrated_indexes.append(index_name)
+        if self.fail_once:
+            self.fail_once = False
+            raise RuntimeError("source unavailable")
+        self.upsert(index_name, [_search_document(index_name)])
+```
+
+Add tests whose consumer-visible assertions establish:
+
+```python
+def test_first_search_hydrates_index_once() -> None:
+    backend = RecordingHydrationBackend()
+    assert backend.search("global", "Dock").total == 1
+    assert backend.search("global", "Dock").total == 1
+    assert backend.hydrated_indexes == ["global"]
+
+
+def test_hydration_is_tracked_per_index() -> None:
+    backend = RecordingHydrationBackend()
+    assert backend.search("global", "Dock").total == 1
+    assert backend.search("private", "Dock").total == 1
+    assert backend.hydrated_indexes == ["global", "private"]
+
+
+def test_failed_hydration_propagates_and_retries() -> None:
+    backend = RecordingHydrationBackend(fail_once=True)
+    with pytest.raises(RuntimeError, match="source unavailable"):
+        backend.search("global", "Dock")
+    assert backend.search("global", "Dock").total == 1
+    assert backend.hydrated_indexes == ["global", "global"]
+
+
+def test_direct_backend_does_not_hydrate_without_opt_in() -> None:
+    backend = DevSearchBackend()
+    assert backend.search("global", "").total == 0
+```
+
+The production mutations caught are removing first-search hydration, marking a
+failed hydration complete, using one global hydration flag, or enabling direct
+instances by default.
+
+Also add the integration test now, before production changes: use the existing
+lightweight `Project` fixture and manager initialization pattern from
+`tests/unit/test_search_indexer.py`, instantiate
+`DevSearchBackend(auto_reindex=True)`, and call
+`search("global", "Alpha")` without calling `SearchIndexer` first. Assert the
+real result contains the expected project identity. Add a second source record
+through the existing synchronous manager lifecycle/invalidation path after
+hydration and assert a subsequent search finds it without rebuilding the whole
+index.
+
+- [ ] **Step 2: Add failing settings tests**
+
+In `tests/unit/test_search_backend_registry.py`, test the setting boundary
+through configured backend state rather than restored request signals:
+
+```python
+def test_dev_auto_reindex_requires_setting_and_debug() -> None:
+    enabled = SimpleNamespace(
+        DEBUG=True,
+        GENERAL_MANAGER={"SEARCH_BACKEND": DevSearchBackend, "SEARCH_AUTO_REINDEX": True},
+    )
+    configure_search_backend_from_settings(enabled)
+    assert get_search_backend().auto_reindex_enabled is True
+
+
+def test_dev_auto_reindex_is_disabled_outside_debug() -> None:
+    disabled = SimpleNamespace(
+        DEBUG=False,
+        GENERAL_MANAGER={"SEARCH_BACKEND": DevSearchBackend, "SEARCH_AUTO_REINDEX": True},
+    )
+    configure_search_backend_from_settings(disabled)
+    assert get_search_backend().auto_reindex_enabled is False
+```
+
+Also cover a true `SEARCH_AUTO_REINDEX` with a non-Dev protocol backend and
+assert its configuration succeeds without DevSearch-specific mutation.
+
+- [ ] **Step 3: Run hydration/configuration tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest \
+  tests/unit/test_search_auto_reindex.py \
+  tests/unit/test_search_backend_registry.py \
+  tests/unit/test_search_indexer.py -q
+```
+
+Expected: failures identify the missing constructor option, hydration method,
+observable enabled state, and settings activation.
+
+- [ ] **Step 4: Implement opt-in per-index hydration in DevSearch**
+
+Add standard-library state in `DevSearchBackend.__init__`:
+
+```python
+def __init__(self, *, auto_reindex: bool = False) -> None:
+    self._indexes: dict[str, _IndexStore] = {}
+    self._auto_reindex = auto_reindex
+    self._hydrated_indexes: set[str] = set()
+    self._hydrating_indexes: set[str] = set()
+    self._hydration_lock = RLock()
+
+@property
+def auto_reindex_enabled(self) -> bool:
+    return self._auto_reindex
+
+def configure_auto_reindex(self, enabled: bool) -> None:
+    self._auto_reindex = enabled
+```
+
+At the beginning of `search()`, call `_ensure_hydrated(index_name)`. Implement
+the guarded behavior as:
+
+```python
+def _ensure_hydrated(self, index_name: str) -> None:
+    if not self._auto_reindex or index_name in self._hydrated_indexes:
+        return
+    with self._hydration_lock:
+        if index_name in self._hydrated_indexes:
+            return
+        if index_name in self._hydrating_indexes:
+            return
+        self._hydrating_indexes.add(index_name)
+        try:
+            self._reindex_configured_managers(index_name)
+        else:
+            self._hydrated_indexes.add(index_name)
+        finally:
+            self._hydrating_indexes.discard(index_name)
+
+def _reindex_configured_managers(self, index_name: str) -> None:
+    from general_manager.search.indexer import SearchIndexer
+    from general_manager.search.registry import iter_index_configs
+
+    indexer = SearchIndexer(self)
+    for manager_class, _index_config in iter_index_configs(index_name):
+        indexer.reindex_manager_index(manager_class, index_name)
+```
+
+Use `threading.RLock`. Do not catch or log hydration errors. Update class/search
+docstrings to describe opt-in lazy lifecycle, retry semantics, and concurrency
+scope.
+
+- [ ] **Step 5: Enable hydration through settings only for DevSearch**
+
+Add a settings helper in `backend_registry.py` that honors nested precedence:
+
+```python
+def _dev_auto_reindex_enabled(django_settings: object) -> bool:
+    config_candidate = getattr(django_settings, _SETTINGS_KEY, None)
+    if isinstance(config_candidate, Mapping) and "SEARCH_AUTO_REINDEX" in config_candidate:
+        configured = config_candidate["SEARCH_AUTO_REINDEX"]
+    else:
+        configured = getattr(django_settings, "SEARCH_AUTO_REINDEX", False)
+    return bool(getattr(django_settings, "DEBUG", False)) and bool(configured)
+```
+
+After resolving a settings-supplied backend, call
+`configure_auto_reindex(...)` only when it is a `DevSearchBackend`. When
+`get_search_backend()` creates its fallback instance, pass the helper result to
+the constructor. Do not alter external backends.
+
+- [ ] **Step 6: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest \
+  tests/unit/test_search_auto_reindex.py \
+  tests/unit/test_search_backend_registry.py \
+  tests/unit/test_search_dev_backend.py \
+  tests/unit/test_search_indexer.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Verify real manager hydration and invalidation**
+
+Run the integration coverage added in Step 1 after the implementation:
+
+```bash
+python -m pytest tests/unit/test_search_auto_reindex.py tests/unit/test_search_indexer.py -q
+```
+
+Expected: all tests pass and no explicit pre-search reindex appears in the test.
+
+- [ ] **Step 8: Update user-facing lifecycle documentation**
+
+In `docs/howto/search.md`, explain that `SEARCH_AUTO_REINDEX=True` with
+`DEBUG=True` lazily fills each DevSearch index on first search in that serving
+process. State that `search_index --reindex` in another process cannot fill a
+running DevSearch backend.
+
+In `docs/concepts/search.md`, replace the claim that DevSearch is only a manually
+filled process-local store with the approved lifecycle: disposable per-process
+projection, per-index first-search hydration, retry-on-failure, synchronous
+same-process invalidation, and restart required for other-process writes.
+Document that every distinct query term is required.
+
+- [ ] **Step 9: Run task verification**
+
+Run:
+
+```bash
+ruff check \
+  src/general_manager/search/backends/dev.py \
+  src/general_manager/search/backend_registry.py \
+  tests/unit/test_search_auto_reindex.py \
+  tests/unit/test_search_backend_registry.py \
+  tests/unit/test_search_dev_backend.py \
+  tests/unit/test_search_indexer.py
+ruff format --check \
+  src/general_manager/search/backends/dev.py \
+  src/general_manager/search/backend_registry.py \
+  tests/unit/test_search_auto_reindex.py \
+  tests/unit/test_search_backend_registry.py \
+  tests/unit/test_search_dev_backend.py \
+  tests/unit/test_search_indexer.py
+mypy src/general_manager/search/backends/dev.py src/general_manager/search/backend_registry.py
+python -m pytest \
+  tests/unit/test_search_auto_reindex.py \
+  tests/unit/test_search_backend_registry.py \
+  tests/unit/test_search_dev_backend.py \
+  tests/unit/test_search_indexer.py \
+  tests/integration/test_graphql_search.py -q
+```
+
+Expected: every command exits zero.
+
+- [ ] **Step 10: Commit Task 2**
+
+```bash
+git add \
+  src/general_manager/search/backends/dev.py \
+  src/general_manager/search/backend_registry.py \
+  tests/unit/test_search_auto_reindex.py \
+  tests/unit/test_search_backend_registry.py \
+  tests/unit/test_search_indexer.py \
+  docs/howto/search.md \
+  docs/concepts/search.md
+git commit -m "feat: lazily hydrate development search"
+```
+
+---
+
+### Task 3: Whole-Feature Verification and Documentation Consistency
+
+**Files:**
+- Modify only if a verification failure identifies a task-scoped defect in files already listed above.
+
+**Interfaces:**
+- Consumes: Task 1 all-term matching and Task 2 lazy-hydration lifecycle.
+- Produces: A verified branch whose docs, types, tests, and runtime behavior agree with the approved spec.
+
+- [ ] **Step 1: Run the complete search test surface**
+
+```bash
+python -m pytest \
+  tests/unit/test_search_*.py \
+  tests/unit/test_graphql_search.py \
+  tests/integration/test_graphql_search.py \
+  tests/integration/test_search_m2m_invalidation.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run repository-standard checks on the final diff**
+
+```bash
+ruff check src/general_manager/search tests/unit/test_search_*.py
+ruff format --check src/general_manager/search tests/unit/test_search_*.py
+mypy src/general_manager/search
+git diff --check
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 3: Confirm the example project configuration**
+
+Run:
+
+```bash
+PYTHONPATH=src:example_project/outer_rim_logistics \
+DJANGO_SETTINGS_MODULE=orl.settings \
+python -m django check
+```
+
+Expected: Django system checks report no issues. The existing example setting
+`SEARCH_AUTO_REINDEX=True` requires no persistent file or management command.
+
+- [ ] **Step 4: Commit verification-only fixes if needed**
+
+If Steps 1-3 required a correction in an already scoped file, commit that
+correction and its regression test together:
+
+```bash
+git add \
+  src/general_manager/search/backends/dev.py \
+  src/general_manager/search/backend_registry.py \
+  tests/unit/test_search_auto_reindex.py \
+  tests/unit/test_search_backend_registry.py \
+  tests/unit/test_search_dev_backend.py \
+  tests/unit/test_search_indexer.py \
+  docs/howto/search.md \
+  docs/concepts/search.md
+git commit -m "fix: complete dev search lifecycle verification"
+```
+
+If no correction was needed, do not create an empty commit.

--- a/docs/superpowers/plans/2026-08-22-dev-search-lifecycle.md
+++ b/docs/superpowers/plans/2026-08-22-dev-search-lifecycle.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the process-local DevSearch backend hydrate itself from configured managers on first use in development and require every distinct query term to match.
 
-**Architecture:** Keep DevSearch as a disposable in-memory projection. First implement all-term eligibility inside its existing scorer, then add opt-in, per-index lazy hydration using `SearchIndexer.reindex_manager_index()` and enable it through the existing `SEARCH_AUTO_REINDEX` plus `DEBUG` settings path.
+**Architecture:** Keep DevSearch as a disposable in-memory projection. First implement all-term eligibility inside its existing scorer, then add opt-in, per-index lazy hydration using `SearchIndexer.reindex_manager_index()` and enable it through the existing `SEARCH_AUTO_REINDEX` setting for DevSearch.
 
 **Tech Stack:** Python 3.12+, Django, pytest/pytest-django, standard-library threading.
 
@@ -15,7 +15,7 @@
 - `DevSearchBackend` remains process-local and uses no persistent runtime files.
 - Add no models, migrations, dependencies, or cross-process coordination.
 - External backend lifecycle and query behavior remain unchanged.
-- Automatic hydration requires both `SEARCH_AUTO_REINDEX` and Django `DEBUG`.
+- Automatic hydration requires `SEARCH_AUTO_REINDEX` and a selected `DevSearchBackend`.
 - Directly constructed DevSearch instances remain isolated unless explicitly opted in.
 - Hydration failures propagate and remain retryable.
 - Existing synchronous invalidation remains the only post-hydration maintenance mechanism.
@@ -214,19 +214,19 @@ In `tests/unit/test_search_backend_registry.py`, test the setting boundary
 through configured backend state rather than restored request signals:
 
 ```python
-def test_dev_auto_reindex_requires_setting_and_debug() -> None:
+def test_dev_auto_reindex_requires_setting() -> None:
     enabled = SimpleNamespace(
-        DEBUG=True,
+        DEBUG=False,
         GENERAL_MANAGER={"SEARCH_BACKEND": DevSearchBackend, "SEARCH_AUTO_REINDEX": True},
     )
     configure_search_backend_from_settings(enabled)
     assert get_search_backend().auto_reindex_enabled is True
 
 
-def test_dev_auto_reindex_is_disabled_outside_debug() -> None:
+def test_dev_auto_reindex_is_disabled_when_setting_is_false() -> None:
     disabled = SimpleNamespace(
-        DEBUG=False,
-        GENERAL_MANAGER={"SEARCH_BACKEND": DevSearchBackend, "SEARCH_AUTO_REINDEX": True},
+        DEBUG=True,
+        GENERAL_MANAGER={"SEARCH_BACKEND": DevSearchBackend, "SEARCH_AUTO_REINDEX": False},
     )
     configure_search_backend_from_settings(disabled)
     assert get_search_backend().auto_reindex_enabled is False
@@ -313,7 +313,7 @@ def _dev_auto_reindex_enabled(django_settings: object) -> bool:
         configured = config_candidate["SEARCH_AUTO_REINDEX"]
     else:
         configured = getattr(django_settings, "SEARCH_AUTO_REINDEX", False)
-    return bool(getattr(django_settings, "DEBUG", False)) and bool(configured)
+    return bool(configured)
 ```
 
 After resolving a settings-supplied backend, call
@@ -347,10 +347,10 @@ Expected: all tests pass and no explicit pre-search reindex appears in the test.
 
 - [ ] **Step 8: Update user-facing lifecycle documentation**
 
-In `docs/howto/search.md`, explain that `SEARCH_AUTO_REINDEX=True` with
-`DEBUG=True` lazily fills each DevSearch index on first search in that serving
-process. State that `search_index --reindex` in another process cannot fill a
-running DevSearch backend.
+In `docs/howto/search.md`, explain that `SEARCH_AUTO_REINDEX=True` lazily fills
+each DevSearch index on first search in that serving process. State that
+`search_index --reindex` in another process cannot fill a running DevSearch
+backend.
 
 In `docs/concepts/search.md`, replace the claim that DevSearch is only a manually
 filled process-local store with the approved lifecycle: disposable per-process

--- a/docs/superpowers/specs/2026-08-22-dev-search-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-08-22-dev-search-lifecycle-design.md
@@ -26,8 +26,8 @@ projection immediately.
 ## Configuration
 
 The existing `SEARCH_AUTO_REINDEX` setting controls lazy hydration. It is
-effective only when Django `DEBUG` is true and the selected backend is
-`DevSearchBackend`. It remains disabled by default unless explicitly enabled.
+effective when the selected backend is `DevSearchBackend` and remains disabled
+by default unless explicitly enabled.
 
 Backend instances constructed directly remain isolated unless their caller
 explicitly opts into automatic hydration. This prevents ordinary unit tests and

--- a/docs/superpowers/specs/2026-08-22-dev-search-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-08-22-dev-search-lifecycle-design.md
@@ -1,0 +1,113 @@
+# DevSearch Lifecycle and All-Term Matching Design
+
+## Goal
+
+Make the service-free development search backend usable from a running Django
+server without introducing persistent search storage. The database and other
+manager interfaces remain the source of truth; each process-local DevSearch
+index is a disposable projection.
+
+Also correct multi-term matching so that a document is eligible only when every
+distinct query term matches.
+
+## Scope
+
+This change applies only to `DevSearchBackend`. External backends retain their
+existing lifecycle and native query behavior. The change adds no files used as
+runtime storage, database models, migrations, dependencies, or cross-process
+cache-coordination mechanism.
+
+Cross-process freshness is deliberately outside this design. A development
+server does not observe changes made by another process until it restarts and
+hydrates again. The normal supported development configuration uses synchronous
+search invalidation so changes made by the serving process update its in-memory
+projection immediately.
+
+## Configuration
+
+The existing `SEARCH_AUTO_REINDEX` setting controls lazy hydration. It is
+effective only when Django `DEBUG` is true and the selected backend is
+`DevSearchBackend`. It remains disabled by default unless explicitly enabled.
+
+Backend instances constructed directly remain isolated unless their caller
+explicitly opts into automatic hydration. This prevents ordinary unit tests and
+programmatic uses from unexpectedly discovering and indexing globally
+registered managers.
+
+The example project keeps `SEARCH_AUTO_REINDEX` enabled, so its runserver works
+without first running `search_index --reindex` in a separate process.
+
+## Lazy Hydration
+
+On the first `search(index_name, ...)` for an unhydrated index, an opted-in
+DevSearch backend reindexes every searchable manager configured for that index
+into the same backend instance. Hydration happens in the process performing the
+search, so the resulting documents are available to that search immediately.
+
+Hydration is tracked per index rather than globally. A lock prevents concurrent
+first searches from rebuilding the same index more than once. The index is
+marked hydrated only after all relevant managers reindex successfully. If
+hydration fails, the search raises the original error and a later search may
+retry; the backend must not silently return a partial index as successfully
+hydrated.
+
+Reindexing uses the existing `SearchIndexer` and registry helpers. The backend
+uses a guarded internal path so indexing operations performed during hydration
+cannot recursively trigger another hydration attempt.
+
+The `search_index --reindex` command remains useful for persistent external
+backends. Running it in a separate process is not presented as a way to fill a
+DevSearch backend.
+
+## Change Maintenance
+
+After hydration, the existing search invalidation hooks continue to call
+upsert/delete operations on the active backend for changes made in that process.
+No second change-tracking system is added.
+
+Documentation will state that asynchronous invalidation or writes performed by
+other processes cannot keep a process-local DevSearch index current. Restarting
+the server rebuilds the projection on its next search.
+
+## Query Matching
+
+Query and document tokenization remain lowercase, whitespace-based, prefix
+matching. Phrase parsing, fuzzy matching, stemming, and production-backend
+parity remain out of scope.
+
+Before ranking, each distinct query token must equal or prefix at least one
+indexed field token in the document. If any term has no match, the document is
+excluded. Once eligible, the existing field-boost and index-boost calculation
+ranks results. Repeated identical query terms do not impose duplicate matching
+requirements or inflate relevance scores.
+
+Empty queries retain their current behavior and match all documents that pass
+type and structured filters.
+
+## Error Handling
+
+- Lazy-hydration discovery, serialization, and source-read errors propagate to
+  the triggering search.
+- A failed hydration is retryable because its index is not marked hydrated.
+- Ordinary search behavior is unchanged when automatic hydration is disabled.
+- External search backends never enter the DevSearch hydration path.
+
+## Tests
+
+Tests will verify:
+
+- a multi-term query excludes a document when only some terms match;
+- every term may match a different searchable field;
+- duplicate terms do not inflate scores;
+- empty-query behavior remains unchanged;
+- opted-in DevSearch hydrates an index once on its first search;
+- hydration is tracked independently per index;
+- hydration failures propagate and remain retryable;
+- disabled, non-debug, directly constructed, and non-Dev backends do not
+  auto-hydrate;
+- a database-backed integration search works without an earlier management
+  command reindex; and
+- existing synchronous invalidation keeps an already hydrated backend current.
+
+Relevant unit tests, Ruff, formatting, mypy, and the focused integration tests
+will be run before completion.

--- a/docs/superpowers/specs/2026-08-22-dev-search-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-08-22-dev-search-lifecycle-design.md
@@ -103,8 +103,8 @@ Tests will verify:
 - opted-in DevSearch hydrates an index once on its first search;
 - hydration is tracked independently per index;
 - hydration failures propagate and remain retryable;
-- disabled, non-debug, directly constructed, and non-Dev backends do not
-  auto-hydrate;
+- missing or false `SEARCH_AUTO_REINDEX`, directly constructed non-opted-in,
+  and non-Dev backends do not auto-hydrate; DEBUG is irrelevant;
 - a database-backed integration search works without an earlier management
   command reindex; and
 - existing synchronous invalidation keeps an already hydrated backend current.

--- a/src/general_manager/search/backend_registry.py
+++ b/src/general_manager/search/backend_registry.py
@@ -27,6 +27,19 @@ class InvalidSearchBackendOptionsError(TypeError):
         super().__init__("SEARCH_BACKEND options must be a mapping.")
 
 
+def _dev_auto_reindex_enabled(django_settings: object) -> bool:
+    """Return whether settings enable DevSearch first-search hydration."""
+    config_candidate = getattr(django_settings, _SETTINGS_KEY, None)
+    if (
+        isinstance(config_candidate, Mapping)
+        and "SEARCH_AUTO_REINDEX" in config_candidate
+    ):
+        configured = config_candidate["SEARCH_AUTO_REINDEX"]
+    else:
+        configured = getattr(django_settings, "SEARCH_AUTO_REINDEX", False)
+    return bool(getattr(django_settings, "DEBUG", False)) and bool(configured)
+
+
 def configure_search_backend(backend: SearchBackend | None) -> None:
     """
     Set the active search backend instance.
@@ -128,6 +141,10 @@ def configure_search_backend_from_settings(django_settings: object) -> None:
     backend_instance = _resolve_backend(backend_setting)
     if backend_setting is not None and backend_instance is None:
         raise SearchBackendNotConfiguredError.from_setting(backend_setting)
+    if isinstance(backend_instance, DevSearchBackend):
+        backend_instance.configure_auto_reindex(
+            _dev_auto_reindex_enabled(django_settings)
+        )
     configure_search_backend(backend_instance)
 
 
@@ -139,7 +156,8 @@ def get_search_backend() -> SearchBackend:
     `configure_search_backend_from_settings(django.conf.settings)`. If settings
     still leave the backend unset, it creates one `DevSearchBackend`, stores it
     as the process-local active backend, and returns that same fallback instance
-    on later calls.
+    on later calls. The fallback enables first-search hydration only when both
+    `DEBUG` and `SEARCH_AUTO_REINDEX` are enabled in Django settings.
 
     Returns:
         The configured or development fallback search backend.
@@ -154,7 +172,7 @@ def get_search_backend() -> SearchBackend:
 
     configure_search_backend_from_settings(settings)
     if _backend is None:
-        _backend = DevSearchBackend()
+        _backend = DevSearchBackend(auto_reindex=_dev_auto_reindex_enabled(settings))
     if _backend is None:
         raise SearchBackendNotConfiguredError()
     return _backend

--- a/src/general_manager/search/backend_registry.py
+++ b/src/general_manager/search/backend_registry.py
@@ -37,7 +37,7 @@ def _dev_auto_reindex_enabled(django_settings: object) -> bool:
         configured = config_candidate["SEARCH_AUTO_REINDEX"]
     else:
         configured = getattr(django_settings, "SEARCH_AUTO_REINDEX", False)
-    return bool(getattr(django_settings, "DEBUG", False)) and bool(configured)
+    return bool(configured)
 
 
 def configure_search_backend(backend: SearchBackend | None) -> None:
@@ -156,8 +156,8 @@ def get_search_backend() -> SearchBackend:
     `configure_search_backend_from_settings(django.conf.settings)`. If settings
     still leave the backend unset, it creates one `DevSearchBackend`, stores it
     as the process-local active backend, and returns that same fallback instance
-    on later calls. The fallback enables first-search hydration only when both
-    `DEBUG` and `SEARCH_AUTO_REINDEX` are enabled in Django settings.
+    on later calls. The fallback enables first-search hydration when
+    `SEARCH_AUTO_REINDEX` is enabled in Django settings.
 
     Returns:
         The configured or development fallback search backend.

--- a/src/general_manager/search/backends/dev.py
+++ b/src/general_manager/search/backends/dev.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from threading import RLock
 
 from general_manager.search.backend import SearchDocument, SearchHit, SearchResult
 from general_manager.utils.filter_parser import apply_lookup
@@ -18,13 +19,32 @@ class _IndexStore:
 
 
 class DevSearchBackend:
-    """Simple process-local in-memory search backend intended for development."""
+    """Process-local development search with optional lazy per-index hydration."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, auto_reindex: bool = False) -> None:
         """
-        Initialize the backend with an empty registry that maps index names (str) to _IndexStore instances.
+        Initialize an empty in-memory registry and optional hydration lifecycle.
+
+        Automatic hydration is disabled for directly constructed backends unless
+        explicitly opted in. When enabled, each index hydrates on its first
+        search in this process. Failed hydration propagates and remains
+        retryable. The lock coordinates only first-search hydration; ordinary
+        reads and writes retain the backend's existing unsynchronized behavior.
         """
         self._indexes: dict[str, _IndexStore] = {}
+        self._auto_reindex = auto_reindex
+        self._hydrated_indexes: set[str] = set()
+        self._hydrating_indexes: set[str] = set()
+        self._hydration_lock = RLock()
+
+    @property
+    def auto_reindex_enabled(self) -> bool:
+        """Return whether first-search hydration is enabled for this backend."""
+        return self._auto_reindex
+
+    def configure_auto_reindex(self, enabled: bool) -> None:
+        """Enable or disable first-search hydration for this backend instance."""
+        self._auto_reindex = enabled
 
     def ensure_index(self, index_name: str, settings: Mapping[str, object]) -> None:
         """
@@ -100,6 +120,10 @@ class DevSearchBackend:
         """
         Search an index for documents matching a query and return scored, optionally filtered and sorted hits.
 
+        When auto-reindex is enabled, the first search for an index lazily
+        hydrates that index in this process before evaluating the query. The
+        hydration guard coordinates concurrent and nested first searches only;
+        a failed source error propagates and the next search can retry.
         The backend reads and writes documents under the `index_name` argument;
         `SearchDocument.index` is stored but not validated. Document IDs are
         unique only inside one in-memory index. Duplicate IDs inside one
@@ -131,8 +155,8 @@ class DevSearchBackend:
         keys, including equal-score default ordering. The backend stores
         document and settings objects by reference, returns hit data from the
         stored `SearchDocument.data` mapping, is
-        process-local memory only, and does not provide persistence or
-        synchronization for concurrent reads/writes.
+        process-local memory only, and does not provide persistence or ordinary
+        read/write synchronization beyond first-search hydration.
 
         Parameters:
             index_name (str): Name of the index to search.
@@ -167,6 +191,7 @@ class DevSearchBackend:
                 operational failures are not normalized and may surface as
                 ordinary Python exceptions.
         """
+        self._ensure_hydrated(index_name)
         if filter_expression is not None:
             raise NotImplementedError(
                 "filter_expression is not supported by the dev backend."
@@ -221,6 +246,31 @@ class DevSearchBackend:
 
         took_ms = int((time.perf_counter() - start) * 1000)
         return SearchResult(hits=hits, total=len(results), took_ms=took_ms)
+
+    def _ensure_hydrated(self, index_name: str) -> None:
+        """Hydrate one index once when this backend has opted into the lifecycle."""
+        if not self._auto_reindex or index_name in self._hydrated_indexes:
+            return
+        with self._hydration_lock:
+            if index_name in self._hydrated_indexes:
+                return
+            if index_name in self._hydrating_indexes:
+                return
+            self._hydrating_indexes.add(index_name)
+            try:
+                self._reindex_configured_managers(index_name)
+                self._hydrated_indexes.add(index_name)
+            finally:
+                self._hydrating_indexes.discard(index_name)
+
+    def _reindex_configured_managers(self, index_name: str) -> None:
+        """Reindex every manager configured for one index into this process."""
+        from general_manager.search.indexer import SearchIndexer
+        from general_manager.search.registry import iter_index_configs
+
+        indexer = SearchIndexer(self)
+        for manager_class, _index_config in iter_index_configs(index_name):
+            indexer.reindex_manager_index(manager_class, index_name)
 
     @staticmethod
     def _tokenize_query(query: str) -> list[str]:

--- a/src/general_manager/search/backends/dev.py
+++ b/src/general_manager/search/backends/dev.py
@@ -108,13 +108,14 @@ class DevSearchBackend:
         is idempotent and replaces the stored settings mapping for the index.
         Operations are not transactional; mutations completed before an
         exception remain in memory. Queries are lowercased and split on
-        whitespace. Indexed tokens are built from every top-level
+        whitespace, with duplicate query tokens removed in first-seen order.
+        Indexed tokens are built from every top-level
         `SearchDocument.data` value: `None` yields no tokens, strings split on
         whitespace, lists/tuples/sets are processed recursively, and all other
         values become `str(value).lower().split()`. Dict values are not
         traversed; they are tokenized from their string representation. A
-        document matches when each query token equals or prefixes a token
-        extracted from any indexed field. Empty queries match every document
+        document matches when every distinct query token equals or prefixes a
+        token extracted from any indexed field. Empty queries match every document
         that passes type and structured filters. The operation
         order is type filtering, structured filtering, query scoring/matching,
         sorting, and then pagination with `results[offset:offset + limit]`;
@@ -230,9 +231,9 @@ class DevSearchBackend:
             query (str): The input query string to tokenize.
 
         Returns:
-            list[str]: A list of lowercase tokens extracted from the query; empty tokens are omitted.
+            list[str]: Distinct lowercase tokens extracted from the query in first-seen order.
         """
-        return [token for token in query.lower().split() if token]
+        return list(dict.fromkeys(query.lower().split()))
 
     def _tokenize_document(self, document: SearchDocument) -> dict[str, set[str]]:
         """
@@ -284,7 +285,11 @@ class DevSearchBackend:
         """
         Compute a relevance score for a document based on matching query tokens and configured boosts.
 
-        Each time a token from `tokens` is present in a field's token set (or is a prefix of a field token) the field's boost is added to the score. After summing matches across all fields, the total is multiplied by `document.index_boost` when it is set.
+        Every distinct query token must be present in at least one field's token
+        set (or be a prefix of a field token). For each matching token, the
+        boosts of all matching fields are added to the score. After summing
+        matches across all fields, the total is multiplied by
+        `document.index_boost` when it is set.
 
         Parameters:
             tokens: The list of query tokens to match against the document's token index.
@@ -297,13 +302,17 @@ class DevSearchBackend:
             return 0.0
         token_index = token_index or {}
         score = 0.0
-        for field_name, field_tokens in token_index.items():
-            field_boost = document.field_boosts.get(field_name, 1.0)
-            for token in tokens:
+        for token in tokens:
+            token_score = 0.0
+            for field_name, field_tokens in token_index.items():
+                field_boost = document.field_boosts.get(field_name, 1.0)
                 if token in field_tokens or any(
                     field_token.startswith(token) for field_token in field_tokens
                 ):
-                    score += field_boost
+                    token_score += field_boost
+            if token_score <= 0:
+                return 0.0
+            score += token_score
         if document.index_boost:
             score *= document.index_boost
         return score

--- a/tests/unit/test_search_auto_reindex.py
+++ b/tests/unit/test_search_auto_reindex.py
@@ -1,8 +1,60 @@
 from __future__ import annotations
 
-from django.test import SimpleTestCase, TestCase
+import pytest
+from django.test import SimpleTestCase, override_settings
 
 from general_manager import apps as gm_apps
+from general_manager.apps import GeneralmanagerConfig
+from general_manager.manager.meta import GeneralManagerMeta
+from general_manager.search.async_tasks import dispatch_index_update
+from general_manager.search.backend import SearchDocument
+from general_manager.search.backend_registry import configure_search_backend
+from general_manager.search.backends.dev import DevSearchBackend
+from tests.unit.test_search_indexer import Project, ProjectInterface
+
+
+def _search_document(index_name: str) -> SearchDocument:
+    """Build one document whose query behavior proves hydration completed."""
+    return SearchDocument(
+        id=f"Project:{index_name}",
+        type="Project",
+        identification={"id": 1},
+        index=index_name,
+        data={"name": "Dockmaster"},
+        field_boosts={"name": 1.0},
+    )
+
+
+class HydrationSourceUnavailableError(RuntimeError):
+    """Raised by the test hydration source when its first read is unavailable."""
+
+    def __init__(self) -> None:
+        super().__init__("source unavailable")
+
+
+class RecordingHydrationBackend(DevSearchBackend):
+    """DevSearch double that populates a real document while hydrating."""
+
+    def __init__(self, *, fail_once: bool = False) -> None:
+        super().__init__(auto_reindex=True)
+        self.hydrated_indexes: list[str] = []
+        self.fail_once = fail_once
+
+    def _reindex_configured_managers(self, index_name: str) -> None:
+        self.hydrated_indexes.append(index_name)
+        if self.fail_once:
+            self.fail_once = False
+            raise HydrationSourceUnavailableError
+        self.upsert(index_name, [_search_document(index_name)])
+
+
+class NestedHydrationBackend(RecordingHydrationBackend):
+    """Exercise the guarded reentrant search path during hydration."""
+
+    def _reindex_configured_managers(self, index_name: str) -> None:
+        self.hydrated_indexes.append(index_name)
+        assert self.search(index_name, "Dock").total == 0
+        self.upsert(index_name, [_search_document(index_name)])
 
 
 class SearchAutoReindexRemovedTests(SimpleTestCase):
@@ -14,35 +66,86 @@ class SearchAutoReindexRemovedTests(SimpleTestCase):
         assert not hasattr(gm_apps.GeneralmanagerConfig, "install_search_auto_reindex")
 
 
-class DevSearchPrefixTests(TestCase):
-    def test_dev_search_prefix_match(self) -> None:
-        """Match documents when the query is a prefix of an indexed token."""
-        from general_manager.search.backends.dev import DevSearchBackend
-        from general_manager.search.backend import SearchDocument
+def test_first_search_hydrates_index_once() -> None:
+    """An opted-in index is populated once and its first query sees documents."""
+    backend = RecordingHydrationBackend()
 
-        backend = DevSearchBackend()
-        backend.ensure_index(
-            "global",
-            {
-                "searchable_fields": ["name"],
-                "filterable_fields": [],
-                "sortable_fields": [],
-                "field_boosts": {},
-            },
+    assert backend.search("global", "Dock").total == 1
+    assert backend.search("global", "Dock").total == 1
+    assert backend.hydrated_indexes == ["global"]
+
+
+def test_hydration_is_tracked_per_index() -> None:
+    """Hydrating one logical index leaves another index pending."""
+    backend = RecordingHydrationBackend()
+
+    assert backend.search("global", "Dock").total == 1
+    assert backend.search("private", "Dock").total == 1
+    assert backend.hydrated_indexes == ["global", "private"]
+
+
+def test_failed_hydration_propagates_and_retries() -> None:
+    """A source failure is visible and does not mark the index complete."""
+    backend = RecordingHydrationBackend(fail_once=True)
+
+    with pytest.raises(RuntimeError, match="source unavailable"):
+        backend.search("global", "Dock")
+
+    assert backend.search("global", "Dock").total == 1
+    assert backend.hydrated_indexes == ["global", "global"]
+
+
+def test_nested_hydration_is_guarded() -> None:
+    """Hydration can query its own index without recursively rebuilding it."""
+    backend = NestedHydrationBackend()
+
+    assert backend.search("global", "Dock").total == 1
+    assert backend.hydrated_indexes == ["global"]
+
+
+def test_direct_backend_does_not_hydrate_without_opt_in() -> None:
+    """Direct development backends retain their inert, isolated default."""
+    backend = DevSearchBackend()
+
+    assert backend.search("global", "").total == 0
+
+
+class DevSearchLifecycleIntegrationTests(SimpleTestCase):
+    """Exercise hydration and the synchronous update path with real managers."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        GeneralmanagerConfig.initialize_general_manager_classes([Project], [Project])
+        self.original_manager_classes = list(GeneralManagerMeta.all_classes)
+        GeneralManagerMeta.all_classes[:] = [Project]
+        self.backend = DevSearchBackend(auto_reindex=True)
+        self.original_data_store = ProjectInterface.data_store.copy()
+        configure_search_backend(self.backend)
+
+    def tearDown(self) -> None:
+        ProjectInterface.data_store = self.original_data_store
+        GeneralManagerMeta.all_classes[:] = self.original_manager_classes
+        configure_search_backend(None)
+        super().tearDown()
+
+    @override_settings(SEARCH_ASYNC=False)
+    def test_hydration_then_synchronous_update_finds_new_source_record(self) -> None:
+        """A hydrated serving backend receives later inline lifecycle writes."""
+        initial = self.backend.search("global", "Alpha")
+        assert [hit.identification for hit in initial.hits] == [{"id": 1}]
+
+        ProjectInterface.data_store[3] = {
+            "name": "Gamma",
+            "status": "public",
+            "secret": "hidden",
+        }
+        dispatch_index_update(
+            action="index",
+            manager_path="tests.unit.test_search_indexer.Project",
+            identification={"id": 3},
+            instance=Project(id=3),
+            index_name="global",
         )
-        backend.upsert(
-            "global",
-            [
-                SearchDocument(
-                    id="JobRoleCatalog:1",
-                    type="JobRoleCatalog",
-                    identification={"id": 1},
-                    index="global",
-                    data={"name": "Dockmaster"},
-                    field_boosts={"name": 1.0},
-                    index_boost=1.0,
-                )
-            ],
-        )
-        result = backend.search("global", "Dock")
-        assert result.total == 1
+
+        updated = self.backend.search("global", "Gamma")
+        assert [hit.identification for hit in updated.hits] == [{"id": 3}]

--- a/tests/unit/test_search_auto_reindex.py
+++ b/tests/unit/test_search_auto_reindex.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event
+
 import pytest
 from django.test import SimpleTestCase, override_settings
 
@@ -11,6 +14,8 @@ from general_manager.search.backend import SearchDocument
 from general_manager.search.backend_registry import configure_search_backend
 from general_manager.search.backends.dev import DevSearchBackend
 from tests.unit.test_search_indexer import Project, ProjectInterface
+
+TEST_TIMEOUT_SECONDS = 2.0
 
 
 def _search_document(index_name: str) -> SearchDocument:
@@ -57,6 +62,21 @@ class NestedHydrationBackend(RecordingHydrationBackend):
         self.upsert(index_name, [_search_document(index_name)])
 
 
+class ConcurrentHydrationBackend(RecordingHydrationBackend):
+    """Hold one rebuild open while another search waits for the same index."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.hydration_started = Event()
+        self.release_hydration = Event()
+
+    def _reindex_configured_managers(self, index_name: str) -> None:
+        self.hydrated_indexes.append(index_name)
+        self.hydration_started.set()
+        assert self.release_hydration.wait(timeout=TEST_TIMEOUT_SECONDS)
+        self.upsert(index_name, [_search_document(index_name)])
+
+
 class SearchAutoReindexRemovedTests(SimpleTestCase):
     def test_legacy_auto_reindex_helpers_are_removed(self) -> None:
         """Keep removed request-triggered auto-reindex helpers unavailable."""
@@ -100,6 +120,29 @@ def test_nested_hydration_is_guarded() -> None:
     backend = NestedHydrationBackend()
 
     assert backend.search("global", "Dock").total == 1
+    assert backend.hydrated_indexes == ["global"]
+
+
+def test_concurrent_first_searches_share_one_completed_hydration() -> None:
+    """Competing first searches wait for one rebuild and see its documents."""
+    backend = ConcurrentHydrationBackend()
+    searches_ready = Barrier(3)
+
+    def search() -> int:
+        searches_ready.wait(timeout=TEST_TIMEOUT_SECONDS)
+        return backend.search("global", "Dock").total
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(search) for _index in range(2)]
+        searches_ready.wait(timeout=TEST_TIMEOUT_SECONDS)
+        try:
+            assert backend.hydration_started.wait(timeout=TEST_TIMEOUT_SECONDS)
+            assert not any(future.done() for future in futures)
+        finally:
+            backend.release_hydration.set()
+        totals = [future.result(timeout=TEST_TIMEOUT_SECONDS) for future in futures]
+
+    assert totals == [1, 1]
     assert backend.hydrated_indexes == ["global"]
 
 

--- a/tests/unit/test_search_backend_registry.py
+++ b/tests/unit/test_search_backend_registry.py
@@ -4,12 +4,14 @@ from types import SimpleNamespace
 
 from django.test import SimpleTestCase, override_settings
 
+from general_manager.search import backend_registry
 from general_manager.search.backend_registry import (
     configure_search_backend,
     configure_search_backend_from_settings,
     get_search_backend,
     _resolve_backend,
 )
+from general_manager.search.backend import SearchResult
 from general_manager.search.backends.dev import DevSearchBackend
 
 
@@ -34,6 +36,30 @@ class _ConfigurableBackend(DevSearchBackend):
         """
         super().__init__()
         self.label = label
+
+
+class _ExternalProtocolBackend:
+    """Minimal non-Dev implementation accepted by the search backend protocol."""
+
+    def ensure_index(self, index_name: str, settings: object) -> None:
+        return None
+
+    def upsert(self, index_name: str, documents: object) -> None:
+        return None
+
+    def delete(self, index_name: str, ids: object) -> None:
+        return None
+
+    def list_document_ids(
+        self,
+        index_name: str,
+        *,
+        types: object = None,
+    ) -> set[str]:
+        return set()
+
+    def search(self, index_name: str, query: str, **kwargs: object) -> SearchResult:
+        return SearchResult(hits=[], total=0)
 
 
 class BackendRegistryTests(SimpleTestCase):
@@ -86,6 +112,60 @@ class BackendRegistryTests(SimpleTestCase):
         configure_search_backend_from_settings(dummy_settings)
         backend = get_search_backend()
         assert isinstance(backend, DevSearchBackend)
+
+    def test_dev_auto_reindex_requires_setting_and_debug(self) -> None:
+        """The settings-selected DevSearch enables hydration only in DEBUG."""
+        enabled = SimpleNamespace(
+            DEBUG=True,
+            GENERAL_MANAGER={
+                "SEARCH_BACKEND": DevSearchBackend,
+                "SEARCH_AUTO_REINDEX": True,
+            },
+        )
+
+        configure_search_backend_from_settings(enabled)
+
+        assert get_search_backend().auto_reindex_enabled is True
+
+    def test_dev_auto_reindex_is_disabled_outside_debug(self) -> None:
+        """A production-mode settings object cannot enable DevSearch hydration."""
+        disabled = SimpleNamespace(
+            DEBUG=False,
+            GENERAL_MANAGER={
+                "SEARCH_BACKEND": DevSearchBackend,
+                "SEARCH_AUTO_REINDEX": True,
+            },
+        )
+
+        configure_search_backend_from_settings(disabled)
+
+        assert get_search_backend().auto_reindex_enabled is False
+
+    def test_dev_auto_reindex_honors_nested_setting_precedence(self) -> None:
+        """The nested lifecycle setting overrides a conflicting top-level value."""
+        django_settings = SimpleNamespace(
+            DEBUG=True,
+            SEARCH_AUTO_REINDEX=True,
+            GENERAL_MANAGER={"SEARCH_AUTO_REINDEX": False},
+        )
+
+        assert backend_registry._dev_auto_reindex_enabled(django_settings) is False
+
+    def test_non_dev_backend_ignores_auto_reindex_setting(self) -> None:
+        """External protocol backends configure without DevSearch mutation."""
+        django_settings = SimpleNamespace(
+            DEBUG=True,
+            GENERAL_MANAGER={
+                "SEARCH_BACKEND": _ExternalProtocolBackend,
+                "SEARCH_AUTO_REINDEX": True,
+            },
+        )
+
+        configure_search_backend_from_settings(django_settings)
+
+        backend = get_search_backend()
+        assert isinstance(backend, _ExternalProtocolBackend)
+        assert not hasattr(backend, "auto_reindex_enabled")
 
     def test_configure_search_backend_from_settings_nested_none_disables(self) -> None:
         from general_manager.search import backend_registry

--- a/tests/unit/test_search_backend_registry.py
+++ b/tests/unit/test_search_backend_registry.py
@@ -113,8 +113,8 @@ class BackendRegistryTests(SimpleTestCase):
         backend = get_search_backend()
         assert isinstance(backend, DevSearchBackend)
 
-    def test_dev_auto_reindex_requires_setting_and_debug(self) -> None:
-        """The settings-selected DevSearch enables hydration only in DEBUG."""
+    def test_dev_auto_reindex_requires_setting(self) -> None:
+        """The settings-selected DevSearch honors its truthy lifecycle setting."""
         enabled = SimpleNamespace(
             DEBUG=True,
             GENERAL_MANAGER={
@@ -127,9 +127,9 @@ class BackendRegistryTests(SimpleTestCase):
 
         assert get_search_backend().auto_reindex_enabled is True
 
-    def test_dev_auto_reindex_is_disabled_outside_debug(self) -> None:
-        """A production-mode settings object cannot enable DevSearch hydration."""
-        disabled = SimpleNamespace(
+    def test_dev_auto_reindex_is_enabled_outside_debug(self) -> None:
+        """DevSearch hydration follows its explicit setting outside DEBUG."""
+        enabled = SimpleNamespace(
             DEBUG=False,
             GENERAL_MANAGER={
                 "SEARCH_BACKEND": DevSearchBackend,
@@ -137,7 +137,32 @@ class BackendRegistryTests(SimpleTestCase):
             },
         )
 
-        configure_search_backend_from_settings(disabled)
+        configure_search_backend_from_settings(enabled)
+
+        assert get_search_backend().auto_reindex_enabled is True
+
+    def test_dev_auto_reindex_is_disabled_when_setting_is_missing(self) -> None:
+        """DevSearch remains inert unless auto-reindex is explicitly configured."""
+        django_settings = SimpleNamespace(
+            DEBUG=False,
+            GENERAL_MANAGER={"SEARCH_BACKEND": DevSearchBackend},
+        )
+
+        configure_search_backend_from_settings(django_settings)
+
+        assert get_search_backend().auto_reindex_enabled is False
+
+    def test_dev_auto_reindex_is_disabled_when_setting_is_false(self) -> None:
+        """A false lifecycle setting disables hydration in every environment."""
+        django_settings = SimpleNamespace(
+            DEBUG=True,
+            GENERAL_MANAGER={
+                "SEARCH_BACKEND": DevSearchBackend,
+                "SEARCH_AUTO_REINDEX": False,
+            },
+        )
+
+        configure_search_backend_from_settings(django_settings)
 
         assert get_search_backend().auto_reindex_enabled is False
 
@@ -166,6 +191,13 @@ class BackendRegistryTests(SimpleTestCase):
         backend = get_search_backend()
         assert isinstance(backend, _ExternalProtocolBackend)
         assert not hasattr(backend, "auto_reindex_enabled")
+
+    @override_settings(DEBUG=False, SEARCH_AUTO_REINDEX=True, GENERAL_MANAGER={})
+    def test_dev_fallback_honors_auto_reindex_outside_debug(self) -> None:
+        """The settings fallback follows the same DevSearch lifecycle setting."""
+        configure_search_backend(None)
+
+        assert get_search_backend().auto_reindex_enabled is True
 
     def test_configure_search_backend_from_settings_nested_none_disables(self) -> None:
         from general_manager.search import backend_registry

--- a/tests/unit/test_search_dev_backend.py
+++ b/tests/unit/test_search_dev_backend.py
@@ -69,6 +69,19 @@ class DevSearchBackendTests(SimpleTestCase):
         assert data is not None
         assert data["name"] == "Beta Project"
 
+    def test_search_requires_every_distinct_query_term(self) -> None:
+        result = self.backend.search("global", "Alpha missing")
+        assert result.total == 0
+
+    def test_search_allows_query_terms_to_match_different_fields(self) -> None:
+        result = self.backend.search("global", "Alpha public")
+        assert [hit.id for hit in result.hits] == ["Project:1"]
+
+    def test_repeated_query_terms_do_not_inflate_score(self) -> None:
+        single = self.backend.search("global", "Alpha")
+        repeated = self.backend.search("global", "Alpha Alpha")
+        assert repeated.hits[0].score == single.hits[0].score
+
     def test_list_document_ids_filters_by_type(self) -> None:
         """Return indexed document IDs restricted to requested type labels."""
         assert self.backend.list_document_ids("global", types=["Project"]) == {


### PR DESCRIPTION
## Summary

Make the service-free DevSearch backend usable from a running Django process without persistent search storage. Each opted-in process lazily rebuilds an index from configured managers on first search, then relies on existing synchronous invalidation. Multi-term queries now require every distinct term.

## Related issue

No related issue.

## What changed

- add opt-in, per-index lazy DevSearch hydration with retry and reentrancy protection
- enable settings-selected hydration when SEARCH_AUTO_REINDEX is true, independent of DEBUG
- require every distinct query term before relevance ranking
- preserve direct-instance defaults and external backend behavior
- update lifecycle documentation, tutorial configuration, design, and tests

## Validation

```text
python -m pytest tests/unit/test_search_auto_reindex.py tests/unit/test_search_backend_registry.py tests/unit/test_search_dev_backend.py tests/unit/test_search_indexer.py -q — 62 passed
python -m pytest -q — 6200 passed, 3 skipped, 2016 subtests passed, 1 pre-existing warning
ruff check — passed
ruff format --check — passed
mypy — passed
```

## Documentation

Updated the search tutorial and concepts documentation to describe disposable per-process hydration, retry behavior, synchronous same-process maintenance, cross-process limitations, and all-term matching.

## Reviewer notes

DevSearch remains intentionally process-local. Changes made by another process are observed after restarting the serving process. No persistence, migrations, models, dependencies, or external-backend changes were added.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Commits follow the Conventional Commits format.
- [x] Relevant tests were added or updated, and python -m pytest passes.
- [x] ruff check, ruff format --check, and mypy --strict pass.
- [x] User-facing documentation is updated where behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development search can optionally hydrate indexes automatically on first search.
  * Failed hydration attempts can be retried, with concurrent requests coordinated safely.
  * Searches now require every distinct query term to match, including across different fields.
  * Index updates remain synchronized within the serving process.
  * Auto-hydration can be configured through application settings.

* **Documentation**
  * Added guidance on lazy hydration, reindexing, process-local behavior, and matching rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->