### PR TITLE
docs: document dev search lifecycle

### DIFF
--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -207,7 +207,7 @@ index-rename migrations.
 
 ::: general_manager.search.async_tasks.dispatch_index_update
 
-### DevSearch compatibility and lifecycle notes
+## DevSearch compatibility and lifecycle notes
 
 `DevSearchBackend` is the built-in process-local backend for development. Its
 existing no-argument construction remains inert and compatible with callers

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -207,6 +207,31 @@ index-rename migrations.
 
 ::: general_manager.search.async_tasks.dispatch_index_update
 
+### DevSearch compatibility and lifecycle notes
+
+`DevSearchBackend` is the built-in process-local backend for development. Its
+existing no-argument construction remains inert and compatible with callers
+that manage indexes explicitly. The new keyword-only
+`DevSearchBackend(*, auto_reindex: bool = False)` option opts a directly
+constructed backend into first-search hydration. The public
+`auto_reindex_enabled: bool` property reports the current setting, and
+`configure_auto_reindex(enabled: bool) -> None` changes it for later searches.
+
+When `SEARCH_AUTO_REINDEX` is truthy in the nested `GENERAL_MANAGER` mapping,
+or in the top-level setting when the nested key is absent, a selected
+`DevSearchBackend` hydrates each index on its first search. The setting is
+ignored for external backends and does not require Django `DEBUG=True`. Each
+configured manager is reindexed in the serving process; source and reindexing
+exceptions propagate to the triggering search, and a failed index remains
+retryable. Same-process synchronous invalidation continues to update a hydrated
+projection, while writes or `search_index --reindex` in another process cannot
+populate a running DevSearch instance.
+
+Multi-term DevSearch queries now require every distinct lowercased query term to
+equal or prefix a token from at least one indexed field. Terms may match
+different fields, repeated terms do not inflate the score, and empty-query
+behavior is unchanged. External backend query semantics are unaffected.
+
 ::: general_manager.search.backends.dev.DevSearchBackend
 
 ::: general_manager.search.backends.meilisearch.MeilisearchBackend

--- a/docs/examples/dev_search_lifecycle.md
+++ b/docs/examples/dev_search_lifecycle.md
@@ -1,0 +1,97 @@
+# Lazy DevSearch hydration
+
+Use the built-in `DevSearchBackend` when a local Django process needs a
+service-free search projection. This recipe enables per-index hydration on the
+first search, keeps later same-process manager changes visible, and makes the
+multi-term matching contract explicit.
+
+## Configure the disposable backend
+
+Put the backend and setting in the same `GENERAL_MANAGER` mapping:
+
+```python
+GENERAL_MANAGER = {
+    "SEARCH_BACKEND": {
+        "class": "general_manager.search.backends.dev.DevSearchBackend",
+        "options": {},
+    },
+    "SEARCH_AUTO_REINDEX": True,
+}
+```
+
+`SEARCH_AUTO_REINDEX` is opt-in and applies only to the selected
+`DevSearchBackend`; it is independent of `DEBUG`. The nested setting takes
+precedence over a top-level `SEARCH_AUTO_REINDEX` value. External search
+backends ignore this DevSearch-specific setting.
+
+## Declare an index and search it
+
+Add a `SearchConfig` to the manager whose fields should be searchable:
+
+```python
+from general_manager import GeneralManager, IndexConfig
+
+
+class Project(GeneralManager):
+    class SearchConfig:
+        indexes = (
+            IndexConfig(
+                name="global",
+                fields=("name", "status"),
+                filters=("status",),
+            ),
+        )
+```
+
+With the setting enabled, the first search for `global` reindexes the
+configured `Project` managers in the serving process before evaluating the
+query:
+
+```python
+from general_manager.search.backend_registry import get_search_backend
+
+
+backend = get_search_backend()
+result = backend.search("global", "alpha public", filters={"status": "public"})
+
+for hit in result.hits:
+    print(hit.id, hit.score)
+```
+
+Every distinct query term must match at least one indexed field token, so
+`"alpha public"` can match `alpha` in `name` and `public` in `status`, while a
+document missing either term is excluded. Repeating a term, as in
+`"alpha alpha"`, does not increase its score.
+
+## Opt in a directly constructed backend
+
+Direct construction stays inert by default. Enable hydration explicitly when a
+programmatic caller owns the backend instance:
+
+```python
+from general_manager.search.backends.dev import DevSearchBackend
+
+
+backend = DevSearchBackend(auto_reindex=True)
+# Equivalent after construction:
+# backend.configure_auto_reindex(True)
+result = backend.search("global", "alpha")
+```
+
+Hydration is tracked independently per index. If manager discovery or
+reindexing raises, the original exception reaches the triggering search and a
+later search retries that index. After successful hydration, synchronous
+manager lifecycle updates in the same process upsert or delete documents as
+usual.
+
+## Keep the process boundary in mind
+
+DevSearch is an in-memory, process-local projection. A separate
+`python manage.py search_index --reindex` process cannot populate the backend of
+an already running server, and writes made by another process are not observed.
+Restart the serving process so its next search can hydrate a fresh projection.
+Use a persistent external backend for production or cross-process search.
+
+For the model and lifecycle details, see the [search concept page](../concepts/search.md)
+and the [search how-to](../howto/search.md). The generated signatures and
+compatibility notes are in the [Search API reference](../api/search.md).

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -14,6 +14,7 @@ The cookbook collects self-contained snippets that demonstrate how to solve doma
 - [Upload a file through GraphQL](graphql_file_upload.md)
 - [Validate a manager with field and non-field rule errors](rule_validation.md)
 - [Installed chat eval commands](chat_eval_cli.md)
+- [Lazy DevSearch hydration](dev_search_lifecycle.md)
 - [Permission patterns](permission_patterns.md)
 - [Permission cookbook](permission_cookbook.md)
 - [Custom audit logger](audit_logger_custom.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,7 @@ nav:
       - examples/graphql_file_upload.md
       - examples/rule_validation.md
       - examples/chat_eval_cli.md
+      - examples/dev_search_lifecycle.md
       - examples/permission_patterns.md
       - examples/permission_cookbook.md
       - examples/audit_logger_custom.md


### PR DESCRIPTION
## Reviewed commits

- 9d70f1c0a1f9fba89eaa834df2049833f334ab1f — design dev search lazy hydration
- 7094037c294f6c41682199bda55e13445420d6fb — plan dev search lifecycle implementation
- 1ab017bd1f50e77a934cc7f861f341265973ae02 — require all dev search query terms
- b3c4e17b1e1863573f95d27038fb86395e606c45 — lazily hydrate development search
- 83574a69d0614e53e660a4d9fba2f0318d590171 — enable dev search reindex outside debug
- 9eba31731768aff8ba34101152ade878afdb6680 — align dev search reindex contract
- fd0319b9399e7d8d7d8f999bad587cd5c967068a — correct dev search configuration example
- 5f8d4c108e27fc4eb091a83474aa4fed261c6f5f — strengthen dev search hydration coverage
- c168bf12d1987538801f3b537995ab9a41edf616 — clarify dev search hydration condition
- 783018308ac4963919b44f156eacfce348245d2b — 0.76.0 release metadata

## Affected public APIs

- `DevSearchBackend(*, auto_reindex: bool = False)` now supports opt-in per-index first-search hydration.
- `DevSearchBackend.auto_reindex_enabled` reports the current opt-in state.
- `DevSearchBackend.configure_auto_reindex(enabled: bool) -> None` changes the state for later searches.
- `SEARCH_AUTO_REINDEX` enables hydration for a selected DevSearch backend, with nested `GENERAL_MANAGER` precedence and no `DEBUG` requirement; external backends ignore it.
- DevSearch multi-term queries now require every distinct query term to match or prefix a token; terms may match different fields and repeated terms do not inflate scores.
- Hydration failures propagate and leave an index retryable; same-process synchronous invalidation remains the maintenance path, and other processes cannot populate a running in-memory backend.

## Documentation changes

- Added `docs/examples/dev_search_lifecycle.md` as a directly usable cookbook recipe.
- Updated `docs/examples/index.md` and `mkdocs.yml` navigation.
- Updated `docs/api/search.md` with exact new signatures, configuration precedence, lifecycle/error compatibility, process boundaries, and query semantics.
- Existing concept/how-to coverage in `docs/concepts/search.md` and `docs/howto/search.md` was reviewed and already covers the current behavior from the in-window commits.

## Validation

- `PYTHONPATH=src python -m pytest tests/docs/test_public_api_docs_coverage.py tests/integration/test_request_docs_examples.py tests/unit/test_search_auto_reindex.py tests/unit/test_search_backend_registry.py tests/unit/test_search_dev_backend.py -q` — 44 passed.
- `python -m mkdocs build --strict --site-dir /tmp/general-manager-docs-review-20260824-final` — passed; only existing unnav-linked planning/ADR notices were reported.
- Four Python cookbook blocks parsed with `ast`.
- File-scoped pre-commit hooks passed.
- `git diff --cached --check` passed.
- Public export registry diff is empty; exact-window commit recheck returned the same 10 SHAs.

## Limitations

- The full test suite, Ruff, and mypy were not run across the repository because this is a documentation-only change; pre-commit correctly skipped source-only Ruff/mypy hooks.
- Independent reviewer dispatch did not return before the bounded wait and was closed; local review and the checks above were completed instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance on DevSearch lifecycle and compatibility behavior.
  - Documented lazy hydration for local processes, including configuration, direct opt-in, first-search behavior, retry semantics, and process-local limitations.
  - Clarified synchronous lifecycle synchronization and optional first-search reindexing.
  - Documented multi-term query matching, including cross-field terms and duplicate-term scoring.
  - Added a cookbook example and linked it in the examples navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->